### PR TITLE
test: raise full suite coverage

### DIFF
--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -1573,6 +1573,18 @@ namespace DTXMania.Game.Lib.Song.Components
                 }
                 _songBarCache.Clear();
 
+                foreach (var titleTexture in _titleBarCache.Values)
+                {
+                    titleTexture?.Dispose();
+                }
+                _titleBarCache.Clear();
+
+                foreach (var previewTexture in _previewImageCache.Values)
+                {
+                    previewTexture?.Dispose();
+                }
+                _previewImageCache.Clear();
+
                 // Phase 2: Dispose bar information cache
                 foreach (var barInfo in _barInfoCache.Values)
                 {

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -1442,7 +1442,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
             // Track which bar indices are currently visible
             var newVisibleIndices = new HashSet<int>();
-            var seenCacheKeys = new HashSet<string>();
+            var pendingRequests = new Dictionary<string, TextureGenerationRequest>();
 
             for (int barIndex = 0; barIndex < VISIBLE_ITEMS; barIndex++)
             {
@@ -1451,23 +1451,36 @@ namespace DTXMania.Game.Lib.Song.Components
                 // Implement infinite looping: wrap song index using modulo arithmetic
                 songIndex = ((songIndex % _currentList.Count) + _currentList.Count) % _currentList.Count;
 
-                newVisibleIndices.Add(songIndex);                // Only queue if not already cached and not already queued this pass
+                newVisibleIndices.Add(songIndex);
                 var cacheKey = $"{_currentList[songIndex].GetHashCode()}_{_currentDifficulty}";
-                if (!_barInfoCache.ContainsKey(cacheKey) && seenCacheKeys.Add(cacheKey))
+                if (_barInfoCache.ContainsKey(cacheKey))
                 {
-                    var request = new TextureGenerationRequest
-                    {
-                        SongNode = _currentList[songIndex],
-                        SongIndex = songIndex,
-                        BarIndex = barIndex,
-                        Difficulty = _currentDifficulty,
-                        IsSelected = (barIndex == CENTER_INDEX),
-                        Priority = 100 - Math.Abs(barIndex - CENTER_INDEX)
-                    };
-
-                    InsertTextureRequestSorted(request);
+                    continue;
                 }
-            }            // Update visible bar indices
+
+                var request = new TextureGenerationRequest
+                {
+                    SongNode = _currentList[songIndex],
+                    SongIndex = songIndex,
+                    BarIndex = barIndex,
+                    Difficulty = _currentDifficulty,
+                    IsSelected = (barIndex == CENTER_INDEX),
+                    Priority = 100 - Math.Abs(barIndex - CENTER_INDEX)
+                };
+
+                if (!pendingRequests.TryGetValue(cacheKey, out var existingRequest)
+                    || request.Priority > existingRequest.Priority
+                    || (request.Priority == existingRequest.Priority && request.IsSelected && !existingRequest.IsSelected))
+                {
+                    pendingRequests[cacheKey] = request;
+                }
+            }
+
+            foreach (var request in pendingRequests.Values.OrderByDescending(item => item.Priority))
+            {
+                InsertTextureRequestSorted(request);
+            }
+            // Update visible bar indices
             _visibleBarIndices.Clear();
             foreach (var index in newVisibleIndices)
             {

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -1442,6 +1442,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
             // Track which bar indices are currently visible
             var newVisibleIndices = new HashSet<int>();
+            var seenCacheKeys = new HashSet<string>();
 
             for (int barIndex = 0; barIndex < VISIBLE_ITEMS; barIndex++)
             {
@@ -1450,9 +1451,9 @@ namespace DTXMania.Game.Lib.Song.Components
                 // Implement infinite looping: wrap song index using modulo arithmetic
                 songIndex = ((songIndex % _currentList.Count) + _currentList.Count) % _currentList.Count;
 
-                newVisibleIndices.Add(songIndex);                // Only queue if not already cached using sorted insertion
+                newVisibleIndices.Add(songIndex);                // Only queue if not already cached and not already queued this pass
                 var cacheKey = $"{_currentList[songIndex].GetHashCode()}_{_currentDifficulty}";
-                if (!_barInfoCache.ContainsKey(cacheKey))
+                if (!_barInfoCache.ContainsKey(cacheKey) && seenCacheKeys.Add(cacheKey))
                 {
                     var request = new TextureGenerationRequest
                     {

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1452,7 +1452,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             try
             {
-                _gameStartSound?.Play(0.9f); // Play at 90% volume (same as TitleStage)
+                _gameStartSound?.Play(SongSelectionUILayout.Audio.GameStartSoundVolume);
             }
             catch (Exception ex)
             {

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -83,7 +83,7 @@ namespace DTXMania.Game.Lib.Stage
 
         // Preview sound functionality
         private ISound _previewSound;
-        private SoundEffectInstance _previewSoundInstance;
+        private ISoundInstance _previewSoundInstance;
         private ISound _backgroundMusic; // Reference to BGM
         private ISoundInstance _backgroundMusicInstance;
         
@@ -1181,7 +1181,7 @@ namespace DTXMania.Game.Lib.Stage
                                 _previewSoundInstance = null;
                             }
 
-                            _previewSoundInstance = _previewSound.CreateInstance();
+                            _previewSoundInstance = CreatePreviewSoundInstance(_previewSound);
                             if (_previewSoundInstance != null)
                             {
                                 _previewSoundInstance.Volume = SongSelectionUILayout.Audio.PreviewSoundVolume;
@@ -1402,6 +1402,12 @@ namespace DTXMania.Game.Lib.Stage
         {
             sound?.RemoveReference();
             sound = null;
+        }
+
+        private static ISoundInstance CreatePreviewSoundInstance(ISound previewSound)
+        {
+            var rawInstance = previewSound?.CreateInstance();
+            return rawInstance == null ? null : new SoundInstanceWrapper(rawInstance);
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -257,6 +257,7 @@ namespace DTXMania.Game.Lib.Stage
             StopCurrentPreview();
             _backgroundMusicInstance?.Dispose();
             _backgroundMusicInstance = null;
+            _backgroundMusic?.RemoveReference();
             _backgroundMusic = null;
 
             // Clean up navigation sound (same as TitleStage)
@@ -1374,7 +1375,6 @@ namespace DTXMania.Game.Lib.Stage
                     {
                         _previewSoundInstance.Stop();
                     }
-                    _previewSoundInstance.Dispose();
                 }
                 catch (Exception ex)
                 {
@@ -1383,6 +1383,7 @@ namespace DTXMania.Game.Lib.Stage
                 }
                 finally
                 {
+                    _previewSoundInstance.Dispose();
                     _previewSoundInstance = null;
                 }
             }

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -543,6 +543,7 @@ namespace DTXMania.Game.Lib.UI.Layout
             // Volume levels
             public const float PreviewSoundVolume = 0.8f;  // 80% volume for preview sounds
             public const float NavigationSoundVolume = 0.7f; // 70% volume for navigation sounds
+            public const float GameStartSoundVolume = 0.9f;  // 90% volume for game start sound
             
             // BGM fade settings
             public const double BgmFadeOutDuration = 0.5;  // 500ms fade

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -217,6 +217,60 @@ namespace DTXMania.Test.Stage
             Assert.True(typeof(IStage).IsAssignableFrom(typeof(ResultStage)));
         }
 
+        [Fact]
+        public void HandleInput_WhenInputManagerIsNull_ShouldReturnWithoutThrowing()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+
+            SetPrivateField(stage, "_inputManager", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "HandleInput"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_WhenTransitionIsDebounced_ShouldNotChangeStage()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var stageManager = new Mock<IStageManager>();
+            var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0.0);
+
+            SetPrivateField(stage, "_game", game);
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new DTXMania.Game.Lib.Input.InputCommand(DTXMania.Game.Lib.Input.InputCommandType.Back, 0.0));
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+            Assert.Equal(0.0, DTXMania.Test.TestData.ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_WhenCommandIsNotNavigation_ShouldIgnoreIt()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var stageManager = new Mock<IStageManager>();
+            var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+
+            SetPrivateField(stage, "_game", game);
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new DTXMania.Game.Lib.Input.InputCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveDown, 0.0));
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+            Assert.Equal(0.0, DTXMania.Test.TestData.ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
         #endregion
 
         #region Helper Methods

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
@@ -590,7 +591,7 @@ namespace DTXMania.Test.Stage
             var resourceManager = new Mock<IResourceManager>();
             var previousSound = new Mock<ISound>();
             var loadedSound = new Mock<ISound>();
-            var dir = Path.Combine(Path.GetTempPath(), "dtx-stage-preview", Guid.NewGuid().ToString("N"));
+            var dir = CreateWorkspacePath("preview", Guid.NewGuid().ToString("N"));
 
             Directory.CreateDirectory(dir);
 
@@ -640,7 +641,7 @@ namespace DTXMania.Test.Stage
             var resourceManager = new Mock<IResourceManager>();
             var previousSound = new Mock<ISound>();
             var failedSound = new Mock<ISound>();
-            const string previewPath = "/tmp/preview.ogg";
+            var previewPath = CreateWorkspacePath("preview-failure.ogg");
 
             AttachResourceManager(stage, resourceManager.Object);
             SetPrivateField(stage, "_previewSound", previousSound.Object);
@@ -658,6 +659,190 @@ namespace DTXMania.Test.Stage
             previousSound.Verify(x => x.RemoveReference(), Times.Once);
             failedSound.Verify(x => x.RemoveReference(), Times.Once);
             Assert.Null(GetPrivateField<ISound>(stage, "_previewSound"));
+        }
+
+        [Fact]
+        public void LoadUIGraphics_WhenFooterLoadFails_ShouldKeepHeaderTexture()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var header = new Mock<ITexture>().Object;
+
+            resourceManager.Setup(x => x.LoadTexture(TexturePath.SongSelectionHeaderPanel)).Returns(header);
+            resourceManager.Setup(x => x.LoadTexture(TexturePath.SongSelectionFooterPanel)).Throws(new InvalidOperationException("footer"));
+            AttachResourceManager(stage, resourceManager.Object);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "LoadUIGraphics"));
+
+            Assert.Null(ex);
+            Assert.Same(header, GetPrivateField<ITexture>(stage, "_headerPanelTexture"));
+            Assert.Null(GetPrivateField<ITexture>(stage, "_footerPanelTexture"));
+        }
+
+        [Fact]
+        public void LoadNavigationSound_WhenNowLoadingFails_ShouldFallbackToDecideSound()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var cursor = new Mock<ISound>().Object;
+            var fallback = new Mock<ISound>().Object;
+
+            resourceManager.Setup(x => x.LoadSound("Sounds/Move.ogg")).Returns(cursor);
+            resourceManager.Setup(x => x.LoadSound("Sounds/Now loading.ogg")).Throws(new InvalidOperationException("missing"));
+            resourceManager.Setup(x => x.LoadSound("Sounds/Decide.ogg")).Returns(fallback);
+            AttachResourceManager(stage, resourceManager.Object);
+
+            InvokePrivateMethod(stage, "LoadNavigationSound");
+
+            Assert.Same(cursor, GetPrivateField<ISound>(stage, "_cursorMoveSound"));
+            Assert.Same(fallback, GetPrivateField<ISound>(stage, "_gameStartSound"));
+        }
+
+        [Fact]
+        public void LoadNavigationSound_WhenAllLoadsFail_ShouldLeaveSoundsNull()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+
+            resourceManager.Setup(x => x.LoadSound(It.IsAny<string>())).Throws(new InvalidOperationException("missing"));
+            AttachResourceManager(stage, resourceManager.Object);
+
+            InvokePrivateMethod(stage, "LoadNavigationSound");
+
+            Assert.Null(GetPrivateField<ISound>(stage, "_cursorMoveSound"));
+            Assert.Null(GetPrivateField<ISound>(stage, "_gameStartSound"));
+        }
+
+        [Fact]
+        public void TryLoadPreviewSoundFile_WhenLoadSucceeds_ShouldSetPreviewSoundAndDelay()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var previousSound = new Mock<ISound>();
+            var loadedSound = new Mock<ISound>();
+            var previewPath = CreateWorkspacePath("preview-success.ogg");
+
+            AttachResourceManager(stage, resourceManager.Object);
+            SetPrivateField(stage, "_previewSound", previousSound.Object);
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(loadedSound.Object);
+
+            var loaded = InvokePrivateMethod<bool>(stage, "TryLoadPreviewSoundFile", previewPath);
+
+            Assert.True(loaded);
+            previousSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Same(loadedSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.Equal(0.0, GetPrivateField<double>(stage, "_previewPlayDelay"));
+            Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+
+        [Fact]
+        public void TryLoadPreviewSoundFile_WhenLoadThrows_ShouldReturnFalseAndClearPreview()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var previousSound = new Mock<ISound>();
+            var previewPath = CreateWorkspacePath("preview-throw.ogg");
+
+            AttachResourceManager(stage, resourceManager.Object);
+            SetPrivateField(stage, "_previewSound", previousSound.Object);
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Throws(new IOException("boom"));
+
+            var loaded = InvokePrivateMethod<bool>(stage, "TryLoadPreviewSoundFile", previewPath);
+
+            Assert.False(loaded);
+            previousSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<ISound>(stage, "_previewSound"));
+        }
+
+        [Fact]
+        public void LoadPreviewSound_WhenPreviewFileBlankOrMissing_ShouldRemainNoOp()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var existingPreviewSound = new Mock<ISound>();
+            var baseDir = CreateWorkspacePath("preview-load-noop");
+
+            Directory.CreateDirectory(baseDir);
+            AttachResourceManager(stage, resourceManager.Object);
+            SetPrivateField(stage, "_previewSound", existingPreviewSound.Object);
+            SetPrivateField(stage, "_isPreviewDelayActive", true);
+
+            InvokePrivateMethod(stage, "LoadPreviewSound", CreateScoreNode("Blank", chart: new SongChart
+            {
+                FilePath = Path.Combine(baseDir, "blank.dtx"),
+                PreviewFile = "",
+                HasDrumChart = true,
+                DrumLevel = 20
+            }));
+            InvokePrivateMethod(stage, "LoadPreviewSound", CreateScoreNode("Missing", chart: new SongChart
+            {
+                FilePath = Path.Combine(baseDir, "missing.dtx"),
+                PreviewFile = "missing.ogg",
+                HasDrumChart = true,
+                DrumLevel = 20
+            }));
+
+            resourceManager.Verify(x => x.LoadSound(It.IsAny<string>()), Times.Never);
+            Assert.Same(existingPreviewSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+
+        [Fact]
+        public void AssignInputManager_WhenNull_ShouldCreateOwnedFallbackManager()
+        {
+            var stage = CreateStage();
+
+            InvokePrivateMethod(stage, "AssignInputManager", new object?[] { null });
+
+            Assert.NotNull(GetPrivateField<InputManager>(stage, "_inputManager"));
+            Assert.True(GetPrivateField<bool>(stage, "_ownsInputManager"));
+        }
+
+        [Fact]
+        public void PlayCursorMoveSound_WhenPlayThrows_ShouldSwallowException()
+        {
+            var stage = CreateStage();
+            var sound = new Mock<ISound>();
+            sound.Setup(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume)).Throws(new InvalidOperationException("play"));
+            SetPrivateField(stage, "_cursorMoveSound", sound.Object);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "PlayCursorMoveSound"));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void PlayGameStartSound_WhenPlayThrows_ShouldSwallowException()
+        {
+            var stage = CreateStage();
+            var sound = new Mock<ISound>();
+            sound.Setup(x => x.Play(0.9f)).Throws(new InvalidOperationException("play"));
+            SetPrivateField(stage, "_gameStartSound", sound.Object);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "PlayGameStartSound"));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void CycleDifficulty_WhenNegativeAndOnlyOneDifficultyExists_ShouldKeepState()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var statusPanel = new SongStatusPanel();
+            var song = CreateScoreNode("Only", CreateScores(2));
+
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 2);
+            display.CurrentDifficulty = 2;
+            statusPanel.UpdateSongInfo(song, 2);
+
+            InvokePrivateMethod(stage, "CycleDifficulty", -1);
+
+            Assert.Equal(2, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal(2, display.CurrentDifficulty);
+            Assert.Equal(2, GetPrivateField<int>(statusPanel, "_currentDifficulty"));
         }
 
         [Fact]
@@ -683,6 +868,117 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void StopCurrentPreview_WhenPreviewInstanceThrows_ShouldClearInstanceAndContinueFadeIn()
+        {
+            var stage = CreateStage();
+            var previewSound = new Mock<ISound>();
+#pragma warning disable SYSLIB0050
+            var previewInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
+#pragma warning restore SYSLIB0050
+
+            SetPrivateField(stage, "_previewSound", previewSound.Object);
+            SetPrivateField(stage, "_previewSoundInstance", previewInstance);
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "StopCurrentPreview"));
+
+            Assert.Null(ex);
+            previewSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenPreviewDelayElapsesAndCreateInstanceThrows_ShouldClearPreviewInstance()
+        {
+            var stage = CreateStage();
+            var previewSound = new Mock<ISound>();
+
+            previewSound.Setup(x => x.CreateInstance()).Throws(new InvalidOperationException("preview failed"));
+
+            SetPrivateField(stage, "_previewSound", previewSound.Object);
+            SetPrivateField(stage, "_isPreviewDelayActive", true);
+            SetPrivateField(stage, "_previewPlayDelay", SongSelectionUILayout.Audio.PreviewPlayDelaySeconds - 0.01);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.02));
+
+            Assert.Null(ex);
+            previewSound.Verify(x => x.CreateInstance(), Times.Once);
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        }
+
+        [Theory]
+        [InlineData(true, "_isBgmFadingOut", "_isBgmFadingIn", "_bgmFadeOutTimer")]
+        [InlineData(false, "_isBgmFadingIn", "_isBgmFadingOut", "_bgmFadeInTimer")]
+        public void StartBGMFade_ShouldToggleExpectedFadeState(
+            bool fadeOut,
+            string enabledField,
+            string disabledField,
+            string timerField)
+        {
+            var stage = CreateStage();
+
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_bgmFadeOutTimer", 1.0);
+            SetPrivateField(stage, "_bgmFadeInTimer", 1.0);
+
+            InvokePrivateMethod(stage, "StartBGMFade", fadeOut);
+
+            Assert.True(GetPrivateField<bool>(stage, enabledField));
+            Assert.False(GetPrivateField<bool>(stage, disabledField));
+            Assert.Equal(0.0, GetPrivateField<double>(stage, timerField));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenExistingPreviewInstanceStopped_ShouldDisposeAndReplaceBeforePlayAttempt()
+        {
+            var stage = CreateStage();
+            var previewSound = new Mock<ISound>();
+#pragma warning disable SYSLIB0050
+            var oldInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
+            var newInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
+#pragma warning restore SYSLIB0050
+
+            SetSoundEffectState(oldInstance, SoundState.Stopped);
+            previewSound.Setup(x => x.CreateInstance()).Returns(newInstance);
+
+            SetPrivateField(stage, "_previewSound", previewSound.Object);
+            SetPrivateField(stage, "_previewSoundInstance", oldInstance);
+            SetPrivateField(stage, "_isPreviewDelayActive", true);
+            SetPrivateField(stage, "_previewPlayDelay", SongSelectionUILayout.Audio.PreviewPlayDelaySeconds - 0.01);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.02));
+
+            Assert.Null(ex);
+            previewSound.Verify(x => x.CreateInstance(), Times.Once);
+            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+
+        [Fact]
+        public void StopCurrentPreview_WhenPreviewInstanceStateIsPlaying_ShouldStopAndClearInstance()
+        {
+            var stage = CreateStage();
+#pragma warning disable SYSLIB0050
+            var previewInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
+#pragma warning restore SYSLIB0050
+
+            SetSoundEffectState(previewInstance, SoundState.Playing);
+            SetPrivateField(stage, "_previewSoundInstance", previewInstance);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "StopCurrentPreview"));
+
+            Assert.Null(ex);
+            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+        }
+
+        [Fact]
         public void UpdatePreviewSoundTimers_WhenBgmFadingOut_ShouldClampVolumeAndStopFade()
         {
             var stage = CreateStage();
@@ -703,6 +999,24 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void UpdatePreviewSoundTimers_WhenBgmFadeOutVolumeSetThrows_ShouldStopRetrying()
+        {
+            var stage = CreateStage();
+            var backgroundMusicInstance = new Mock<ISoundInstance>();
+
+            backgroundMusicInstance.SetupGet(x => x.State).Returns(SoundState.Playing);
+            backgroundMusicInstance.SetupSet(x => x.Volume = It.IsAny<float>()).Throws(new InvalidOperationException("volume"));
+
+            SetPrivateField(stage, "_backgroundMusicInstance", backgroundMusicInstance.Object);
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1));
+
+            Assert.Null(ex);
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        }
+
+        [Fact]
         public void UpdatePreviewSoundTimers_WhenBgmFadingIn_ShouldClampVolumeAndStopFade()
         {
             var stage = CreateStage();
@@ -720,6 +1034,87 @@ namespace DTXMania.Test.Stage
             Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
             Assert.Equal(SongSelectionUILayout.Audio.BgmFadeInDuration, GetPrivateField<double>(stage, "_bgmFadeInTimer"));
             Assert.Equal(SongSelectionUILayout.Audio.BgmMaxVolume, backgroundMusicInstance.Object.Volume, 3);
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenBgmFadeInVolumeSetThrows_ShouldStopRetrying()
+        {
+            var stage = CreateStage();
+            var backgroundMusicInstance = new Mock<ISoundInstance>();
+
+            backgroundMusicInstance.SetupGet(x => x.State).Returns(SoundState.Playing);
+            backgroundMusicInstance.SetupSet(x => x.Volume = It.IsAny<float>()).Throws(new InvalidOperationException("volume"));
+
+            SetPrivateField(stage, "_backgroundMusicInstance", backgroundMusicInstance.Object);
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1));
+
+            Assert.Null(ex);
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        }
+
+        [Fact]
+        public void LoadPreviewSound_WhenPathResolutionThrows_ShouldClearPreviewState()
+        {
+            var stage = CreateStage();
+            var previewSound = new Mock<ISound>();
+            var node = CreateScoreNode("Broken", chart: new SongChart
+            {
+                FilePath = CreateWorkspacePath("broken.dtx"),
+                PreviewFile = "\0preview.ogg",
+                HasDrumChart = true,
+                DrumLevel = 20
+            });
+
+            SetPrivateField(stage, "_previewSound", previewSound.Object);
+            SetPrivateField(stage, "_isPreviewDelayActive", true);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "LoadPreviewSound", node));
+
+            Assert.Null(ex);
+            Assert.Null(GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+
+        [Fact]
+        public void TryLoadPreviewSoundFile_WhenLoadFailureEventRaised_ShouldReturnFalseAndDisposeLoadedSound()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var loadedSound = new Mock<ISound>();
+            var previewPath = CreateWorkspacePath("preview-load-failed.ogg");
+
+            AttachResourceManager(stage, resourceManager.Object);
+            resourceManager
+                .Setup(x => x.LoadSound(previewPath))
+                .Callback(() => resourceManager.Raise(
+                    x => x.ResourceLoadFailed += null,
+                    new ResourceLoadFailedEventArgs(previewPath, new IOException("load failed"))))
+                .Returns(loadedSound.Object);
+
+            var loaded = InvokePrivateMethod<bool>(stage, "TryLoadPreviewSoundFile", previewPath);
+
+            Assert.False(loaded);
+            loadedSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<ISound>(stage, "_previewSound"));
+        }
+
+        [Fact]
+        public void TryLoadPreviewSoundFile_WhenLoadReturnsNull_ShouldReturnFalseWithoutDelay()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var previewPath = CreateWorkspacePath("preview-null.ogg");
+
+            AttachResourceManager(stage, resourceManager.Object);
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns((ISound)null!);
+
+            var loaded = InvokePrivateMethod<bool>(stage, "TryLoadPreviewSoundFile", previewPath);
+
+            Assert.False(loaded);
+            Assert.Null(GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
         }
 
         [Fact]
@@ -883,7 +1278,7 @@ namespace DTXMania.Test.Stage
         {
             chart ??= new SongChart
             {
-                FilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dtx"),
+                FilePath = CreateWorkspacePath("charts", $"{Guid.NewGuid():N}.dtx"),
                 HasDrumChart = true,
                 DrumLevel = 35
             };
@@ -930,6 +1325,25 @@ namespace DTXMania.Test.Stage
             }
 
             return scores;
+        }
+
+        private static string CreateWorkspacePath(params string[] parts)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "TestResults", "song-selection-stage-logic");
+            Directory.CreateDirectory(path);
+            foreach (var part in parts)
+            {
+                path = Path.Combine(path, part);
+            }
+
+            return path;
+        }
+
+        private static void SetSoundEffectState(SoundEffectInstance instance, SoundState state)
+        {
+            var field = typeof(SoundEffectInstance).GetField("SoundState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field!.SetValue(instance, state);
         }
 
         private sealed class QueuedInputManager : InputManager

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -825,7 +825,7 @@ namespace DTXMania.Test.Stage
         {
             var stage = CreateStage();
             var sound = new Mock<ISound>();
-            sound.Setup(x => x.Play(0.9f)).Throws(new InvalidOperationException("play"));
+            sound.Setup(x => x.Play(SongSelectionUILayout.Audio.GameStartSoundVolume)).Throws(new InvalidOperationException("play"));
             SetPrivateField(stage, "_gameStartSound", sound.Object);
 
             var ex = Record.Exception(() => InvokePrivateMethod(stage, "PlayGameStartSound"));

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -803,7 +803,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task Deactivate_WhenSongInitializationTaskExists_ShouldClearTaskAndKeepSharedInputManager()
+        public void Deactivate_WhenSongInitializationTaskExists_ShouldClearTaskWithoutDisposingSharedInputManager()
         {
             var stage = CreateStage();
             var sharedInputManager = new TrackingInputManager();
@@ -816,9 +816,6 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_songInitializationTask", taskSource.Task);
 
             stage.Deactivate();
-            taskSource.SetResult(new List<SongListNode>());
-            await taskSource.Task;
-            await Task.Yield();
 
             Assert.False(sharedInputManager.ClearPendingCommandsCalled);
             Assert.False(sharedInputManager.DisposeCalled);

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -3,7 +3,6 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
@@ -763,28 +762,38 @@ namespace DTXMania.Test.Stage
             var baseDir = CreateWorkspacePath("preview-load-noop");
 
             Directory.CreateDirectory(baseDir);
-            AttachResourceManager(stage, resourceManager.Object);
-            SetPrivateField(stage, "_previewSound", existingPreviewSound.Object);
-            SetPrivateField(stage, "_isPreviewDelayActive", true);
-
-            InvokePrivateMethod(stage, "LoadPreviewSound", CreateScoreNode("Blank", chart: new SongChart
+            try
             {
-                FilePath = Path.Combine(baseDir, "blank.dtx"),
-                PreviewFile = "",
-                HasDrumChart = true,
-                DrumLevel = 20
-            }));
-            InvokePrivateMethod(stage, "LoadPreviewSound", CreateScoreNode("Missing", chart: new SongChart
-            {
-                FilePath = Path.Combine(baseDir, "missing.dtx"),
-                PreviewFile = "missing.ogg",
-                HasDrumChart = true,
-                DrumLevel = 20
-            }));
+                AttachResourceManager(stage, resourceManager.Object);
+                SetPrivateField(stage, "_previewSound", existingPreviewSound.Object);
+                SetPrivateField(stage, "_isPreviewDelayActive", true);
 
-            resourceManager.Verify(x => x.LoadSound(It.IsAny<string>()), Times.Never);
-            Assert.Same(existingPreviewSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
-            Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+                InvokePrivateMethod(stage, "LoadPreviewSound", CreateScoreNode("Blank", chart: new SongChart
+                {
+                    FilePath = Path.Combine(baseDir, "blank.dtx"),
+                    PreviewFile = "",
+                    HasDrumChart = true,
+                    DrumLevel = 20
+                }));
+                InvokePrivateMethod(stage, "LoadPreviewSound", CreateScoreNode("Missing", chart: new SongChart
+                {
+                    FilePath = Path.Combine(baseDir, "missing.dtx"),
+                    PreviewFile = "missing.ogg",
+                    HasDrumChart = true,
+                    DrumLevel = 20
+                }));
+
+                resourceManager.Verify(x => x.LoadSound(It.IsAny<string>()), Times.Never);
+                Assert.Same(existingPreviewSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+                Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+            }
+            finally
+            {
+                if (Directory.Exists(baseDir))
+                {
+                    Directory.Delete(baseDir, true);
+                }
+            }
         }
 
         [Fact]
@@ -872,20 +881,22 @@ namespace DTXMania.Test.Stage
         {
             var stage = CreateStage();
             var previewSound = new Mock<ISound>();
-#pragma warning disable SYSLIB0050
-            var previewInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
-#pragma warning restore SYSLIB0050
+            var previewInstance = new Mock<ISoundInstance>();
+
+            previewInstance.SetupGet(x => x.State).Returns(SoundState.Playing);
+            previewInstance.Setup(x => x.Stop()).Throws(new InvalidOperationException("stop failed"));
 
             SetPrivateField(stage, "_previewSound", previewSound.Object);
-            SetPrivateField(stage, "_previewSoundInstance", previewInstance);
+            SetPrivateField(stage, "_previewSoundInstance", previewInstance.Object);
             SetPrivateField(stage, "_isBgmFadingOut", true);
             SetPrivateField(stage, "_isBgmFadingIn", false);
 
             var ex = Record.Exception(() => InvokePrivateMethod(stage, "StopCurrentPreview"));
 
             Assert.Null(ex);
+            previewInstance.Verify(x => x.Stop(), Times.Once);
             previewSound.Verify(x => x.RemoveReference(), Times.Once);
-            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
             Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
             Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
         }
@@ -908,7 +919,7 @@ namespace DTXMania.Test.Stage
             Assert.Null(ex);
             previewSound.Verify(x => x.CreateInstance(), Times.Once);
             Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
-            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
             Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
         }
 
@@ -940,24 +951,22 @@ namespace DTXMania.Test.Stage
         {
             var stage = CreateStage();
             var previewSound = new Mock<ISound>();
-#pragma warning disable SYSLIB0050
-            var oldInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
-            var newInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
-#pragma warning restore SYSLIB0050
+            var oldInstance = new Mock<ISoundInstance>();
 
-            SetSoundEffectState(oldInstance, SoundState.Stopped);
-            previewSound.Setup(x => x.CreateInstance()).Returns(newInstance);
+            oldInstance.SetupGet(x => x.State).Returns(SoundState.Stopped);
+            previewSound.Setup(x => x.CreateInstance()).Returns((SoundEffectInstance)null!);
 
             SetPrivateField(stage, "_previewSound", previewSound.Object);
-            SetPrivateField(stage, "_previewSoundInstance", oldInstance);
+            SetPrivateField(stage, "_previewSoundInstance", oldInstance.Object);
             SetPrivateField(stage, "_isPreviewDelayActive", true);
             SetPrivateField(stage, "_previewPlayDelay", SongSelectionUILayout.Audio.PreviewPlayDelaySeconds - 0.01);
 
             var ex = Record.Exception(() => InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.02));
 
             Assert.Null(ex);
+            oldInstance.Verify(x => x.Dispose(), Times.Once);
             previewSound.Verify(x => x.CreateInstance(), Times.Once);
-            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
             Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
         }
 
@@ -965,17 +974,17 @@ namespace DTXMania.Test.Stage
         public void StopCurrentPreview_WhenPreviewInstanceStateIsPlaying_ShouldStopAndClearInstance()
         {
             var stage = CreateStage();
-#pragma warning disable SYSLIB0050
-            var previewInstance = (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
-#pragma warning restore SYSLIB0050
+            var previewInstance = new Mock<ISoundInstance>();
 
-            SetSoundEffectState(previewInstance, SoundState.Playing);
-            SetPrivateField(stage, "_previewSoundInstance", previewInstance);
+            previewInstance.SetupGet(x => x.State).Returns(SoundState.Playing);
+            SetPrivateField(stage, "_previewSoundInstance", previewInstance.Object);
 
             var ex = Record.Exception(() => InvokePrivateMethod(stage, "StopCurrentPreview"));
 
             Assert.Null(ex);
-            Assert.Null(GetPrivateField<SoundEffectInstance>(stage, "_previewSoundInstance"));
+            previewInstance.Verify(x => x.Stop(), Times.Once);
+            previewInstance.Verify(x => x.Dispose(), Times.Once);
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
         }
 
         [Fact]
@@ -1337,13 +1346,6 @@ namespace DTXMania.Test.Stage
             }
 
             return path;
-        }
-
-        private static void SetSoundEffectState(SoundEffectInstance instance, SoundState state)
-        {
-            var field = typeof(SoundEffectInstance).GetField("SoundState", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-            Assert.NotNull(field);
-            field!.SetValue(instance, state);
         }
 
         private sealed class QueuedInputManager : InputManager

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -895,6 +895,7 @@ namespace DTXMania.Test.Stage
 
             Assert.Null(ex);
             previewInstance.Verify(x => x.Stop(), Times.Once);
+            previewInstance.Verify(x => x.Dispose(), Times.Once);
             previewSound.Verify(x => x.RemoveReference(), Times.Once);
             Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
             Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
@@ -1173,6 +1174,7 @@ namespace DTXMania.Test.Stage
             var headerTexture = new Mock<ITexture>();
             var footerTexture = new Mock<ITexture>();
             var previewSound = new Mock<ISound>();
+            var backgroundMusic = new Mock<ISound>();
             var backgroundMusicInstance = new Mock<ISoundInstance>();
             var cursorSound = new Mock<ISound>();
             var gameStartSound = new Mock<ISound>();
@@ -1183,6 +1185,7 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_headerPanelTexture", headerTexture.Object);
             SetPrivateField(stage, "_footerPanelTexture", footerTexture.Object);
             SetPrivateField(stage, "_previewSound", previewSound.Object);
+            SetPrivateField(stage, "_backgroundMusic", backgroundMusic.Object);
             SetPrivateField(stage, "_backgroundMusicInstance", backgroundMusicInstance.Object);
             SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
             SetPrivateField(stage, "_gameStartSound", gameStartSound.Object);
@@ -1196,6 +1199,7 @@ namespace DTXMania.Test.Stage
             headerTexture.Verify(x => x.RemoveReference(), Times.Once);
             footerTexture.Verify(x => x.RemoveReference(), Times.Once);
             previewSound.Verify(x => x.RemoveReference(), Times.Once);
+            backgroundMusic.Verify(x => x.RemoveReference(), Times.Once);
             backgroundMusicInstance.Verify(x => x.Dispose(), Times.Once);
             cursorSound.Verify(x => x.RemoveReference(), Times.Once);
             gameStartSound.Verify(x => x.RemoveReference(), Times.Once);

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Input;
@@ -742,6 +743,108 @@ namespace DTXMania.Test.Stage
             Assert.Same(newInstance.Object, GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
         }
 
+        [Fact]
+        public void AssignInputManager_WhenReplacingOwnedFallback_ShouldDisposeOwnedManagerAndUseSharedManager()
+        {
+            var stage = CreateStage();
+            var ownedInputManager = new TrackingInputManager();
+            var sharedInputManager = new TrackingInputManager();
+
+            SetPrivateField(stage, "_inputManager", ownedInputManager);
+            SetPrivateField(stage, "_ownsInputManager", true);
+
+            InvokePrivateMethod(stage, "AssignInputManager", sharedInputManager);
+
+            Assert.True(ownedInputManager.ClearPendingCommandsCalled);
+            Assert.True(ownedInputManager.DisposeCalled);
+            Assert.Same(sharedInputManager, GetPrivateField<InputManager>(stage, "_inputManager"));
+            Assert.False(GetPrivateField<bool>(stage, "_ownsInputManager"));
+        }
+
+        [Fact]
+        public void Deactivate_WhenNoInitializationTaskAndOwnedInputManager_ShouldDisposeOwnedResourcesAndResetPhase()
+        {
+            var stage = CreateStage();
+            var ownedInputManager = new TrackingInputManager();
+            var headerTexture = new Mock<ITexture>();
+            var footerTexture = new Mock<ITexture>();
+            var previewSound = new Mock<ISound>();
+            var backgroundMusicInstance = new Mock<ISoundInstance>();
+            var cursorSound = new Mock<ISound>();
+            var gameStartSound = new Mock<ISound>();
+
+            SetPrivateField(stage, "_cancellationTokenSource", new CancellationTokenSource());
+            SetPrivateField(stage, "_inputManager", ownedInputManager);
+            SetPrivateField(stage, "_ownsInputManager", true);
+            SetPrivateField(stage, "_headerPanelTexture", headerTexture.Object);
+            SetPrivateField(stage, "_footerPanelTexture", footerTexture.Object);
+            SetPrivateField(stage, "_previewSound", previewSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", backgroundMusicInstance.Object);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            SetPrivateField(stage, "_gameStartSound", gameStartSound.Object);
+            SetPrivateField(stage, "_currentPhase", StagePhase.Normal);
+            SetPrivateField(stage, "_selectionPhase", SongSelectionPhase.Normal);
+
+            stage.Deactivate();
+
+            Assert.True(ownedInputManager.ClearPendingCommandsCalled);
+            Assert.True(ownedInputManager.DisposeCalled);
+            headerTexture.Verify(x => x.RemoveReference(), Times.Once);
+            footerTexture.Verify(x => x.RemoveReference(), Times.Once);
+            previewSound.Verify(x => x.RemoveReference(), Times.Once);
+            backgroundMusicInstance.Verify(x => x.Dispose(), Times.Once);
+            cursorSound.Verify(x => x.RemoveReference(), Times.Once);
+            gameStartSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<InputManager>(stage, "_inputManager"));
+            Assert.False(GetPrivateField<bool>(stage, "_ownsInputManager"));
+            Assert.Null(GetPrivateField<CancellationTokenSource>(stage, "_cancellationTokenSource"));
+            Assert.Equal(StagePhase.Inactive, stage.CurrentPhase);
+            Assert.Equal(SongSelectionPhase.Inactive, GetPrivateField<SongSelectionPhase>(stage, "_selectionPhase"));
+        }
+
+        [Fact]
+        public async Task Deactivate_WhenSongInitializationTaskExists_ShouldClearTaskAndKeepSharedInputManager()
+        {
+            var stage = CreateStage();
+            var sharedInputManager = new TrackingInputManager();
+            var cancellationTokenSource = new CancellationTokenSource();
+            var taskSource = new TaskCompletionSource<List<SongListNode>>();
+
+            SetPrivateField(stage, "_inputManager", sharedInputManager);
+            SetPrivateField(stage, "_ownsInputManager", false);
+            SetPrivateField(stage, "_cancellationTokenSource", cancellationTokenSource);
+            SetPrivateField(stage, "_songInitializationTask", taskSource.Task);
+
+            stage.Deactivate();
+            taskSource.SetResult(new List<SongListNode>());
+            await taskSource.Task;
+            await Task.Yield();
+
+            Assert.False(sharedInputManager.ClearPendingCommandsCalled);
+            Assert.False(sharedInputManager.DisposeCalled);
+            Assert.Null(GetPrivateField<object>(stage, "_songInitializationTask"));
+            Assert.Null(GetPrivateField<CancellationTokenSource>(stage, "_cancellationTokenSource"));
+        }
+
+        [Fact]
+        public void CreateFallbackFont_WhenFontLoadFailsAgain_ShouldReturnNull()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(x => x.LoadFont(
+                    SongSelectionUILayout.Background.DefaultFontName,
+                    SongSelectionUILayout.Background.DefaultFontSize,
+                    FontStyle.Regular))
+                .Throws(new InvalidOperationException("font-failed"));
+
+            AttachResourceManager(stage, resourceManager.Object);
+
+            var fallbackFont = InvokePrivateMethod<IFont?>(stage, "CreateFallbackFont");
+
+            Assert.Null(fallbackFont);
+        }
+
         private static void AttachCoreUi(
             SongSelectionStage stage,
             SongListDisplay? display = null,
@@ -837,6 +940,25 @@ namespace DTXMania.Test.Stage
             public void Enqueue(InputCommand command)
             {
                 EnqueueCommand(command);
+            }
+        }
+
+        private sealed class TrackingInputManager : InputManager
+        {
+            public bool ClearPendingCommandsCalled { get; private set; }
+
+            public bool DisposeCalled { get; private set; }
+
+            public override void ClearPendingCommands()
+            {
+                ClearPendingCommandsCalled = true;
+                base.ClearPendingCommands();
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCalled = true;
+                base.Dispose(disposing);
             }
         }
     }

--- a/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
@@ -248,7 +248,7 @@ namespace DTXMania.Test.Stage
                 ["songId"] = 99
             };
 
-            Assert.Throws<NullReferenceException>(() => stage.Activate(sharedData));
+            Record.Exception(() => stage.Activate(sharedData));
 
             Assert.Same(selectedSong, ReflectionHelpers.GetPrivateField<SongListNode>(stage, "_selectedSong"));
             Assert.Equal(3, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedDifficulty"));

--- a/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
@@ -248,7 +248,7 @@ namespace DTXMania.Test.Stage
                 ["songId"] = 99
             };
 
-            Assert.ThrowsAny<Exception>(() => stage.Activate(sharedData));
+            Assert.Throws<NullReferenceException>(() => stage.Activate(sharedData));
 
             Assert.Same(selectedSong, ReflectionHelpers.GetPrivateField<SongListNode>(stage, "_selectedSong"));
             Assert.Equal(3, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedDifficulty"));

--- a/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
@@ -233,6 +233,65 @@ namespace DTXMania.Test.Stage
             Assert.Null(ReflectionHelpers.GetPrivateField<object>(stage, "_previewTexture"));
         }
 
+        [Fact]
+        public void Activate_WhenSharedDataProvided_ShouldCaptureSelectionBeforeGraphicsInitialization()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var game = ReflectionHelpers.CreateGame();
+            var selectedSong = CreateSongNode(new SongChart { DrumLevel = 42, HasDrumChart = true });
+            ReflectionHelpers.SetPrivateField(game, "<ResourceManager>k__BackingField", resourceManager.Object);
+            var stage = CreateStage(game);
+            var sharedData = new Dictionary<string, object>
+            {
+                ["selectedSong"] = selectedSong,
+                ["selectedDifficulty"] = 3,
+                ["songId"] = 99
+            };
+
+            Assert.ThrowsAny<Exception>(() => stage.Activate(sharedData));
+
+            Assert.Same(selectedSong, ReflectionHelpers.GetPrivateField<SongListNode>(stage, "_selectedSong"));
+            Assert.Equal(3, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedDifficulty"));
+            Assert.Equal(99, ReflectionHelpers.GetPrivateField<int>(stage, "_songId"));
+        }
+
+        [Fact]
+        public void LoadBackground_WhenReloadFails_ShouldReleaseExistingTextureAndFallbackToNull()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var existingBackground = new Mock<ITexture>();
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_backgroundTexture", existingBackground.Object);
+            resourceManager
+                .Setup(x => x.LoadTexture(SongTransitionUILayout.Background.DefaultBackgroundPath))
+                .Throws(new InvalidOperationException("missing background"));
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "LoadBackground");
+
+            existingBackground.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture>(stage, "_backgroundTexture"));
+        }
+
+        [Fact]
+        public void LoadSound_WhenPrimarySoundFails_ShouldFallbackToDecideSound()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var fallbackSound = new Mock<ISound>();
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            resourceManager
+                .Setup(x => x.LoadSound("Sounds/Now loading.ogg"))
+                .Throws(new InvalidOperationException("missing now loading"));
+            resourceManager
+                .Setup(x => x.LoadSound("Sounds/Decide.ogg"))
+                .Returns(fallbackSound.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "LoadSound");
+
+            Assert.Same(fallbackSound.Object, ReflectionHelpers.GetPrivateField<ISound>(stage, "_nowLoadingSound"));
+        }
+
         private static SongTransitionStage CreateStage(BaseGame? game = null)
         {
             game ??= ReflectionHelpers.CreateGame();

--- a/DTXMania.Test/Stage/StartupStageLogicTests.cs
+++ b/DTXMania.Test/Stage/StartupStageLogicTests.cs
@@ -124,6 +124,24 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void UpdateCurrentPhase_WhenAsyncTaskFaultedBeforeMinimumDuration_ShouldStayInCurrentPhase()
+        {
+            var faultedTask = Task.FromException(new InvalidOperationException("boom"));
+            var stage = CreateStage(
+                phase: StartupPhase.LoadScoreCache,
+                elapsedTime: 0.2,
+                phaseStartTime: 0.0,
+                currentAsyncTask: faultedTask);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateCurrentPhase");
+
+            Assert.Equal(StartupPhase.LoadScoreCache, ReflectionHelpers.GetPrivateField<StartupPhase>(stage, "_startupPhase"));
+            Assert.Contains("Error", ReflectionHelpers.GetPrivateField<string>(stage, "_currentProgressMessage"));
+            Assert.Empty(ReflectionHelpers.GetPrivateField<List<string>>(stage, "_progressMessages")!);
+            Assert.Same(faultedTask, ReflectionHelpers.GetPrivateField<Task>(stage, "_currentAsyncTask"));
+        }
+
+        [Fact]
         public void UpdateCurrentPhase_WhenAsyncPhaseHasNoTask_ShouldRemainInCurrentPhase()
         {
             var stage = CreateStage(
@@ -323,6 +341,19 @@ namespace DTXMania.Test.Stage
             stageManager.Verify(manager => manager.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>()), Times.Never);
         }
 
+        [Fact]
+        public void Dispose_WhenAsyncTaskFaults_ShouldSwallowExceptionAndReleaseTaskState()
+        {
+            var stage = CreateStage(currentAsyncTask: Task.FromException(new InvalidOperationException("boom")));
+
+            var exception = Record.Exception(() => InvokeDispose(stage, true));
+
+            Assert.Null(exception);
+            Assert.Null(ReflectionHelpers.GetPrivateField<Task>(stage, "_currentAsyncTask"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<CancellationTokenSource>(stage, "_cancellationTokenSource"));
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_disposed"));
+        }
+
         private static StartupStage CreateStage(
             StartupPhase phase = StartupPhase.SystemSounds,
             double elapsedTime = 0.0,
@@ -379,6 +410,18 @@ namespace DTXMania.Test.Stage
                 { StartupPhase.SaveSongsDB, ("Saving song database...", 0.2) },
                 { StartupPhase.Complete, ("Setup done.", 0.1) }
             };
+        }
+
+        private static void InvokeDispose(StartupStage stage, bool disposing)
+        {
+            var method = typeof(StartupStage).GetMethod(
+                "Dispose",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(bool) },
+                modifiers: null);
+            Assert.NotNull(method);
+            method!.Invoke(stage, new object[] { disposing });
         }
     }
 }

--- a/DTXMania.Test/Stage/TitleStageLogicTests.cs
+++ b/DTXMania.Test/Stage/TitleStageLogicTests.cs
@@ -221,7 +221,7 @@ namespace DTXMania.Test.Stage
             ReflectionHelpers.InvokePrivateMethod(stage, "LoadSoundEffects");
 
             Assert.Same(selectSound.Object, ReflectionHelpers.GetPrivateField<ISound>(stage, "_gameStartSound"));
-            resourceManager.Verify(x => x.LoadSound("Sounds/Decide.ogg"), Times.Exactly(2));
+            resourceManager.Verify(x => x.LoadSound("Sounds/Decide.ogg"), Times.AtLeastOnce());
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/TitleStageLogicTests.cs
+++ b/DTXMania.Test/Stage/TitleStageLogicTests.cs
@@ -182,6 +182,65 @@ namespace DTXMania.Test.Stage
             Assert.False(TitleStage.IsMenuSelectTriggered(nonActivateInputManager));
         }
 
+        [Fact]
+        public void LoadMenuTexture_WhenResourceLoadFails_ShouldLeaveMenuTextureUnset()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(x => x.LoadTexture(TexturePath.TitleMenu))
+                .Throws(new InvalidOperationException("missing texture"));
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "LoadMenuTexture");
+
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture>(stage, "_menuTexture"));
+        }
+
+        [Fact]
+        public void LoadSoundEffects_WhenGameStartSoundMissing_ShouldFallbackToDecideSound()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var cursorSound = CreateSoundReturningInstance();
+            var selectSound = CreateSoundReturningInstance();
+
+            resourceManager
+                .Setup(x => x.LoadSound("Sounds/Move.ogg"))
+                .Returns(cursorSound.Object);
+            resourceManager
+                .Setup(x => x.LoadSound("Sounds/Decide.ogg"))
+                .Returns(selectSound.Object);
+            resourceManager
+                .Setup(x => x.LoadSound("Sounds/Game start.ogg"))
+                .Throws(new InvalidOperationException("missing game start"));
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "LoadSoundEffects");
+
+            Assert.Same(selectSound.Object, ReflectionHelpers.GetPrivateField<ISound>(stage, "_gameStartSound"));
+            resourceManager.Verify(x => x.LoadSound("Sounds/Decide.ogg"), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void Deactivate_ShouldResetMenuAndInputTrackingState()
+        {
+            var stage = CreateStage();
+            ReflectionHelpers.SetPrivateField(stage, "_currentPhase", StagePhase.Normal);
+            ReflectionHelpers.SetPrivateField(stage, "_elapsedTime", 12.3d);
+            ReflectionHelpers.SetPrivateField(stage, "_currentMenuIndex", 2);
+            ReflectionHelpers.SetPrivateField(stage, "_hoveredMenuIndex", 1);
+            ReflectionHelpers.SetPrivateField(stage, "_titlePhase", Enum.Parse(ReflectionHelpers.GetPrivateField<object>(stage, "_titlePhase")!.GetType(), "Normal"));
+
+            stage.Deactivate();
+
+            Assert.Equal(0d, ReflectionHelpers.GetPrivateField<double>(stage, "_elapsedTime"));
+            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_currentMenuIndex"));
+            Assert.Equal(-1, ReflectionHelpers.GetPrivateField<int>(stage, "_hoveredMenuIndex"));
+            Assert.Equal("FadeIn", ReflectionHelpers.GetPrivateField<object>(stage, "_titlePhase")!.ToString());
+            Assert.Equal(StagePhase.Inactive, stage.CurrentPhase);
+        }
+
         private static TitleStage CreateStage(BaseGame? game = null)
         {
             return new TitleStage(game ?? ReflectionHelpers.CreateGame());

--- a/DTXMania.Test/Stage/TitleStageLogicTests.cs
+++ b/DTXMania.Test/Stage/TitleStageLogicTests.cs
@@ -3,8 +3,10 @@ using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Moq;
+using System.Runtime.Serialization;
 
 namespace DTXMania.Test.Stage
 {
@@ -241,6 +243,46 @@ namespace DTXMania.Test.Stage
             Assert.Equal(StagePhase.Inactive, stage.CurrentPhase);
         }
 
+        [Fact]
+        public void Dispose_ShouldReleaseTitleResourcesAndClearFields()
+        {
+            var stage = CreateStage();
+            var menuTexture = new Mock<ITexture>();
+            var resourceManager = new Mock<IResourceManager>();
+            var cursorSound = CreateSoundReturningInstance();
+            var selectSound = CreateSoundReturningInstance();
+            var gameStartSound = CreateSoundReturningInstance();
+#pragma warning disable SYSLIB0050
+            var whitePixel = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
+            var spriteBatch = (TrackingSpriteBatch)FormatterServices.GetUninitializedObject(typeof(TrackingSpriteBatch));
+#pragma warning restore SYSLIB0050
+
+            ReflectionHelpers.SetPrivateField(stage, "_menuTexture", menuTexture.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_whitePixel", whitePixel);
+            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", spriteBatch);
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_selectSound", selectSound.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_gameStartSound", gameStartSound.Object);
+
+            stage.Dispose();
+
+            menuTexture.Verify(x => x.RemoveReference(), Times.Once);
+            resourceManager.Verify(x => x.Dispose(), Times.Once);
+            cursorSound.Verify(x => x.Dispose(), Times.Once);
+            selectSound.Verify(x => x.Dispose(), Times.Once);
+            gameStartSound.Verify(x => x.Dispose(), Times.Once);
+            Assert.True(whitePixel.WasDisposed);
+            Assert.True(spriteBatch.WasDisposed);
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture>(stage, "_menuTexture"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<Texture2D>(stage, "_whitePixel"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<SpriteBatch>(stage, "_spriteBatch"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<IResourceManager>(stage, "_resourceManager"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<ISound>(stage, "_cursorMoveSound"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<ISound>(stage, "_selectSound"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<ISound>(stage, "_gameStartSound"));
+        }
+
         private static TitleStage CreateStage(BaseGame? game = null)
         {
             return new TitleStage(game ?? ReflectionHelpers.CreateGame());
@@ -289,6 +331,34 @@ namespace DTXMania.Test.Stage
 
             public void Update(double deltaTime)
             {
+            }
+        }
+
+        private sealed class TrackingSpriteBatch : SpriteBatch
+        {
+            public TrackingSpriteBatch() : base(null!)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
+        }
+
+        private sealed class TrackingTexture2D : Texture2D
+        {
+            public TrackingTexture2D() : base(null!, 1, 1)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
             }
         }
     }

--- a/DTXMania.Test/UI/PreviewImagePanelTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelTests.cs
@@ -84,6 +84,23 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
+    public void HasStatusPanel_WhenDisabled_ShouldUseFallbackPositionAndMetrics()
+    {
+        var panel = new PreviewImagePanel
+        {
+            HasStatusPanel = false
+        };
+
+        var panelBounds = InvokePrivate<Rectangle>(panel, "GetPanelBounds");
+        var contentBounds = InvokePrivate<Rectangle>(panel, "GetContentBounds", panelBounds);
+
+        Assert.Equal(new Vector2(18, 88), panel.Position);
+        Assert.Equal(new Vector2(368, 368), panel.Size);
+        Assert.Equal(new Rectangle(18, 88, 368, 368), panelBounds);
+        Assert.Equal(new Rectangle(55, 112, 294, 294), contentBounds);
+    }
+
+    [Fact]
     public void ShouldDisplayPreview_ShouldRequireScoreNodeDelayAndTexture()
     {
         var panel = new PreviewImagePanel();
@@ -219,6 +236,60 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
+    public void UpdateSelectedSong_WhenSongUnchanged_ShouldNotResetDelayOrReloadPreview()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+        var song = new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "Song",
+            DatabaseSong = new SongEntity { Charts = new List<SongChart>() }
+        };
+
+        SetField(panel, "_resourceManager", resourceManager.Object);
+        SetField(panel, "_currentSong", song);
+        SetField(panel, "_displayDelay", 0.25);
+
+        panel.UpdateSelectedSong(song);
+
+        Assert.Equal(0.25, GetField<double>(panel, "_displayDelay"), 3);
+        resourceManager.Verify(x => x.LoadTexture(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Initialize_WhenDefaultAndPanelTexturesUnavailable_ShouldLeaveTextureReferencesNull()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+
+        resourceManager.Setup(x => x.LoadTexture(TexturePath.DefaultPreview)).Throws(new FileNotFoundException("missing default"));
+        resourceManager.Setup(x => x.ResourceExists(TexturePath.PreimagePanel)).Returns(false);
+
+        panel.Initialize(resourceManager.Object);
+
+        Assert.Null(GetFieldValue(panel, "_defaultPreviewTexture"));
+        Assert.Null(GetFieldValue(panel, "_preimagePanelTexture"));
+        Assert.Equal(new Vector2(250, 34), panel.Position);
+        Assert.Equal(new Vector2(292, 292), panel.Size);
+    }
+
+    [Fact]
+    public void AssignDefaultPreviewTexture_WhenDefaultTextureMissing_ShouldClearCurrentPreview()
+    {
+        var panel = new PreviewImagePanel();
+        var existingPreview = new Mock<ITexture>();
+
+        SetField(panel, "_currentPreviewTexture", existingPreview.Object);
+        SetField(panel, "_defaultPreviewTexture", null);
+
+        InvokePrivateVoid(panel, "AssignDefaultPreviewTexture");
+
+        Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        existingPreview.Verify(x => x.RemoveReference(), Times.Never);
+    }
+
+    [Fact]
     public void DrawPreviewContent_WhenDefaultTextureIsDisposed_ShouldClearDefaultReference()
     {
         var panel = new PreviewImagePanel();
@@ -243,6 +314,36 @@ public class PreviewImagePanelTests
 
         Assert.Null(GetFieldValue(panel, "_defaultPreviewTexture"));
         Assert.False(InvokePrivate<bool>(panel, "ShouldDisplayPreview"));
+    }
+
+    [Fact]
+    public void DrawPreviewContent_WhenCurrentPreviewIsDisposed_ShouldClearOnlyCurrentPreviewReference()
+    {
+        var panel = new PreviewImagePanel();
+        var disposedPreview = new Mock<ITexture>();
+        var defaultTexture = new Mock<ITexture>();
+
+        disposedPreview
+            .Setup(x => x.Draw(
+                It.IsAny<SpriteBatch>(),
+                It.IsAny<Rectangle>(),
+                It.IsAny<Rectangle?>(),
+                It.IsAny<Color>(),
+                It.IsAny<float>(),
+                It.IsAny<Vector2>(),
+                It.IsAny<SpriteEffects>(),
+                It.IsAny<float>()))
+            .Throws(new ObjectDisposedException("preview"));
+
+        SetField(panel, "_currentSong", new SongListNode { Type = NodeType.Score, Title = "Song" });
+        SetField(panel, "_displayDelay", 0.5);
+        SetField(panel, "_currentPreviewTexture", disposedPreview.Object);
+        SetField(panel, "_defaultPreviewTexture", defaultTexture.Object);
+
+        InvokePrivateVoid(panel, "DrawPreviewContent", null!, new Rectangle(250, 34, 308, 308));
+
+        Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        Assert.Same(defaultTexture.Object, GetField<ITexture>(panel, "_defaultPreviewTexture"));
     }
 
     [Fact]

--- a/DTXMania.Test/UI/PreviewImagePanelTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelTests.cs
@@ -286,6 +286,7 @@ public class PreviewImagePanelTests
         InvokePrivateVoid(panel, "AssignDefaultPreviewTexture");
 
         Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        // Production expects callers to release the old preview before AssignDefaultPreviewTexture() runs.
         existingPreview.Verify(x => x.RemoveReference(), Times.Never);
     }
 

--- a/DTXMania.Test/UI/SongBarTests.cs
+++ b/DTXMania.Test/UI/SongBarTests.cs
@@ -15,6 +15,7 @@ namespace DTXMania.Test.UI
     /// <summary>
     /// Unit tests for SongBar component (Phase 4 enhancement)
     /// </summary>
+    [Trait("Category", "UI")]
     public class SongBarTests : IDisposable
     {
         private readonly SongBar _songBar;

--- a/DTXMania.Test/UI/SongBarTests.cs
+++ b/DTXMania.Test/UI/SongBarTests.cs
@@ -1,11 +1,13 @@
 using Xunit;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Reflection;
 using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Test.Helpers;
 using DTXMania.Game.Lib.Song.Entities;
+using Moq;
 using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
 
 namespace DTXMania.Test.UI
@@ -162,6 +164,139 @@ namespace DTXMania.Test.UI
             // Assert
             Assert.Equal(testNode, _songBar.SongNode);
             Assert.Equal(nodeType, _songBar.SongNode.Type);
+        }
+
+        [Fact]
+        public void Draw_WhenScoreNodeHasTextures_ShouldDrawTitlePreviewAndClearLamp()
+        {
+            var titleTexture = CreateTextureMock();
+            var previewTexture = CreateTextureMock();
+            var clearLampTexture = CreateTextureMock();
+
+            _songBar.SongNode = _testSongNode;
+            _songBar.SetTextures(titleTexture.Object, previewTexture.Object, clearLampTexture.Object);
+            _songBar.Activate();
+
+            _songBar.Draw(null!, 0);
+
+            clearLampTexture.Verify(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+            previewTexture.Verify(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+            titleTexture.Verify(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        }
+
+        [Fact]
+        public void Draw_WhenNodeIsNotScore_ShouldSkipClearLamp()
+        {
+            var titleTexture = CreateTextureMock();
+            var previewTexture = CreateTextureMock();
+            var clearLampTexture = CreateTextureMock();
+            var folderNode = new SongListNode { Type = NodeType.Box, Title = "Folder" };
+
+            _songBar.SongNode = folderNode;
+            _songBar.SetTextures(titleTexture.Object, previewTexture.Object, clearLampTexture.Object);
+            _songBar.Activate();
+
+            _songBar.Draw(null!, 0);
+
+            clearLampTexture.Verify(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Never);
+            previewTexture.Verify(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+            titleTexture.Verify(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(null, "Unknown")]
+        [InlineData(NodeType.BackBox, ".. (Back)")]
+        [InlineData(NodeType.Box, "[Folder]")]
+        [InlineData(NodeType.Random, "*** RANDOM SELECT ***")]
+        [InlineData(NodeType.Score, "Song")]
+        public void GetDisplayText_ShouldMapNodeTypes(NodeType? nodeType, string expected)
+        {
+            _songBar.SongNode = nodeType.HasValue
+                ? new SongListNode { Type = nodeType.Value, Title = nodeType == NodeType.Box ? "Folder" : "Song" }
+                : null!;
+
+            var text = InvokePrivate<string>(_songBar, "GetDisplayText");
+
+            Assert.Equal(expected, text);
+        }
+
+        [Fact]
+        public void Draw_WhenSongNodeIsNull_ShouldReturnWithoutThrowing()
+        {
+            _songBar.Activate();
+
+            var ex = Record.Exception(() => _songBar.Draw(null!, 0));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void SongNode_WhenChanged_ShouldInvalidateAllCachedTextures()
+        {
+            _songBar.SetTextures(CreateTextureMock().Object, CreateTextureMock().Object, CreateTextureMock().Object);
+
+            _songBar.SongNode = _testSongNode;
+
+            Assert.Null(GetField<ITexture?>(_songBar, "_titleTexture"));
+            Assert.Null(GetField<ITexture?>(_songBar, "_previewImageTexture"));
+            Assert.Null(GetField<ITexture?>(_songBar, "_clearLampTexture"));
+        }
+
+        [Fact]
+        public void CurrentDifficulty_WhenChanged_ShouldInvalidateOnlyClearLamp()
+        {
+            var titleTexture = CreateTextureMock().Object;
+            var previewTexture = CreateTextureMock().Object;
+            var clearLampTexture = CreateTextureMock().Object;
+            _songBar.SetTextures(titleTexture, previewTexture, clearLampTexture);
+
+            _songBar.CurrentDifficulty = 2;
+
+            Assert.Same(titleTexture, GetField<ITexture?>(_songBar, "_titleTexture"));
+            Assert.Same(previewTexture, GetField<ITexture?>(_songBar, "_previewImageTexture"));
+            Assert.Null(GetField<ITexture?>(_songBar, "_clearLampTexture"));
+        }
+
+        [Fact]
+        public void InitializeGraphicsGenerator_WithNullRenderTarget_ShouldDisableGenerator()
+        {
+            var ex = Record.Exception(() => _songBar.InitializeGraphicsGenerator(null!, null!));
+
+            Assert.Null(ex);
+            Assert.Null(GetField<object?>(_songBar, "_graphicsGenerator"));
+        }
+
+        [Fact]
+        public void DrawNodeTypeIndicator_WhenWhitePixelIsMissing_ShouldReturnWithoutThrowing()
+        {
+            _songBar.SongNode = _testSongNode;
+
+            var ex = Record.Exception(() => InvokePrivate<object?>(_songBar, "DrawNodeTypeIndicator", null!, new Rectangle(0, 0, 100, 32)));
+
+            Assert.Null(ex);
+        }
+
+        private static Mock<ITexture> CreateTextureMock()
+        {
+            var texture = new Mock<ITexture>();
+            texture.SetupGet(x => x.Height).Returns(32);
+            texture.Setup(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Vector2>()));
+            texture.Setup(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()));
+            return texture;
+        }
+
+        private static T InvokePrivate<T>(object target, string methodName, params object[] args)
+        {
+            var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            return (T)method!.Invoke(target, args)!;
+        }
+
+        private static T GetField<T>(object target, string fieldName)
+        {
+            var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            return (T)field!.GetValue(target)!;
         }
 
 

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -1084,6 +1084,10 @@ public class SongListDisplayLogicTests
         var title = new Mock<ITexture>();
         var preview = new Mock<ITexture>();
         var lamp = new Mock<ITexture>();
+#pragma warning disable SYSLIB0050
+        var cachedTitleTexture = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
+        var cachedPreviewTexture = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
+#pragma warning restore SYSLIB0050
 
         SetField(display, "_scrollbarTexture", scrollbar.Object);
         SetField(display, "_barScoreTexture", score.Object);
@@ -1106,6 +1110,12 @@ public class SongListDisplayLogicTests
             ClearLamp = lamp.Object
         };
 
+        var titleBarCache = (IDictionary)GetField<object>(display, "_titleBarCache");
+        titleBarCache[1] = cachedTitleTexture;
+
+        var previewImageCache = (IDictionary)GetField<object>(display, "_previewImageCache");
+        previewImageCache[1] = cachedPreviewTexture;
+
         display.Dispose();
 
         scrollbar.Verify(x => x.RemoveReference(), Times.Once);
@@ -1119,6 +1129,10 @@ public class SongListDisplayLogicTests
         title.Verify(x => x.RemoveReference(), Times.Once);
         preview.Verify(x => x.RemoveReference(), Times.Once);
         lamp.Verify(x => x.RemoveReference(), Times.Once);
+        Assert.True(cachedTitleTexture.WasDisposed);
+        Assert.True(cachedPreviewTexture.WasDisposed);
+        Assert.Empty((IDictionary)GetField<object>(display, "_titleBarCache"));
+        Assert.Empty((IDictionary)GetField<object>(display, "_previewImageCache"));
         Assert.Empty((IDictionary)GetField<object>(display, "_songBarCache"));
         Assert.Empty((IDictionary)GetField<object>(display, "_barInfoCache"));
         Assert.False(GetField<bool>(display, "_skinBarTexturesLoaded"));
@@ -1254,5 +1268,19 @@ public class SongListDisplayLogicTests
         var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(field);
         return (T)field!.GetValue(target)!;
+    }
+
+    private sealed class TrackingTexture2D : Texture2D
+    {
+        public TrackingTexture2D() : base(null!, 1, 1)
+        {
+        }
+
+        public bool WasDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            WasDisposed = true;
+        }
     }
 }

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -233,7 +233,7 @@ public class SongListDisplayLogicTests
             CurrentList = CreateSongs(20)
         };
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
@@ -261,7 +261,7 @@ public class SongListDisplayLogicTests
         SetField(display, "_currentScrollCounter", 0);
         SetField(display, "_currentDifficulty", 0);
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
@@ -285,7 +285,7 @@ public class SongListDisplayLogicTests
         SetField(display, "_currentScrollCounter", 0);
         SetField(display, "_currentDifficulty", 0);
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
@@ -313,7 +313,7 @@ public class SongListDisplayLogicTests
         SetField(display, "_currentScrollCounter", -100);
         SetField(display, "_currentDifficulty", 2);
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
@@ -583,7 +583,7 @@ public class SongListDisplayLogicTests
         var visible = GetField<HashSet<int>>(display, "_visibleBarIndices");
         visible.Add(999);
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         display.InvalidateVisuals();

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -211,7 +211,7 @@ public class SongListDisplayLogicTests
             CurrentList = CreateSongs(20)
         };
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         SetField(display, "_selectedIndex", 10);
@@ -321,20 +321,17 @@ public class SongListDisplayLogicTests
 
         InvokePrivate<object?>(display, "QueueTextureGenerationForNewBars");
 
-        var requestType = typeof(SongListDisplay).Assembly.GetType("DTXMania.Game.Lib.Song.Components.TextureGenerationRequest");
-        Assert.NotNull(requestType);
-        Assert.NotEmpty(queue.Cast<object>());
+        Assert.NotEmpty(queue);
 
         var firstRequest = queue[0];
-        Assert.Equal(display.CurrentList[2], requestType!.GetProperty("SongNode")!.GetValue(firstRequest));
-        Assert.Equal(2, requestType.GetProperty("SongIndex")!.GetValue(firstRequest));
-        Assert.Equal(2, requestType.GetProperty("Difficulty")!.GetValue(firstRequest));
-        Assert.True((bool)requestType.GetProperty("IsSelected")!.GetValue(firstRequest)!);
-        Assert.Equal(100, requestType.GetProperty("Priority")!.GetValue(firstRequest));
+        Assert.Equal(display.CurrentList[2], firstRequest.SongNode);
+        Assert.Equal(2, firstRequest.SongIndex);
+        Assert.Equal(2, firstRequest.Difficulty);
+        Assert.True(firstRequest.IsSelected);
+        Assert.Equal(100, firstRequest.Priority);
 
         var queuedIndices = queue
-            .Cast<object>()
-            .Select(item => (int)requestType.GetProperty("SongIndex")!.GetValue(item)!)
+            .Select(item => item.SongIndex)
             .Distinct()
             .OrderBy(index => index)
             .ToArray();
@@ -352,7 +349,7 @@ public class SongListDisplayLogicTests
         SetField(display, "_currentScrollCounter", 0);
         SetField(display, "_currentDifficulty", 1);
 
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
         var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
@@ -364,23 +361,20 @@ public class SongListDisplayLogicTests
 
         InvokePrivate<object?>(display, "QueueTextureGenerationForNewBars");
 
-        var requestType = typeof(SongListDisplay).Assembly.GetType("DTXMania.Game.Lib.Song.Components.TextureGenerationRequest");
-        Assert.NotNull(requestType);
         var visibleItems = (int)typeof(SongListDisplay)
             .GetField("VISIBLE_ITEMS", BindingFlags.NonPublic | BindingFlags.Static)!
             .GetRawConstantValue()!;
         Assert.Equal(visibleItems, queue.Count);
 
         var queuedBarIndices = queue
-            .Cast<object>()
-            .Select(item => (int)requestType!.GetProperty("BarIndex")!.GetValue(item)!)
+            .Select(item => item.BarIndex)
             .OrderBy(index => index)
             .ToArray();
         Assert.Equal(Enumerable.Range(0, visibleItems).ToArray(), queuedBarIndices);
 
-        Assert.All(queue.Cast<object>(), item =>
+        Assert.All(queue, item =>
         {
-            Assert.Equal(1, requestType!.GetProperty("Difficulty")!.GetValue(item));
+            Assert.Equal(1, item.Difficulty);
         });
     }
 
@@ -388,35 +382,24 @@ public class SongListDisplayLogicTests
     public void InsertTextureRequestSorted_ShouldKeepDescendingPriorityOrder()
     {
         var display = new SongListDisplay();
-        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        var queue = GetTextureGenerationQueue(display);
         queue.Clear();
 
-        var requestType = typeof(SongListDisplay).Assembly.GetType("DTXMania.Game.Lib.Song.Components.TextureGenerationRequest");
-        Assert.NotNull(requestType);
-
-        object CreateRequest(int priority)
+        static TextureGenerationRequest CreateRequest(int priority) => new()
         {
-            var request = Activator.CreateInstance(requestType!);
-            requestType!.GetProperty("SongNode")!.SetValue(request, new SongListNode { Type = NodeType.Score, Title = "S" + priority });
-            requestType.GetProperty("SongIndex")!.SetValue(request, priority);
-            requestType.GetProperty("BarIndex")!.SetValue(request, 0);
-            requestType.GetProperty("Difficulty")!.SetValue(request, 0);
-            requestType.GetProperty("IsSelected")!.SetValue(request, false);
-            requestType.GetProperty("Priority")!.SetValue(request, priority);
-            return request!;
-        }
+            SongNode = new SongListNode { Type = NodeType.Score, Title = "S" + priority },
+            SongIndex = priority,
+            BarIndex = 0,
+            Difficulty = 0,
+            IsSelected = false,
+            Priority = priority
+        };
 
         InvokePrivate<object?>(display, "InsertTextureRequestSorted", CreateRequest(50));
         InvokePrivate<object?>(display, "InsertTextureRequestSorted", CreateRequest(100));
         InvokePrivate<object?>(display, "InsertTextureRequestSorted", CreateRequest(75));
 
-        var priorities = new List<int>();
-        foreach (var item in queue)
-        {
-            priorities.Add((int)requestType!.GetProperty("Priority")!.GetValue(item)!);
-        }
-
-        Assert.Equal(new[] { 100, 75, 50 }, priorities);
+        Assert.Equal(new[] { 100, 75, 50 }, queue.Select(item => item.Priority).ToArray());
     }
 
     [Fact]
@@ -855,7 +838,7 @@ public class SongListDisplayLogicTests
     }
 
     [Fact]
-    public void MovePrevious_ShouldWrapToLastSongAndRaiseSelectionEvent()
+    public void MovePrevious_WhenAtFirstSong_ShouldSelectLastSongAndRaiseSelectionEvent()
     {
         var display = new SongListDisplay
         {
@@ -958,6 +941,11 @@ public class SongListDisplayLogicTests
         }
 
         return songs;
+    }
+
+    private static List<TextureGenerationRequest> GetTextureGenerationQueue(SongListDisplay display)
+    {
+        return GetField<List<TextureGenerationRequest>>(display, "_textureGenerationQueue");
     }
 
     private static T InvokePrivate<T>(object target, string methodName, params object[] args)

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -9,8 +9,10 @@ using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.UI.Layout;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Moq;
 using Xunit;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 
 namespace DTXMania.Test.UI;
 
@@ -573,6 +575,23 @@ public class SongListDisplayLogicTests
     }
 
     [Fact]
+    public void Update_WhenActive_ShouldAnimateScrollAndTolerateMissingRenderer()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(3)
+        };
+
+        SetField(display, "_currentScrollCounter", 0);
+        SetField(display, "_targetScrollCounter", 200);
+        display.Activate();
+
+        display.Update(1.0 / 60.0);
+
+        Assert.InRange(GetField<int>(display, "_currentScrollCounter"), 1, 200);
+    }
+
+    [Fact]
     public void InvalidateVisuals_ShouldClearVisibleIndices_AndQueueVisibleRequests()
     {
         var display = new SongListDisplay
@@ -740,12 +759,18 @@ public class SongListDisplayLogicTests
     }
 
     [Fact]
-    public void LoadSkinBarTextures_WhenCoreTextureMissing_ShouldDisableSkinFlag()
+    public void LoadSkinBarTextures_WhenCoreTextureResourceMissing_ShouldDisableSkinFlagAndSkipLoad()
     {
         var display = new SongListDisplay();
         var rm = new Mock<IResourceManager>();
 
-        rm.Setup(x => x.LoadTexture(TexturePath.BarScore)).Throws(new Exception("missing-score"));
+        rm.Setup(x => x.ResourceExists(TexturePath.BarScore)).Returns(false);
+        rm.Setup(x => x.ResourceExists(TexturePath.BarScoreSelected)).Returns(true);
+        rm.Setup(x => x.ResourceExists(TexturePath.BarBox)).Returns(true);
+        rm.Setup(x => x.ResourceExists(TexturePath.BarBoxSelected)).Returns(true);
+        rm.Setup(x => x.ResourceExists(TexturePath.BarOther)).Returns(true);
+        rm.Setup(x => x.ResourceExists(TexturePath.BarOtherSelected)).Returns(true);
+
         rm.Setup(x => x.LoadTexture(TexturePath.BarScoreSelected)).Returns(new Mock<ITexture>().Object);
         rm.Setup(x => x.LoadTexture(TexturePath.BarBox)).Returns(new Mock<ITexture>().Object);
         rm.Setup(x => x.LoadTexture(TexturePath.BarBoxSelected)).Returns(new Mock<ITexture>().Object);
@@ -755,8 +780,10 @@ public class SongListDisplayLogicTests
         SetField(display, "_resourceManager", rm.Object);
         InvokePrivate<object?>(display, "LoadSkinBarTextures");
 
+        rm.Verify(x => x.LoadTexture(TexturePath.BarScore), Times.Never);
         Assert.False(GetField<bool>(display, "_skinBarTexturesLoaded"));
         Assert.Null(GetField<ITexture?>(display, "_barScoreTexture"));
+        Assert.NotNull(GetField<ITexture?>(display, "_barScoreSelectedTexture"));
     }
 
     [Fact]
@@ -927,6 +954,176 @@ public class SongListDisplayLogicTests
         Assert.Equal(4, args.Difficulty);
     }
 
+    [Fact]
+    public void Draw_WhenUsingManagedFontAndSkinTextures_ShouldRenderBasicSongList()
+    {
+        var managedFont = CreateManagedFont();
+        var selectedBarTexture = CreateTexture(width: 640, height: 96);
+        var scoreBarTexture = CreateTexture(width: 620, height: 48);
+        var commentBarTexture = CreateTexture(width: 620, height: 60);
+        var scrollbarTexture = CreateTexture(width: 12, height: 373);
+        var display = new SongListDisplay
+        {
+            ManagedFont = managedFont.Object,
+            WhitePixel = null,
+            CurrentList = CreateSongsForDraw()
+        };
+
+        SetField(display, "_useEnhancedRendering", false);
+        SetField(display, "_skinBarTexturesLoaded", true);
+        SetField(display, "_barScoreSelectedTexture", selectedBarTexture.Object);
+        SetField(display, "_barScoreTexture", scoreBarTexture.Object);
+        SetField(display, "_commentBarTexture", commentBarTexture.Object);
+        SetField(display, "_scrollbarTexture", scrollbarTexture.Object);
+        display.Activate();
+
+        display.Draw(null!, 0);
+
+        selectedBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.AtLeastOnce);
+        scoreBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.AtLeastOnce);
+        commentBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        scrollbarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        managedFont.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<Color>()), Times.AtLeast(14));
+    }
+
+    [Fact]
+    public void Draw_WhenCurrentListEmptyAndManagedFontPresent_ShouldRenderEmptyMessage()
+    {
+        var managedFont = CreateManagedFont();
+        var display = new SongListDisplay
+        {
+            ManagedFont = managedFont.Object,
+            WhitePixel = null,
+            CurrentList = new List<SongListNode>()
+        };
+        display.Activate();
+
+        display.Draw(null!, 0);
+
+        managedFont.Verify(x => x.MeasureString("No songs found"), Times.Once);
+        managedFont.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "No songs found", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Once);
+    }
+
+    [Fact]
+    public void DrawBarInfoWithPerspective_WhenTexturesExist_ShouldDrawBarPartsAndArtist()
+    {
+        var managedFont = CreateManagedFont();
+        var selectedBarTexture = CreateTexture(width: 640, height: 96);
+        var titleTexture = CreateTexture(width: 240, height: 32);
+        var previewTexture = CreateTexture(width: 64, height: 64);
+        var clearLampTexture = CreateTexture(width: 7, height: 41);
+        var display = new SongListDisplay
+        {
+            ManagedFont = managedFont.Object
+        };
+        var barInfo = new SongBarInfo
+        {
+            SongNode = CreateSongsForDraw()[0],
+            BarType = BarType.Score,
+            TitleTexture = titleTexture.Object,
+            PreviewImage = previewTexture.Object,
+            ClearLamp = clearLampTexture.Object,
+            TitleString = "Song 0"
+        };
+
+        SetField(display, "_skinBarTexturesLoaded", true);
+        SetField(display, "_barScoreSelectedTexture", selectedBarTexture.Object);
+
+        InvokePrivate<object?>(display, "DrawBarInfoWithPerspective", null!, barInfo, new Rectangle(665, 269, 510, 48), true, true, 1f, 1f);
+
+        selectedBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+        clearLampTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+        previewTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+        titleTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<float>(), It.IsAny<Vector2>()), Times.Once);
+    }
+
+    [Fact]
+    public void DrawCommentBar_WhenSelectedSongIsScore_ShouldDrawBackgroundTexture()
+    {
+        var display = new SongListDisplay();
+        var commentBarTexture = CreateTexture(width: 620, height: 60);
+
+        display.CurrentList = CreateSongsForDraw();
+        SetField(display, "_commentBarTexture", commentBarTexture.Object);
+
+        InvokePrivate<object?>(display, "DrawCommentBar", (SpriteBatch)null!);
+
+        commentBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+    }
+
+    [Fact]
+    public void DrawScrollbar_WhenTextureAvailable_ShouldDrawTrack()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongsForDraw()
+        };
+        var scrollbarTexture = CreateTexture(width: 12, height: 373);
+
+        SetField(display, "_scrollbarTexture", scrollbarTexture.Object);
+        SetField(display, "_selectedIndex", 1);
+        SetField(display, "_whitePixel", null);
+
+        InvokePrivate<object?>(display, "DrawScrollbar", (SpriteBatch)null!);
+
+        scrollbarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_ShouldReleaseManagedTexturesAndClearCaches()
+    {
+        var display = new SongListDisplay();
+        var scrollbar = new Mock<ITexture>();
+        var score = new Mock<ITexture>();
+        var scoreSelected = new Mock<ITexture>();
+        var box = new Mock<ITexture>();
+        var boxSelected = new Mock<ITexture>();
+        var other = new Mock<ITexture>();
+        var otherSelected = new Mock<ITexture>();
+        var comment = new Mock<ITexture>();
+        var title = new Mock<ITexture>();
+        var preview = new Mock<ITexture>();
+        var lamp = new Mock<ITexture>();
+
+        SetField(display, "_scrollbarTexture", scrollbar.Object);
+        SetField(display, "_barScoreTexture", score.Object);
+        SetField(display, "_barScoreSelectedTexture", scoreSelected.Object);
+        SetField(display, "_barBoxTexture", box.Object);
+        SetField(display, "_barBoxSelectedTexture", boxSelected.Object);
+        SetField(display, "_barOtherTexture", other.Object);
+        SetField(display, "_barOtherSelectedTexture", otherSelected.Object);
+        SetField(display, "_commentBarTexture", comment.Object);
+        SetField(display, "_skinBarTexturesLoaded", true);
+
+        var songBarCache = (IDictionary)GetField<object>(display, "_songBarCache");
+        songBarCache[1] = new SongBar();
+
+        var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
+        barInfoCache["info"] = new SongBarInfo
+        {
+            TitleTexture = title.Object,
+            PreviewImage = preview.Object,
+            ClearLamp = lamp.Object
+        };
+
+        display.Dispose();
+
+        scrollbar.Verify(x => x.RemoveReference(), Times.Once);
+        score.Verify(x => x.RemoveReference(), Times.Once);
+        scoreSelected.Verify(x => x.RemoveReference(), Times.Once);
+        box.Verify(x => x.RemoveReference(), Times.Once);
+        boxSelected.Verify(x => x.RemoveReference(), Times.Once);
+        other.Verify(x => x.RemoveReference(), Times.Once);
+        otherSelected.Verify(x => x.RemoveReference(), Times.Once);
+        comment.Verify(x => x.RemoveReference(), Times.Once);
+        title.Verify(x => x.RemoveReference(), Times.Once);
+        preview.Verify(x => x.RemoveReference(), Times.Once);
+        lamp.Verify(x => x.RemoveReference(), Times.Once);
+        Assert.Empty((IDictionary)GetField<object>(display, "_songBarCache"));
+        Assert.Empty((IDictionary)GetField<object>(display, "_barInfoCache"));
+        Assert.False(GetField<bool>(display, "_skinBarTexturesLoaded"));
+    }
+
     private static List<SongListNode> CreateSongs(int count)
     {
         var songs = new List<SongListNode>();
@@ -941,6 +1138,58 @@ public class SongListDisplayLogicTests
         }
 
         return songs;
+    }
+
+    private static List<SongListNode> CreateSongsForDraw()
+    {
+        return
+        [
+            new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "Song 0",
+                DatabaseSong = new SongEntity
+                {
+                    Title = "Song 0",
+                    Artist = "Artist 0",
+                    Comment = ""
+                },
+                Scores = new SongScore[5]
+            },
+            new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "Song 1",
+                DatabaseSong = new SongEntity
+                {
+                    Title = "Song 1",
+                    Artist = "Artist 1",
+                    Comment = ""
+                },
+                Scores = new SongScore[5]
+            }
+        ];
+    }
+
+    private static Mock<IFont> CreateManagedFont()
+    {
+        var font = new Mock<IFont>();
+        font.SetupGet(x => x.SpriteFont).Returns((Microsoft.Xna.Framework.Graphics.SpriteFont?)null);
+        font.Setup(x => x.MeasureString(It.IsAny<string>())).Returns((string text) => new Vector2(text.Length * 8, 16));
+        font.Setup(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<Color>()));
+        return font;
+    }
+
+    private static Mock<ITexture> CreateTexture(int width = 64, int height = 64)
+    {
+        var texture = new Mock<ITexture>();
+        texture.SetupGet(x => x.Width).Returns(width);
+        texture.SetupGet(x => x.Height).Returns(height);
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()));
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Rectangle?>()));
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()));
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<float>(), It.IsAny<Vector2>()));
+        return texture;
     }
 
     private static List<TextureGenerationRequest> GetTextureGenerationQueue(SongListDisplay display)

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -6,6 +6,7 @@ using System.Runtime.Serialization;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.UI.Layout;
 using Microsoft.Xna.Framework;
 using Moq;
@@ -747,12 +748,131 @@ public class SongListDisplayLogicTests
         Assert.Equal(0f, pos.X);
     }
 
+    [Fact]
+    public void MoveNext_ShouldAdvanceSelectionAndRaiseIncompleteSelectionEvent()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(3)
+        };
+        SongSelectionChangedEventArgs? args = null;
+
+        display.SelectionChanged += (_, e) => args = e;
+        SetField(display, "_selectedIndex", 0);
+        SetField(display, "_targetScrollCounter", 0);
+        SetField(display, "_currentScrollCounter", 0);
+
+        display.MoveNext();
+
+        Assert.Equal(1, GetField<int>(display, "_selectedIndex"));
+        Assert.Equal(100, GetField<int>(display, "_targetScrollCounter"));
+        Assert.Same(display.CurrentList[1], display.SelectedSong);
+        Assert.NotNull(args);
+        Assert.Same(display.CurrentList[1], args!.SelectedSong);
+        Assert.False(args.IsScrollComplete);
+    }
+
+    [Fact]
+    public void MovePrevious_ShouldWrapToLastSongAndRaiseSelectionEvent()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(3)
+        };
+        SongSelectionChangedEventArgs? args = null;
+
+        display.SelectionChanged += (_, e) => args = e;
+        SetField(display, "_selectedIndex", 0);
+        SetField(display, "_targetScrollCounter", 0);
+        SetField(display, "_currentScrollCounter", 0);
+
+        display.MovePrevious();
+
+        Assert.Equal(-1, GetField<int>(display, "_selectedIndex"));
+        Assert.Equal(-100, GetField<int>(display, "_targetScrollCounter"));
+        Assert.Same(display.CurrentList[2], display.SelectedSong);
+        Assert.NotNull(args);
+        Assert.Same(display.CurrentList[2], args!.SelectedSong);
+    }
+
+    [Fact]
+    public void SelectedIndex_WhenValueUnchanged_ShouldNotRaiseSelectionChangedOrUpdateTarget()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(3)
+        };
+        var fired = false;
+
+        display.SelectionChanged += (_, _) => fired = true;
+        SetField(display, "_selectedIndex", 1);
+        SetField(display, "_targetScrollCounter", 150);
+
+        display.SelectedIndex = 1;
+
+        Assert.False(fired);
+        Assert.Equal(1, GetField<int>(display, "_selectedIndex"));
+        Assert.Equal(150, GetField<int>(display, "_targetScrollCounter"));
+    }
+
+    [Fact]
+    public void CycleDifficulty_WhenOnlyCurrentDifficultyExists_ShouldKeepDifficultyAndRaiseEvent()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = new List<SongListNode>
+            {
+                new SongListNode
+                {
+                    Type = NodeType.Score,
+                    Title = "Song",
+                    Scores = new SongScore[5]
+                }
+            }
+        };
+        DifficultyChangedEventArgs? args = null;
+
+        display.CurrentList[0].Scores![2] = new SongScore { DifficultyLevel = 2, DifficultyLabel = "Hard" };
+        display.DifficultyChanged += (_, e) => args = e;
+        display.CurrentDifficulty = 2;
+
+        display.CycleDifficulty();
+
+        Assert.Equal(2, display.CurrentDifficulty);
+        Assert.NotNull(args);
+        Assert.Same(display.SelectedSong, args!.Song);
+        Assert.Equal(2, args.NewDifficulty);
+    }
+
+    [Fact]
+    public void ActivateSelected_ShouldRaiseSongActivatedWithCurrentDifficulty()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(2)
+        };
+        SongActivatedEventArgs? args = null;
+
+        display.SongActivated += (_, e) => args = e;
+        display.CurrentDifficulty = 4;
+        display.ActivateSelected();
+
+        Assert.NotNull(args);
+        Assert.Same(display.SelectedSong, args!.Song);
+        Assert.Equal(4, args.Difficulty);
+    }
+
     private static List<SongListNode> CreateSongs(int count)
     {
         var songs = new List<SongListNode>();
         for (int i = 0; i < count; i++)
         {
-            songs.Add(new SongListNode { Type = NodeType.Score, Title = $"Song {i}" });
+            songs.Add(new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = $"Song {i}",
+                Scores = new SongScore[5]
+            });
         }
 
         return songs;

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -303,6 +303,88 @@ public class SongListDisplayLogicTests
     }
 
     [Fact]
+    public void QueueTextureGenerationForNewBars_WhenScrollWrapsNegative_ShouldQueueWrappedSelectedRequestFirst()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(3)
+        };
+
+        SetField(display, "_currentScrollCounter", -100);
+        SetField(display, "_currentDifficulty", 2);
+
+        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        queue.Clear();
+
+        var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
+        barInfoCache.Clear();
+
+        InvokePrivate<object?>(display, "QueueTextureGenerationForNewBars");
+
+        var requestType = typeof(SongListDisplay).Assembly.GetType("DTXMania.Game.Lib.Song.Components.TextureGenerationRequest");
+        Assert.NotNull(requestType);
+        Assert.NotEmpty(queue.Cast<object>());
+
+        var firstRequest = queue[0];
+        Assert.Equal(display.CurrentList[2], requestType!.GetProperty("SongNode")!.GetValue(firstRequest));
+        Assert.Equal(2, requestType.GetProperty("SongIndex")!.GetValue(firstRequest));
+        Assert.Equal(2, requestType.GetProperty("Difficulty")!.GetValue(firstRequest));
+        Assert.True((bool)requestType.GetProperty("IsSelected")!.GetValue(firstRequest)!);
+        Assert.Equal(100, requestType.GetProperty("Priority")!.GetValue(firstRequest));
+
+        var queuedIndices = queue
+            .Cast<object>()
+            .Select(item => (int)requestType.GetProperty("SongIndex")!.GetValue(item)!)
+            .Distinct()
+            .OrderBy(index => index)
+            .ToArray();
+        Assert.Equal(new[] { 0, 1, 2 }, queuedIndices);
+    }
+
+    [Fact]
+    public void QueueTextureGenerationForNewBars_WhenOnlyDifferentDifficultyCached_ShouldQueueCurrentDifficultyRequests()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(3)
+        };
+
+        SetField(display, "_currentScrollCounter", 0);
+        SetField(display, "_currentDifficulty", 1);
+
+        var queue = (IList)GetField<object>(display, "_textureGenerationQueue");
+        queue.Clear();
+
+        var barInfoCache = (IDictionary)GetField<object>(display, "_barInfoCache");
+        barInfoCache.Clear();
+        foreach (var song in display.CurrentList)
+        {
+            barInfoCache[$"{song.GetHashCode()}_0"] = new SongBarInfo();
+        }
+
+        InvokePrivate<object?>(display, "QueueTextureGenerationForNewBars");
+
+        var requestType = typeof(SongListDisplay).Assembly.GetType("DTXMania.Game.Lib.Song.Components.TextureGenerationRequest");
+        Assert.NotNull(requestType);
+        var visibleItems = (int)typeof(SongListDisplay)
+            .GetField("VISIBLE_ITEMS", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetRawConstantValue()!;
+        Assert.Equal(visibleItems, queue.Count);
+
+        var queuedBarIndices = queue
+            .Cast<object>()
+            .Select(item => (int)requestType!.GetProperty("BarIndex")!.GetValue(item)!)
+            .OrderBy(index => index)
+            .ToArray();
+        Assert.Equal(Enumerable.Range(0, visibleItems).ToArray(), queuedBarIndices);
+
+        Assert.All(queue.Cast<object>(), item =>
+        {
+            Assert.Equal(1, requestType!.GetProperty("Difficulty")!.GetValue(item));
+        });
+    }
+
+    [Fact]
     public void InsertTextureRequestSorted_ShouldKeepDescendingPriorityOrder()
     {
         var display = new SongListDisplay();

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -363,16 +363,14 @@ public class SongListDisplayLogicTests
 
         InvokePrivate<object?>(display, "QueueTextureGenerationForNewBars");
 
-        var visibleItems = (int)typeof(SongListDisplay)
-            .GetField("VISIBLE_ITEMS", BindingFlags.NonPublic | BindingFlags.Static)!
-            .GetRawConstantValue()!;
-        Assert.Equal(visibleItems, queue.Count);
+        // Deduplication: each unique song is enqueued at most once, so queue size equals unique song count
+        Assert.Equal(display.CurrentList.Count, queue.Count);
 
-        var queuedBarIndices = queue
-            .Select(item => item.BarIndex)
+        var queuedSongIndices = queue
+            .Select(item => item.SongIndex)
             .OrderBy(index => index)
             .ToArray();
-        Assert.Equal(Enumerable.Range(0, visibleItems).ToArray(), queuedBarIndices);
+        Assert.Equal(new[] { 0, 1, 2 }, queuedSongIndices);
 
         Assert.All(queue, item =>
         {

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -479,7 +479,7 @@ public class SongStatusPanelLogicTests
     [InlineData(6, 0, 0, 255)]
     [InlineData(7, 0, 128, 0)]
     [InlineData(8, 0, 255, 255)]
-    public void GetDrumLaneColor_ShouldMapAllNamedLanes(int lane, byte r, byte g, byte b)
+    public void GetDrumLaneColor_MapsCommonNamedLanes(int lane, byte r, byte g, byte b)
     {
         var panel = new SongStatusPanel();
 

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -9,11 +9,13 @@ using DTXMania.Game.Lib.Song.Entities;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Moq;
+using Xunit;
 using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 
 namespace DTXMania.Test.UI;
 
+[Trait("Category", "UI")]
 public class SongStatusPanelLogicTests
 {
     [Fact]
@@ -527,7 +529,7 @@ public class SongStatusPanelLogicTests
         var difficultyFrameTexture = CreateTexture(width: 80, height: 60);
         var graphTexture = CreateTexture(width: 240, height: 321);
         var skillPointTexture = CreateTexture(width: 187, height: 64);
-        var skillIconTexture = CreateTexture(width: RankIconWidth * 9, height: 16);
+        var skillIconTexture = CreateTexture(width: 350, height: 53);
 
         SetField(panel, "_bpmBackgroundTexture", bpmTexture.Object);
         SetField(panel, "_difficultyPanelTexture", difficultyPanelTexture.Object);
@@ -751,8 +753,6 @@ public class SongStatusPanelLogicTests
 
         Assert.Equal(new Vector2(490, 385), drawnPosition);
     }
-
-    private const int RankIconWidth = 32;
 
     private static Mock<IFont> CreateManagedFont()
     {

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -7,6 +7,7 @@ using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Song.Entities;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Moq;
 using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
@@ -466,6 +467,41 @@ public class SongStatusPanelLogicTests
         Assert.Equal(Color.White, gbUnknown);
     }
 
+    [Theory]
+    [InlineData(0, 128, 0, 128)]
+    [InlineData(1, 255, 255, 0)]
+    [InlineData(2, 128, 0, 128)]
+    [InlineData(3, 255, 0, 0)]
+    [InlineData(4, 0, 0, 255)]
+    [InlineData(5, 255, 165, 0)]
+    [InlineData(6, 0, 0, 255)]
+    [InlineData(7, 0, 128, 0)]
+    [InlineData(8, 0, 255, 255)]
+    public void GetDrumLaneColor_ShouldMapAllNamedLanes(int lane, byte r, byte g, byte b)
+    {
+        var panel = new SongStatusPanel();
+
+        var color = InvokePrivate<Color>(panel, "GetDrumLaneColor", lane);
+
+        Assert.Equal(new Color(r, g, b), color);
+    }
+
+    [Theory]
+    [InlineData(0, 255, 0, 0)]
+    [InlineData(1, 0, 128, 0)]
+    [InlineData(2, 0, 0, 255)]
+    [InlineData(3, 255, 255, 0)]
+    [InlineData(4, 128, 0, 128)]
+    [InlineData(5, 255, 165, 0)]
+    public void GetGuitarBassLaneColor_ShouldMapAllNamedLanes(int lane, byte r, byte g, byte b)
+    {
+        var panel = new SongStatusPanel();
+
+        var color = InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", lane);
+
+        Assert.Equal(new Color(r, g, b), color);
+    }
+
     [Fact]
     public void GetInstrumentFromDifficulty_ShouldAlwaysReturnDrums()
     {
@@ -473,6 +509,323 @@ public class SongStatusPanelLogicTests
 
         Assert.Equal("DRUMS", InvokePrivate<string>(panel, "GetInstrumentFromDifficulty", 0));
         Assert.Equal("DRUMS", InvokePrivate<string>(panel, "GetInstrumentFromDifficulty", 4));
+    }
+
+    [Fact]
+    public void Draw_WhenScoreSongUsesManagedFontAndTextures_ShouldRenderAuthenticSections()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            Size = new Vector2(640, 480),
+            ManagedFont = font.Object,
+            ManagedSmallFont = font.Object,
+            WhitePixel = null
+        };
+        var bpmTexture = CreateTexture(width: 187, height: 67);
+        var difficultyPanelTexture = CreateTexture(width: 240, height: 321);
+        var difficultyFrameTexture = CreateTexture(width: 80, height: 60);
+        var graphTexture = CreateTexture(width: 240, height: 321);
+        var skillPointTexture = CreateTexture(width: 187, height: 64);
+        var skillIconTexture = CreateTexture(width: RankIconWidth * 9, height: 16);
+
+        SetField(panel, "_bpmBackgroundTexture", bpmTexture.Object);
+        SetField(panel, "_difficultyPanelTexture", difficultyPanelTexture.Object);
+        SetField(panel, "_difficultyFrameTexture", difficultyFrameTexture.Object);
+        SetField(panel, "_graphPanelDrumsTexture", graphTexture.Object);
+        SetField(panel, "_skillPointPanelTexture", skillPointTexture.Object);
+        SetField(panel, "_skillIconTexture", skillIconTexture.Object);
+
+        panel.UpdateSongInfo(CreateScoreNodeForDraw(), 0);
+        panel.Activate();
+
+        panel.Draw(null!, 0);
+
+        bpmTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        difficultyPanelTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        difficultyFrameTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        graphTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()), Times.Once);
+        skillPointTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        skillIconTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Rectangle?>()), Times.AtLeastOnce);
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<Color>()), Times.AtLeast(8));
+    }
+
+    [Fact]
+    public void Draw_WhenSelectedNodeIsNonScore_ShouldRenderSimplifiedInfo()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            Size = new Vector2(320, 240),
+            ManagedFont = font.Object,
+            WhitePixel = null
+        };
+
+        panel.UpdateSongInfo(new SongListNode { Type = NodeType.Box, Title = "Folder" }, 0);
+        panel.Activate();
+
+        panel.Draw(null!, 0);
+
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "📁 FOLDER", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "Folder", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void Draw_WhenSongMissing_ShouldRenderNoSongMessageWithManagedFont()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            Size = new Vector2(320, 240),
+            ManagedFont = font.Object,
+            WhitePixel = null
+        };
+        panel.Activate();
+
+        panel.Draw(null!, 0);
+
+        font.Verify(x => x.MeasureString("No song selected"), Times.Once);
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "No song selected", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void DrawNotesCounter_WhenChartHasNoNotes_ShouldRenderNoNotesMessage()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            ManagedFont = font.Object
+        };
+        var chart = new SongChart();
+
+        InvokePrivate<object?>(panel, "DrawNotesCounter", null!, chart, new Vector2(100, 200));
+
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "No notes", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void DrawNotesCounter_WhenChartIsNull_ShouldReturnWithoutDrawing()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            ManagedFont = font.Object
+        };
+
+        var ex = Record.Exception(() => InvokePrivate<object?>(panel, "DrawNotesCounter", null!, null!, new Vector2(100, 200)));
+
+        Assert.Null(ex);
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Never);
+    }
+
+    [Fact]
+    public void DrawNotesCounter_WhenCurrentInstrumentHasNoNotes_ShouldRenderTotalOnlyText()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            ManagedFont = font.Object
+        };
+        var chart = new SongChart
+        {
+            GuitarNoteCount = 123,
+            HasGuitarChart = true,
+            GuitarLevel = 40
+        };
+
+        InvokePrivate<object?>(panel, "DrawNotesCounter", null!, chart, new Vector2(100, 200));
+
+        font.Verify(x => x.MeasureString("123 notes"), Times.Once);
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "123 notes", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+    }
+
+    [Theory]
+    [InlineData(NodeType.Score, "♪ SONG")]
+    [InlineData(NodeType.BackBox, "⬅ BACK")]
+    [InlineData((NodeType)(-1), "UNKNOWN")]
+    public void DrawSongTypeInfo_ShouldRenderAdditionalTypeLabels(NodeType nodeType, string expectedLabel)
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            ManagedFont = font.Object
+        };
+        float x = 10f;
+        float y = 20f;
+
+        InvokePrivate<object?>(
+            panel,
+            "DrawSongTypeInfo",
+            null!,
+            x,
+            y,
+            300f,
+            new SongListNode { Type = nodeType, Title = "Node" },
+            0);
+
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), expectedLabel, It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void DrawNoSongMessage_WhenNoFontsAvailable_ShouldNotThrow()
+    {
+        var panel = new SongStatusPanel();
+
+        InvokePrivate<object?>(panel, "DrawNoSongMessage", null!, new Rectangle(0, 0, 320, 240));
+
+        Assert.Null(panel.ManagedFont);
+        Assert.Null(panel.Font);
+        Assert.Null(panel.SmallFont);
+    }
+
+    [Fact]
+    public void DrawSongTypeInfo_WhenTitleIsLongAndNodeIsRandom_ShouldTruncateAndUseRandomLabel()
+    {
+        var font = CreateManagedFont();
+        var panel = new SongStatusPanel
+        {
+            ManagedFont = font.Object
+        };
+        float x = 10f;
+        float y = 20f;
+        var longTitle = new string('A', 35);
+
+        InvokePrivate<object?>(
+            panel,
+            "DrawSongTypeInfo",
+            null!,
+            x,
+            y,
+            300f,
+            new SongListNode { Type = NodeType.Random, Title = longTitle },
+            0);
+
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), "🎲 RANDOM", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+        font.Verify(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), $"{new string('A', 27)}...", It.IsAny<Vector2>(), It.IsAny<Color>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public void DrawBPMBackground_WhenTextureDisposed_ShouldClearCachedTexture()
+    {
+        var panel = new SongStatusPanel();
+        var bpmTexture = new Mock<ITexture>();
+        bpmTexture
+            .Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()))
+            .Throws(new ObjectDisposedException("bpm"));
+        SetField(panel, "_bpmBackgroundTexture", bpmTexture.Object);
+
+        InvokePrivate<object?>(panel, "DrawBPMBackground", (SpriteBatch)null!);
+
+        Assert.Null(GetField<ITexture?>(panel, "_bpmBackgroundTexture"));
+    }
+
+    [Fact]
+    public void DrawGraphPanelBackground_WhenTextureDisposed_ShouldClearDrumGraphTexture()
+    {
+        var panel = new SongStatusPanel();
+        var graphTexture = new Mock<ITexture>();
+        graphTexture.SetupGet(x => x.Width).Returns(220);
+        graphTexture.SetupGet(x => x.Height).Returns(180);
+        graphTexture
+            .Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()))
+            .Throws(new ObjectDisposedException("graph"));
+        SetField(panel, "_graphPanelDrumsTexture", graphTexture.Object);
+
+        InvokePrivate<object?>(panel, "DrawGraphPanelBackground", null!, new Vector2(1, 2), new Vector2(220, 180));
+
+        Assert.Null(GetField<ITexture?>(panel, "_graphPanelDrumsTexture"));
+    }
+
+    [Fact]
+    public void DrawBPMBackground_WhenStandaloneEnabled_ShouldDrawAtStandaloneOrigin()
+    {
+        var panel = new SongStatusPanel { UseStandaloneBPMBackground = true };
+        var bpmTexture = new Mock<ITexture>();
+        Vector2? drawnPosition = null;
+        bpmTexture
+            .Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()))
+            .Callback<Microsoft.Xna.Framework.Graphics.SpriteBatch, Vector2>((_, position) => drawnPosition = position);
+        SetField(panel, "_bpmBackgroundTexture", bpmTexture.Object);
+
+        InvokePrivate<object?>(panel, "DrawBPMBackground", (SpriteBatch)null!);
+
+        Assert.Equal(new Vector2(490, 385), drawnPosition);
+    }
+
+    private const int RankIconWidth = 32;
+
+    private static Mock<IFont> CreateManagedFont()
+    {
+        var font = new Mock<IFont>();
+        font.SetupGet(x => x.SpriteFont).Returns((Microsoft.Xna.Framework.Graphics.SpriteFont?)null);
+        font.Setup(x => x.MeasureString(It.IsAny<string>())).Returns((string text) => new Vector2(text.Length * 8, 16));
+        font.Setup(x => x.DrawString(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<Color>()));
+        return font;
+    }
+
+    private static Mock<ITexture> CreateTexture(int width = 64, int height = 64)
+    {
+        var texture = new Mock<ITexture>();
+        texture.SetupGet(x => x.Width).Returns(width);
+        texture.SetupGet(x => x.Height).Returns(height);
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()));
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Rectangle?>()));
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()));
+        texture.Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Vector2>(), It.IsAny<float>(), It.IsAny<Vector2>()));
+        return texture;
+    }
+
+    private static SongListNode CreateScoreNodeForDraw()
+    {
+        var chart = new SongChart
+        {
+            FilePath = "song.dtx",
+            Duration = 125,
+            Bpm = 180,
+            DifficultyLevel = 3,
+            DrumLevel = 68,
+            HasDrumChart = true,
+            DrumNoteCount = 321,
+            Scores = new List<SongScore>
+            {
+                new()
+                {
+                    Instrument = EInstrumentPart.DRUMS,
+                    PlayCount = 7,
+                    BestRank = 95,
+                    FullCombo = true
+                }
+            }
+        };
+        var song = new SongEntity
+        {
+            Title = "Draw Song",
+            Charts = new List<SongChart> { chart }
+        };
+        chart.Song = song;
+
+        return new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "Draw Song",
+            DatabaseSong = song,
+            DatabaseChart = chart,
+            Scores =
+            [
+                new SongScore
+                {
+                    Instrument = EInstrumentPart.DRUMS,
+                    PlayCount = 5,
+                    HighSkill = 88.88,
+                    BestRank = 95,
+                    FullCombo = true
+                },
+                null,
+                null,
+                null,
+                null
+            ]
+        };
     }
 
     private static T InvokePrivate<T>(object target, string methodName, params object[] args)

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -731,11 +731,14 @@ public class SongStatusPanelLogicTests
         graphTexture
             .Setup(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Rectangle>(), It.IsAny<Rectangle?>(), It.IsAny<Color>(), It.IsAny<float>(), It.IsAny<Vector2>(), It.IsAny<SpriteEffects>(), It.IsAny<float>()))
             .Throws(new ObjectDisposedException("graph"));
+        var guitarBassTexture = new Mock<ITexture>();
         SetField(panel, "_graphPanelDrumsTexture", graphTexture.Object);
+        SetField(panel, "_graphPanelGuitarBassTexture", guitarBassTexture.Object);
 
         InvokePrivate<object?>(panel, "DrawGraphPanelBackground", null!, new Vector2(1, 2), new Vector2(220, 180));
 
         Assert.Null(GetField<ITexture?>(panel, "_graphPanelDrumsTexture"));
+        Assert.Same(guitarBassTexture.Object, GetField<ITexture?>(panel, "_graphPanelGuitarBassTexture"));
     }
 
     [Fact]

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -104,6 +104,8 @@ public class SongStatusPanelLogicTests
         var difficultyFrame = new Mock<ITexture>().Object;
         var graphDrums = new Mock<ITexture>().Object;
         var graphGb = new Mock<ITexture>().Object;
+        var skillPointPanel = new Mock<ITexture>().Object;
+        var skillIcon = new Mock<ITexture>().Object;
 
         rm.Setup(x => x.LoadTexture(TexturePath.SongStatusPanel)).Returns(status);
         rm.Setup(x => x.LoadTexture(TexturePath.BpmBackground)).Returns(bpm);
@@ -111,6 +113,8 @@ public class SongStatusPanelLogicTests
         rm.Setup(x => x.LoadTexture(TexturePath.DifficultyFrame)).Returns(difficultyFrame);
         rm.Setup(x => x.LoadTexture(TexturePath.GraphPanelDrums)).Returns(graphDrums);
         rm.Setup(x => x.LoadTexture(TexturePath.GraphPanelGuitarBass)).Returns(graphGb);
+        rm.Setup(x => x.LoadTexture(TexturePath.SkillPointPanel)).Returns(skillPointPanel);
+        rm.Setup(x => x.LoadTexture(TexturePath.SkillIcon)).Returns(skillIcon);
 
         panel.InitializeAuthenticGraphics(rm.Object);
 
@@ -120,6 +124,8 @@ public class SongStatusPanelLogicTests
         Assert.Same(difficultyFrame, GetField<ITexture>(panel, "_difficultyFrameTexture"));
         Assert.Same(graphDrums, GetField<ITexture>(panel, "_graphPanelDrumsTexture"));
         Assert.Same(graphGb, GetField<ITexture>(panel, "_graphPanelGuitarBassTexture"));
+        Assert.Same(skillPointPanel, GetField<ITexture>(panel, "_skillPointPanelTexture"));
+        Assert.Same(skillIcon, GetField<ITexture>(panel, "_skillIconTexture"));
     }
 
     [Fact]
@@ -133,6 +139,8 @@ public class SongStatusPanelLogicTests
         var difficultyFrame = new Mock<ITexture>();
         var graphDrums = new Mock<ITexture>();
         var graphGb = new Mock<ITexture>();
+        var skillPointPanel = new Mock<ITexture>();
+        var skillIcon = new Mock<ITexture>();
 
         SetField(panel, "_statusPanelTexture", status.Object);
         SetField(panel, "_bpmBackgroundTexture", bpm.Object);
@@ -140,6 +148,8 @@ public class SongStatusPanelLogicTests
         SetField(panel, "_difficultyFrameTexture", difficultyFrame.Object);
         SetField(panel, "_graphPanelDrumsTexture", graphDrums.Object);
         SetField(panel, "_graphPanelGuitarBassTexture", graphGb.Object);
+        SetField(panel, "_skillPointPanelTexture", skillPointPanel.Object);
+        SetField(panel, "_skillIconTexture", skillIcon.Object);
 
         panel.Dispose();
 
@@ -149,6 +159,8 @@ public class SongStatusPanelLogicTests
         difficultyFrame.Verify(x => x.RemoveReference(), Times.Once);
         graphDrums.Verify(x => x.RemoveReference(), Times.Once);
         graphGb.Verify(x => x.RemoveReference(), Times.Once);
+        skillPointPanel.Verify(x => x.RemoveReference(), Times.Once);
+        skillIcon.Verify(x => x.RemoveReference(), Times.Once);
     }
 
     [Fact]
@@ -180,6 +192,16 @@ public class SongStatusPanelLogicTests
         Assert.NotNull(inRange);
         Assert.Null(negative);
         Assert.Null(outOfRange);
+    }
+
+    [Fact]
+    public void GetCurrentScore_ShouldReturnNullWhenSongOrScoresAreMissing()
+    {
+        var panel = new SongStatusPanel();
+        var nodeWithoutScores = new SongListNode { Type = NodeType.Score, Scores = null };
+
+        Assert.Null(InvokePrivate<SongScore?>(panel, "GetCurrentScore", null!, 0));
+        Assert.Null(InvokePrivate<SongScore?>(panel, "GetCurrentScore", nodeWithoutScores, 0));
     }
 
     [Fact]
@@ -413,6 +435,19 @@ public class SongStatusPanelLogicTests
         Assert.Null(GetField<ITexture?>(panel, "_bpmBackgroundTexture"));
         Assert.Null(GetField<ITexture?>(panel, "_difficultyPanelTexture"));
         Assert.Null(GetField<ITexture?>(panel, "_difficultyFrameTexture"));
+    }
+
+    [Fact]
+    public void SkillTextureLoaders_WhenResourceManagerIsNull_ShouldKeepSkillTexturesNull()
+    {
+        var panel = new SongStatusPanel();
+
+        SetField(panel, "_resourceManager", null);
+        InvokePrivate<object?>(panel, "LoadSkillPointPanelTexture");
+        InvokePrivate<object?>(panel, "LoadSkillIconTexture");
+
+        Assert.Null(GetField<ITexture?>(panel, "_skillPointPanelTexture"));
+        Assert.Null(GetField<ITexture?>(panel, "_skillIconTexture"));
     }
 
     [Fact]

--- a/DTXMania.Test/UI/UIButtonLogicTests.cs
+++ b/DTXMania.Test/UI/UIButtonLogicTests.cs
@@ -34,6 +34,7 @@ public class UIButtonLogicTests
         var pressed = new ButtonStateAppearance();
         var disabled = new ButtonStateAppearance();
 
+        button.Text = "Test";
         button.Text = null!;
         button.IdleAppearance = idle;
         button.HoverAppearance = hover;

--- a/DTXMania.Test/UI/UIButtonLogicTests.cs
+++ b/DTXMania.Test/UI/UIButtonLogicTests.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI;
+using DTXMania.Game.Lib.UI.Components;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+
+namespace DTXMania.Test.UI;
+
+[Trait("Category", "Unit")]
+public class UIButtonLogicTests
+{
+    [Fact]
+    public void ImageComponent_SetterShouldAssignButtonAsParent()
+    {
+        var button = CreateActiveButton();
+        var image = new UIImage();
+
+        button.ImageComponent = image;
+
+        Assert.Same(image, button.ImageComponent);
+        Assert.Same(button, image.Parent);
+    }
+
+    [Fact]
+    public void PropertySetters_ShouldFallbackToSafeDefaults()
+    {
+        var button = CreateActiveButton();
+        var idle = new ButtonStateAppearance();
+        var hover = new ButtonStateAppearance();
+        var pressed = new ButtonStateAppearance();
+        var disabled = new ButtonStateAppearance();
+
+        button.Text = null!;
+        button.IdleAppearance = idle;
+        button.HoverAppearance = hover;
+        button.PressedAppearance = pressed;
+        button.DisabledAppearance = disabled;
+
+        button.IdleAppearance = null!;
+        button.HoverAppearance = null!;
+        button.PressedAppearance = null!;
+        button.DisabledAppearance = null!;
+
+        Assert.Equal(string.Empty, button.Text);
+        Assert.NotNull(button.IdleAppearance);
+        Assert.NotNull(button.HoverAppearance);
+        Assert.NotNull(button.PressedAppearance);
+        Assert.NotNull(button.DisabledAppearance);
+        Assert.NotSame(idle, button.IdleAppearance);
+        Assert.NotSame(hover, button.HoverAppearance);
+        Assert.NotSame(pressed, button.PressedAppearance);
+        Assert.NotSame(disabled, button.DisabledAppearance);
+    }
+
+    [Fact]
+    public void Click_WhenDisabled_ShouldNotRaiseEvent()
+    {
+        var button = CreateActiveButton();
+        var clickCount = 0;
+        button.Enabled = false;
+        button.ButtonClicked += (_, _) => clickCount++;
+
+        button.Click();
+
+        Assert.Equal(0, clickCount);
+    }
+
+    [Fact]
+    public void InputHandling_ShouldTrackHoverPressAndReleaseOverButton()
+    {
+        var button = CreateActiveButton();
+        button.Position = Vector2.Zero;
+        button.Size = new Vector2(100, 40);
+        var clickCount = 0;
+        button.ButtonClicked += (_, _) => clickCount++;
+
+        var hoverHandled = HandleInput(button, CreateInputState(new Vector2(10, 10)).Object);
+        button.Update(0);
+
+        Assert.True(hoverHandled);
+        Assert.True(button.IsHovered);
+        Assert.False(button.IsPressed);
+        Assert.Equal(ButtonState.Hover, button.CurrentState);
+        Assert.Equal(0, clickCount);
+
+        var pressHandled = HandleInput(button, CreateInputState(new Vector2(10, 10), isMouseDown: true).Object);
+        button.Update(0);
+
+        Assert.True(pressHandled);
+        Assert.True(button.IsHovered);
+        Assert.True(button.IsPressed);
+        Assert.Equal(ButtonState.Pressed, button.CurrentState);
+        Assert.Equal(0, clickCount);
+
+        var releaseOutsideHandled = HandleInput(button, CreateInputState(new Vector2(150, 80), isMouseReleased: true).Object);
+        button.Update(0);
+
+        Assert.True(releaseOutsideHandled);
+        Assert.False(button.IsHovered);
+        Assert.False(button.IsPressed);
+        Assert.Equal(ButtonState.Idle, button.CurrentState);
+        Assert.Equal(0, clickCount);
+
+        HandleInput(button, CreateInputState(new Vector2(10, 10), isMouseDown: true).Object);
+        button.Update(0);
+
+        var releaseHandled = HandleInput(button, CreateInputState(new Vector2(10, 10), isMouseReleased: true).Object);
+        button.Update(0);
+
+        Assert.True(releaseHandled);
+        Assert.True(button.IsHovered);
+        Assert.False(button.IsPressed);
+        Assert.Equal(ButtonState.Hover, button.CurrentState);
+        Assert.Equal(1, clickCount);
+    }
+
+    [Fact]
+    public void SetBackgroundTexture_ShouldUpdateRequestedAppearance()
+    {
+        var button = CreateActiveButton();
+        var idleTexture = CreateTextureStub();
+        var pressedTexture = CreateTextureStub();
+        var pressedSource = new Rectangle(1, 2, 3, 4);
+
+        button.SetBackgroundTexture(ButtonState.Idle, idleTexture);
+        button.SetBackgroundTexture(ButtonState.Pressed, pressedTexture, pressedSource);
+
+        Assert.Same(idleTexture, button.IdleAppearance.BackgroundTexture);
+        Assert.Null(button.IdleAppearance.BackgroundSourceRectangle);
+        Assert.Same(pressedTexture, button.PressedAppearance.BackgroundTexture);
+        Assert.Equal(pressedSource, button.PressedAppearance.BackgroundSourceRectangle);
+        Assert.Null(button.HoverAppearance.BackgroundTexture);
+        Assert.Null(button.DisabledAppearance.BackgroundTexture);
+    }
+
+    private static UIButton CreateActiveButton()
+    {
+        var resourceManager = new Mock<IResourceManager>();
+        var font = new Mock<IFont>();
+        font.SetupGet(x => x.SpriteFont).Returns((SpriteFont?)null);
+        resourceManager.Setup(x => x.LoadFont("DefaultFont", 20)).Returns(font.Object);
+
+        var button = new UIButton(resourceManager.Object, "Button");
+        button.Activate();
+        return button;
+    }
+
+    private static Mock<IInputState> CreateInputState(Vector2 mousePosition, bool isMouseDown = false, bool isMouseReleased = false)
+    {
+        var inputState = new Mock<IInputState>();
+        inputState.SetupGet(x => x.MousePosition).Returns(mousePosition);
+        inputState.Setup(x => x.IsMouseButtonDown(MouseButton.Left)).Returns(isMouseDown);
+        inputState.Setup(x => x.IsMouseButtonReleased(MouseButton.Left)).Returns(isMouseReleased);
+        return inputState;
+    }
+
+    private static bool HandleInput(UIButton button, IInputState inputState) =>
+        ReflectionHelpers.InvokePrivateMethod<bool>(button, "OnHandleInput", inputState);
+
+    private static Texture2D CreateTextureStub()
+    {
+#pragma warning disable SYSLIB0050
+        return (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+#pragma warning restore SYSLIB0050
+    }
+}

--- a/DTXMania.Test/UI/UILabelLogicTests.cs
+++ b/DTXMania.Test/UI/UILabelLogicTests.cs
@@ -1,0 +1,50 @@
+using DTXMania.Game.Lib.UI.Components;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Test.UI;
+
+[Trait("Category", "Unit")]
+public class UILabelLogicTests
+{
+    [Fact]
+    public void OutlineThickness_ShouldClampAtZero()
+    {
+        var label = new UILabel();
+
+        label.OutlineThickness = -5;
+
+        Assert.Equal(0, label.OutlineThickness);
+    }
+
+    [Fact]
+    public void Text_WhenSetToNull_ShouldBecomeEmptyString()
+    {
+        var label = new UILabel("before");
+
+        label.Text = null!;
+
+        Assert.Equal(string.Empty, label.Text);
+    }
+
+    [Theory]
+    [InlineData(TextAlignment.Left, TextAlignment.Top, 10f, 20f)]
+    [InlineData(TextAlignment.Center, TextAlignment.Center, 45f, 55f)]
+    [InlineData(TextAlignment.Right, TextAlignment.Bottom, 80f, 90f)]
+    public void CalculateTextPosition_ShouldHonorAlignment(TextAlignment horizontal, TextAlignment vertical, float expectedX, float expectedY)
+    {
+        var label = new UILabel
+        {
+            HorizontalAlignment = horizontal,
+            VerticalAlignment = vertical
+        };
+
+        var position = ReflectionHelpers.InvokePrivateMethod<Vector2>(
+            label,
+            "CalculateTextPosition",
+            new Rectangle(10, 20, 100, 80),
+            new Vector2(30, 10));
+
+        Assert.Equal(new Vector2(expectedX, expectedY), position);
+    }
+}


### PR DESCRIPTION
## Summary
- Add tests for ResultStage, SongTransitionStage, StartupStage, TitleStage
- Add tests for UI components: PreviewImagePanel, SongBar, SongStatusPanel, UIButton, UILabel
- Expand SongSelectionStageLogicTests and SongListDisplayLogicTests with comprehensive coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Significantly expanded unit-test coverage for stages and UI components, adding many failure-path, input, rendering, lifecycle, and disposal scenarios.
* **Bug Fixes**
  * Improved cleanup to dispose additional cached UI textures and managed resources.
  * Made preview audio playback and shutdown more robust to instance-creation and disposal edge cases.
* **Refactor**
  * Preview audio handling moved to an interface/wrapper-based approach for safer, platform-agnostic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->