### PR TITLE
test: raise full suite coverage to 5pt win

### DIFF
--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1529,11 +1529,19 @@ namespace DTXMania.Game.Lib.Stage
                 try
                 {
                     _backgroundMusicInstance.Stop();
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        $"SongSelectionStage.SetBackgroundMusic: Error stopping previous BGM instance: {ex.Message}");
+                }
+
+                try
+                {
                     _backgroundMusicInstance.Dispose();
                 }
                 catch (Exception ex)
                 {
-                    // Log but don't throw - cleanup should be best-effort
                     System.Diagnostics.Debug.WriteLine(
                         $"SongSelectionStage.SetBackgroundMusic: Error disposing previous BGM instance: {ex.Message}");
                 }

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1,10 +1,12 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.KeyAssign;
+using DTXMania.Game.Lib.Utilities;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework.Input;
 
@@ -122,6 +124,28 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void HandleInput_WhenMoveLeftPressedOnResolution_UpdatesWorkingConfigAndMarksChanges()
+    {
+        var (stage, configManager, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            configManager.Config.ScreenWidth = 1920;
+            configManager.Config.ScreenHeight = 1080;
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Left), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            var workingConfig = ReflectionHelpers.GetPrivateField<ConfigData>(stage, "_workingConfig");
+            Assert.NotNull(workingConfig);
+            Assert.Equal(1280, workingConfig!.ScreenWidth);
+            Assert.Equal(720, workingConfig.ScreenHeight);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+        }
+    }
+
+    [Fact]
     public void HandleInput_WhenActivatePressedOnToggleItem_TogglesWorkingFlag()
     {
         var (stage, configManager, inputManager) = CreateStage();
@@ -159,6 +183,226 @@ public class ConfigStageLogicTests
             Assert.NotNull(drumPanel);
             Assert.Same(drumPanel, activePanel);
             Assert.True(activePanel!.IsActive);
+        }
+    }
+
+    [Fact]
+    public void OnPanelSaved_WhenDrumPanelSaves_ShouldCaptureWorkingBindingsAndMarkUnsavedChanges()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+            var drumPanel = ReflectionHelpers.GetPrivateField<DrumKeyAssignPanel>(stage, "_drumPanel");
+            Assert.NotNull(drumPanel);
+
+            var updatedBindings = new KeyBindings();
+            updatedBindings.ClearAllBindings();
+            updatedBindings.BindButton("Key.Z", 6);
+            ReflectionHelpers.SetPrivateField(drumPanel!, "_workingBindings", updatedBindings);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnPanelSaved", drumPanel!, EventArgs.Empty);
+
+            var workingBindings = ReflectionHelpers.GetPrivateField<KeyBindings>(stage, "_workingDrumBindings");
+            Assert.NotNull(workingBindings);
+            Assert.Equal(6, workingBindings!.GetLane("Key.Z"));
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+        }
+    }
+
+    [Fact]
+    public void IsConfigNavigationCommandPressed_WhenInputManagerReportsPressed_ShouldReturnTrue()
+    {
+        var configManager = new ConfigManager();
+        using var inputManager = new ForcedCommandInputManager(configManager, InputCommandType.MoveUp);
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", configManager);
+        ReflectionHelpers.SetPrivateField(game, "<InputManager>k__BackingField", inputManager);
+        var stage = new ConfigStage(game);
+
+        InitializeStageMenu(stage, includePanels: false);
+
+        var result = (bool)ReflectionHelpers.InvokePrivateMethod(stage, "IsConfigNavigationCommandPressed", InputCommandType.MoveUp)!;
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HandleInput_WhenBackCommandPressed_ShouldReturnToTitleStage()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Moq.Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Escape), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    StageType.Title,
+                    Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
+                Moq.Times.Once);
+        }
+    }
+
+    [Fact]
+    public void HandleInput_WhenActivatePressedOnBackButton_ShouldReturnToTitleStage()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Moq.Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
+            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count);
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    StageType.Title,
+                    Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
+                Moq.Times.Once);
+        }
+    }
+
+    [Fact]
+    public void HandleInput_WhenActivatePressedOnSaveButton_ShouldApplyConfigurationAndTransitionToTitle()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Moq.Mock<IStageManager>();
+            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
+            var workingConfig = new ConfigData
+            {
+                ScreenWidth = 1920,
+                ScreenHeight = 1080,
+                FullScreen = true,
+                VSyncWait = false,
+                NoFail = true,
+                AutoPlay = true
+            };
+            var workingSystemBindings = new Dictionary<Keys, InputCommandType>
+            {
+                [Keys.W] = InputCommandType.MoveUp,
+                [Keys.S] = InputCommandType.MoveDown,
+                [Keys.A] = InputCommandType.MoveLeft,
+                [Keys.D] = InputCommandType.MoveRight,
+                [Keys.Enter] = InputCommandType.Activate,
+                [Keys.Escape] = InputCommandType.Back
+            };
+            var configManager = new RecordingConfigManager(new ConfigData());
+
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_configManager", configManager);
+            ReflectionHelpers.SetPrivateField(stage, "_workingConfig", workingConfig);
+            ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", new KeyBindings());
+            ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", workingSystemBindings);
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count + 1);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.Equal(AppPaths.GetConfigFilePath(), configManager.LastSavePath);
+            Assert.Equal(1920, configManager.Config.ScreenWidth);
+            Assert.Equal(1080, configManager.Config.ScreenHeight);
+            Assert.True(configManager.Config.FullScreen);
+            Assert.False(configManager.Config.VSyncWait);
+            Assert.True(configManager.Config.NoFail);
+            Assert.True(configManager.Config.AutoPlay);
+            Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+
+            var snapshot = inputManager.GetKeyMappingSnapshot();
+            Assert.Equal(workingSystemBindings.Count, snapshot.Count);
+            foreach (var (key, command) in workingSystemBindings)
+            {
+                Assert.True(snapshot.ContainsKey(key));
+                Assert.Equal(command, snapshot[key]);
+            }
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    StageType.Title,
+                    Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
+                Moq.Times.Once);
+        }
+    }
+
+    [Fact]
+    public void ApplyConfiguration_WhenSaveFails_ShouldRollBackConfigStateAndReturnFalse()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var originalConfig = new ConfigData
+            {
+                ScreenWidth = 1280,
+                ScreenHeight = 720,
+                FullScreen = false,
+                VSyncWait = true,
+                NoFail = false,
+                AutoPlay = false,
+                KeyBindings = new Dictionary<string, int> { ["Key.A"] = 0 },
+                UnboundDrumLanes = new HashSet<int> { 3 },
+                UnboundDrumButtons = new HashSet<string> { "Key.B" },
+                SystemKeyBindings = new Dictionary<string, string> { ["MoveUp"] = "Up" }
+            };
+            var workingConfig = new ConfigData
+            {
+                ScreenWidth = 2560,
+                ScreenHeight = 1440,
+                FullScreen = true,
+                VSyncWait = false,
+                NoFail = true,
+                AutoPlay = true
+            };
+            var configManager = new RecordingConfigManager(originalConfig, new IOException("disk full"));
+            var snapshotBefore = new Dictionary<Keys, InputCommandType>(inputManager.GetKeyMappingSnapshot());
+
+            ReflectionHelpers.SetPrivateField(stage, "_configManager", configManager);
+            ReflectionHelpers.SetPrivateField(stage, "_workingConfig", workingConfig);
+            ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", new KeyBindings());
+            ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", new Dictionary<Keys, InputCommandType>
+            {
+                [Keys.W] = InputCommandType.MoveUp,
+                [Keys.S] = InputCommandType.MoveDown
+            });
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+            var result = (bool)ReflectionHelpers.InvokePrivateMethod(stage, "ApplyConfiguration")!;
+
+            Assert.False(result);
+            Assert.Equal(AppPaths.GetConfigFilePath(), configManager.LastSavePath);
+            Assert.Equal(1280, configManager.Config.ScreenWidth);
+            Assert.Equal(720, configManager.Config.ScreenHeight);
+            Assert.False(configManager.Config.FullScreen);
+            Assert.True(configManager.Config.VSyncWait);
+            Assert.False(configManager.Config.NoFail);
+            Assert.False(configManager.Config.AutoPlay);
+            Assert.Equal(0, configManager.Config.KeyBindings["Key.A"]);
+            Assert.Contains(3, configManager.Config.UnboundDrumLanes);
+            Assert.Contains("Key.B", configManager.Config.UnboundDrumButtons);
+            Assert.Equal("Up", configManager.Config.SystemKeyBindings["MoveUp"]);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+
+            var snapshotAfter = inputManager.GetKeyMappingSnapshot();
+            Assert.Equal(snapshotBefore.Count, snapshotAfter.Count);
+            foreach (var (key, command) in snapshotBefore)
+            {
+                Assert.True(snapshotAfter.ContainsKey(key));
+                Assert.Equal(command, snapshotAfter[key]);
+            }
         }
     }
 
@@ -234,5 +478,53 @@ public class ConfigStageLogicTests
     {
         ReflectionHelpers.SetPrivateField(stage, "_currentKeyboardState", current);
         ReflectionHelpers.SetPrivateField(stage, "_previousKeyboardState", previous);
+    }
+
+    private sealed class RecordingConfigManager : IConfigManager
+    {
+        private readonly Exception? _saveException;
+
+        public RecordingConfigManager(ConfigData config, Exception? saveException = null)
+        {
+            Config = config;
+            _saveException = saveException;
+        }
+
+        public ConfigData Config { get; }
+
+        public string? LastSavePath { get; private set; }
+
+        public void LoadConfig(string filePath)
+        {
+        }
+
+        public void SaveConfig(string filePath)
+        {
+            LastSavePath = filePath;
+            if (_saveException != null)
+            {
+                throw _saveException;
+            }
+        }
+
+        public void ResetToDefaults()
+        {
+        }
+    }
+
+    private sealed class ForcedCommandInputManager : InputManagerCompat
+    {
+        private readonly InputCommandType _pressedCommand;
+
+        public ForcedCommandInputManager(ConfigManager configManager, InputCommandType pressedCommand)
+            : base(configManager)
+        {
+            _pressedCommand = pressedCommand;
+        }
+
+        public override bool IsCommandPressed(InputCommandType command)
+        {
+            return command == _pressedCommand;
+        }
     }
 }

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -68,7 +68,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenMoveUpPressedAtFirstItem_WrapsToSaveButton()
+    public void MoveUpPressedAtFirstItem_ShouldWrapToSaveButton()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -85,7 +85,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenMoveDownPressedAtSaveButton_WrapsToFirstItem()
+    public void MoveDownPressedAtSaveButton_ShouldWrapToFirstItem()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -102,7 +102,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenMoveRightPressedOnResolution_UpdatesWorkingConfigAndMarksChanges()
+    public void MoveRightPressedOnResolution_ShouldUpdateWorkingConfigAndMarkChanges()
     {
         var (stage, configManager, inputManager) = CreateStage();
         using (inputManager)
@@ -124,7 +124,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenMoveLeftPressedOnResolution_UpdatesWorkingConfigAndMarksChanges()
+    public void MoveLeftPressedOnResolution_ShouldUpdateWorkingConfigAndMarkChanges()
     {
         var (stage, configManager, inputManager) = CreateStage();
         using (inputManager)
@@ -146,7 +146,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenActivatePressedOnToggleItem_TogglesWorkingFlag()
+    public void ActivatePressedOnToggleItem_ShouldToggleWorkingFlag()
     {
         var (stage, configManager, inputManager) = CreateStage();
         using (inputManager)
@@ -166,7 +166,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenActivatePressedOnDrumKeyMapping_OpensAndActivatesPanel()
+    public void ActivatePressedOnDrumKeyMapping_ShouldOpenAndActivatePanel()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -187,7 +187,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void OnPanelSaved_WhenDrumPanelSaves_ShouldCaptureWorkingBindingsAndMarkUnsavedChanges()
+    public void DrumPanelSaves_ShouldCaptureWorkingBindingsAndMarkUnsavedChanges()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -211,13 +211,13 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void IsConfigNavigationCommandPressed_WhenInputManagerReportsPressed_ShouldReturnTrue()
+    public void InputManagerReportsPressed_ShouldReturnTrueForConfigNavigationCommand()
     {
         var configManager = new ConfigManager();
         using var inputManager = new ForcedCommandInputManager(configManager, InputCommandType.MoveUp);
         var game = ReflectionHelpers.CreateGame();
-        ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", configManager);
-        ReflectionHelpers.SetPrivateField(game, "<InputManager>k__BackingField", inputManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
         var stage = new ConfigStage(game);
 
         InitializeStageMenu(stage, includePanels: false);
@@ -228,7 +228,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenBackCommandPressed_ShouldReturnToTitleStage()
+    public void BackCommandPressed_ShouldReturnToTitleStage()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -250,7 +250,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenActivatePressedOnBackButton_ShouldReturnToTitleStage()
+    public void ActivatePressedOnBackButton_ShouldReturnToTitleStage()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -274,90 +274,109 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void HandleInput_WhenActivatePressedOnSaveButton_ShouldApplyConfigurationAndTransitionToTitle()
+    public void ActivatePressedOnSaveButton_ShouldApplyConfigurationAndTransitionToTitle()
     {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
+        var redirectedSavePath = CreateConfigSavePath();
+        var configManager = new RecordingConfigManager(new ConfigData(), redirectedSavePath: redirectedSavePath);
+
+        try
         {
-            InitializeStageMenu(stage, includePanels: false);
-            var stageManager = new Moq.Mock<IStageManager>();
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            var workingConfig = new ConfigData
+            var (stage, _, inputManager) = CreateStage(configManager);
+            using (inputManager)
             {
-                ScreenWidth = 1920,
-                ScreenHeight = 1080,
-                FullScreen = true,
-                VSyncWait = false,
-                NoFail = true,
-                AutoPlay = true
-            };
-            var workingSystemBindings = new Dictionary<Keys, InputCommandType>
-            {
-                [Keys.W] = InputCommandType.MoveUp,
-                [Keys.S] = InputCommandType.MoveDown,
-                [Keys.A] = InputCommandType.MoveLeft,
-                [Keys.D] = InputCommandType.MoveRight,
-                [Keys.Enter] = InputCommandType.Activate,
-                [Keys.Escape] = InputCommandType.Back
-            };
-            var configManager = new RecordingConfigManager(new ConfigData());
+                InitializeStageMenu(stage, includePanels: false);
+                var stageManager = new Moq.Mock<IStageManager>();
+                var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
+                var workingConfig = new ConfigData
+                {
+                    ScreenWidth = 1920,
+                    ScreenHeight = 1080,
+                    FullScreen = true,
+                    VSyncWait = false,
+                    NoFail = true,
+                    AutoPlay = true
+                };
+                var workingDrumBindings = CreateWorkingDrumBindings();
+                var workingSystemBindings = new Dictionary<Keys, InputCommandType>
+                {
+                    [Keys.W] = InputCommandType.MoveUp,
+                    [Keys.S] = InputCommandType.MoveDown,
+                    [Keys.A] = InputCommandType.MoveLeft,
+                    [Keys.D] = InputCommandType.MoveRight,
+                    [Keys.Enter] = InputCommandType.Activate,
+                    [Keys.Escape] = InputCommandType.Back
+                };
 
-            stage.StageManager = stageManager.Object;
-            ReflectionHelpers.SetPrivateField(stage, "_configManager", configManager);
-            ReflectionHelpers.SetPrivateField(stage, "_workingConfig", workingConfig);
-            ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", new KeyBindings());
-            ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", workingSystemBindings);
-            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count + 1);
-            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+                stage.StageManager = stageManager.Object;
+                ReflectionHelpers.SetPrivateField(stage, "_workingConfig", workingConfig);
+                ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", workingDrumBindings);
+                ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", workingSystemBindings);
+                ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+                ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count + 1);
+                SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
-            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+                ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
-            Assert.Equal(AppPaths.GetConfigFilePath(), configManager.LastSavePath);
-            Assert.Equal(1920, configManager.Config.ScreenWidth);
-            Assert.Equal(1080, configManager.Config.ScreenHeight);
-            Assert.True(configManager.Config.FullScreen);
-            Assert.False(configManager.Config.VSyncWait);
-            Assert.True(configManager.Config.NoFail);
-            Assert.True(configManager.Config.AutoPlay);
-            Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+                Assert.Equal(AppPaths.GetConfigFilePath(), configManager.LastSavePath);
+                Assert.Equal(1920, configManager.Config.ScreenWidth);
+                Assert.Equal(1080, configManager.Config.ScreenHeight);
+                Assert.True(configManager.Config.FullScreen);
+                Assert.False(configManager.Config.VSyncWait);
+                Assert.True(configManager.Config.NoFail);
+                Assert.True(configManager.Config.AutoPlay);
+                Assert.Equal(4, configManager.Config.KeyBindings["Key.Z"]);
+                Assert.DoesNotContain("Key.S", configManager.Config.KeyBindings.Keys);
+                Assert.Contains(0, configManager.Config.UnboundDrumLanes);
+                Assert.Contains("Key.S", configManager.Config.UnboundDrumButtons);
+                Assert.Equal("W", configManager.Config.SystemKeyBindings["SystemKey.MoveUp"]);
+                Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
 
-            var snapshot = inputManager.GetKeyMappingSnapshot();
-            Assert.Equal(workingSystemBindings.Count, snapshot.Count);
-            foreach (var (key, command) in workingSystemBindings)
-            {
-                Assert.True(snapshot.ContainsKey(key));
-                Assert.Equal(command, snapshot[key]);
+                Assert.Equal(4, inputManager.ModularInputManager.KeyBindings.GetLane("Key.Z"));
+                Assert.Equal(-1, inputManager.ModularInputManager.KeyBindings.GetLane("Key.A"));
+                Assert.Equal(-1, inputManager.ModularInputManager.KeyBindings.GetLane("Key.S"));
+
+                var snapshot = inputManager.GetKeyMappingSnapshot();
+                Assert.Equal(workingSystemBindings.Count, snapshot.Count);
+                foreach (var (key, command) in workingSystemBindings)
+                {
+                    Assert.True(snapshot.ContainsKey(key));
+                    Assert.Equal(command, snapshot[key]);
+                }
+
+                stageManager.Verify(
+                    manager => manager.ChangeStage(
+                        StageType.Title,
+                        Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
+                    Moq.Times.Once);
             }
-
-            stageManager.Verify(
-                manager => manager.ChangeStage(
-                    StageType.Title,
-                    Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
-                Moq.Times.Once);
+        }
+        finally
+        {
+            DeleteConfigSavePath(redirectedSavePath);
         }
     }
 
     [Fact]
-    public void ApplyConfiguration_WhenSaveFails_ShouldRollBackConfigStateAndReturnFalse()
+    public void SaveFailure_ShouldRollBackConfigStateAndReturnFalse()
     {
-        var (stage, _, inputManager) = CreateStage();
+        var configManager = new RecordingConfigManager(originalConfig: new ConfigData
+        {
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            FullScreen = false,
+            VSyncWait = true,
+            NoFail = false,
+            AutoPlay = false,
+            KeyBindings = new Dictionary<string, int> { ["Key.A"] = 0 },
+            UnboundDrumLanes = new HashSet<int> { 3 },
+            UnboundDrumButtons = new HashSet<string> { "Key.B" },
+            SystemKeyBindings = new Dictionary<string, string> { ["SystemKey.MoveUp"] = "Up" }
+        }, saveException: new IOException("disk full"));
+        var (stage, _, inputManager) = CreateStage(configManager);
+
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
-            var originalConfig = new ConfigData
-            {
-                ScreenWidth = 1280,
-                ScreenHeight = 720,
-                FullScreen = false,
-                VSyncWait = true,
-                NoFail = false,
-                AutoPlay = false,
-                KeyBindings = new Dictionary<string, int> { ["Key.A"] = 0 },
-                UnboundDrumLanes = new HashSet<int> { 3 },
-                UnboundDrumButtons = new HashSet<string> { "Key.B" },
-                SystemKeyBindings = new Dictionary<string, string> { ["MoveUp"] = "Up" }
-            };
             var workingConfig = new ConfigData
             {
                 ScreenWidth = 2560,
@@ -367,12 +386,11 @@ public class ConfigStageLogicTests
                 NoFail = true,
                 AutoPlay = true
             };
-            var configManager = new RecordingConfigManager(originalConfig, new IOException("disk full"));
+            var workingDrumBindings = CreateWorkingDrumBindings();
             var snapshotBefore = new Dictionary<Keys, InputCommandType>(inputManager.GetKeyMappingSnapshot());
 
-            ReflectionHelpers.SetPrivateField(stage, "_configManager", configManager);
             ReflectionHelpers.SetPrivateField(stage, "_workingConfig", workingConfig);
-            ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", new KeyBindings());
+            ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", workingDrumBindings);
             ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", new Dictionary<Keys, InputCommandType>
             {
                 [Keys.W] = InputCommandType.MoveUp,
@@ -391,9 +409,10 @@ public class ConfigStageLogicTests
             Assert.False(configManager.Config.NoFail);
             Assert.False(configManager.Config.AutoPlay);
             Assert.Equal(0, configManager.Config.KeyBindings["Key.A"]);
+            Assert.DoesNotContain("Key.Z", configManager.Config.KeyBindings.Keys);
             Assert.Contains(3, configManager.Config.UnboundDrumLanes);
             Assert.Contains("Key.B", configManager.Config.UnboundDrumButtons);
-            Assert.Equal("Up", configManager.Config.SystemKeyBindings["MoveUp"]);
+            Assert.Equal("Up", configManager.Config.SystemKeyBindings["SystemKey.MoveUp"]);
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
 
             var snapshotAfter = inputManager.GetKeyMappingSnapshot();
@@ -407,7 +426,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void OnDeactivate_WhenPanelIsActive_DeactivatesPanelAndClearsKeyboardState()
+    public void PanelIsActiveOnDeactivate_ShouldDeactivatePanelAndClearKeyboardState()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -452,14 +471,72 @@ public class ConfigStageLogicTests
         Assert.Equal(InputCommandType.Activate, snapshot[Keys.F]);
     }
 
-    private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage()
+    private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
     {
-        var configManager = new ConfigManager();
+        configManager ??= new ConfigManager();
         var inputManager = new InputManagerCompat(configManager);
         var game = ReflectionHelpers.CreateGame();
-        ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", configManager);
-        ReflectionHelpers.SetPrivateField(game, "<InputManager>k__BackingField", inputManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
         return (new ConfigStage(game), configManager, inputManager);
+    }
+
+    private static KeyBindings CreateWorkingDrumBindings()
+    {
+        var workingDrumBindings = new KeyBindings();
+        workingDrumBindings.UnbindLane(0);
+        workingDrumBindings.UnbindLane(4);
+        workingDrumBindings.BindButton("Key.Z", 4);
+        return workingDrumBindings;
+    }
+
+    private static string CreateConfigSavePath()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "TestResults",
+            "config-stage-logic",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "Config.ini");
+    }
+
+    private static void DeleteConfigSavePath(string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static void CopyConfigData(ConfigData target, ConfigData source)
+    {
+        target.DTXManiaVersion = source.DTXManiaVersion;
+        target.SkinPath = source.SkinPath;
+        target.DTXPath = source.DTXPath;
+        target.UseBoxDefSkin = source.UseBoxDefSkin;
+        target.SystemSkinRoot = source.SystemSkinRoot;
+        target.LastUsedSkin = source.LastUsedSkin;
+        target.ScreenWidth = source.ScreenWidth;
+        target.ScreenHeight = source.ScreenHeight;
+        target.FullScreen = source.FullScreen;
+        target.VSyncWait = source.VSyncWait;
+        target.MasterVolume = source.MasterVolume;
+        target.BGMVolume = source.BGMVolume;
+        target.SEVolume = source.SEVolume;
+        target.BufferSizeMs = source.BufferSizeMs;
+        target.ScrollSpeed = source.ScrollSpeed;
+        target.AutoPlay = source.AutoPlay;
+        target.NoFail = source.NoFail;
+        target.EnableGameApi = source.EnableGameApi;
+        target.GameApiPort = source.GameApiPort;
+        target.GameApiKey = source.GameApiKey;
+
+        target.KeyBindings = new Dictionary<string, int>(source.KeyBindings);
+        target.UnboundDrumLanes = new HashSet<int>(source.UnboundDrumLanes);
+        target.UnboundDrumButtons = new HashSet<string>(source.UnboundDrumButtons);
+        target.SystemKeyBindings = new Dictionary<string, string>(source.SystemKeyBindings);
     }
 
     private static void InitializeStageMenu(ConfigStage stage, bool includePanels)
@@ -480,35 +557,32 @@ public class ConfigStageLogicTests
         ReflectionHelpers.SetPrivateField(stage, "_previousKeyboardState", previous);
     }
 
-    private sealed class RecordingConfigManager : IConfigManager
+    private sealed class RecordingConfigManager : ConfigManager, IConfigManager
     {
         private readonly Exception? _saveException;
+        private readonly string? _redirectedSavePath;
 
-        public RecordingConfigManager(ConfigData config, Exception? saveException = null)
+        public RecordingConfigManager(ConfigData originalConfig, Exception? saveException = null, string? redirectedSavePath = null)
         {
-            Config = config;
             _saveException = saveException;
+            _redirectedSavePath = redirectedSavePath;
+            CopyConfigData(Config, originalConfig);
         }
-
-        public ConfigData Config { get; }
 
         public string? LastSavePath { get; private set; }
 
-        public void LoadConfig(string filePath)
-        {
-        }
+        public new void SaveConfig(string filePath)
+            => ((IConfigManager)this).SaveConfig(filePath);
 
-        public void SaveConfig(string filePath)
+        void IConfigManager.SaveConfig(string filePath)
         {
             LastSavePath = filePath;
             if (_saveException != null)
             {
                 throw _saveException;
             }
-        }
 
-        public void ResetToDefaults()
-        {
+            base.SaveConfig(_redirectedSavePath ?? filePath);
         }
     }
 

--- a/DTXMania.Test/DTXMania.Test.Mac.csproj
+++ b/DTXMania.Test/DTXMania.Test.Mac.csproj
@@ -30,7 +30,7 @@
 
   <!-- Include all source files except problematic graphics tests -->
   <ItemGroup>
-    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongStatusPanelTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs" />
+    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongStatusPanelTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Stage/Performance/PooledEffectsManagerTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs" />
   </ItemGroup>
 
   <!-- Include xunit configuration if it exists -->

--- a/DTXMania.Test/Resources/ManagedFontLogicTests.cs
+++ b/DTXMania.Test/Resources/ManagedFontLogicTests.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+
+namespace DTXMania.Test.Resources;
+
+[Trait("Category", "Unit")]
+public class ManagedFontLogicTests
+{
+    [Fact]
+    public void InitializeFontFactory_WhenContentManagerIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => ManagedFont.InitializeFontFactory(null!));
+    }
+
+    [Fact]
+    public void CreateFont_WhenFactoryIsNotInitialized_ShouldThrowInvalidOperationException()
+    {
+        var state = CaptureFontFactoryState();
+
+        try
+        {
+            RestoreFontFactoryState(contentManager: null, defaultFont: null, loadedFonts: new Dictionary<string, SpriteFont>());
+
+            var exception = Assert.Throws<InvalidOperationException>(() => ManagedFont.CreateFont((GraphicsDevice)null!, "Arial", 16));
+            Assert.Contains("Font factory not initialized", exception.Message);
+        }
+        finally
+        {
+            RestoreFontFactoryState(state.ContentManager, state.DefaultFont, state.LoadedFonts);
+        }
+    }
+
+    [Fact]
+    public void Constructor_WithUninitializedSpriteFont_ShouldBuildCharacterCacheAndUseUnknownSourcePath()
+    {
+        var spriteFont = CreateUninitializedSpriteFont();
+
+        var font = new ManagedFont(spriteFont, null!, 18);
+
+        Assert.Same(spriteFont, font.SpriteFont);
+        Assert.Equal("Unknown", font.SourcePath);
+        Assert.Equal(18, font.Size);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(font, "_characterCacheBuilt"));
+        Assert.False(font.SupportsCharacter('A'));
+    }
+
+    [Fact]
+    public void CreateFont_WithExistingSpriteFont_ShouldUseLineSpacingAsFontSize()
+    {
+        var spriteFont = CreateUninitializedSpriteFont(lineSpacing: 28);
+
+        var font = ManagedFont.CreateFont(spriteFont, "ExistingFont");
+
+        Assert.Same(spriteFont, font.SpriteFont);
+        Assert.Equal("ExistingFont", font.SourcePath);
+        Assert.Equal(28, font.Size);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(font, "_characterCacheBuilt"));
+    }
+
+    [Fact]
+    public void CreateFont_WhenClosestCachedSpriteFontExists_ShouldReuseCachedFont()
+    {
+        var state = CaptureFontFactoryState();
+        var spriteFont = CreateUninitializedSpriteFont();
+#pragma warning disable SYSLIB0050
+        var contentManager = (ContentManager)FormatterServices.GetUninitializedObject(typeof(ContentManager));
+#pragma warning restore SYSLIB0050
+
+        try
+        {
+            RestoreFontFactoryState(
+                contentManager,
+                defaultFont: null,
+                loadedFonts: new Dictionary<string, SpriteFont> { ["NotoSerifJP-24"] = spriteFont });
+
+            var font = ManagedFont.CreateFont((GraphicsDevice)null!, "CachedFont", 20, FontStyle.Bold);
+
+            Assert.Same(spriteFont, font.SpriteFont);
+            Assert.Equal("CachedFont", font.SourcePath);
+            Assert.Equal(20, font.Size);
+            Assert.Equal(FontStyle.Bold, font.Style);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(font, "_characterCacheBuilt"));
+        }
+        finally
+        {
+            RestoreFontFactoryState(state.ContentManager, state.DefaultFont, state.LoadedFonts);
+        }
+    }
+
+    [Fact]
+    public void SupportsCharacter_WhenDisposed_ShouldReturnFalse()
+    {
+        var font = CreateManagedFont();
+        ReflectionHelpers.SetPrivateField(font, "_disposed", true);
+
+        Assert.False(font.SupportsCharacter('A'));
+    }
+
+    [Fact]
+    public void SupportsCharacter_WithCustomCharacterSet_ShouldBuildCacheAndReturnMembership()
+    {
+        var font = CreateManagedFont(customCharacters: new HashSet<char> { 'A', 'B', '?' });
+
+        Assert.True(font.SupportsCharacter('A'));
+        Assert.False(font.SupportsCharacter('Z'));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(font, "_characterCacheBuilt"));
+    }
+
+    [Fact]
+    public void AddReferenceAndRemoveReference_ShouldTrackReferenceCountAndDisposeAtZero()
+    {
+        var font = CreateManagedFont();
+
+        font.AddReference();
+        font.AddReference();
+        Assert.Equal(2, font.ReferenceCount);
+
+        font.RemoveReference();
+        Assert.Equal(1, font.ReferenceCount);
+        Assert.False(font.IsDisposed);
+
+        font.RemoveReference();
+        Assert.True(font.IsDisposed);
+    }
+
+    [Fact]
+    public void AddReference_WhenDisposed_ShouldThrowObjectDisposedException()
+    {
+        var font = CreateManagedFont();
+        ReflectionHelpers.SetPrivateField(font, "_disposed", true);
+
+        Assert.Throws<ObjectDisposedException>(() => font.AddReference());
+    }
+
+    [Fact]
+    public void MeasureString_WhenUsingCustomGlyphs_ShouldRespectGlyphWidthsAndNewlines()
+    {
+        var font = CreateManagedFont(
+            customCharacters: new HashSet<char> { 'A', 'B' },
+            glyphs: new Dictionary<char, Rectangle>
+            {
+                ['A'] = new Rectangle(0, 0, 10, 16),
+                ['B'] = new Rectangle(10, 0, 12, 16)
+            },
+            lineSpacing: 16);
+
+        var size = font.MeasureString("AB\nC");
+
+        Assert.Equal(new Vector2(22, 32), size);
+    }
+
+    [Fact]
+    public void MeasureString_WhenDisposedOrTextEmpty_ShouldReturnZero()
+    {
+        var font = CreateManagedFont();
+
+        Assert.Equal(Vector2.Zero, font.MeasureString(string.Empty));
+
+        ReflectionHelpers.SetPrivateField(font, "_disposed", true);
+        Assert.Equal(Vector2.Zero, font.MeasureString("text"));
+    }
+
+    [Fact]
+    public void SanitizeText_ShouldReplaceUnsupportedCharactersUsingFallbackRules()
+    {
+        var font = CreateManagedFont(customCharacters: new HashSet<char> { 'A', '?', '.', '-', '"', '\'', 'ア' });
+
+        var sanitized = InvokePrivate<string>(font, "SanitizeText", "Ａ…—“あ");
+
+        Assert.Equal("A.-\"ア", sanitized);
+    }
+
+    [Fact]
+    public void GetCharacterReplacement_ShouldUseHiraganaKatakanaAndHalfwidthFallbacks()
+    {
+        var font = CreateManagedFont(customCharacters: new HashSet<char> { 'ア', 'あ', 'A', '?', '.' });
+
+        Assert.Equal('ア', InvokePrivate<char>(font, "GetCharacterReplacement", 'あ'));
+        Assert.Equal('あ', InvokePrivate<char>(font, "GetCharacterReplacement", 'ア'));
+        Assert.Equal('A', InvokePrivate<char>(font, "GetCharacterReplacement", 'Ａ'));
+        Assert.Equal('.', InvokePrivate<char>(font, "GetCharacterReplacement", '…'));
+        Assert.Equal('?', InvokePrivate<char>(font, "GetCharacterReplacement", '漢'));
+    }
+
+    [Fact]
+    public void WrapText_ShouldSplitOnWordBoundariesUsingMeasuredWidth()
+    {
+        var font = CreateManagedFont(
+            customCharacters: new HashSet<char> { 'A', 'B', 'C' },
+            glyphs: new Dictionary<char, Rectangle>
+            {
+                ['A'] = new Rectangle(0, 0, 10, 16),
+                ['B'] = new Rectangle(10, 0, 10, 16),
+                ['C'] = new Rectangle(20, 0, 10, 16)
+            });
+
+        var lines = InvokePrivate<List<string>>(font, "WrapText", "AA BB CCC", 30f);
+
+        Assert.Equal(["AA", "BB", "CCC"], lines);
+    }
+
+    [Fact]
+    public void DrawString_WhenUsingCustomGlyphsAndSpriteBatchIsNull_ShouldSwallowCustomRenderErrors()
+    {
+        var font = CreateManagedFont(
+            customCharacters: new HashSet<char> { 'A', '?' },
+            glyphs: new Dictionary<char, Rectangle>
+            {
+                ['A'] = new Rectangle(0, 0, 10, 16),
+                ['?'] = new Rectangle(10, 0, 8, 16)
+            });
+
+        var exception = Record.Exception(() => font.DrawString(null!, "AA?", Vector2.Zero, Color.White));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void CreateTextTexture_WithLegacyOverload_ShouldThrowInvalidOperationException()
+    {
+        var font = CreateManagedFont();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => font.CreateTextTexture(null!, "text", new TextRenderOptions()));
+        Assert.Contains("shared RenderTarget", exception.Message);
+    }
+
+    [Fact]
+    public void CreateTextTexture_WithMissingSpriteFontOrEmptyText_ShouldReturnNull()
+    {
+        var font = CreateManagedFont();
+
+        Assert.Null(font.CreateTextTexture(null!, "text", new TextRenderOptions(), null!));
+        Assert.Null(font.CreateTextTexture(null!, string.Empty, new TextRenderOptions(), null!));
+    }
+
+    [Fact]
+    public void CreateTextTexture_WhenSharedRenderTargetIsNullAndSpriteFontExists_ShouldThrowArgumentNullException()
+    {
+        var font = CreateManagedFont();
+#pragma warning disable SYSLIB0050
+        var spriteFont = (SpriteFont)FormatterServices.GetUninitializedObject(typeof(SpriteFont));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(font, "_spriteFont", spriteFont);
+
+        Assert.Throws<ArgumentNullException>(() => font.CreateTextTexture(null!, "text", new TextRenderOptions(), null!));
+    }
+
+    [Fact]
+    public void GenerateCacheKey_ShouldReflectTextAndRenderOptions()
+    {
+        var font = CreateManagedFont();
+        var optionsA = new TextRenderOptions { TextColor = Color.Red, EnableOutline = true, OutlineThickness = 2 };
+        var optionsB = new TextRenderOptions { TextColor = Color.Blue, EnableOutline = true, OutlineThickness = 2 };
+
+        var keyA = InvokePrivate<string>(font, "GenerateCacheKey", "text", optionsA);
+        var keyB = InvokePrivate<string>(font, "GenerateCacheKey", "text", optionsB);
+
+        Assert.NotEqual(keyA, keyB);
+        Assert.Contains("text", keyA);
+    }
+
+    [Fact]
+    public void CacheTextTexture_ThenDispose_ShouldDisposeCachedTextures()
+    {
+        var font = CreateManagedFont();
+        var texture = new Mock<ITexture>();
+        var options = new TextRenderOptions { TextColor = Color.Gold };
+
+        InvokePrivate<object?>(font, "CacheTextTexture", "key", "text", texture.Object, options);
+        font.Dispose();
+
+        texture.Verify(x => x.Dispose(), Times.Once);
+        Assert.True(font.IsDisposed);
+    }
+
+    [Fact]
+    public void LoadFont_DefaultImplementation_ShouldThrowNotSupportedException()
+    {
+        var font = CreateManagedFont();
+        var exception = Assert.Throws<TargetInvocationException>(() => InvokePrivate<object?>(font, "LoadFont", null!, "font.ttf", 18, FontStyle.Regular));
+
+        Assert.IsType<NotSupportedException>(exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData("font.ttf", true)]
+    [InlineData("font.otf", true)]
+    [InlineData("font.ttc", true)]
+    [InlineData("font.spritefont", true)]
+    [InlineData("font.png", false)]
+    public void IsSupportedFontFile_ShouldRecognizeExpectedExtensions(string path, bool expected)
+    {
+        var font = CreateManagedFont();
+
+        var result = InvokePrivate<bool>(font, "IsSupportedFontFile", path);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void TryDrawCharacter_AndIsJapaneseCharacter_ShouldRecognizeJapaneseRanges()
+    {
+        var font = CreateManagedFont();
+
+        Assert.True(InvokePrivate<bool>(font, "TryDrawCharacter", 'あ'));
+        Assert.False(InvokePrivate<bool>(font, "TryDrawCharacter", 'A'));
+        Assert.True(InvokePrivate<bool>(font, "IsJapaneseCharacter", '漢'));
+        Assert.False(InvokePrivate<bool>(font, "IsJapaneseCharacter", 'A'));
+    }
+
+    [Fact]
+    public void GetKerning_ShouldAlwaysReturnZero()
+    {
+        var font = CreateManagedFont();
+
+        Assert.Equal(Vector2.Zero, font.GetKerning('A', 'V'));
+    }
+
+    private static ManagedFont CreateManagedFont(
+        HashSet<char>? customCharacters = null,
+        Dictionary<char, Rectangle>? glyphs = null,
+        int lineSpacing = 16,
+        bool includeCustomTexture = true)
+    {
+#pragma warning disable SYSLIB0050
+        var font = (ManagedFont)FormatterServices.GetUninitializedObject(typeof(ManagedFont));
+        var customTexture = includeCustomTexture
+            ? (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D))
+            : null;
+#pragma warning restore SYSLIB0050
+
+        ReflectionHelpers.SetPrivateField(font, "_spriteFont", null);
+        ReflectionHelpers.SetPrivateField(font, "_sourcePath", "TestFont");
+        ReflectionHelpers.SetPrivateField(font, "_size", 16);
+        ReflectionHelpers.SetPrivateField(font, "_style", FontStyle.Regular);
+        ReflectionHelpers.SetPrivateField(font, "_referenceCount", 0);
+        ReflectionHelpers.SetPrivateField(font, "_disposed", false);
+        ReflectionHelpers.SetPrivateField(font, "_lockObject", new object());
+        ReflectionHelpers.SetPrivateField(font, "_defaultCharacter", '?');
+        ReflectionHelpers.SetPrivateField(font, "_supportedCharacters", new HashSet<char>());
+        ReflectionHelpers.SetPrivateField(font, "_characterCacheBuilt", false);
+        ReflectionHelpers.SetPrivateField(font, "_customFontTexture", customTexture);
+        ReflectionHelpers.SetPrivateField(font, "_customFontGlyphs", glyphs ?? new Dictionary<char, Rectangle>());
+        ReflectionHelpers.SetPrivateField(font, "_customFontCharacters", customCharacters ?? new HashSet<char>());
+        ReflectionHelpers.SetPrivateField(font, "_customLineSpacing", lineSpacing);
+
+        var cacheField = typeof(ManagedFont).GetField("_textRenderCache", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(cacheField);
+        cacheField!.SetValue(font, Activator.CreateInstance(cacheField.FieldType));
+
+        return font;
+    }
+
+    private static SpriteFont CreateUninitializedSpriteFont(int lineSpacing = 0)
+    {
+#pragma warning disable SYSLIB0050
+        var spriteFont = (SpriteFont)FormatterServices.GetUninitializedObject(typeof(SpriteFont));
+#pragma warning restore SYSLIB0050
+
+        var lineSpacingField = typeof(SpriteFont).GetField("<LineSpacing>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(lineSpacingField);
+        lineSpacingField!.SetValue(spriteFont, lineSpacing);
+
+        return spriteFont;
+    }
+
+    private static T InvokePrivate<T>(object target, string methodName, params object?[] args)
+    {
+        var method = typeof(ManagedFont).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(target, args)!;
+    }
+
+    private static (ContentManager? ContentManager, SpriteFont? DefaultFont, Dictionary<string, SpriteFont> LoadedFonts) CaptureFontFactoryState()
+    {
+        var contentField = typeof(ManagedFont).GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic);
+        var defaultField = typeof(ManagedFont).GetField("_defaultFont", BindingFlags.Static | BindingFlags.NonPublic);
+        var loadedFontsField = typeof(ManagedFont).GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(contentField);
+        Assert.NotNull(defaultField);
+        Assert.NotNull(loadedFontsField);
+
+        var loadedFonts = (Dictionary<string, SpriteFont>)loadedFontsField!.GetValue(null)!;
+        return (
+            (ContentManager?)contentField!.GetValue(null),
+            (SpriteFont?)defaultField!.GetValue(null),
+            new Dictionary<string, SpriteFont>(loadedFonts));
+    }
+
+    private static void RestoreFontFactoryState(ContentManager? contentManager, SpriteFont? defaultFont, Dictionary<string, SpriteFont> loadedFonts)
+    {
+        var contentField = typeof(ManagedFont).GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic);
+        var defaultField = typeof(ManagedFont).GetField("_defaultFont", BindingFlags.Static | BindingFlags.NonPublic);
+        var loadedFontsField = typeof(ManagedFont).GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic);
+
+        Assert.NotNull(contentField);
+        Assert.NotNull(defaultField);
+        Assert.NotNull(loadedFontsField);
+
+        contentField!.SetValue(null, contentManager);
+        defaultField!.SetValue(null, defaultFont);
+
+        var targetLoadedFonts = (Dictionary<string, SpriteFont>)loadedFontsField!.GetValue(null)!;
+        targetLoadedFonts.Clear();
+        foreach (var (key, value) in loadedFonts)
+        {
+            targetLoadedFonts[key] = value;
+        }
+    }
+}

--- a/DTXMania.Test/Resources/ManagedFontLogicTests.cs
+++ b/DTXMania.Test/Resources/ManagedFontLogicTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
@@ -11,6 +11,7 @@ using Moq;
 
 namespace DTXMania.Test.Resources;
 
+[Collection("ManagedFont")]
 [Trait("Category", "Unit")]
 public class ManagedFontLogicTests
 {
@@ -70,9 +71,7 @@ public class ManagedFontLogicTests
     {
         var state = CaptureFontFactoryState();
         var spriteFont = CreateUninitializedSpriteFont();
-#pragma warning disable SYSLIB0050
-        var contentManager = (ContentManager)FormatterServices.GetUninitializedObject(typeof(ContentManager));
-#pragma warning restore SYSLIB0050
+        var contentManager = (ContentManager)RuntimeHelpers.GetUninitializedObject(typeof(ContentManager));
 
         try
         {
@@ -245,9 +244,7 @@ public class ManagedFontLogicTests
     public void CreateTextTexture_WhenSharedRenderTargetIsNullAndSpriteFontExists_ShouldThrowArgumentNullException()
     {
         var font = CreateManagedFont();
-#pragma warning disable SYSLIB0050
-        var spriteFont = (SpriteFont)FormatterServices.GetUninitializedObject(typeof(SpriteFont));
-#pragma warning restore SYSLIB0050
+        var spriteFont = (SpriteFont)RuntimeHelpers.GetUninitializedObject(typeof(SpriteFont));
         ReflectionHelpers.SetPrivateField(font, "_spriteFont", spriteFont);
 
         Assert.Throws<ArgumentNullException>(() => font.CreateTextTexture(null!, "text", new TextRenderOptions(), null!));
@@ -330,12 +327,10 @@ public class ManagedFontLogicTests
         int lineSpacing = 16,
         bool includeCustomTexture = true)
     {
-#pragma warning disable SYSLIB0050
-        var font = (ManagedFont)FormatterServices.GetUninitializedObject(typeof(ManagedFont));
+        var font = (ManagedFont)RuntimeHelpers.GetUninitializedObject(typeof(ManagedFont));
         var customTexture = includeCustomTexture
-            ? (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D))
+            ? (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D))
             : null;
-#pragma warning restore SYSLIB0050
 
         ReflectionHelpers.SetPrivateField(font, "_spriteFont", null);
         ReflectionHelpers.SetPrivateField(font, "_sourcePath", "TestFont");
@@ -359,17 +354,50 @@ public class ManagedFontLogicTests
         return font;
     }
 
+    // SpriteFont's LineSpacing storage differs across MonoGame/compiler builds, so the helper
+    // verifies the runtime member shape before setting it instead of assuming one backing-field name.
     private static SpriteFont CreateUninitializedSpriteFont(int lineSpacing = 0)
     {
-#pragma warning disable SYSLIB0050
-        var spriteFont = (SpriteFont)FormatterServices.GetUninitializedObject(typeof(SpriteFont));
-#pragma warning restore SYSLIB0050
+        var spriteFont = (SpriteFont)RuntimeHelpers.GetUninitializedObject(typeof(SpriteFont));
+        var bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
 
-        var lineSpacingField = typeof(SpriteFont).GetField("<LineSpacing>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(lineSpacingField);
-        lineSpacingField!.SetValue(spriteFont, lineSpacing);
+        foreach (var fieldName in new[] { "<LineSpacing>k__BackingField", "LineSpacing", "_lineSpacing", "lineSpacing" })
+        {
+            var lineSpacingField = typeof(SpriteFont).GetField(fieldName, bindingFlags);
+            if (lineSpacingField?.FieldType == typeof(int))
+            {
+                lineSpacingField.SetValue(spriteFont, lineSpacing);
+                return spriteFont;
+            }
+        }
 
-        return spriteFont;
+        var fallbackField = typeof(SpriteFont)
+            .GetFields(bindingFlags)
+            .FirstOrDefault(field =>
+                field.FieldType == typeof(int) &&
+                field.Name.Contains("LineSpacing", StringComparison.OrdinalIgnoreCase));
+        if (fallbackField != null)
+        {
+            fallbackField.SetValue(spriteFont, lineSpacing);
+            return spriteFont;
+        }
+
+        var property = typeof(SpriteFont).GetProperty("LineSpacing", bindingFlags);
+        var setter = property?.GetSetMethod(nonPublic: true);
+        if (property?.PropertyType == typeof(int) && setter != null)
+        {
+            setter.Invoke(spriteFont, new object[] { lineSpacing });
+            return spriteFont;
+        }
+
+        var availableMembers = string.Join(
+            ", ",
+            typeof(SpriteFont)
+                .GetMembers(bindingFlags)
+                .Where(member => member.MemberType is MemberTypes.Field or MemberTypes.Property)
+                .Select(member => $"{member.MemberType}:{member.Name}"));
+        throw new InvalidOperationException(
+            $"Unable to initialize SpriteFont.LineSpacing. Expected a writable field or property matching LineSpacing. Available members: {availableMembers}");
     }
 
     private static T InvokePrivate<T>(object target, string methodName, params object?[] args)

--- a/DTXMania.Test/Resources/ManagedSpriteTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedSpriteTextureTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Xunit;
+
+namespace DTXMania.Test.Resources
+{
+    [Trait("Category", "Unit")]
+    public class ManagedSpriteTextureTests
+    {
+        [Fact]
+        public void PropertyAndIndexHelpers_ShouldReturnExpectedValues()
+        {
+            var texture = CreateSpriteTexture(spriteWidth: 16, spriteHeight: 8, spritesPerRow: 4, totalSprites: 16);
+
+            Assert.Equal(16, texture.SpriteWidth);
+            Assert.Equal(8, texture.SpriteHeight);
+            Assert.Equal(4, texture.SpritesPerRow);
+            Assert.Equal(16, texture.TotalSprites);
+            Assert.Equal(new Vector2(16, 8), texture.SpriteSize);
+
+            Assert.Equal(new Rectangle(16, 8, 16, 8), texture.GetSpriteSourceRectangle(5));
+            Assert.Equal((1, 2), texture.GetRowCol(6));
+            Assert.Equal(11, texture.GetSpriteIndex(2, 3));
+        }
+
+        [Fact]
+        public void IndexHelpers_WhenValuesAreOutOfRange_ShouldThrow()
+        {
+            var texture = CreateSpriteTexture(spriteWidth: 16, spriteHeight: 8, spritesPerRow: 4, totalSprites: 16);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteSourceRectangle(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteSourceRectangle(16));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteSourceRectangle(0, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteSourceRectangle(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteSourceRectangle(0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetRowCol(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetRowCol(16));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteIndex(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteIndex(0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => texture.GetSpriteIndex(0, 4));
+        }
+
+        [Fact]
+        public void DrawSpriteOverloads_WhenTextureIsNull_ShouldReturnWithoutThrowing()
+        {
+            var texture = CreateSpriteTexture(spriteWidth: 16, spriteHeight: 8, spritesPerRow: 4, totalSprites: 16);
+
+            var exception = Record.Exception(() =>
+            {
+                texture.DrawSprite((SpriteBatch)null!, 0, Vector2.Zero);
+                texture.DrawSprite((SpriteBatch)null!, 1, new Vector2(10, 20), new Vector2(2, 3));
+                texture.DrawSprite((SpriteBatch)null!, 2, new Vector2(30, 40), new Vector2(1.5f, 0.5f), 0.25f, new Vector2(2, 1), Color.Cyan);
+                texture.DrawSprite((SpriteBatch)null!, 0, 1, new Vector2(50, 60));
+                texture.DrawSprite((SpriteBatch)null!, 1, 2, new Vector2(70, 80), 0.5f);
+                texture.DrawSprite((SpriteBatch)null!, 3, new Rectangle(5, 6, 20, 10));
+            });
+
+            Assert.Null(exception);
+        }
+
+        private static ManagedSpriteTexture CreateSpriteTexture(int spriteWidth, int spriteHeight, int spritesPerRow, int totalSprites)
+        {
+#pragma warning disable SYSLIB0050
+            var texture = (ManagedSpriteTexture)FormatterServices.GetUninitializedObject(typeof(ManagedSpriteTexture));
+#pragma warning restore SYSLIB0050
+
+            ReflectionHelpers.SetPrivateField(texture, "_texture", null);
+            ReflectionHelpers.SetPrivateField(texture, "_sourcePath", "test.png");
+            ReflectionHelpers.SetPrivateField(texture, "_referenceCount", 0);
+            ReflectionHelpers.SetPrivateField(texture, "_disposed", false);
+            ReflectionHelpers.SetPrivateField(texture, "_lockObject", new object());
+            ReflectionHelpers.SetPrivateField(texture, "_transparency", 255);
+            ReflectionHelpers.SetPrivateField(texture, "_scaleRatio", Vector3.One);
+            ReflectionHelpers.SetPrivateField(texture, "_zAxisRotation", 0f);
+            ReflectionHelpers.SetPrivateField(texture, "_additiveBlending", false);
+            ReflectionHelpers.SetPrivateField(texture, "_spriteWidth", spriteWidth);
+            ReflectionHelpers.SetPrivateField(texture, "_spriteHeight", spriteHeight);
+            ReflectionHelpers.SetPrivateField(texture, "_spritesPerRow", spritesPerRow);
+            ReflectionHelpers.SetPrivateField(texture, "_totalSprites", totalSprites);
+
+            return texture;
+        }
+    }
+}

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -183,7 +183,9 @@ namespace DTXMania.Test.Resources
 
         private static ManagedTexture CreateManagedTexture(Texture2D? texture = null, bool disposed = false)
         {
+#pragma warning disable SYSLIB0050
             var managedTexture = (ManagedTexture)FormatterServices.GetUninitializedObject(typeof(ManagedTexture));
+#pragma warning restore SYSLIB0050
 
             ReflectionHelpers.SetPrivateField(managedTexture, "_texture", texture);
             ReflectionHelpers.SetPrivateField(managedTexture, "_sourcePath", "TestTexture");

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -1,7 +1,10 @@
 using DTXMania.Game.Lib.Resources;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace DTXMania.Test.Resources
@@ -75,6 +78,91 @@ namespace DTXMania.Test.Resources
             Assert.Equal(innerException, exception2.InnerException);
         }
 
+        [Fact]
+        public void FilePathConstructor_WhenGraphicsDeviceIsNull_ShouldThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ManagedTexture(null!, "texture.png", "source"));
+        }
+
+        [Fact]
+        public void ExistingTextureConstructor_WhenSourcePathIsNull_ShouldFallbackToUnknown()
+        {
+#pragma warning disable SYSLIB0050
+            var texture = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+#pragma warning restore SYSLIB0050
+
+            var managedTexture = new ManagedTexture(null!, texture, null!);
+
+            Assert.Same(texture, managedTexture.Texture);
+            Assert.Equal("Unknown", managedTexture.SourcePath);
+        }
+
+        [Fact]
+        public void AddReferenceAndRemoveReference_ShouldTrackReferenceCountWithoutDisposing()
+        {
+            var managedTexture = CreateManagedTexture();
+
+            managedTexture.AddReference();
+            managedTexture.AddReference();
+            managedTexture.RemoveReference();
+
+            Assert.Equal(1, managedTexture.ReferenceCount);
+            Assert.False(managedTexture.IsDisposed);
+        }
+
+        [Fact]
+        public void AddReference_WhenDisposed_ShouldThrowObjectDisposedException()
+        {
+            var managedTexture = CreateManagedTexture(disposed: true);
+
+            Assert.Throws<ObjectDisposedException>(() => managedTexture.AddReference());
+        }
+
+        [Fact]
+        public void Properties_WhenTextureIsMissing_ShouldUseSafeDefaultsAndClampValues()
+        {
+            var managedTexture = CreateManagedTexture();
+
+            managedTexture.Transparency = 999;
+            managedTexture.ZAxisRotation = 1.25f;
+            managedTexture.ScaleRatio = new Vector3(2f, 3f, 1f);
+            managedTexture.AdditiveBlending = true;
+
+            Assert.Equal(0L, managedTexture.MemoryUsage);
+            Assert.Equal(255, managedTexture.Transparency);
+            managedTexture.Transparency = -5;
+            Assert.Equal(0, managedTexture.Transparency);
+            Assert.Equal(1.25f, managedTexture.ZAxisRotation);
+            Assert.Equal(new Vector3(2f, 3f, 1f), managedTexture.ScaleRatio);
+            Assert.True(managedTexture.AdditiveBlending);
+        }
+
+        [Fact]
+        public void DrawOverloads_WhenTextureIsMissing_ShouldReturnWithoutThrowing()
+        {
+            var managedTexture = CreateManagedTexture();
+
+            var exception = Record.Exception(() =>
+            {
+                managedTexture.Draw(null!, Vector2.Zero);
+                managedTexture.Draw(null!, Vector2.Zero, null);
+                managedTexture.Draw(null!, new Rectangle(0, 0, 10, 10), null, Color.White, 0f, Vector2.Zero, SpriteEffects.None, 0f);
+                managedTexture.Draw(null!, Vector2.One, Vector2.One, 0f, Vector2.Zero);
+            });
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void CloneAndColorOperations_WhenTextureIsMissing_ShouldThrowObjectDisposedException()
+        {
+            var managedTexture = CreateManagedTexture();
+
+            Assert.Throws<ObjectDisposedException>(() => managedTexture.Clone());
+            Assert.Throws<ObjectDisposedException>(() => managedTexture.GetColorData());
+            Assert.Throws<ObjectDisposedException>(() => managedTexture.SetColorData(Array.Empty<Color>()));
+            Assert.Throws<ObjectDisposedException>(() => managedTexture.SaveToFile(Path.Combine(Path.GetTempPath(), "texture.png")));
+        }
 
         public void Dispose()
         {
@@ -90,6 +178,32 @@ namespace DTXMania.Test.Resources
             {
                 // Ignore cleanup errors in tests
             }
+        }
+
+        private static ManagedTexture CreateManagedTexture(Texture2D? texture = null, bool disposed = false)
+        {
+#pragma warning disable SYSLIB0050
+            var managedTexture = (ManagedTexture)FormatterServices.GetUninitializedObject(typeof(ManagedTexture));
+#pragma warning restore SYSLIB0050
+
+            SetField(managedTexture, "_texture", texture);
+            SetField(managedTexture, "_sourcePath", "TestTexture");
+            SetField(managedTexture, "_referenceCount", 0);
+            SetField(managedTexture, "_disposed", disposed);
+            SetField(managedTexture, "_lockObject", new object());
+            SetField(managedTexture, "_transparency", 255);
+            SetField(managedTexture, "_scaleRatio", Vector3.One);
+            SetField(managedTexture, "_zAxisRotation", 0f);
+            SetField(managedTexture, "_additiveBlending", false);
+
+            return managedTexture;
+        }
+
+        private static void SetField(object target, string fieldName, object? value)
+        {
+            var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+            field!.SetValue(target, value);
         }
     }
 }

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -118,22 +118,33 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
-        public void Properties_WhenTextureIsMissing_ShouldUseSafeDefaultsAndClampValues()
+        public void Properties_WhenTextureIsMissing_ShouldUseSafeDefaults()
         {
             var managedTexture = CreateManagedTexture();
 
-            managedTexture.Transparency = 999;
             managedTexture.ZAxisRotation = 1.25f;
             managedTexture.ScaleRatio = new Vector3(2f, 3f, 1f);
             managedTexture.AdditiveBlending = true;
 
             Assert.Equal(0L, managedTexture.MemoryUsage);
-            Assert.Equal(255, managedTexture.Transparency);
-            managedTexture.Transparency = -5;
-            Assert.Equal(0, managedTexture.Transparency);
             Assert.Equal(1.25f, managedTexture.ZAxisRotation);
             Assert.Equal(new Vector3(2f, 3f, 1f), managedTexture.ScaleRatio);
             Assert.True(managedTexture.AdditiveBlending);
+        }
+
+        [Theory]
+        [InlineData(999, 255)]
+        [InlineData(-5, 0)]
+        [InlineData(0, 0)]
+        [InlineData(255, 255)]
+        [InlineData(128, 128)]
+        public void Transparency_ShouldClampToByteRange(int input, int expected)
+        {
+            var managedTexture = CreateManagedTexture();
+
+            managedTexture.Transparency = input;
+
+            Assert.Equal(expected, managedTexture.Transparency);
         }
 
         [Fact]
@@ -156,11 +167,20 @@ namespace DTXMania.Test.Resources
         public void CloneAndColorOperations_WhenTextureIsMissing_ShouldThrowObjectDisposedException()
         {
             var managedTexture = CreateManagedTexture();
+            var tempPath = Path.Combine(Path.GetTempPath(), "texture.png");
 
             Assert.Throws<ObjectDisposedException>(() => managedTexture.Clone());
             Assert.Throws<ObjectDisposedException>(() => managedTexture.GetColorData());
             Assert.Throws<ObjectDisposedException>(() => managedTexture.SetColorData(Array.Empty<Color>()));
-            Assert.Throws<ObjectDisposedException>(() => managedTexture.SaveToFile(Path.Combine(Path.GetTempPath(), "texture.png")));
+            try
+            {
+                Assert.Throws<ObjectDisposedException>(() => managedTexture.SaveToFile(tempPath));
+            }
+            finally
+            {
+                if (File.Exists(tempPath))
+                    File.Delete(tempPath);
+            }
         }
 
         public void Dispose()

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -1,9 +1,9 @@
 using DTXMania.Game.Lib.Resources;
+using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.IO;
-using System.Reflection;
 using System.Runtime.Serialization;
 using Xunit;
 
@@ -13,6 +13,7 @@ namespace DTXMania.Test.Resources
     /// Basic unit tests for ManagedTexture interfaces and data structures
     /// Tests core functionality without MonoGame dependencies
     /// </summary>
+    [Trait("Category", "Unit")]
     public class ManagedTextureTests : IDisposable
     {
         private readonly string _testImagePath;
@@ -182,28 +183,19 @@ namespace DTXMania.Test.Resources
 
         private static ManagedTexture CreateManagedTexture(Texture2D? texture = null, bool disposed = false)
         {
-#pragma warning disable SYSLIB0050
             var managedTexture = (ManagedTexture)FormatterServices.GetUninitializedObject(typeof(ManagedTexture));
-#pragma warning restore SYSLIB0050
 
-            SetField(managedTexture, "_texture", texture);
-            SetField(managedTexture, "_sourcePath", "TestTexture");
-            SetField(managedTexture, "_referenceCount", 0);
-            SetField(managedTexture, "_disposed", disposed);
-            SetField(managedTexture, "_lockObject", new object());
-            SetField(managedTexture, "_transparency", 255);
-            SetField(managedTexture, "_scaleRatio", Vector3.One);
-            SetField(managedTexture, "_zAxisRotation", 0f);
-            SetField(managedTexture, "_additiveBlending", false);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_texture", texture);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_sourcePath", "TestTexture");
+            ReflectionHelpers.SetPrivateField(managedTexture, "_referenceCount", 0);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_disposed", disposed);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_lockObject", new object());
+            ReflectionHelpers.SetPrivateField(managedTexture, "_transparency", 255);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_scaleRatio", Vector3.One);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_zAxisRotation", 0f);
+            ReflectionHelpers.SetPrivateField(managedTexture, "_additiveBlending", false);
 
             return managedTexture;
-        }
-
-        private static void SetField(object target, string fieldName, object? value)
-        {
-            var field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(field);
-            field!.SetValue(target, value);
         }
     }
 }

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.IO;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using Xunit;
 
 namespace DTXMania.Test.Resources
@@ -88,9 +88,7 @@ namespace DTXMania.Test.Resources
         [Fact]
         public void ExistingTextureConstructor_WhenSourcePathIsNull_ShouldFallbackToUnknown()
         {
-#pragma warning disable SYSLIB0050
-            var texture = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
-#pragma warning restore SYSLIB0050
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
 
             var managedTexture = new ManagedTexture(null!, texture, null!);
 
@@ -183,9 +181,7 @@ namespace DTXMania.Test.Resources
 
         private static ManagedTexture CreateManagedTexture(Texture2D? texture = null, bool disposed = false)
         {
-#pragma warning disable SYSLIB0050
-            var managedTexture = (ManagedTexture)FormatterServices.GetUninitializedObject(typeof(ManagedTexture));
-#pragma warning restore SYSLIB0050
+            var managedTexture = (ManagedTexture)RuntimeHelpers.GetUninitializedObject(typeof(ManagedTexture));
 
             ReflectionHelpers.SetPrivateField(managedTexture, "_texture", texture);
             ReflectionHelpers.SetPrivateField(managedTexture, "_sourcePath", "TestTexture");

--- a/DTXMania.Test/Stage/Performance/PadRendererTests.cs
+++ b/DTXMania.Test/Stage/Performance/PadRendererTests.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Linq;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI.Layout;
@@ -14,6 +13,7 @@ namespace DTXMania.Test.Stage.Performance
     /// Unit tests for PadRenderer component
     /// Tests pad visual state management without requiring graphics rendering
     /// </summary>
+    [Trait("Category", "Performance")]
     public class PadRendererTests
     {
         [Fact]
@@ -74,16 +74,17 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(0.0, visuals[4].TimePressed);
         }
 
-        [Fact]
-        public void TriggerPadPress_WhenLaneIsInvalid_ShouldLeavePadVisualsUnchanged()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(PerformanceUILayout.LaneCount)]
+        public void TriggerPadPress_WhenLaneIsInvalid_ShouldLeavePadVisualsUnchanged(int laneIndex)
         {
             var renderer = CreateRenderer();
             var visuals = GetPadVisuals(renderer);
             visuals[2].State = PadState.Pressed;
             visuals[2].TimePressed = 12.0;
 
-            renderer.TriggerPadPress(-1);
-            renderer.TriggerPadPress(PerformanceUILayout.LaneCount);
+            renderer.TriggerPadPress(laneIndex);
 
             Assert.Equal(PadState.Pressed, visuals[2].State);
             Assert.Equal(12.0, visuals[2].TimePressed);
@@ -172,16 +173,15 @@ namespace DTXMania.Test.Stage.Performance
 
         private static PadRenderer CreateRenderer()
         {
-#pragma warning disable SYSLIB0050
-            var renderer = (PadRenderer)FormatterServices.GetUninitializedObject(typeof(PadRenderer));
-#pragma warning restore SYSLIB0050
-            ReflectionHelpers.SetPrivateField(
-                renderer,
-                "_padVisuals",
-                Enumerable.Range(0, PerformanceUILayout.LaneCount)
-                    .Select(_ => new PadVisual())
-                    .ToArray());
-            return renderer;
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager.Setup(x => x.LoadTexture(It.IsAny<string>())).Returns((ITexture)null!);
+            return new PadRenderer(CreateGraphicsDeviceStub(), resourceManager.Object);
+        }
+
+        private static Microsoft.Xna.Framework.Graphics.GraphicsDevice CreateGraphicsDeviceStub()
+        {
+            return (Microsoft.Xna.Framework.Graphics.GraphicsDevice)RuntimeHelpers.GetUninitializedObject(
+                typeof(Microsoft.Xna.Framework.Graphics.GraphicsDevice));
         }
 
         private static PadVisual[] GetPadVisuals(PadRenderer renderer)

--- a/DTXMania.Test/Stage/Performance/PadRendererTests.cs
+++ b/DTXMania.Test/Stage/Performance/PadRendererTests.cs
@@ -1,6 +1,12 @@
 using System;
-using Xunit;
+using System.Linq;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.TestData;
+using Moq;
+using Xunit;
 
 namespace DTXMania.Test.Stage.Performance
 {
@@ -53,6 +59,134 @@ namespace DTXMania.Test.Stage.Performance
             // Assert
             Assert.Equal(PadState.Pressed, padVisual.State);
             Assert.Equal(50.0, padVisual.TimePressed);
+        }
+
+        [Fact]
+        public void TriggerPadPress_WhenLaneIsValid_ShouldSetPadPressedAndResetTimer()
+        {
+            var renderer = CreateRenderer();
+            var visuals = GetPadVisuals(renderer);
+            visuals[4].TimePressed = 32.5;
+
+            renderer.TriggerPadPress(4, isJudgedHit: false);
+
+            Assert.Equal(PadState.Pressed, visuals[4].State);
+            Assert.Equal(0.0, visuals[4].TimePressed);
+        }
+
+        [Fact]
+        public void TriggerPadPress_WhenLaneIsInvalid_ShouldLeavePadVisualsUnchanged()
+        {
+            var renderer = CreateRenderer();
+            var visuals = GetPadVisuals(renderer);
+            visuals[2].State = PadState.Pressed;
+            visuals[2].TimePressed = 12.0;
+
+            renderer.TriggerPadPress(-1);
+            renderer.TriggerPadPress(PerformanceUILayout.LaneCount);
+
+            Assert.Equal(PadState.Pressed, visuals[2].State);
+            Assert.Equal(12.0, visuals[2].TimePressed);
+        }
+
+        [Fact]
+        public void Update_WhenPressedPadExceedsJudgedDuration_ShouldResetToIdle()
+        {
+            var renderer = CreateRenderer();
+            var visuals = GetPadVisuals(renderer);
+            visuals[1].State = PadState.Pressed;
+            visuals[1].TimePressed = 0.0;
+
+            renderer.Update(0.1);
+
+            Assert.Equal(PadState.Idle, visuals[1].State);
+            Assert.Equal(0.0, visuals[1].TimePressed);
+        }
+
+        [Fact]
+        public void Update_WhenPressedPadDurationIsBelowThreshold_ShouldRemainPressed()
+        {
+            var renderer = CreateRenderer();
+            var visuals = GetPadVisuals(renderer);
+            visuals[1].State = PadState.Pressed;
+
+            renderer.Update(0.05);
+
+            Assert.Equal(PadState.Pressed, visuals[1].State);
+            Assert.Equal(50.0, visuals[1].TimePressed, 3);
+        }
+
+        [Fact]
+        public void CalculateCellDimensions_WhenSpriteSheetLoaded_ShouldUseExpectedGrid()
+        {
+            var renderer = CreateRenderer();
+            var spriteSheet = new Mock<ITexture>();
+            spriteSheet.SetupGet(x => x.Width).Returns(400);
+            spriteSheet.SetupGet(x => x.Height).Returns(150);
+            ReflectionHelpers.SetPrivateField(renderer, "_padSpriteSheet", spriteSheet.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(renderer, "CalculateCellDimensions");
+
+            Assert.Equal(4, ReflectionHelpers.GetPrivateField<int>(renderer, "_spriteColumns"));
+            Assert.Equal(100, ReflectionHelpers.GetPrivateField<int>(renderer, "_cellWidth"));
+            Assert.Equal(50, ReflectionHelpers.GetPrivateField<int>(renderer, "_cellHeight"));
+        }
+
+        [Theory]
+        [InlineData(0, 0, 0)]
+        [InlineData(1, 1, 0)]
+        [InlineData(2, 0, 2)]
+        [InlineData(3, 0, 1)]
+        [InlineData(4, 1, 1)]
+        [InlineData(5, 1, 2)]
+        [InlineData(6, 2, 1)]
+        [InlineData(7, 3, 1)]
+        [InlineData(8, 2, 0)]
+        [InlineData(9, 3, 0)]
+        [InlineData(99, -1, -1)]
+        public void GetSpritePositionForLane_ShouldReturnExpectedMapping(int laneIndex, int expectedColumn, int expectedRow)
+        {
+            var renderer = CreateRenderer();
+
+            var result = ReflectionHelpers.InvokePrivateMethod<(int columnIndex, int rowIndex)>(
+                renderer,
+                "GetSpritePositionForLane",
+                laneIndex);
+
+            Assert.Equal((expectedColumn, expectedRow), result);
+        }
+
+        [Fact]
+        public void Dispose_ShouldReleaseSpriteSheetAndMarkRendererDisposed()
+        {
+            var renderer = CreateRenderer();
+            var spriteSheet = new Mock<ITexture>();
+            ReflectionHelpers.SetPrivateField(renderer, "_padSpriteSheet", spriteSheet.Object);
+
+            renderer.Dispose();
+
+            spriteSheet.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture?>(renderer, "_padSpriteSheet"));
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderer, "_disposed"));
+        }
+
+        private static PadRenderer CreateRenderer()
+        {
+#pragma warning disable SYSLIB0050
+            var renderer = (PadRenderer)FormatterServices.GetUninitializedObject(typeof(PadRenderer));
+#pragma warning restore SYSLIB0050
+            ReflectionHelpers.SetPrivateField(
+                renderer,
+                "_padVisuals",
+                Enumerable.Range(0, PerformanceUILayout.LaneCount)
+                    .Select(_ => new PadVisual())
+                    .ToArray());
+            return renderer;
+        }
+
+        private static PadVisual[] GetPadVisuals(PadRenderer renderer)
+        {
+            return ReflectionHelpers.GetPrivateField<PadVisual[]>(renderer, "_padVisuals")!;
         }
     }
 }

--- a/DTXMania.Test/Stage/Performance/PooledEffectsManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/PooledEffectsManagerTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    [Trait("Category", "Performance")]
+    public class PooledEffectsManagerTests
+    {
+        private static readonly int InitialPoolSize =
+            (int)typeof(PooledEffectsManager)
+                .GetField("InitialPoolSize", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetRawConstantValue()!;
+
+        private static readonly int MaxPoolSize =
+            (int)typeof(PooledEffectsManager)
+                .GetField("MaxPoolSize", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetRawConstantValue()!;
+
+        [Fact]
+        public void SpawnHitEffect_WhenPoolContainsReusableInstance_ShouldUsePoolAndTrackHit()
+        {
+            var manager = CreateManager(totalSprites: 4);
+
+            manager.SpawnHitEffect(3);
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(InitialPoolSize - 1, stats.PoolSize);
+            Assert.Equal(1, stats.ActiveInstances);
+            Assert.Equal(1, stats.TotalRequests);
+            Assert.Equal(1, stats.PoolHits);
+            Assert.Equal(0, stats.PoolMisses);
+
+            var activeEffect = GetActiveEffects(manager).Single();
+            var position = (Vector2)activeEffect.GetType().GetProperty("Position")!.GetValue(activeEffect)!;
+            Assert.Equal(new Vector2(PerformanceUILayout.GetLaneX(3), PerformanceUILayout.JudgementLineY), position);
+        }
+
+        [Fact]
+        public void SpawnHitEffect_WhenInitialPoolIsExhausted_ShouldCreateNewInstanceAndTrackMiss()
+        {
+            var manager = CreateManager(totalSprites: 5);
+            for (int i = 0; i < InitialPoolSize; i++)
+            {
+                manager.SpawnHitEffect(i % PerformanceUILayout.LaneCount);
+            }
+
+            manager.SpawnHitEffect(5);
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(InitialPoolSize + 1, stats.ActiveInstances);
+            Assert.Equal(InitialPoolSize + 1, stats.TotalRequests);
+            Assert.Equal(InitialPoolSize, stats.PoolHits);
+            Assert.Equal(1, stats.PoolMisses);
+            Assert.Equal(0, stats.PoolSize);
+        }
+
+        [Fact]
+        public void SpawnHitEffect_WhenActiveEffectsAlreadyAtMaxPoolSize_ShouldSkipAddingNewEffect()
+        {
+            var manager = CreateManager(totalSprites: 3);
+            for (int i = 0; i < MaxPoolSize; i++)
+            {
+                manager.SpawnHitEffect(i % PerformanceUILayout.LaneCount);
+            }
+
+            manager.SpawnHitEffect(1);
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(MaxPoolSize, stats.ActiveInstances);
+            Assert.Equal(MaxPoolSize + 1, stats.TotalRequests);
+            Assert.Equal(InitialPoolSize, stats.PoolHits);
+            Assert.Equal((MaxPoolSize + 1) - InitialPoolSize, stats.PoolMisses);
+        }
+
+        [Fact]
+        public void Update_WhenActiveEffectExpires_ShouldReturnItToPool()
+        {
+            var manager = CreateManager(totalSprites: 2);
+            manager.SpawnHitEffect(0);
+
+            manager.Update(1.0);
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(0, stats.ActiveInstances);
+            Assert.Equal(InitialPoolSize, stats.PoolSize);
+        }
+
+        [Fact]
+        public void ResetStats_ShouldClearCountersWithoutChangingActiveEffectCounts()
+        {
+            var manager = CreateManager(totalSprites: 4);
+            manager.SpawnHitEffect(0);
+            manager.SpawnHitEffect(1);
+
+            manager.ResetStats();
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(2, stats.ActiveInstances);
+            Assert.Equal(0, stats.TotalRequests);
+            Assert.Equal(0, stats.PoolHits);
+            Assert.Equal(0, stats.PoolMisses);
+        }
+
+        [Fact]
+        public void ClearAllEffects_ShouldMoveActiveEffectsBackToPool()
+        {
+            var manager = CreateManager(totalSprites: 3);
+            manager.SpawnHitEffect(0);
+            manager.SpawnHitEffect(1);
+
+            manager.ClearAllEffects();
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(0, stats.ActiveInstances);
+            Assert.Equal(InitialPoolSize, stats.PoolSize);
+        }
+
+        [Fact]
+        public void Dispose_ShouldClearEffectsAndDisposeHitTexture()
+        {
+            var manager = CreateManager(totalSprites: 3);
+            var hitTexture = ReflectionHelpers.GetPrivateField<ManagedSpriteTexture>(manager, "_hitEffectTexture")!;
+            manager.SpawnHitEffect(0);
+
+            manager.Dispose();
+
+            var stats = manager.GetPoolingStats();
+            Assert.Equal(0, stats.ActiveInstances);
+            Assert.Equal(InitialPoolSize, stats.PoolSize);
+            Assert.True(hitTexture.IsDisposed);
+        }
+
+        private static PooledEffectsManager CreateManager(int totalSprites)
+        {
+#pragma warning disable SYSLIB0050
+            var manager = (PooledEffectsManager)FormatterServices.GetUninitializedObject(typeof(PooledEffectsManager));
+            var hitTexture = (ManagedSpriteTexture)FormatterServices.GetUninitializedObject(typeof(ManagedSpriteTexture));
+#pragma warning restore SYSLIB0050
+
+            ReflectionHelpers.SetPrivateField(hitTexture, "_spriteWidth", 8);
+            ReflectionHelpers.SetPrivateField(hitTexture, "_spriteHeight", 32);
+            ReflectionHelpers.SetPrivateField(hitTexture, "_spritesPerRow", totalSprites);
+            ReflectionHelpers.SetPrivateField(hitTexture, "_totalSprites", totalSprites);
+            ReflectionHelpers.SetPrivateField(hitTexture, "_lockObject", new object());
+
+            ReflectionHelpers.SetPrivateField(manager, "_effectPool", CreatePrivateCollection("_effectPool"));
+            ReflectionHelpers.SetPrivateField(manager, "_activeEffects", CreatePrivateCollection("_activeEffects"));
+            ReflectionHelpers.SetPrivateField(manager, "_hitEffectTexture", hitTexture);
+            ReflectionHelpers.SetPrivateField(manager, "_activeLock", new object());
+            ReflectionHelpers.SetPrivateField(manager, "_totalRequests", 0L);
+            ReflectionHelpers.SetPrivateField(manager, "_poolHits", 0L);
+            ReflectionHelpers.SetPrivateField(manager, "_poolMisses", 0L);
+            ReflectionHelpers.InvokePrivateMethod(manager, "InitializePool");
+
+            return manager;
+        }
+
+        private static object CreatePrivateCollection(string fieldName)
+        {
+            var fieldType = typeof(PooledEffectsManager)
+                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
+                .FieldType;
+            return Activator.CreateInstance(fieldType)!;
+        }
+
+        private static IReadOnlyList<object> GetActiveEffects(PooledEffectsManager manager)
+        {
+            return ((IEnumerable)ReflectionHelpers.GetPrivateField<object>(manager, "_activeEffects")!)
+                .Cast<object>()
+                .ToList();
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Performance/PooledEffectsManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/PooledEffectsManagerTests.cs
@@ -3,12 +3,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
+using Moq;
 using Xunit;
 
 namespace DTXMania.Test.Stage.Performance
@@ -16,25 +17,17 @@ namespace DTXMania.Test.Stage.Performance
     [Trait("Category", "Performance")]
     public class PooledEffectsManagerTests
     {
-        private static readonly int InitialPoolSize =
-            (int)typeof(PooledEffectsManager)
-                .GetField("InitialPoolSize", BindingFlags.Static | BindingFlags.NonPublic)!
-                .GetRawConstantValue()!;
-
-        private static readonly int MaxPoolSize =
-            (int)typeof(PooledEffectsManager)
-                .GetField("MaxPoolSize", BindingFlags.Static | BindingFlags.NonPublic)!
-                .GetRawConstantValue()!;
-
         [Fact]
         public void SpawnHitEffect_WhenPoolContainsReusableInstance_ShouldUsePoolAndTrackHit()
         {
-            var manager = CreateManager(totalSprites: 4);
+            using var fixture = CreateManager(totalSprites: 4);
+            var manager = fixture.Manager;
+            var initialPoolSize = manager.GetPoolingStats().PoolSize;
 
             manager.SpawnHitEffect(3);
 
             var stats = manager.GetPoolingStats();
-            Assert.Equal(InitialPoolSize - 1, stats.PoolSize);
+            Assert.Equal(initialPoolSize - 1, stats.PoolSize);
             Assert.Equal(1, stats.ActiveInstances);
             Assert.Equal(1, stats.TotalRequests);
             Assert.Equal(1, stats.PoolHits);
@@ -48,8 +41,11 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void SpawnHitEffect_WhenInitialPoolIsExhausted_ShouldCreateNewInstanceAndTrackMiss()
         {
-            var manager = CreateManager(totalSprites: 5);
-            for (int i = 0; i < InitialPoolSize; i++)
+            using var fixture = CreateManager(totalSprites: 5);
+            var manager = fixture.Manager;
+            var initialPoolSize = manager.GetPoolingStats().PoolSize;
+
+            for (int i = 0; i < initialPoolSize; i++)
             {
                 manager.SpawnHitEffect(i % PerformanceUILayout.LaneCount);
             }
@@ -57,48 +53,78 @@ namespace DTXMania.Test.Stage.Performance
             manager.SpawnHitEffect(5);
 
             var stats = manager.GetPoolingStats();
-            Assert.Equal(InitialPoolSize + 1, stats.ActiveInstances);
-            Assert.Equal(InitialPoolSize + 1, stats.TotalRequests);
-            Assert.Equal(InitialPoolSize, stats.PoolHits);
+            Assert.Equal(initialPoolSize + 1, stats.ActiveInstances);
+            Assert.Equal(initialPoolSize + 1, stats.TotalRequests);
+            Assert.Equal(initialPoolSize, stats.PoolHits);
             Assert.Equal(1, stats.PoolMisses);
             Assert.Equal(0, stats.PoolSize);
         }
 
         [Fact]
-        public void SpawnHitEffect_WhenActiveEffectsAlreadyAtMaxPoolSize_ShouldSkipAddingNewEffect()
+        public void SpawnHitEffect_WhenActiveEffectsAlreadyAtCapacity_ShouldSkipAddingNewEffect()
         {
-            var manager = CreateManager(totalSprites: 3);
-            for (int i = 0; i < MaxPoolSize; i++)
+            using var fixture = CreateManager(totalSprites: 3);
+            var manager = fixture.Manager;
+            var previousStats = manager.GetPoolingStats();
+            EffectPoolingStats? skippedEffectStats = null;
+
+            for (int i = 0; i < 1000; i++)
             {
                 manager.SpawnHitEffect(i % PerformanceUILayout.LaneCount);
+                var currentStats = manager.GetPoolingStats();
+                if (currentStats.ActiveInstances == previousStats.ActiveInstances)
+                {
+                    skippedEffectStats = currentStats;
+                    Assert.Equal(previousStats.TotalRequests + 1, currentStats.TotalRequests);
+                    Assert.Equal(previousStats.PoolHits, currentStats.PoolHits);
+                    Assert.Equal(previousStats.PoolMisses + 1, currentStats.PoolMisses);
+                    break;
+                }
+
+                previousStats = currentStats;
             }
+
+            Assert.NotNull(skippedEffectStats);
 
             manager.SpawnHitEffect(1);
 
             var stats = manager.GetPoolingStats();
-            Assert.Equal(MaxPoolSize, stats.ActiveInstances);
-            Assert.Equal(MaxPoolSize + 1, stats.TotalRequests);
-            Assert.Equal(InitialPoolSize, stats.PoolHits);
-            Assert.Equal((MaxPoolSize + 1) - InitialPoolSize, stats.PoolMisses);
+            Assert.Equal(skippedEffectStats!.ActiveInstances, stats.ActiveInstances);
+            Assert.Equal(skippedEffectStats.TotalRequests + 1, stats.TotalRequests);
+            Assert.Equal(skippedEffectStats.PoolHits, stats.PoolHits);
+            Assert.Equal(skippedEffectStats.PoolMisses + 1, stats.PoolMisses);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(PerformanceUILayout.LaneCount)]
+        public void SpawnHitEffect_InvalidLane_ThrowsArgumentOutOfRange(int lane)
+        {
+            using var fixture = CreateManager(totalSprites: 4);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => fixture.Manager.SpawnHitEffect(lane));
         }
 
         [Fact]
         public void Update_WhenActiveEffectExpires_ShouldReturnItToPool()
         {
-            var manager = CreateManager(totalSprites: 2);
+            using var fixture = CreateManager(totalSprites: 2);
+            var manager = fixture.Manager;
+            var initialPoolSize = manager.GetPoolingStats().PoolSize;
             manager.SpawnHitEffect(0);
 
             manager.Update(1.0);
 
             var stats = manager.GetPoolingStats();
             Assert.Equal(0, stats.ActiveInstances);
-            Assert.Equal(InitialPoolSize, stats.PoolSize);
+            Assert.Equal(initialPoolSize, stats.PoolSize);
         }
 
         [Fact]
         public void ResetStats_ShouldClearCountersWithoutChangingActiveEffectCounts()
         {
-            var manager = CreateManager(totalSprites: 4);
+            using var fixture = CreateManager(totalSprites: 4);
+            var manager = fixture.Manager;
             manager.SpawnHitEffect(0);
             manager.SpawnHitEffect(1);
 
@@ -114,7 +140,9 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void ClearAllEffects_ShouldMoveActiveEffectsBackToPool()
         {
-            var manager = CreateManager(totalSprites: 3);
+            using var fixture = CreateManager(totalSprites: 3);
+            var manager = fixture.Manager;
+            var initialPoolSize = manager.GetPoolingStats().PoolSize;
             manager.SpawnHitEffect(0);
             manager.SpawnHitEffect(1);
 
@@ -122,55 +150,28 @@ namespace DTXMania.Test.Stage.Performance
 
             var stats = manager.GetPoolingStats();
             Assert.Equal(0, stats.ActiveInstances);
-            Assert.Equal(InitialPoolSize, stats.PoolSize);
+            Assert.Equal(initialPoolSize, stats.PoolSize);
         }
 
         [Fact]
         public void Dispose_ShouldClearEffectsAndDisposeHitTexture()
         {
-            var manager = CreateManager(totalSprites: 3);
-            var hitTexture = ReflectionHelpers.GetPrivateField<ManagedSpriteTexture>(manager, "_hitEffectTexture")!;
+            using var fixture = CreateManager(totalSprites: 3);
+            var manager = fixture.Manager;
+            var initialPoolSize = manager.GetPoolingStats().PoolSize;
             manager.SpawnHitEffect(0);
 
             manager.Dispose();
 
             var stats = manager.GetPoolingStats();
             Assert.Equal(0, stats.ActiveInstances);
-            Assert.Equal(InitialPoolSize, stats.PoolSize);
-            Assert.True(hitTexture.IsDisposed);
+            Assert.Equal(initialPoolSize, stats.PoolSize);
+            Assert.True(fixture.HitTexture.WasDisposed);
         }
 
-        private static PooledEffectsManager CreateManager(int totalSprites)
+        private static ManagerFixture CreateManager(int totalSprites)
         {
-#pragma warning disable SYSLIB0050
-            var manager = (PooledEffectsManager)FormatterServices.GetUninitializedObject(typeof(PooledEffectsManager));
-            var hitTexture = (ManagedSpriteTexture)FormatterServices.GetUninitializedObject(typeof(ManagedSpriteTexture));
-#pragma warning restore SYSLIB0050
-
-            ReflectionHelpers.SetPrivateField(hitTexture, "_spriteWidth", 8);
-            ReflectionHelpers.SetPrivateField(hitTexture, "_spriteHeight", 32);
-            ReflectionHelpers.SetPrivateField(hitTexture, "_spritesPerRow", totalSprites);
-            ReflectionHelpers.SetPrivateField(hitTexture, "_totalSprites", totalSprites);
-            ReflectionHelpers.SetPrivateField(hitTexture, "_lockObject", new object());
-
-            ReflectionHelpers.SetPrivateField(manager, "_effectPool", CreatePrivateCollection("_effectPool"));
-            ReflectionHelpers.SetPrivateField(manager, "_activeEffects", CreatePrivateCollection("_activeEffects"));
-            ReflectionHelpers.SetPrivateField(manager, "_hitEffectTexture", hitTexture);
-            ReflectionHelpers.SetPrivateField(manager, "_activeLock", new object());
-            ReflectionHelpers.SetPrivateField(manager, "_totalRequests", 0L);
-            ReflectionHelpers.SetPrivateField(manager, "_poolHits", 0L);
-            ReflectionHelpers.SetPrivateField(manager, "_poolMisses", 0L);
-            ReflectionHelpers.InvokePrivateMethod(manager, "InitializePool");
-
-            return manager;
-        }
-
-        private static object CreatePrivateCollection(string fieldName)
-        {
-            var fieldType = typeof(PooledEffectsManager)
-                .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
-                .FieldType;
-            return Activator.CreateInstance(fieldType)!;
+            return new ManagerFixture(totalSprites);
         }
 
         private static IReadOnlyList<object> GetActiveEffects(PooledEffectsManager manager)
@@ -178,6 +179,61 @@ namespace DTXMania.Test.Stage.Performance
             return ((IEnumerable)ReflectionHelpers.GetPrivateField<object>(manager, "_activeEffects")!)
                 .Cast<object>()
                 .ToList();
+        }
+
+        private static Microsoft.Xna.Framework.Graphics.GraphicsDevice CreateGraphicsDeviceStub()
+        {
+            return (Microsoft.Xna.Framework.Graphics.GraphicsDevice)RuntimeHelpers.GetUninitializedObject(
+                typeof(Microsoft.Xna.Framework.Graphics.GraphicsDevice));
+        }
+
+        private static TrackingTexture2D CreateTrackingTexture(int width, int height)
+        {
+            var texture = (TrackingTexture2D)RuntimeHelpers.GetUninitializedObject(typeof(TrackingTexture2D));
+            ReflectionHelpers.SetPrivateField(texture, "width", width);
+            ReflectionHelpers.SetPrivateField(texture, "height", height);
+            ReflectionHelpers.SetPrivateField(texture, "<TexelWidth>k__BackingField", 1f / width);
+            ReflectionHelpers.SetPrivateField(texture, "<TexelHeight>k__BackingField", 1f / height);
+            return texture;
+        }
+
+        private sealed class ManagerFixture : IDisposable
+        {
+            public ManagerFixture(int totalSprites)
+            {
+                HitTexture = CreateTrackingTexture(width: 8 * totalSprites, height: 32);
+                var graphicsDevice = CreateGraphicsDeviceStub();
+                var loadedTexture = new ManagedTexture(graphicsDevice, HitTexture, "Graphics/hit_fx.png");
+                var resourceManager = new Mock<IResourceManager>();
+                resourceManager
+                    .Setup(x => x.LoadTexture("Graphics/hit_fx.png"))
+                    .Returns(loadedTexture);
+
+                Manager = new PooledEffectsManager(graphicsDevice, resourceManager.Object);
+            }
+
+            public PooledEffectsManager Manager { get; }
+
+            public TrackingTexture2D HitTexture { get; }
+
+            public void Dispose()
+            {
+                Manager.Dispose();
+            }
+        }
+
+        private sealed class TrackingTexture2D : Microsoft.Xna.Framework.Graphics.Texture2D
+        {
+            public TrackingTexture2D() : base(null!, 1, 1)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
         }
     }
 }

--- a/DTXMania.Test/Stage/Performance/PooledEffectsManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/PooledEffectsManagerTests.cs
@@ -169,6 +169,41 @@ namespace DTXMania.Test.Stage.Performance
             Assert.True(fixture.HitTexture.WasDisposed);
         }
 
+        [Fact]
+        public void Constructor_WhenResourceManagerIsNull_ShouldThrowNullReferenceException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            Assert.Throws<NullReferenceException>(() =>
+                new PooledEffectsManager(graphicsDevice, null!));
+        }
+
+        [Fact]
+        public void Constructor_WhenLoadTextureReturnsNull_ShouldThrowNullReferenceException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(x => x.LoadTexture(It.IsAny<string>()))
+                .Returns((ManagedTexture?)null!);
+
+            Assert.Throws<NullReferenceException>(() =>
+                new PooledEffectsManager(graphicsDevice, resourceManager.Object));
+        }
+
+        [Fact]
+        public void Constructor_WhenLoadTextureThrows_ShouldPropagateException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(x => x.LoadTexture(It.IsAny<string>()))
+                .Throws(new InvalidOperationException("Texture load failed"));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                new PooledEffectsManager(graphicsDevice, resourceManager.Object));
+        }
+
         private static ManagerFixture CreateManager(int totalSprites)
         {
             return new ManagerFixture(totalSprites);

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -3,8 +3,12 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
 using DTXMania.Game;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI;
+using Microsoft.Xna.Framework.Graphics;
 using Moq;
 using Xunit;
 
@@ -271,6 +275,98 @@ namespace DTXMania.Test.Stage
             Assert.Equal(0.0, DTXMania.Test.TestData.ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
         }
 
+        [Fact]
+        public void OnUpdate_WhenQueuedBackCommandExists_ShouldProcessInputAndReturnToSongSelect()
+        {
+            var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var stageManager = new Mock<IStageManager>();
+            var inputManager = new TrackingInputManager();
+
+            inputManager.Enqueue(new InputCommand(InputCommandType.Back, 0.0));
+            SetPrivateField(stage, "_game", game);
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_inputManager", inputManager);
+            SetPrivateField(stage, "_uiManager", new UIManager());
+            SetPrivateField(stage, "_elapsedTime", 0.0);
+
+            InvokePrivateMethod(stage, "OnUpdate", 0.25);
+
+            Assert.True(inputManager.UpdateCalled);
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    StageType.SongSelect,
+                    It.Is<IStageTransition>(transition => transition is DTXManiaFadeTransition),
+                    null),
+                Times.Once);
+            Assert.Equal(2.0, DTXMania.Test.TestData.ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void ReturnToSongSelect_ShouldUseFadeTransitionWithNullSharedData()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var stageManager = new Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "ReturnToSongSelect");
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    StageType.SongSelect,
+                    It.Is<IStageTransition>(transition => transition is DTXManiaFadeTransition),
+                    null),
+                Times.Once);
+        }
+
+        [Fact]
+        public void CleanupComponents_ShouldDisposeTrackedResourcesAndClearFields()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+            var whitePixel = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
+            var font = (TrackingBitmapFont)FormatterServices.GetUninitializedObject(typeof(TrackingBitmapFont));
+#pragma warning restore SYSLIB0050
+
+            SetPrivateField(stage, "_whitePixel", whitePixel);
+            SetPrivateField(stage, "_resultFont", font);
+
+            InvokePrivateMethod(stage, "CleanupComponents");
+
+            Assert.True(whitePixel.WasDisposed);
+            Assert.True(font.WasDisposed);
+            Assert.Null(GetPrivateField<Texture2D>(stage, "_whitePixel"));
+            Assert.Null(GetPrivateField<BitmapFont>(stage, "_resultFont"));
+        }
+
+        [Fact]
+        public void Dispose_WhenDisposing_ShouldReleaseSpriteBatchAndCleanupComponents()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+            var spriteBatch = (TrackingSpriteBatch)FormatterServices.GetUninitializedObject(typeof(TrackingSpriteBatch));
+            var whitePixel = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
+            var font = (TrackingBitmapFont)FormatterServices.GetUninitializedObject(typeof(TrackingBitmapFont));
+#pragma warning restore SYSLIB0050
+
+            SetPrivateField(stage, "_game", DTXMania.Test.TestData.ReflectionHelpers.CreateGame());
+            SetPrivateField(stage, "_spriteBatch", spriteBatch);
+            SetPrivateField(stage, "_uiManager", new UIManager());
+            SetPrivateField(stage, "_whitePixel", whitePixel);
+            SetPrivateField(stage, "_resultFont", font);
+            SetPrivateField(stage, "_disposed", false);
+
+            InvokeDispose(stage, true);
+
+            Assert.True(spriteBatch.WasDisposed);
+            Assert.True(whitePixel.WasDisposed);
+            Assert.True(font.WasDisposed);
+        }
+
         #endregion
 
         #region Helper Methods
@@ -319,6 +415,76 @@ namespace DTXMania.Test.Stage
                 type = type.BaseType;
             }
             Assert.Fail($"Field '{fieldName}' not found");
+        }
+
+        private static void InvokeDispose(ResultStage stage, bool disposing)
+        {
+            var method = typeof(ResultStage).GetMethod(
+                "Dispose",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                binder: null,
+                types: new[] { typeof(bool) },
+                modifiers: null);
+            Assert.NotNull(method);
+            method!.Invoke(stage, new object[] { disposing });
+        }
+
+        private sealed class TrackingInputManager : InputManager
+        {
+            public bool UpdateCalled { get; private set; }
+
+            public void Enqueue(InputCommand command)
+            {
+                EnqueueCommand(command);
+            }
+
+            public override void Update(double deltaTime = 0)
+            {
+                UpdateCalled = true;
+                base.Update(deltaTime);
+            }
+        }
+
+        private sealed class TrackingSpriteBatch : SpriteBatch
+        {
+            public TrackingSpriteBatch() : base(null!)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
+        }
+
+        private sealed class TrackingTexture2D : Texture2D
+        {
+            public TrackingTexture2D() : base(null!, 1, 1)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
+        }
+
+        private sealed class TrackingBitmapFont : BitmapFont
+        {
+            public TrackingBitmapFont() : base((IResourceManager)null!, new BitmapFont.BitmapFontConfig(), allowNullGraphicsDevice: true)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
         }
 
         #endregion

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -337,6 +337,66 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void SelectRandomSong_WhenNoPlayableSongsExist_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode>
+            {
+                CreateBoxNode("Folder"),
+                new SongListNode { Type = NodeType.Random, Title = "Random" },
+                new SongListNode { Type = NodeType.BackBox, Title = ".." }
+            });
+
+            InvokePrivateMethod(stage, "SelectRandomSong");
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    It.IsAny<StageType>(),
+                    It.IsAny<IStageTransition>(),
+                    It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void OnSongActivated_WhenSongIsNull_ShouldLeaveStageStateUnchanged()
+        {
+            var stage = CreateStage();
+            var currentSongList = new List<SongListNode> { CreateScoreNode("Song") };
+            var navigationStack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+
+            SetPrivateField(stage, "_currentSongList", currentSongList);
+            navigationStack.Push(new SongListNode { Title = "Root" });
+
+            InvokePrivateMethod(stage, "OnSongActivated", stage, new SongActivatedEventArgs(null!, 0));
+
+            Assert.Same(currentSongList, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Single(navigationStack);
+        }
+
+        [Fact]
+        public void HandleSongActivation_WhenBackBoxNodeProvided_ShouldNavigateBack()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root Song") };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("Child Song") });
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Child");
+            GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!.Push(new SongListNode { Children = rootSongs, Title = "Root" });
+
+            InvokePrivateMethod(stage, "HandleSongActivation", new SongListNode { Type = NodeType.BackBox, Title = ".. (Back)" });
+
+            Assert.Same(rootSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Same(rootSongs[0], display.CurrentList[0]);
+        }
+
+        [Fact]
         public void UpdateBreadcrumb_ShouldUseRootFallbackAndCurrentBreadcrumb()
         {
             var stage = CreateStage();
@@ -371,10 +431,38 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void ExecuteInputCommand_MoveDown_ShouldMoveSelectionAndPlayCursorSound()
+        public void OnUpdate_WhenOwnedInputManagerHasQueuedMoveDown_ShouldProcessInputAndAdvancePhase()
         {
             var stage = CreateStage();
             var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode> { CreateScoreNode("Song A"), CreateScoreNode("Song B") }
+            };
+            var inputManager = new UpdatingQueuedInputManager();
+            inputManager.Enqueue(new InputCommand(InputCommandType.MoveDown, 0.0));
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_inputManager", inputManager);
+            SetPrivateField(stage, "_ownsInputManager", true);
+            SetPrivateField(stage, "_uiManager", new DTXMania.Game.Lib.UI.UIManager());
+            SetPrivateField(stage, "_selectionPhase", SongSelectionPhase.FadeIn);
+            SetPrivateField(stage, "_currentPhase", StagePhase.FadeIn);
+            SetPrivateField(stage, "_elapsedTime", 0.0);
+            SetPrivateField(stage, "_phaseStartTime", 0.0);
+
+            InvokePrivateMethod(stage, "OnUpdate", SongSelectionUILayout.Timing.FadeInDuration);
+
+            Assert.True(inputManager.UpdateCalled);
+            Assert.Equal(SongSelectionPhase.Normal, GetPrivateField<SongSelectionPhase>(stage, "_selectionPhase"));
+            Assert.Equal(StagePhase.Normal, stage.CurrentPhase);
+            Assert.Equal("Song B", display.SelectedSong.Title);
+        }
+
+        [Fact]
+    public void ExecuteInputCommand_MoveDown_ShouldMoveSelectionAndPlayCursorSound()
+    {
+        var stage = CreateStage();
+        var display = new SongListDisplay
             {
                 CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
             };
@@ -387,15 +475,82 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveDown, 0.0));
 
             Assert.Equal("B", display.SelectedSong!.Title);
-            Assert.Equal(3.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
-            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
-        }
+        Assert.Equal(3.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
+        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+    }
 
-        [Fact]
-        public void ExecuteInputCommand_MoveLeftInStatusPanel_ShouldCycleBackwardDifficulty()
+    [Fact]
+    public void ExecuteInputCommand_MoveUp_ShouldMoveSelectionAndPlayCursorSound()
+    {
+        var stage = CreateStage();
+        var display = new SongListDisplay
         {
-            var stage = CreateStage();
-            var song = CreateScoreNode("Song", CreateScores(0, 2, 4));
+            CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+        };
+        var cursorSound = new Mock<ISound>();
+
+        AttachCoreUi(stage, display: display);
+        display.MoveNext();
+        SetPrivateField(stage, "_elapsedTime", 2.5);
+        SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+
+        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveUp, 0.0));
+
+        Assert.Equal("A", display.SelectedSong!.Title);
+        Assert.Equal(2.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
+        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+    }
+
+    [Fact]
+    public void ExecuteInputCommand_MoveUpInStatusPanel_ShouldStillMoveSelectionAndPlayCursorSound()
+    {
+        var stage = CreateStage();
+        var display = new SongListDisplay
+        {
+            CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+        };
+        var cursorSound = new Mock<ISound>();
+
+        AttachCoreUi(stage, display: display);
+        display.MoveNext();
+        SetPrivateField(stage, "_isInStatusPanel", true);
+        SetPrivateField(stage, "_elapsedTime", 4.5);
+        SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+
+        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveUp, 0.0));
+
+        Assert.Equal("A", display.SelectedSong!.Title);
+        Assert.Equal(4.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
+        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+    }
+
+    [Fact]
+    public void ExecuteInputCommand_MoveDownInStatusPanel_ShouldStillMoveSelectionAndPlayCursorSound()
+    {
+        var stage = CreateStage();
+        var display = new SongListDisplay
+        {
+            CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+        };
+        var cursorSound = new Mock<ISound>();
+
+        AttachCoreUi(stage, display: display);
+        SetPrivateField(stage, "_isInStatusPanel", true);
+        SetPrivateField(stage, "_elapsedTime", 5.5);
+        SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+
+        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveDown, 0.0));
+
+        Assert.Equal("B", display.SelectedSong!.Title);
+        Assert.Equal(5.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
+        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+    }
+
+    [Fact]
+    public void ExecuteInputCommand_MoveLeftInStatusPanel_ShouldCycleBackwardDifficulty()
+    {
+        var stage = CreateStage();
+        var song = CreateScoreNode("Song", CreateScores(0, 2, 4));
             var display = new SongListDisplay
             {
                 CurrentList = [song]
@@ -505,11 +660,11 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void HandleActivateInput_WhenSongSelected_ShouldEnterStatusPanel()
-        {
-            var stage = CreateStage();
-            var statusPanel = new SongStatusPanel { Visible = false };
-            var selectedSong = CreateScoreNode("Song");
+    public void HandleActivateInput_WhenSongSelected_ShouldEnterStatusPanel()
+    {
+        var stage = CreateStage();
+        var statusPanel = new SongStatusPanel { Visible = false };
+        var selectedSong = CreateScoreNode("Song");
 
             AttachCoreUi(stage, statusPanel: statusPanel);
             SetPrivateField(stage, "_selectedSong", selectedSong);
@@ -517,14 +672,31 @@ namespace DTXMania.Test.Stage
 
             InvokePrivateMethod(stage, "HandleActivateInput");
 
-            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
-            Assert.True(statusPanel.Visible);
-        }
+        Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+        Assert.True(statusPanel.Visible);
+    }
 
-        [Fact]
-        public void HandleActivateInput_WhenInStatusPanel_ShouldSelectSong()
-        {
-            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+    [Fact]
+    public void ExecuteInputCommand_Activate_ShouldDelegateToActivateHandler()
+    {
+        var stage = CreateStage();
+        var statusPanel = new SongStatusPanel { Visible = false };
+        var selectedSong = CreateScoreNode("Song");
+
+        AttachCoreUi(stage, statusPanel: statusPanel);
+        SetPrivateField(stage, "_selectedSong", selectedSong);
+        SetPrivateField(stage, "_isInStatusPanel", false);
+
+        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
+
+        Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+        Assert.True(statusPanel.Visible);
+    }
+
+    [Fact]
+    public void HandleActivateInput_WhenInStatusPanel_ShouldSelectSong()
+    {
+        var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
             var stage = CreateStage(game);
             var stageManager = new Mock<IStageManager>();
             var selectedSong = CreateScoreNode("Song", songId: 99);
@@ -1149,6 +1321,31 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void SetBackgroundMusic_WhenOldCleanupThrows_ShouldStillReplaceReferences()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            var newSound = new Mock<ISound>();
+            var newInstance = new Mock<ISoundInstance>();
+
+            oldSound.Setup(x => x.RemoveReference()).Throws(new InvalidOperationException("remove failed"));
+            oldInstance.Setup(x => x.Stop()).Throws(new InvalidOperationException("stop failed"));
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(newSound.Object, newInstance.Object));
+
+            Assert.Null(exception);
+            oldSound.Verify(x => x.RemoveReference(), Times.Once);
+            oldInstance.Verify(x => x.Stop(), Times.Once);
+            oldInstance.Verify(x => x.Dispose(), Times.Never);
+            Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+            Assert.Same(newInstance.Object, GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
+        }
+
+        [Fact]
         public void AssignInputManager_WhenReplacingOwnedFallback_ShouldDisposeOwnedManagerAndUseSharedManager()
         {
             var stage = CreateStage();
@@ -1357,6 +1554,22 @@ namespace DTXMania.Test.Stage
             public void Enqueue(InputCommand command)
             {
                 EnqueueCommand(command);
+            }
+        }
+
+        private sealed class UpdatingQueuedInputManager : InputManager
+        {
+            public bool UpdateCalled { get; private set; }
+
+            public void Enqueue(InputCommand command)
+            {
+                EnqueueCommand(command);
+            }
+
+            public override void Update(double deltaTime = 0)
+            {
+                UpdateCalled = true;
+                base.Update(deltaTime);
             }
         }
 

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -458,93 +458,41 @@ namespace DTXMania.Test.Stage
             Assert.Equal("Song B", display.SelectedSong.Title);
         }
 
-        [Fact]
-    public void ExecuteInputCommand_MoveDown_ShouldMoveSelectionAndPlayCursorSound()
-    {
-        var stage = CreateStage();
-        var display = new SongListDisplay
+        [Theory]
+        [InlineData(InputCommandType.MoveDown, false, false, 3.5, "B")]
+        [InlineData(InputCommandType.MoveUp, false, true, 2.5, "A")]
+        [InlineData(InputCommandType.MoveUp, true, true, 4.5, "A")]
+        [InlineData(InputCommandType.MoveDown, true, false, 5.5, "B")]
+        public void ExecuteInputCommand_MoveNavigation_ShouldMoveSelectionAndPlayCursorSound(
+            InputCommandType command,
+            bool isInStatusPanel,
+            bool startAtSecondItem,
+            double elapsedTime,
+            string expectedSelectedTitle)
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
             {
                 CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
             };
             var cursorSound = new Mock<ISound>();
 
             AttachCoreUi(stage, display: display);
-            SetPrivateField(stage, "_elapsedTime", 3.5);
+            if (startAtSecondItem)
+            {
+                display.MoveNext();
+            }
+
+            SetPrivateField(stage, "_isInStatusPanel", isInStatusPanel);
+            SetPrivateField(stage, "_elapsedTime", elapsedTime);
             SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
 
-            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveDown, 0.0));
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(command, 0.0));
 
-            Assert.Equal("B", display.SelectedSong!.Title);
-        Assert.Equal(3.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
-        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
-    }
-
-    [Fact]
-    public void ExecuteInputCommand_MoveUp_ShouldMoveSelectionAndPlayCursorSound()
-    {
-        var stage = CreateStage();
-        var display = new SongListDisplay
-        {
-            CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
-        };
-        var cursorSound = new Mock<ISound>();
-
-        AttachCoreUi(stage, display: display);
-        display.MoveNext();
-        SetPrivateField(stage, "_elapsedTime", 2.5);
-        SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
-
-        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveUp, 0.0));
-
-        Assert.Equal("A", display.SelectedSong!.Title);
-        Assert.Equal(2.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
-        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
-    }
-
-    [Fact]
-    public void ExecuteInputCommand_MoveUpInStatusPanel_ShouldStillMoveSelectionAndPlayCursorSound()
-    {
-        var stage = CreateStage();
-        var display = new SongListDisplay
-        {
-            CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
-        };
-        var cursorSound = new Mock<ISound>();
-
-        AttachCoreUi(stage, display: display);
-        display.MoveNext();
-        SetPrivateField(stage, "_isInStatusPanel", true);
-        SetPrivateField(stage, "_elapsedTime", 4.5);
-        SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
-
-        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveUp, 0.0));
-
-        Assert.Equal("A", display.SelectedSong!.Title);
-        Assert.Equal(4.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
-        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
-    }
-
-    [Fact]
-    public void ExecuteInputCommand_MoveDownInStatusPanel_ShouldStillMoveSelectionAndPlayCursorSound()
-    {
-        var stage = CreateStage();
-        var display = new SongListDisplay
-        {
-            CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
-        };
-        var cursorSound = new Mock<ISound>();
-
-        AttachCoreUi(stage, display: display);
-        SetPrivateField(stage, "_isInStatusPanel", true);
-        SetPrivateField(stage, "_elapsedTime", 5.5);
-        SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
-
-        InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveDown, 0.0));
-
-        Assert.Equal("B", display.SelectedSong!.Title);
-        Assert.Equal(5.5, GetPrivateField<double>(stage, "_lastNavigationTime"));
-        cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
-    }
+            Assert.Equal(expectedSelectedTitle, display.SelectedSong!.Title);
+            Assert.Equal(elapsedTime, GetPrivateField<double>(stage, "_lastNavigationTime"));
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
 
     [Fact]
     public void ExecuteInputCommand_MoveLeftInStatusPanel_ShouldCycleBackwardDifficulty()
@@ -1340,7 +1288,7 @@ namespace DTXMania.Test.Stage
             Assert.Null(exception);
             oldSound.Verify(x => x.RemoveReference(), Times.Once);
             oldInstance.Verify(x => x.Stop(), Times.Once);
-            oldInstance.Verify(x => x.Dispose(), Times.Never);
+            oldInstance.Verify(x => x.Dispose(), Times.Once);
             Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
             Assert.Same(newInstance.Object, GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
         }

--- a/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.IO;
 using System.Reflection;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Resources;
@@ -290,6 +292,104 @@ namespace DTXMania.Test.Stage
             ReflectionHelpers.InvokePrivateMethod(stage, "LoadSound");
 
             Assert.Same(fallbackSound.Object, ReflectionHelpers.GetPrivateField<ISound>(stage, "_nowLoadingSound"));
+        }
+
+        [Fact]
+        public void OnUpdate_WhenAutoTransitionDelayElapsed_ShouldTransitionToPerformance()
+        {
+            var stageManager = new Mock<IStageManager>();
+            var game = ReflectionHelpers.CreateGame(totalGameTime: 3.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_selectedSong", CreateSongNode(new SongChart { DrumLevel = 55, HasDrumChart = true }));
+            ReflectionHelpers.SetPrivateField(stage, "_currentPhase", StagePhase.Normal);
+            ReflectionHelpers.SetPrivateField(stage, "_elapsedTime", SongTransitionUILayout.Timing.AutoTransitionDelay);
+
+            InvokePrivateMethod(stage, "OnUpdate", 0.0);
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.Performance,
+                    It.IsAny<IStageTransition>(),
+                    It.IsAny<Dictionary<string, object>>()),
+                Times.Once);
+            Assert.Equal(3.0, ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void LoadFonts_WhenReloadFails_ShouldReleaseExistingFontsAndLeaveFieldsNull()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var titleFont = new Mock<IFont>();
+            var artistFont = new Mock<IFont>();
+
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_titleFont", titleFont.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_artistFont", artistFont.Object);
+
+            resourceManager
+                .Setup(x => x.LoadFont("NotoSerifJP", SongTransitionUILayout.SongTitle.FontSize))
+                .Throws(new InvalidOperationException("missing title font"));
+            resourceManager
+                .Setup(x => x.LoadFont("NotoSerifJP", SongTransitionUILayout.Artist.FontSize))
+                .Throws(new InvalidOperationException("missing artist font"));
+
+            InvokePrivateMethod(stage, "LoadFonts");
+
+            titleFont.Verify(x => x.RemoveReference(), Times.Once);
+            artistFont.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(ReflectionHelpers.GetPrivateField<IFont>(stage, "_titleFont"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<IFont>(stage, "_artistFont"));
+        }
+
+        [Fact]
+        public void LoadPreviewImage_WhenPrimaryPreviewExists_ShouldLoadAbsolutePreviewPath()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var previewTexture = new Mock<ITexture>();
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                var chartPath = Path.Combine(tempDir, "sample.dtx");
+                var previewFileName = "preview.png";
+                var previewPath = Path.Combine(tempDir, previewFileName);
+                File.WriteAllText(chartPath, "chart");
+                File.WriteAllText(previewPath, "preview");
+
+                ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+                ReflectionHelpers.SetPrivateField(stage, "_selectedSong", CreateSongNode(new SongChart
+                {
+                    FilePath = chartPath,
+                    PreviewImage = previewFileName
+                }));
+                resourceManager
+                    .Setup(x => x.LoadTexture(Path.GetFullPath(previewPath)))
+                    .Returns(previewTexture.Object);
+
+                InvokePrivateMethod(stage, "LoadPreviewImage");
+
+                resourceManager.Verify(x => x.LoadTexture(Path.GetFullPath(previewPath)), Times.Once);
+                Assert.Same(previewTexture.Object, ReflectionHelpers.GetPrivateField<ITexture>(stage, "_previewTexture"));
+            }
+            finally
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void GetDifficultyName_WhenDifficultyOutsideKnownRange_ShouldReturnUnknown()
+        {
+            var stage = CreateStage();
+
+            var result = InvokePrivateMethod<string>(stage, "GetDifficultyName", 9);
+
+            Assert.Equal("Unknown", result);
         }
 
         private static SongTransitionStage CreateStage(BaseGame? game = null)

--- a/DTXMania.Test/Stage/StartupStageLogicTests.cs
+++ b/DTXMania.Test/Stage/StartupStageLogicTests.cs
@@ -106,6 +106,24 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void UpdateCurrentPhase_WhenAsyncTaskCompletedBeforeMinimumDuration_ShouldStayInCurrentPhase()
+        {
+            var completedTask = Task.CompletedTask;
+            var stage = CreateStage(
+                phase: StartupPhase.SongListDB,
+                elapsedTime: 0.1,
+                phaseStartTime: 0.0,
+                currentAsyncTask: completedTask);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateCurrentPhase");
+
+            Assert.Equal(StartupPhase.SongListDB, ReflectionHelpers.GetPrivateField<StartupPhase>(stage, "_startupPhase"));
+            Assert.Contains("Complete", ReflectionHelpers.GetPrivateField<string>(stage, "_currentProgressMessage"));
+            Assert.Empty(ReflectionHelpers.GetPrivateField<List<string>>(stage, "_progressMessages")!);
+            Assert.Same(completedTask, ReflectionHelpers.GetPrivateField<Task>(stage, "_currentAsyncTask"));
+        }
+
+        [Fact]
         public void UpdateCurrentPhase_WhenAsyncTaskFaulted_ShouldAdvanceAfterMinimumDuration()
         {
             var faultedTask = Task.FromException(new InvalidOperationException("boom"));
@@ -232,6 +250,17 @@ namespace DTXMania.Test.Stage
             ReflectionHelpers.InvokePrivateMethod(stage, "PerformPhaseOperationSync", phase, 0.0);
 
             Assert.NotNull(ReflectionHelpers.GetPrivateField<Task>(stage, "_currentAsyncTask"));
+        }
+
+        [Fact]
+        public void PerformPhaseOperationSync_WhenAsyncTaskAlreadyExists_ShouldNotReplaceIt()
+        {
+            var existingTask = Task.Delay(Timeout.Infinite, new CancellationToken(true));
+            var stage = CreateStage(currentAsyncTask: existingTask);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "PerformPhaseOperationSync", StartupPhase.LoadScoreCache, 0.0);
+
+            Assert.Same(existingTask, ReflectionHelpers.GetPrivateField<Task>(stage, "_currentAsyncTask"));
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/TitleStageLogicTests.cs
+++ b/DTXMania.Test/Stage/TitleStageLogicTests.cs
@@ -1,4 +1,5 @@
 using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage;
@@ -7,6 +8,7 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Moq;
 using System.Runtime.Serialization;
+using XnaButtonState = Microsoft.Xna.Framework.Input.ButtonState;
 
 namespace DTXMania.Test.Stage
 {
@@ -225,6 +227,105 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void HandleInput_WhenMoveDownPressed_ShouldAdvanceCursor()
+        {
+            var game = ReflectionHelpers.CreateGame();
+            var inputManager = new StubInputManagerCompat();
+            var cursorSound = CreateSoundReturningInstance();
+            var stage = CreateStage(game);
+
+            inputManager.SetPressedCommand(InputCommandType.MoveDown);
+            ReflectionHelpers.SetPrivateField(game, "<InputManager>k__BackingField", inputManager);
+            ReflectionHelpers.SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentMenuIndex"));
+            cursorSound.Verify(x => x.Play(0.7f), Times.Once);
+        }
+
+        [Fact]
+        public void HandleMouseInput_WhenHoverChanges_ShouldUpdateCursorAndPlaySound()
+        {
+            const int menuX = 506;
+            const int menuY = 513;
+            const int itemHeight = 39;
+
+            var stage = CreateStage();
+            var cursorSound = CreateSoundReturningInstance();
+
+            ReflectionHelpers.SetPrivateField(stage, "_currentMenuIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_hoveredMenuIndex", -1);
+            ReflectionHelpers.SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(menuX + 10, menuY + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(menuX + 10, menuY + itemHeight + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleMouseInput");
+
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentMenuIndex"));
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_hoveredMenuIndex"));
+            cursorSound.Verify(x => x.Play(0.7f), Times.Once);
+        }
+
+        [Fact]
+        public void HandleMouseInput_WhenLeftClickPressedOnHoveredItem_ShouldSelectHoveredEntry()
+        {
+            const int menuX = 506;
+            const int menuY = 513;
+            const int itemHeight = 39;
+
+            var game = ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var selectSound = CreateSoundReturningInstance();
+
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_selectSound", selectSound.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(menuX + 10, menuY + itemHeight + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(menuX + 10, menuY + itemHeight + 10, 0, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleMouseInput");
+
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentMenuIndex"));
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.Config,
+                    It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
+                Times.Once);
+            selectSound.Verify(x => x.Play(0.8f), Times.Once);
+        }
+
+        [Fact]
+        public void IsMouseButtonPressed_ShouldDetectRightAndMiddleEdgeTransitions()
+        {
+            var stage = CreateStage();
+            var mouseButtonType = typeof(TitleStage).GetNestedType("MouseButton", System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(mouseButtonType);
+
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(0, 0, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(0, 0, 0, XnaButtonState.Released, XnaButtonState.Pressed, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released));
+
+            var rightPressed = ReflectionHelpers.InvokePrivateMethod<bool>(stage, "IsMouseButtonPressed", Enum.Parse(mouseButtonType!, "Right"));
+            var middlePressed = ReflectionHelpers.InvokePrivateMethod<bool>(stage, "IsMouseButtonPressed", Enum.Parse(mouseButtonType!, "Middle"));
+
+            Assert.True(rightPressed);
+            Assert.True(middlePressed);
+        }
+
+        [Fact]
+        public void PlaySelectSound_WhenSoundThrows_ShouldNotPropagate()
+        {
+            var stage = CreateStage();
+            var sound = new Mock<ISound>();
+            sound.Setup(x => x.Play(0.8f)).Throws(new InvalidOperationException("audio failed"));
+            ReflectionHelpers.SetPrivateField(stage, "_selectSound", sound.Object);
+
+            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "PlaySelectSound"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void Deactivate_ShouldResetMenuAndInputTrackingState()
         {
             var stage = CreateStage();
@@ -331,6 +432,30 @@ namespace DTXMania.Test.Stage
 
             public void Update(double deltaTime)
             {
+            }
+        }
+
+        private sealed class StubInputManagerCompat : InputManagerCompat
+        {
+            private readonly HashSet<InputCommandType> _pressedCommands = new();
+            private bool _backTriggered;
+
+            public StubInputManagerCompat() : base(new ConfigManager())
+            {
+            }
+
+            public override bool IsBackActionTriggered() => _backTriggered;
+
+            public override bool IsCommandPressed(InputCommandType command) => _pressedCommands.Contains(command);
+
+            public void SetBackTriggered(bool value)
+            {
+                _backTriggered = value;
+            }
+
+            public void SetPressedCommand(InputCommandType command)
+            {
+                _pressedCommands.Add(command);
             }
         }
 

--- a/DTXMania.Test/Stage/TitleStageLogicTests.cs
+++ b/DTXMania.Test/Stage/TitleStageLogicTests.cs
@@ -15,6 +15,10 @@ namespace DTXMania.Test.Stage
     [Trait("Category", "Unit")]
     public class TitleStageLogicTests
     {
+        private const int MenuX = 506;
+        private const int MenuY = 513;
+        private const int ItemHeight = 39;
+
         [Fact]
         public void MoveCursorUp_FromFirstItem_ShouldWrapToLastAndPlaySound()
         {
@@ -235,7 +239,7 @@ namespace DTXMania.Test.Stage
             var stage = CreateStage(game);
 
             inputManager.SetPressedCommand(InputCommandType.MoveDown);
-            ReflectionHelpers.SetPrivateField(game, "<InputManager>k__BackingField", inputManager);
+            ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
             ReflectionHelpers.SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -247,18 +251,14 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void HandleMouseInput_WhenHoverChanges_ShouldUpdateCursorAndPlaySound()
         {
-            const int menuX = 506;
-            const int menuY = 513;
-            const int itemHeight = 39;
-
             var stage = CreateStage();
             var cursorSound = CreateSoundReturningInstance();
 
             ReflectionHelpers.SetPrivateField(stage, "_currentMenuIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_hoveredMenuIndex", -1);
             ReflectionHelpers.SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(menuX + 10, menuY + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
-            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(menuX + 10, menuY + itemHeight + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(MenuX + 10, MenuY + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(MenuX + 10, MenuY + ItemHeight + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleMouseInput");
 
@@ -270,10 +270,6 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void HandleMouseInput_WhenLeftClickPressedOnHoveredItem_ShouldSelectHoveredEntry()
         {
-            const int menuX = 506;
-            const int menuY = 513;
-            const int itemHeight = 39;
-
             var game = ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
             var stage = CreateStage(game);
             var stageManager = new Mock<IStageManager>();
@@ -281,8 +277,8 @@ namespace DTXMania.Test.Stage
 
             stage.StageManager = stageManager.Object;
             ReflectionHelpers.SetPrivateField(stage, "_selectSound", selectSound.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(menuX + 10, menuY + itemHeight + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
-            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(menuX + 10, menuY + itemHeight + 10, 0, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(MenuX + 10, MenuY + ItemHeight + 10, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(MenuX + 10, MenuY + ItemHeight + 10, 0, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleMouseInput");
 
@@ -295,8 +291,10 @@ namespace DTXMania.Test.Stage
             selectSound.Verify(x => x.Play(0.8f), Times.Once);
         }
 
-        [Fact]
-        public void IsMouseButtonPressed_ShouldDetectRightAndMiddleEdgeTransitions()
+        [Theory]
+        [InlineData("Right")]
+        [InlineData("Middle")]
+        public void IsMouseButtonPressed_WhenEdgeTransitionOccurs_ShouldReturnTrue(string mouseButtonName)
         {
             var stage = CreateStage();
             var mouseButtonType = typeof(TitleStage).GetNestedType("MouseButton", System.Reflection.BindingFlags.NonPublic);
@@ -305,11 +303,12 @@ namespace DTXMania.Test.Stage
             ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(0, 0, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
             ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(0, 0, 0, XnaButtonState.Released, XnaButtonState.Pressed, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released));
 
-            var rightPressed = ReflectionHelpers.InvokePrivateMethod<bool>(stage, "IsMouseButtonPressed", Enum.Parse(mouseButtonType!, "Right"));
-            var middlePressed = ReflectionHelpers.InvokePrivateMethod<bool>(stage, "IsMouseButtonPressed", Enum.Parse(mouseButtonType!, "Middle"));
+            var pressed = ReflectionHelpers.InvokePrivateMethod<bool>(
+                stage,
+                "IsMouseButtonPressed",
+                Enum.Parse(mouseButtonType!, mouseButtonName));
 
-            Assert.True(rightPressed);
-            Assert.True(middlePressed);
+            Assert.True(pressed);
         }
 
         [Fact]

--- a/DTXMania.Test/TestData/ReflectionHelpers.cs
+++ b/DTXMania.Test/TestData/ReflectionHelpers.cs
@@ -62,6 +62,16 @@ namespace DTXMania.Test.TestData
             field!.SetValue(target, value);
         }
 
+        internal static void SetProperty(object target, string propertyName, object? value)
+        {
+            var property = GetProperty(target.GetType(), propertyName);
+            Assert.NotNull(property);
+
+            var setter = property!.GetSetMethod(nonPublic: true);
+            Assert.NotNull(setter);
+            setter!.Invoke(target, new[] { value });
+        }
+
         internal static FieldInfo? GetField(Type type, string fieldName)
         {
             while (type != null)
@@ -86,6 +96,22 @@ namespace DTXMania.Test.TestData
                 if (method != null)
                 {
                     return method;
+                }
+
+                type = type.BaseType!;
+            }
+
+            return null;
+        }
+
+        internal static PropertyInfo? GetProperty(Type type, string propertyName)
+        {
+            while (type != null)
+            {
+                var property = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                if (property != null)
+                {
+                    return property;
                 }
 
                 type = type.BaseType!;

--- a/DTXMania.Test/UI/PreviewImagePanelTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelTests.cs
@@ -236,6 +236,168 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
+    public void LoadPreviewImageComprehensive_WhenPreviewMissingAndDefaultTextureUnavailable_ShouldClearCurrentPreview()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+        var existingPreview = new Mock<ITexture>();
+        var dir = Path.Combine(Path.GetTempPath(), "dtx-preview-empty", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            var scoreNode = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "NoPreviewSong",
+                DirectoryPath = dir
+            };
+
+            SetField(panel, "_resourceManager", resourceManager.Object);
+            SetField(panel, "_currentPreviewTexture", existingPreview.Object);
+
+            InvokePrivate<object?>(panel, "LoadPreviewImageComprehensive", scoreNode);
+
+            existingPreview.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void LoadPreviewImageComprehensive_WhenNodeIsNotScore_ShouldReleaseCurrentPreviewAndSkipLoading()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+        var existingPreview = new Mock<ITexture>();
+
+        SetField(panel, "_resourceManager", resourceManager.Object);
+        SetField(panel, "_currentPreviewTexture", existingPreview.Object);
+
+        InvokePrivate<object?>(panel, "LoadPreviewImageComprehensive", new SongListNode { Type = NodeType.Box, Title = "Folder" });
+
+        existingPreview.Verify(x => x.RemoveReference(), Times.Once);
+        Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        resourceManager.Verify(x => x.LoadTexture(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void LoadPreviewImageComprehensive_WhenPreviewMissingAndDefaultTextureExists_ShouldAssignDefaultTexture()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+        var defaultTexture = new Mock<ITexture>();
+        var dir = Path.Combine(Path.GetTempPath(), "dtx-preview-default", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            var scoreNode = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "DefaultPreviewSong",
+                DirectoryPath = dir
+            };
+
+            SetField(panel, "_resourceManager", resourceManager.Object);
+            SetField(panel, "_defaultPreviewTexture", defaultTexture.Object);
+
+            InvokePrivate<object?>(panel, "LoadPreviewImageComprehensive", scoreNode);
+
+            defaultTexture.Verify(x => x.AddReference(), Times.Once);
+            Assert.Same(defaultTexture.Object, GetField<ITexture>(panel, "_currentPreviewTexture"));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void LoadPreviewImageComprehensive_WhenUnexpectedLoadFailureOccurs_ShouldFallbackToDefaultTexture()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+        var defaultTexture = new Mock<ITexture>();
+        var dir = Path.Combine(Path.GetTempPath(), "dtx-preview-invalid-op", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            var previewPath = Path.Combine(dir, "preview.jpg");
+            File.WriteAllText(previewPath, "x");
+
+            var scoreNode = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "FallbackSong",
+                DirectoryPath = dir
+            };
+
+            resourceManager.Setup(x => x.LoadTexture(previewPath)).Throws(new InvalidOperationException("broken preview"));
+            SetField(panel, "_resourceManager", resourceManager.Object);
+            SetField(panel, "_defaultPreviewTexture", defaultTexture.Object);
+
+            InvokePrivate<object?>(panel, "LoadPreviewImageComprehensive", scoreNode);
+
+            defaultTexture.Verify(x => x.AddReference(), Times.Once);
+            Assert.Same(defaultTexture.Object, GetField<ITexture>(panel, "_currentPreviewTexture"));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void LoadPreviewImageComprehensive_WhenUnexpectedLoadFailureOccursWithoutDefault_ShouldClearPreview()
+    {
+        var panel = new PreviewImagePanel();
+        var resourceManager = new Mock<IResourceManager>();
+        var dir = Path.Combine(Path.GetTempPath(), "dtx-preview-invalid-op-null", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            var previewPath = Path.Combine(dir, "preview.jpg");
+            File.WriteAllText(previewPath, "x");
+
+            var scoreNode = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "NoDefaultFallbackSong",
+                DirectoryPath = dir
+            };
+
+            resourceManager.Setup(x => x.LoadTexture(previewPath)).Throws(new InvalidOperationException("broken preview"));
+            SetField(panel, "_resourceManager", resourceManager.Object);
+
+            InvokePrivate<object?>(panel, "LoadPreviewImageComprehensive", scoreNode);
+
+            Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void UpdateSelectedSong_WhenSongUnchanged_ShouldNotResetDelayOrReloadPreview()
     {
         var panel = new PreviewImagePanel();
@@ -402,6 +564,19 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
+    public void ResolveSongDirectoryPath_WhenAllFallbacksReceiveInvalidPath_ShouldReturnOriginalValue()
+    {
+        var panel = new PreviewImagePanel();
+        var invalidPath = "invalid\0preview";
+
+        panel.SongsRootPath = Path.GetTempPath();
+
+        var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", invalidPath);
+
+        Assert.Equal(invalidPath, resolved);
+    }
+
+    [Fact]
     public void FindPreviewImageFile_ShouldFindPreviewByKnownNamesAndExtensions()
     {
         var panel = new PreviewImagePanel();
@@ -424,6 +599,109 @@ public class PreviewImagePanelTests
                 Directory.Delete(dir, recursive: true);
             }
         }
+    }
+
+    [Fact]
+    public void FindPreviewImageFile_WhenNoKnownPreviewExists_ShouldReturnNull()
+    {
+        var panel = new PreviewImagePanel();
+        var dir = Path.Combine(Path.GetTempPath(), "dtx-preview-none", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "notes.txt"), "x");
+
+            var found = InvokePrivate<string?>(panel, "FindPreviewImageFile", dir);
+
+            Assert.Null(found);
+        }
+        finally
+        {
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void DrawBackground_WhenFrameTextureIsLoaded_ShouldUseNaturalTextureBounds()
+    {
+        var panel = new PreviewImagePanel();
+        var frameTexture = new Mock<ITexture>();
+        Rectangle? drawnBounds = null;
+
+        frameTexture.SetupGet(x => x.Width).Returns(308);
+        frameTexture.SetupGet(x => x.Height).Returns(308);
+        frameTexture
+            .Setup(x => x.Draw(
+                It.IsAny<SpriteBatch>(),
+                It.IsAny<Rectangle>(),
+                It.IsAny<Rectangle?>(),
+                It.IsAny<Color>(),
+                It.IsAny<float>(),
+                It.IsAny<Vector2>(),
+                It.IsAny<SpriteEffects>(),
+                It.IsAny<float>()))
+            .Callback<SpriteBatch, Rectangle, Rectangle?, Color, float, Vector2, SpriteEffects, float>(
+                (_, destination, _, _, _, _, _, _) => drawnBounds = destination);
+
+        SetField(panel, "_preimagePanelTexture", frameTexture.Object);
+
+        InvokePrivateVoid(panel, "DrawBackground", null!, new Rectangle(10, 20, 400, 400));
+
+        Assert.Equal(new Rectangle(10, 20, 308, 308), drawnBounds);
+    }
+
+    [Fact]
+    public void DrawPreviewContent_WhenPreviewDrawThrowsUnexpectedException_ShouldKeepTextureReference()
+    {
+        var panel = new PreviewImagePanel();
+        var previewTexture = new Mock<ITexture>();
+
+        previewTexture
+            .Setup(x => x.Draw(
+                It.IsAny<SpriteBatch>(),
+                It.IsAny<Rectangle>(),
+                It.IsAny<Rectangle?>(),
+                It.IsAny<Color>(),
+                It.IsAny<float>(),
+                It.IsAny<Vector2>(),
+                It.IsAny<SpriteEffects>(),
+                It.IsAny<float>()))
+            .Throws(new InvalidOperationException("boom"));
+
+        SetField(panel, "_currentSong", new SongListNode { Type = NodeType.Score, Title = "Song" });
+        SetField(panel, "_displayDelay", 0.5);
+        SetField(panel, "_currentPreviewTexture", previewTexture.Object);
+
+        var exception = Record.Exception(() => InvokePrivateVoid(panel, "DrawPreviewContent", null!, new Rectangle(250, 34, 308, 308)));
+
+        Assert.Null(exception);
+        Assert.Same(previewTexture.Object, GetField<ITexture>(panel, "_currentPreviewTexture"));
+    }
+
+    [Fact]
+    public void Dispose_ShouldReleaseCurrentDefaultAndFrameTextures()
+    {
+        var panel = new PreviewImagePanel();
+        var currentPreview = new Mock<ITexture>();
+        var defaultPreview = new Mock<ITexture>();
+        var frameTexture = new Mock<ITexture>();
+
+        SetField(panel, "_currentPreviewTexture", currentPreview.Object);
+        SetField(panel, "_defaultPreviewTexture", defaultPreview.Object);
+        SetField(panel, "_preimagePanelTexture", frameTexture.Object);
+
+        panel.Dispose();
+
+        currentPreview.Verify(x => x.RemoveReference(), Times.Once);
+        defaultPreview.Verify(x => x.RemoveReference(), Times.Once);
+        frameTexture.Verify(x => x.RemoveReference(), Times.Once);
+        Assert.Null(GetFieldValue(panel, "_currentPreviewTexture"));
+        Assert.Null(GetFieldValue(panel, "_defaultPreviewTexture"));
+        Assert.Null(GetFieldValue(panel, "_preimagePanelTexture"));
     }
 
     private static T InvokePrivate<T>(object target, string methodName, params object[] args)

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -35,6 +35,16 @@ public class SongListDisplayLogicTests
     }
 
     [Fact]
+    public void GetDisplayText_WhenScoreTitleMissing_ShouldFallbackToUnknownSong()
+    {
+        var display = new SongListDisplay();
+
+        var text = InvokePrivate<string>(display, "GetDisplayText", new SongListNode { Type = NodeType.Score, Title = null });
+
+        Assert.Equal("Unknown", text);
+    }
+
+    [Fact]
     public void TruncateTextToWidth_ShouldReturnOriginalOrTruncated()
     {
         var display = new SongListDisplay();
@@ -124,6 +134,63 @@ public class SongListDisplayLogicTests
         InvokePrivate<object?>(display, "UpdateScrollAnimation", 1.0 / 60.0);
         var backward = GetField<int>(display, "_currentScrollCounter");
         Assert.InRange(backward, -300, -1);
+    }
+
+    [Fact]
+    public void UpdateScrollAnimation_WhenCrossingTwoBars_ShouldQueueTextureGenerationForVisibleBars()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList = CreateSongs(12)
+        };
+        var queue = GetTextureGenerationQueue(display);
+        queue.Clear();
+
+        SetField(display, "_selectedIndex", 5);
+        SetField(display, "_currentDifficulty", 1);
+        SetField(display, "_currentScrollCounter", 0);
+        SetField(display, "_targetScrollCounter", 300);
+
+        InvokePrivate<object?>(display, "UpdateScrollAnimation", 1.0);
+
+        Assert.Equal(300, GetField<int>(display, "_currentScrollCounter"));
+        Assert.NotEmpty(queue);
+    }
+
+    [Fact]
+    public void CycleDifficulty_WhenCurrentSlotIsMissing_ShouldWrapToNextAvailableScore()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList =
+            [
+                new SongListNode
+                {
+                    Type = NodeType.Score,
+                    Title = "Song",
+                    Scores =
+                    [
+                        null,
+                        new SongScore { DifficultyLevel = 1 },
+                        null,
+                        null,
+                        new SongScore { DifficultyLevel = 4 }
+                    ]
+                }
+            ]
+        };
+
+        DifficultyChangedEventArgs? args = null;
+        display.DifficultyChanged += (_, e) => args = e;
+        display.CurrentDifficulty = 0;
+
+        display.CycleDifficulty();
+        Assert.Equal(1, display.CurrentDifficulty);
+        Assert.NotNull(args);
+        Assert.Equal(1, args!.NewDifficulty);
+
+        display.CycleDifficulty();
+        Assert.Equal(4, display.CurrentDifficulty);
     }
 
     [Fact]
@@ -1047,6 +1114,42 @@ public class SongListDisplayLogicTests
         InvokePrivate<object?>(display, "DrawCommentBar", (SpriteBatch)null!);
 
         commentBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+    }
+
+    [Fact]
+    public void DrawCommentBar_WhenTextureMissingAndResourceManagerAvailable_ShouldLazyLoadAndDraw()
+    {
+        var display = new SongListDisplay
+        {
+            CurrentList =
+            [
+                new SongListNode
+                {
+                    Type = NodeType.Score,
+                    Title = "Song 0",
+                    DatabaseSong = new SongEntity
+                    {
+                        Title = "Song 0",
+                        Artist = "Artist 0",
+                        Comment = "A comment"
+                    },
+                    Scores = new SongScore[5]
+                }
+            ]
+        };
+        var resourceManager = new Mock<IResourceManager>();
+        var commentBarTexture = CreateTexture(width: 620, height: 60);
+
+        resourceManager.Setup(x => x.LoadTexture(TexturePath.CommentBar)).Returns(commentBarTexture.Object);
+        SetField(display, "_resourceManager", resourceManager.Object);
+        SetField(display, "_commentBarTexture", null);
+        SetField(display, "_font", null);
+
+        InvokePrivate<object?>(display, "DrawCommentBar", (SpriteBatch)null!);
+
+        resourceManager.Verify(x => x.LoadTexture(TexturePath.CommentBar), Times.Once);
+        commentBarTexture.Verify(x => x.Draw(It.IsAny<Microsoft.Xna.Framework.Graphics.SpriteBatch>(), It.IsAny<Vector2>()), Times.Once);
+        Assert.Same(commentBarTexture.Object, GetField<ITexture>(display, "_commentBarTexture"));
     }
 
     [Fact]

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -757,6 +757,123 @@ public class SongStatusPanelLogicTests
         Assert.Equal(new Vector2(490, 385), drawnPosition);
     }
 
+    [Fact]
+    public void DrawBPMSection_WhenAuthenticTextureMissing_ShouldUseFallbackLabels()
+    {
+        var panel = new SongStatusPanel();
+        var managedFont = CreateManagedFont();
+        var song = CreateScoreNodeForDraw();
+
+        panel.ManagedFont = managedFont.Object;
+        panel.ManagedSmallFont = managedFont.Object;
+
+        InvokePrivate<object?>(panel, "DrawBPMSection", null!, Rectangle.Empty, song, 0);
+
+        managedFont.Verify(
+            x => x.DrawString(It.IsAny<SpriteBatch>(), "Length: 2:05", It.IsAny<Vector2>(), It.IsAny<Color>()),
+            Times.Exactly(2));
+        managedFont.Verify(
+            x => x.DrawString(It.IsAny<SpriteBatch>(), "BPM: 180", It.IsAny<Vector2>(), It.IsAny<Color>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public void DrawRankSymbol_WhenScoreHasRankAndFullCombo_ShouldDrawRankAndBadge()
+    {
+        var panel = new SongStatusPanel();
+        var sourceRects = new List<Rectangle?>();
+        var skillIcon = new Mock<ITexture>();
+        skillIcon.SetupGet(x => x.Height).Returns(20);
+        skillIcon
+            .Setup(x => x.Draw(It.IsAny<SpriteBatch>(), It.IsAny<Vector2>(), It.IsAny<Rectangle?>()))
+            .Callback<SpriteBatch, Vector2, Rectangle?>((_, _, sourceRect) => sourceRects.Add(sourceRect));
+
+        SetField(panel, "_skillIconTexture", skillIcon.Object);
+
+        var score = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            PlayCount = 5,
+            BestRank = 95,
+            FullCombo = true
+        };
+        var chartInfo = new SongStatusPanel.ChartLevelInfo
+        {
+            InstrumentColumn = 0,
+            InstrumentName = "DRUMS",
+            Chart = new SongChart
+            {
+                Scores = new List<SongScore> { score }
+            }
+        };
+
+        InvokePrivate<object?>(panel, "DrawRankSymbol", null!, 10, 20, chartInfo, 0);
+
+        var expectedRankIndex = SongScore.ComputeRankIndex(SongScore.NormalizeStoredBestRank(score.BestRank));
+        Assert.Equal(2, sourceRects.Count);
+        Assert.Equal(new Rectangle(35 * expectedRankIndex, 0, 35, 20), sourceRects[0]);
+        Assert.Equal(new Rectangle(35 * 8, 0, 35, 20), sourceRects[1]);
+    }
+
+    [Fact]
+    public void LaneColorHelpers_ShouldReturnExpectedDrumAndGuitarBassColors()
+    {
+        var panel = new SongStatusPanel();
+
+        Assert.Equal(Color.Purple, InvokePrivate<Color>(panel, "GetDrumLaneColor", 0));
+        Assert.Equal(Color.Yellow, InvokePrivate<Color>(panel, "GetDrumLaneColor", 1));
+        Assert.Equal(Color.Orange, InvokePrivate<Color>(panel, "GetDrumLaneColor", 5));
+        Assert.Equal(Color.White, InvokePrivate<Color>(panel, "GetDrumLaneColor", 99));
+
+        Assert.Equal(Color.Red, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 0));
+        Assert.Equal(Color.Green, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 1));
+        Assert.Equal(Color.Purple, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 4));
+        Assert.Equal(Color.White, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 99));
+    }
+
+    [Fact]
+    public void GetAvailableChartsWithLevels_ShouldExpandSupportedInstrumentsAndDeduplicateByGridSlot()
+    {
+        var panel = new SongStatusPanel();
+        var chart1 = new SongChart { DifficultyLevel = 1, HasDrumChart = true, DrumLevel = 30, HasGuitarChart = true, GuitarLevel = 45 };
+        var chart2 = new SongChart { DifficultyLevel = 1, HasDrumChart = true, DrumLevel = 60, HasBassChart = true, BassLevel = 25 };
+        var chart3 = new SongChart { DifficultyLevel = 3, HasDrumChart = true, DrumLevel = 80 };
+        var song = new SongEntity { Charts = new List<SongChart> { chart1, chart2, chart3 } };
+
+        SetField(panel, "_currentSong", new SongListNode { Type = NodeType.Score, DatabaseSong = song });
+
+        var chartLevels = InvokePrivate<List<SongStatusPanel.ChartLevelInfo>>(panel, "GetAvailableChartsWithLevels");
+
+        Assert.Equal(4, chartLevels.Count);
+        Assert.Contains(chartLevels, info => info.Chart == chart1 && info.InstrumentColumn == 0 && info.Level == 30);
+        Assert.DoesNotContain(chartLevels, info => info.Chart == chart2 && info.InstrumentColumn == 0);
+        Assert.Contains(chartLevels, info => info.Chart == chart1 && info.InstrumentColumn == 1 && info.Level == 45);
+        Assert.Contains(chartLevels, info => info.Chart == chart2 && info.InstrumentColumn == 2 && info.Level == 25);
+        Assert.Contains(chartLevels, info => info.Chart == chart3 && info.InstrumentColumn == 0 && info.Level == 80);
+    }
+
+    [Fact]
+    public void IsChartSelected_ShouldRequireMatchingInstrumentAndCurrentChart()
+    {
+        var panel = new SongStatusPanel();
+        var chart1 = new SongChart { DifficultyLevel = 1, HasDrumChart = true, DrumLevel = 30, HasGuitarChart = true, GuitarLevel = 45 };
+        var chart2 = new SongChart { DifficultyLevel = 2, HasDrumChart = true, DrumLevel = 60 };
+        var song = new SongEntity { Charts = new List<SongChart> { chart1, chart2 } };
+
+        SetField(panel, "_currentSong", new SongListNode { Type = NodeType.Score, DatabaseSong = song });
+        SetField(panel, "_currentDifficulty", 0);
+
+        var chartLevels = InvokePrivate<List<SongStatusPanel.ChartLevelInfo>>(panel, "GetAvailableChartsWithLevels");
+        var selectedDrum = chartLevels.Single(info => info.Chart == chart1 && info.InstrumentColumn == 0);
+        var guitarInfo = chartLevels.Single(info => info.Chart == chart1 && info.InstrumentColumn == 1);
+        var method = typeof(SongStatusPanel).GetMethod("IsChartSelected", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        Assert.False((bool)method!.Invoke(panel, new object?[] { null })!);
+        Assert.True(InvokePrivate<bool>(panel, "IsChartSelected", selectedDrum));
+        Assert.False(InvokePrivate<bool>(panel, "IsChartSelected", guitarInfo));
+    }
+
     private static Mock<IFont> CreateManagedFont()
     {
         var font = new Mock<IFont>();

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -816,22 +816,6 @@ public class SongStatusPanelLogicTests
     }
 
     [Fact]
-    public void LaneColorHelpers_ShouldReturnExpectedDrumAndGuitarBassColors()
-    {
-        var panel = new SongStatusPanel();
-
-        Assert.Equal(Color.Purple, InvokePrivate<Color>(panel, "GetDrumLaneColor", 0));
-        Assert.Equal(Color.Yellow, InvokePrivate<Color>(panel, "GetDrumLaneColor", 1));
-        Assert.Equal(Color.Orange, InvokePrivate<Color>(panel, "GetDrumLaneColor", 5));
-        Assert.Equal(Color.White, InvokePrivate<Color>(panel, "GetDrumLaneColor", 99));
-
-        Assert.Equal(Color.Red, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 0));
-        Assert.Equal(Color.Green, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 1));
-        Assert.Equal(Color.Purple, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 4));
-        Assert.Equal(Color.White, InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 99));
-    }
-
-    [Fact]
     public void GetAvailableChartsWithLevels_ShouldExpandSupportedInstrumentsAndDeduplicateByGridSlot()
     {
         var panel = new SongStatusPanel();
@@ -845,11 +829,11 @@ public class SongStatusPanelLogicTests
         var chartLevels = InvokePrivate<List<SongStatusPanel.ChartLevelInfo>>(panel, "GetAvailableChartsWithLevels");
 
         Assert.Equal(4, chartLevels.Count);
-        Assert.Contains(chartLevels, info => info.Chart == chart1 && info.InstrumentColumn == 0 && info.Level == 30);
-        Assert.DoesNotContain(chartLevels, info => info.Chart == chart2 && info.InstrumentColumn == 0);
-        Assert.Contains(chartLevels, info => info.Chart == chart1 && info.InstrumentColumn == 1 && info.Level == 45);
-        Assert.Contains(chartLevels, info => info.Chart == chart2 && info.InstrumentColumn == 2 && info.Level == 25);
-        Assert.Contains(chartLevels, info => info.Chart == chart3 && info.InstrumentColumn == 0 && info.Level == 80);
+        Assert.Equal(1, chartLevels.GroupBy(info => new { info.Chart.DifficultyLevel, info.InstrumentColumn }).Max(group => group.Count()));
+        Assert.Contains(chartLevels, info => info.InstrumentColumn == 0 && info.Chart.DifficultyLevel == 1 && info.Level == 30);
+        Assert.Contains(chartLevels, info => info.InstrumentColumn == 1 && info.Chart.DifficultyLevel == 1 && info.Level == 45);
+        Assert.Contains(chartLevels, info => info.InstrumentColumn == 2 && info.Chart.DifficultyLevel == 1 && info.Level == 25);
+        Assert.Contains(chartLevels, info => info.InstrumentColumn == 0 && info.Chart.DifficultyLevel == 3 && info.Level == 80);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add 3 new test files: `ManagedFontLogicTests`, `ManagedSpriteTextureTests`, `PooledEffectsManagerTests`
- Expand existing tests across 11 files covering stage logic (Config, SongSelection, SongTransition, Startup, Title, Result), resources (ManagedTexture), performance (PadRenderer), and UI (PreviewImagePanel, SongListDisplay, SongStatusPanel)
- +2,383 lines of new test assertions driving coverage toward the 5pt target on Windows CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broad expansion of unit and performance tests across configuration, font/texture handling, UI panels, stage flows, and effect pooling to improve reliability and prevent regressions.
* **Bug Fixes / Stability**
  * Hardened background-music cleanup to better handle stop/dispose failures during stage transitions, reducing risk of runtime crashes and state inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->