### PR TITLE
test: extract virtual hooks for testability and expand unit test coverage

### DIFF
--- a/DTXMania.Game/Lib/Graphics/RenderTargetManager.cs
+++ b/DTXMania.Game/Lib/Graphics/RenderTargetManager.cs
@@ -47,7 +47,7 @@ namespace DTXMania.Game.Lib.Graphics
                     existingInfo.DepthFormat == depthFormat &&
                     existingInfo.MultiSampleCount == multiSampleCount &&
                     existingInfo.RenderTarget != null &&
-                    !existingInfo.RenderTarget.IsDisposed)
+                    !IsRenderTargetDisposed(existingInfo.RenderTarget))
                 {
                     return existingInfo.RenderTarget;
                 }
@@ -58,8 +58,7 @@ namespace DTXMania.Game.Lib.Graphics
             }
 
             // Create new render target
-            var renderTarget = new RenderTarget2D(_graphicsDevice, width, height, false, 
-                format, depthFormat, multiSampleCount, RenderTargetUsage.DiscardContents);
+            var renderTarget = CreateRenderTarget(width, height, format, depthFormat, multiSampleCount);
 
             var info = new RenderTargetInfo
             {
@@ -84,7 +83,7 @@ namespace DTXMania.Game.Lib.Graphics
         {
             if (_renderTargets.TryGetValue(name, out var info))
             {
-                return info.RenderTarget?.IsDisposed == false ? info.RenderTarget : null;
+                return info.RenderTarget != null && !IsRenderTargetDisposed(info.RenderTarget) ? info.RenderTarget : null;
             }
             return null;
         }
@@ -119,11 +118,13 @@ namespace DTXMania.Game.Lib.Graphics
             foreach (var (name, info) in recreateList)
             {
                 info.RenderTarget?.Dispose();
-                
-                var newRenderTarget = new RenderTarget2D(_graphicsDevice, 
-                    info.Width, info.Height, false, 
-                    info.Format, info.DepthFormat, info.MultiSampleCount, 
-                    RenderTargetUsage.DiscardContents);
+
+                var newRenderTarget = CreateRenderTarget(
+                    info.Width,
+                    info.Height,
+                    info.Format,
+                    info.DepthFormat,
+                    info.MultiSampleCount);
 
                 info.RenderTarget = newRenderTarget;
                 _renderTargets[name] = info;
@@ -146,6 +147,29 @@ namespace DTXMania.Game.Lib.Graphics
                 _renderTargets.Clear();
                 _disposed = true;
             }
+        }
+
+        protected virtual RenderTarget2D CreateRenderTarget(
+            int width,
+            int height,
+            SurfaceFormat format,
+            DepthFormat depthFormat,
+            int multiSampleCount)
+        {
+            return new RenderTarget2D(
+                _graphicsDevice,
+                width,
+                height,
+                false,
+                format,
+                depthFormat,
+                multiSampleCount,
+                RenderTargetUsage.DiscardContents);
+        }
+
+        protected virtual bool IsRenderTargetDisposed(RenderTarget2D renderTarget)
+        {
+            return renderTarget.IsDisposed;
         }
 
         private class RenderTargetInfo

--- a/DTXMania.Game/Lib/Graphics/RenderTargetManager.cs
+++ b/DTXMania.Game/Lib/Graphics/RenderTargetManager.cs
@@ -118,15 +118,22 @@ namespace DTXMania.Game.Lib.Graphics
             foreach (var (name, info) in recreateList)
             {
                 info.RenderTarget?.Dispose();
+                info.RenderTarget = null;
 
-                var newRenderTarget = CreateRenderTarget(
-                    info.Width,
-                    info.Height,
-                    info.Format,
-                    info.DepthFormat,
-                    info.MultiSampleCount);
+                try
+                {
+                    info.RenderTarget = CreateRenderTarget(
+                        info.Width,
+                        info.Height,
+                        info.Format,
+                        info.DepthFormat,
+                        info.MultiSampleCount);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.WriteLine($"RenderTargetManager: {ex.GetType().Name} recreating '{name}' ({info.Width}x{info.Height}): {ex.Message}");
+                }
 
-                info.RenderTarget = newRenderTarget;
                 _renderTargets[name] = info;
             }
         }

--- a/DTXMania.Game/Lib/Resources/ManagedTexture.cs
+++ b/DTXMania.Game/Lib/Resources/ManagedTexture.cs
@@ -69,12 +69,88 @@ namespace DTXMania.Game.Lib.Resources
 
         #endregion
 
+        #region Virtual Hooks
+
+        protected virtual int GetTextureWidthCore()
+        {
+            return _texture?.Width ?? 0;
+        }
+
+        protected virtual int GetTextureHeightCore()
+        {
+            return _texture?.Height ?? 0;
+        }
+
+        protected virtual GraphicsDevice GetGraphicsDeviceCore(Texture2D texture)
+        {
+            return texture.GraphicsDevice;
+        }
+
+        protected virtual void DrawTextureCore(SpriteBatch spriteBatch, Vector2 position, Color color)
+        {
+            spriteBatch.Draw(_texture, position, color);
+        }
+
+        protected virtual void DrawTextureCore(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle, Color color)
+        {
+            spriteBatch.Draw(_texture, position, sourceRectangle, color);
+        }
+
+        protected virtual void DrawTextureCore(SpriteBatch spriteBatch, Rectangle destinationRectangle, Rectangle? sourceRectangle,
+            Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
+        {
+            spriteBatch.Draw(_texture, destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth);
+        }
+
+        protected virtual void DrawTextureCore(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle, Color color,
+            float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+        {
+            spriteBatch.Draw(_texture, position, sourceRectangle, color, rotation, origin, scale, effects, layerDepth);
+        }
+
+        protected virtual Texture2D CreateTextureCore(GraphicsDevice graphicsDevice, int width, int height)
+        {
+            return new Texture2D(graphicsDevice, width, height);
+        }
+
+        protected virtual void GetTextureDataCore(Texture2D texture, Color[] data)
+        {
+            texture.GetData(data);
+        }
+
+        protected virtual void SetTextureDataCore(Texture2D texture, Color[] data)
+        {
+            texture.SetData(data);
+        }
+
+        protected virtual Stream OpenReadCore(string filePath)
+        {
+            return File.OpenRead(filePath);
+        }
+
+        protected virtual Stream CreateFileCore(string filePath)
+        {
+            return File.Create(filePath);
+        }
+
+        protected virtual Texture2D LoadTextureFromStreamCore(GraphicsDevice graphicsDevice, Stream stream)
+        {
+            return Texture2D.FromStream(graphicsDevice, stream);
+        }
+
+        protected virtual void SaveTextureAsPngCore(Texture2D texture, Stream stream, int width, int height)
+        {
+            texture.SaveAsPng(stream, width, height);
+        }
+
+        #endregion
+
         #region ITexture Properties
 
         public Texture2D Texture => _texture;
         public string SourcePath => _sourcePath;
-        public int Width => _texture?.Width ?? 0;
-        public int Height => _texture?.Height ?? 0;
+        public int Width => GetTextureWidthCore();
+        public int Height => GetTextureHeightCore();
         public Vector2 Size => new Vector2(Width, Height);
         public bool IsDisposed => _disposed;
         public int ReferenceCount => _referenceCount;
@@ -145,7 +221,7 @@ namespace DTXMania.Game.Lib.Resources
                 return;
 
             var color = Color.White * (_transparency / 255f);
-            spriteBatch.Draw(_texture, position, color);
+            DrawTextureCore(spriteBatch, position, color);
         }
 
         public void Draw(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle)
@@ -154,7 +230,7 @@ namespace DTXMania.Game.Lib.Resources
                 return;
 
             var color = Color.White * (_transparency / 255f);
-            spriteBatch.Draw(_texture, position, sourceRectangle, color);
+            DrawTextureCore(spriteBatch, position, sourceRectangle, color);
         }
 
         public void Draw(SpriteBatch spriteBatch, Rectangle destinationRectangle, Rectangle? sourceRectangle,
@@ -164,8 +240,7 @@ namespace DTXMania.Game.Lib.Resources
                 return;
 
             var finalColor = color * (_transparency / 255f);
-            spriteBatch.Draw(_texture, destinationRectangle, sourceRectangle, finalColor, 
-                           rotation, origin, effects, layerDepth);
+            DrawTextureCore(spriteBatch, destinationRectangle, sourceRectangle, finalColor, rotation, origin, effects, layerDepth);
         }
 
         public void Draw(SpriteBatch spriteBatch, Vector2 position, Vector2 scale, float rotation, Vector2 origin)
@@ -177,8 +252,7 @@ namespace DTXMania.Game.Lib.Resources
             var finalScale = scale * new Vector2(_scaleRatio.X, _scaleRatio.Y);
             var finalRotation = rotation + _zAxisRotation;
 
-            spriteBatch.Draw(_texture, position, null, color, finalRotation, origin, finalScale, 
-                           SpriteEffects.None, 0f);
+            DrawTextureCore(spriteBatch, position, null, color, finalRotation, origin, finalScale, SpriteEffects.None, 0f);
         }
 
         #endregion
@@ -191,12 +265,12 @@ namespace DTXMania.Game.Lib.Resources
                 throw new ObjectDisposedException(nameof(ManagedTexture));
 
             // Create a new texture with the same data
-            var newTexture = new Texture2D(_texture.GraphicsDevice, Width, Height);
+            var newTexture = CreateTextureCore(GetGraphicsDeviceCore(_texture), Width, Height);
             var colorData = new Color[Width * Height];
-            _texture.GetData(colorData);
-            newTexture.SetData(colorData);
+            GetTextureDataCore(_texture, colorData);
+            SetTextureDataCore(newTexture, colorData);
 
-            var clone = new ManagedTexture(_texture.GraphicsDevice, newTexture, _sourcePath + "_clone")
+            var clone = new ManagedTexture(GetGraphicsDeviceCore(_texture), newTexture, _sourcePath + "_clone")
             {
                 _transparency = _transparency,
                 _scaleRatio = _scaleRatio,
@@ -213,7 +287,7 @@ namespace DTXMania.Game.Lib.Resources
                 throw new ObjectDisposedException(nameof(ManagedTexture));
 
             var colorData = new Color[Width * Height];
-            _texture.GetData(colorData);
+            GetTextureDataCore(_texture, colorData);
             return colorData;
         }
 
@@ -225,7 +299,7 @@ namespace DTXMania.Game.Lib.Resources
             if (colorData.Length != Width * Height)
                 throw new ArgumentException("Color data array size doesn't match texture size");
 
-            _texture.SetData(colorData);
+            SetTextureDataCore(_texture, colorData);
         }
 
         public void SaveToFile(string filePath)
@@ -238,9 +312,9 @@ namespace DTXMania.Game.Lib.Resources
 
             try
             {
-                using (var stream = File.Create(filePath))
+                using (var stream = CreateFileCore(filePath))
                 {
-                    _texture.SaveAsPng(stream, Width, Height);
+                    SaveTextureAsPngCore(_texture, stream, Width, Height);
                 }
             }
             catch (Exception ex)
@@ -255,9 +329,9 @@ namespace DTXMania.Game.Lib.Resources
 
         private void LoadTextureFromFile(GraphicsDevice graphicsDevice, string filePath, TextureCreationParams creationParams)
         {
-            using (var stream = File.OpenRead(filePath))
+            using (var stream = OpenReadCore(filePath))
             {
-                _texture = Texture2D.FromStream(graphicsDevice, stream);
+                _texture = LoadTextureFromStreamCore(graphicsDevice, stream);
             }
 
             // Apply transparency if requested

--- a/DTXMania.Game/Lib/Resources/ResourceManager.cs
+++ b/DTXMania.Game/Lib/Resources/ResourceManager.cs
@@ -123,7 +123,7 @@ namespace DTXMania.Game.Lib.Resources
                 };
 
                 // Load and create texture
-                var texture = new ManagedTexture(_graphicsDevice, resolvedPath, path, creationParams);
+                var texture = CreateTextureCore(resolvedPath, path, creationParams);
                 texture.AddReference();
 
                 // Cache the texture
@@ -180,7 +180,7 @@ namespace DTXMania.Game.Lib.Resources
             try
             {
                 // Create font using ManagedFont factory
-                var font = ManagedFont.CreateFont(_graphicsDevice, normalizedPath, size, style);
+                var font = CreateFontCore(normalizedPath, size, style);
                 font.AddReference();
 
                 // Cache the font
@@ -249,7 +249,7 @@ namespace DTXMania.Game.Lib.Resources
                 }
 
                 // Load and create sound
-                var sound = new ManagedSound(resolvedPath, path);
+                var sound = CreateSoundCore(resolvedPath, path);
                 sound.AddReference();
 
                 // Cache the sound
@@ -289,10 +289,7 @@ namespace DTXMania.Game.Lib.Resources
             }
 
             // Create new texture (either no cache entry or disposed texture was removed)
-            var texture = new Texture2D(_graphicsDevice, 1, 1);
-            texture.SetData(new[] { color });
-
-            var managedTexture = new ManagedTexture(_graphicsDevice, texture, cacheKey);
+            var managedTexture = CreateColorTextureCore(color, cacheKey);
             managedTexture.AddReference();
 
             _textureCache.TryAdd(cacheKey, managedTexture);
@@ -583,6 +580,28 @@ namespace DTXMania.Game.Lib.Resources
 
         #region Private Helper Methods
 
+        protected virtual ITexture CreateTextureCore(string resolvedPath, string originalPath, TextureCreationParams creationParams)
+        {
+            return new ManagedTexture(_graphicsDevice, resolvedPath, originalPath, creationParams);
+        }
+
+        protected virtual IFont CreateFontCore(string normalizedPath, int size, FontStyle style)
+        {
+            return ManagedFont.CreateFont(_graphicsDevice, normalizedPath, size, style);
+        }
+
+        protected virtual ISound CreateSoundCore(string resolvedPath, string originalPath)
+        {
+            return new ManagedSound(resolvedPath, originalPath);
+        }
+
+        protected virtual ITexture CreateColorTextureCore(Color color, string cacheKey)
+        {
+            var texture = new Texture2D(_graphicsDevice, 1, 1);
+            texture.SetData(new[] { color });
+            return new ManagedTexture(_graphicsDevice, texture, cacheKey);
+        }
+
         private void InitializeDefaultSkinPath()
         {
             // DTXMania pattern: Default skin uses System/Graphics/ directly, custom skins use System/{SkinName}/Graphics/
@@ -705,7 +724,7 @@ namespace DTXMania.Game.Lib.Resources
             return isValid;
         }
 
-        private ITexture CreateFallbackTexture(string originalPath)
+        protected virtual ITexture CreateFallbackTexture(string originalPath)
         {
             // Create a simple 1x1 white texture as fallback
             var texture = new Texture2D(_graphicsDevice, 1, 1);
@@ -716,7 +735,7 @@ namespace DTXMania.Game.Lib.Resources
             return fallback;
         }
 
-        private IFont CreateFallbackFont(string originalPath, int size, FontStyle style)
+        protected virtual IFont CreateFallbackFont(string originalPath, int size, FontStyle style)
         {
             // Create fallback font using system default
             try
@@ -732,7 +751,7 @@ namespace DTXMania.Game.Lib.Resources
             }
         }
 
-        private ISound CreateFallbackSound(string originalPath)
+        protected virtual ISound CreateFallbackSound(string originalPath)
         {
             // Create a silent fallback sound (stub implementation)
             try

--- a/DTXMania.Game/Lib/Resources/ResourceManager.cs
+++ b/DTXMania.Game/Lib/Resources/ResourceManager.cs
@@ -578,7 +578,7 @@ namespace DTXMania.Game.Lib.Resources
 
         #endregion
 
-        #region Private Helper Methods
+        #region Virtual Hooks
 
         protected virtual ITexture CreateTextureCore(string resolvedPath, string originalPath, TextureCreationParams creationParams)
         {
@@ -744,9 +744,10 @@ namespace DTXMania.Game.Lib.Resources
                 fallback.AddReference();
                 return fallback;
             }
-            catch
+            catch (Exception ex)
             {
                 // If even Arial fails, return null - calling code should handle this
+                Debug.WriteLine($"ResourceManager: {ex.GetType().Name} creating fallback font for '{originalPath}': {ex.Message}");
                 return null;
             }
         }
@@ -765,9 +766,10 @@ namespace DTXMania.Game.Lib.Resources
                 fallback.AddReference();
                 return fallback;
             }
-            catch
+            catch (Exception ex)
             {
                 // If even silent sound fails, return null - calling code should handle this
+                Debug.WriteLine($"ResourceManager: {ex.GetType().Name} creating fallback sound for '{originalPath}': {ex.Message}");
                 return null;
             }
         }

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -439,6 +439,12 @@ namespace DTXMania.Game.Lib.Song.Components
             _graphicsGenerator?.Dispose();
             _graphicsGenerator = new DefaultGraphicsGenerator(graphicsDevice, sharedRenderTarget);
 
+            // Pre-generate common bar textures so draw-time never switches render targets
+            _graphicsGenerator.PreGenerateCommonTextures(
+                panelWidth: 0, panelHeight: 0,
+                barWidth: SongSelectionUILayout.SongBars.BarWidth,
+                barHeight: SongSelectionUILayout.SongBars.BarHeight);
+
             // Initialize graphics generators for cached song bars
             foreach (var songBar in _songBarCache.Values)
             {

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -164,11 +164,16 @@ namespace DTXMania.Game.Lib.Song.Components
                 _graphicsGenerator = null;
             }
             
-            // Pre-generate panel background so draw-time never switches render targets
+            // Pre-generate panel background and BPM fallback so draw-time never switches render targets
             if (_graphicsGenerator != null)
             {
                 _graphicsGenerator.PreGenerateCommonTextures(
                     (int)Size.X, (int)Size.Y, 0, 0);
+
+                // Pre-generate BPM fallback texture for skins that lack 5_BPM.png
+                _graphicsGenerator.GenerateBPMBackground(
+                    (int)SongSelectionUILayout.BPMSection.Size.X,
+                    (int)SongSelectionUILayout.BPMSection.Size.Y, true);
             }
 
             // Try to load level number font if ResourceManager is already available

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -164,6 +164,13 @@ namespace DTXMania.Game.Lib.Song.Components
                 _graphicsGenerator = null;
             }
             
+            // Pre-generate panel background so draw-time never switches render targets
+            if (_graphicsGenerator != null)
+            {
+                _graphicsGenerator.PreGenerateCommonTextures(
+                    (int)Size.X, (int)Size.Y, 0, 0);
+            }
+
             // Try to load level number font if ResourceManager is already available
             if (graphicsDevice != null && _resourceManager != null)
             {

--- a/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
@@ -142,21 +142,25 @@ namespace DTXMania.Game.Lib.Stage.Performance
             List<JudgementTextPopup>? activePopups = null,
             bool disposed = false)
         {
-            return new JudgementTextPopupManager(graphicsDevice, resourceManager, font, activePopups, disposed);
+            var manager = new JudgementTextPopupManager(graphicsDevice, resourceManager, font, activePopups);
+            if (disposed)
+            {
+                manager.Dispose();
+            }
+
+            return manager;
         }
 
         private JudgementTextPopupManager(
             GraphicsDevice graphicsDevice,
             IResourceManager resourceManager,
             BitmapFont? font,
-            List<JudgementTextPopup>? activePopups = null,
-            bool disposed = false)
+            List<JudgementTextPopup>? activePopups = null)
         {
             _graphicsDevice = graphicsDevice ?? throw new ArgumentNullException(nameof(graphicsDevice));
             _resourceManager = resourceManager ?? throw new ArgumentNullException(nameof(resourceManager));
             _activePopups = activePopups ?? new List<JudgementTextPopup>();
             _font = font;
-            _disposed = disposed;
         }
 
         #endregion
@@ -300,6 +304,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 if (!font.IsLoaded)
                 {
                     System.Diagnostics.Debug.WriteLine("JudgementTextPopupManager: Failed to load judgement text font");
+                    font.Dispose();
+                    return null;
                 }
 
                 return font;

--- a/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
@@ -185,6 +185,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 var popup = new JudgementTextPopup(text, lanePosition);
                 _activePopups.Add(popup);
             }
+            else
+            {
+                System.Diagnostics.Debug.WriteLine($"JudgementTextPopupManager: No display text registered for JudgementType.{judgementEvent.Type}");
+            }
         }
 
         /// <summary>
@@ -312,7 +316,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"JudgementTextPopupManager: Error loading font: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"JudgementTextPopupManager: {ex.GetType().Name} loading judgement font: {ex.Message}");
                 return null;
             }
         }

--- a/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
@@ -100,7 +101,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         #region Fields
 
         private readonly List<JudgementTextPopup> _activePopups;
-        private readonly BitmapFont _font;
+        private readonly BitmapFont? _font;
         private readonly IResourceManager _resourceManager;
         private readonly GraphicsDevice _graphicsDevice;
         private bool _disposed = false;
@@ -130,27 +131,32 @@ namespace DTXMania.Game.Lib.Stage.Performance
         #region Constructor
 
         public JudgementTextPopupManager(GraphicsDevice graphicsDevice, IResourceManager resourceManager)
+            : this(graphicsDevice, resourceManager, LoadJudgementFont(graphicsDevice, resourceManager))
+        {
+        }
+
+        internal static JudgementTextPopupManager CreateForTesting(
+            GraphicsDevice graphicsDevice,
+            IResourceManager resourceManager,
+            BitmapFont? font = null,
+            List<JudgementTextPopup>? activePopups = null,
+            bool disposed = false)
+        {
+            return new JudgementTextPopupManager(graphicsDevice, resourceManager, font, activePopups, disposed);
+        }
+
+        private JudgementTextPopupManager(
+            GraphicsDevice graphicsDevice,
+            IResourceManager resourceManager,
+            BitmapFont? font,
+            List<JudgementTextPopup>? activePopups = null,
+            bool disposed = false)
         {
             _graphicsDevice = graphicsDevice ?? throw new ArgumentNullException(nameof(graphicsDevice));
             _resourceManager = resourceManager ?? throw new ArgumentNullException(nameof(resourceManager));
-            _activePopups = new List<JudgementTextPopup>();
-
-            // Load the NotoSerifJP Bold 28 font
-            try
-            {
-                var fontConfig = CreateJudgementTextFontConfig();
-                _font = new BitmapFont(_graphicsDevice, _resourceManager, fontConfig);
-
-                if (!_font.IsLoaded)
-                {
-                    System.Diagnostics.Debug.WriteLine("JudgementTextPopupManager: Failed to load judgement text font");
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"JudgementTextPopupManager: Error loading font: {ex.Message}");
-                _font = null;
-            }
+            _activePopups = activePopups ?? new List<JudgementTextPopup>();
+            _font = font;
+            _disposed = disposed;
         }
 
         #endregion
@@ -283,7 +289,29 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// Create font configuration for judgement text
         /// Based on NotoSerifJP Bold 28 specification
         /// </summary>
-        private BitmapFont.BitmapFontConfig CreateJudgementTextFontConfig()
+        private static BitmapFont? LoadJudgementFont(GraphicsDevice graphicsDevice, IResourceManager resourceManager)
+        {
+            ArgumentNullException.ThrowIfNull(graphicsDevice);
+            ArgumentNullException.ThrowIfNull(resourceManager);
+
+            try
+            {
+                var font = new BitmapFont(graphicsDevice, resourceManager, CreateJudgementTextFontConfig());
+                if (!font.IsLoaded)
+                {
+                    System.Diagnostics.Debug.WriteLine("JudgementTextPopupManager: Failed to load judgement text font");
+                }
+
+                return font;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"JudgementTextPopupManager: Error loading font: {ex.Message}");
+                return null;
+            }
+        }
+
+        private static BitmapFont.BitmapFontConfig CreateJudgementTextFontConfig()
         {
             // Use the standardized judgement text font configuration
             return BitmapFont.CreateJudgementTextFontConfig();

--- a/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
@@ -173,7 +173,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         #endregion
 
-        #region Private Methods
+        #region Virtual Hooks
 
         protected virtual void DrawPadSpriteCore(ITexture texture, SpriteBatch spriteBatch, Rectangle destRect, Rectangle sourceRect, Color tint)
         {
@@ -228,8 +228,9 @@ namespace DTXMania.Game.Lib.Stage.Performance
                             break;
                         }
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        Debug.WriteLine($"PadRenderer: {ex.GetType().Name} loading texture from '{path}': {ex.Message}");
                         // Continue trying other paths
                     }
                 }
@@ -242,6 +243,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             catch (Exception ex)
             {
                 // Failed to load pad texture, pads won't be rendered
+                Debug.WriteLine($"PadRenderer: All pad texture paths failed, falling back to solid-color rendering. {ex.GetType().Name}: {ex.Message}");
                 _padSpriteSheet = null;
             }
         }

--- a/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
@@ -174,6 +174,31 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         #region Private Methods
 
+        protected virtual void DrawPadSpriteCore(ITexture texture, SpriteBatch spriteBatch, Rectangle destRect, Rectangle sourceRect, Color tint)
+        {
+            texture.Draw(
+                spriteBatch,
+                destRect,
+                sourceRect,
+                tint,
+                0f,
+                Vector2.Zero,
+                SpriteEffects.None,
+                BaseDepth);
+        }
+
+        protected virtual Texture2D CreateFallbackTextureCore()
+        {
+            var texture = new Texture2D(_graphicsDevice, 1, 1);
+            texture.SetData(new[] { Color.White });
+            return texture;
+        }
+
+        protected virtual void DrawFallbackTextureCore(SpriteBatch spriteBatch, Texture2D texture, Rectangle destRect, Color color)
+        {
+            spriteBatch.Draw(texture, destRect, null, color, 0f, Vector2.Zero, SpriteEffects.None, BaseDepth);
+        }
+
         /// <summary>
         /// Loads the pad sprite sheet texture and calculates cell dimensions
         /// </summary>
@@ -323,16 +348,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             Color tint = pad.State == PadState.Pressed ? Color.White * 1.5f : Color.White;
             
             // Draw with point sampling and alpha blending at configured depth
-            _padSpriteSheet.Draw(
-                spriteBatch,
-                destRect,
-                sourceRect,
-                tint,
-                0f,
-                Vector2.Zero,
-                SpriteEffects.None,
-                BaseDepth  // Use configurable depth for proper layering
-            );
+            DrawPadSpriteCore(_padSpriteSheet, spriteBatch, destRect, sourceRect, tint);
             return true;
         }
 
@@ -344,13 +360,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
             // Create fallback texture if needed
             if (_fallbackTexture == null)
             {
-                _fallbackTexture = new Texture2D(_graphicsDevice, 1, 1);
-                _fallbackTexture.SetData(new[] { Color.White });
+                _fallbackTexture = CreateFallbackTextureCore();
             }
 
             // Draw colored rectangle fallback
             Color padColor = pad.State == PadState.Pressed ? Color.Red : Color.Yellow;
-            spriteBatch.Draw(_fallbackTexture, destRect, null, padColor, 0f, Vector2.Zero, SpriteEffects.None, BaseDepth);
+            DrawFallbackTextureCore(spriteBatch, _fallbackTexture, destRect, padColor);
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -223,7 +224,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
                         _padSpriteSheet = _resourceManager.LoadTexture(path);
                         if (_padSpriteSheet != null)
                         {
-                            System.Console.WriteLine($"[DEBUG] PadRenderer loaded texture from: {path}");
+                            Debug.WriteLine($"PadRenderer loaded texture from: {path}");
                             break;
                         }
                     }
@@ -256,14 +257,14 @@ namespace DTXMania.Game.Lib.Stage.Performance
             var texW = _padSpriteSheet.Width;
             var texH = _padSpriteSheet.Height;
             
-            System.Console.WriteLine($"[DEBUG] PadRenderer texture dimensions: {texW}x{texH}");
+            Debug.WriteLine($"PadRenderer texture dimensions: {texW}x{texH}");
 
             // Use defined sprite sheet dimensions
             _spriteColumns = SpriteSheetColumns;
             _cellWidth = texW / SpriteSheetColumns;
             _cellHeight = texH / SpriteSheetRows;
             
-            System.Console.WriteLine($"[DEBUG] PadRenderer cell dimensions: {_cellWidth}x{_cellHeight} (columns={_spriteColumns}, rows={SpriteSheetRows})");
+            Debug.WriteLine($"PadRenderer cell dimensions: {_cellWidth}x{_cellHeight} (columns={_spriteColumns}, rows={SpriteSheetRows})");
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/StartupStage.cs
+++ b/DTXMania.Game/Lib/Stage/StartupStage.cs
@@ -591,7 +591,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error during database service initialization: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error during database service initialization: {ex.GetType().Name}: {ex.Message}");
             }
         }
 
@@ -607,7 +607,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error during score cache loading: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error during score cache loading: {ex.GetType().Name}: {ex.Message}");
             }
         }
 
@@ -634,7 +634,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error during filesystem change detection: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error during filesystem change detection: {ex.GetType().Name}: {ex.Message}");
                 // On error, assume enumeration is needed to be safe
                 _needsEnumeration = true;
             }
@@ -690,7 +690,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error during song enumeration: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error during song enumeration: {ex.GetType().Name}: {ex.Message}");
             }
         }
 
@@ -701,35 +701,14 @@ namespace DTXMania.Game.Lib.Stage
         {
             try
             {
-                // The current BuildSongListsAsync method is just a placeholder
-                // We need to call the actual method that builds the song list from database
                 System.Diagnostics.Debug.WriteLine("Building song lists from database...");
-                
-                // This is the critical method that actually populates _rootSongs from the database
-                await CallBuildSongListFromDatabaseAsync().ConfigureAwait(false);
-                
-                // Verify the results
+                await BuildSongListFromDatabaseCoreAsync(_songPaths).ConfigureAwait(false);
                 int songCount = GetRootSongCount();
                 System.Diagnostics.Debug.WriteLine($"Song lists building complete: {songCount} root nodes loaded");
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error during song lists building: {ex.Message}");
-            }
-        }
-
-        /// <summary>
-        /// Helper method to call the private BuildSongListFromDatabaseAsync method
-        /// </summary>
-        private async Task CallBuildSongListFromDatabaseAsync()
-        {
-            try
-            {
-                await BuildSongListFromDatabaseCoreAsync(_songPaths).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"Error calling BuildSongListFromDatabaseAsync: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error during song lists building: {ex.GetType().Name}: {ex.Message}");
             }
         }
 
@@ -754,7 +733,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error during songs DB save: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error during songs DB save: {ex.GetType().Name}: {ex.Message}");
             }
         }
 

--- a/DTXMania.Game/Lib/Stage/StartupStage.cs
+++ b/DTXMania.Game/Lib/Stage/StartupStage.cs
@@ -108,6 +108,52 @@ namespace DTXMania.Game.Lib.Stage
 
         #endregion
 
+        #region Graphics Hooks
+
+        protected virtual GraphicsDevice GetGraphicsDeviceCore()
+        {
+            return _game.GraphicsDevice;
+        }
+
+        protected virtual Viewport GetViewportCore()
+        {
+            return _game.GraphicsDevice.Viewport;
+        }
+
+        protected virtual SpriteBatch CreateSpriteBatchCore(GraphicsDevice graphicsDevice)
+        {
+            return new SpriteBatch(graphicsDevice);
+        }
+
+        protected virtual Texture2D CreateWhitePixelCore(GraphicsDevice graphicsDevice)
+        {
+            var whitePixel = new Texture2D(graphicsDevice, 1, 1);
+            whitePixel.SetData(new[] { Color.White });
+            return whitePixel;
+        }
+
+        protected virtual BitmapFont CreateBitmapFontCore(GraphicsDevice graphicsDevice, IResourceManager resourceManager, BitmapFont.BitmapFontConfig config)
+        {
+            return new BitmapFont(graphicsDevice, resourceManager, config);
+        }
+
+        protected virtual void BeginSpriteBatchCore(SpriteBatch spriteBatch)
+        {
+            spriteBatch.Begin(samplerState: SamplerState.LinearClamp);
+        }
+
+        protected virtual void EndSpriteBatchCore(SpriteBatch spriteBatch)
+        {
+            spriteBatch.End();
+        }
+
+        protected virtual void DrawSolidRectCore(SpriteBatch spriteBatch, Texture2D texture, Rectangle destination, Color color)
+        {
+            spriteBatch.Draw(texture, destination, color);
+        }
+
+        #endregion
+
         #region BaseStage Implementation
 
         protected override void OnActivate()
@@ -115,18 +161,16 @@ namespace DTXMania.Game.Lib.Stage
             System.Diagnostics.Debug.WriteLine("Activating Startup Stage");
 
             // Initialize graphics resources
-            var graphicsDevice = _game.GraphicsDevice;
-            _spriteBatch = new SpriteBatch(graphicsDevice);
-
-            _whitePixel = new Texture2D(graphicsDevice, 1, 1);
-            _whitePixel.SetData(new[] { Color.White });
+            var graphicsDevice = GetGraphicsDeviceCore();
+            _spriteBatch = CreateSpriteBatchCore(graphicsDevice);
+            _whitePixel = CreateWhitePixelCore(graphicsDevice);
 
             // Initialize ResourceManager using factory
             _resourceManager = _game.ResourceManager;
 
             // Initialize bitmap font for text rendering
             var consoleFontConfig = BitmapFont.CreateConsoleFontConfig();
-            _bitmapFont = new BitmapFont(graphicsDevice, _resourceManager, consoleFontConfig);
+            _bitmapFont = CreateBitmapFontCore(graphicsDevice, _resourceManager, consoleFontConfig);
 
             // Load background texture (DTXManiaNX uses 1_background.jpg)
 
@@ -167,7 +211,7 @@ namespace DTXMania.Game.Lib.Stage
             if (_spriteBatch == null)
                 return;
 
-            _spriteBatch.Begin(samplerState: SamplerState.LinearClamp);
+            BeginSpriteBatchCore(_spriteBatch);
 
             // Draw background
             DrawStageBackground(_spriteBatch);
@@ -175,10 +219,8 @@ namespace DTXMania.Game.Lib.Stage
             // Draw fallback if no background loaded
             if (!IsBackgroundReady && _whitePixel != null)
             {
-                var viewport = _game.GraphicsDevice.Viewport;
-                _spriteBatch.Draw(_whitePixel,
-                    new Rectangle(0, 0, viewport.Width, viewport.Height),
-                    new Color(16, 16, 32));
+                var viewport = GetViewportCore();
+                DrawSolidRectCore(_spriteBatch, _whitePixel, new Rectangle(0, 0, viewport.Width, viewport.Height), new Color(16, 16, 32));
             }
 
             // Draw version info (DTXMania pattern)
@@ -190,7 +232,7 @@ namespace DTXMania.Game.Lib.Stage
             // Draw current progress
             DrawCurrentProgress();
 
-            _spriteBatch.End();
+            EndSpriteBatchCore(_spriteBatch);
         }
 
         protected override void OnDeactivate()
@@ -488,13 +530,63 @@ namespace DTXMania.Game.Lib.Stage
         /// <summary>
         /// Initialize database service async operation
         /// </summary>
+        protected virtual string GetSongsDatabasePath()
+        {
+            return AppPaths.GetSongsDatabasePath();
+        }
+
+        protected virtual void EnsureDirectory(string path)
+        {
+            AppPaths.EnsureDirectory(path);
+        }
+
+        protected virtual Task<bool> InitializeDatabaseServiceCoreAsync(string databasePath)
+        {
+            return _songManager.InitializeDatabaseServiceAsync(databasePath, false);
+        }
+
+        protected virtual Task<bool> LoadScoreCacheCoreAsync(string[] songPaths)
+        {
+            return _songManager.LoadScoreCacheAsync(songPaths);
+        }
+
+        protected virtual Task<bool> NeedsEnumerationCoreAsync(string[] songPaths, bool forceEnumeration)
+        {
+            return _songManager.NeedsEnumerationAsync(songPaths, forceEnumeration);
+        }
+
+        protected virtual Task<int> EnumerateSongsOnlyCoreAsync(string[] songPaths, IProgress<EnumerationProgress> progressReporter, CancellationToken cancellationToken)
+        {
+            return _songManager.EnumerateSongsOnlyAsync(songPaths, progressReporter, cancellationToken);
+        }
+
+        protected virtual Task BuildSongListFromDatabaseCoreAsync(string[] songPaths)
+        {
+            return _songManager.BuildSongListFromDatabasePublicAsync(songPaths);
+        }
+
+        protected virtual int GetRootSongCount()
+        {
+            return _songManager.RootSongs.Count;
+        }
+
+        protected virtual Task<bool> SaveSongsDatabaseCoreAsync()
+        {
+            return _songManager.SaveSongsDBAsync();
+        }
+
+        protected virtual void MarkSongManagerInitialized()
+        {
+            _songManager.SetInitialized();
+        }
+
         private async Task InitializeDatabaseServiceAsync()
         {
             try
             {
-                var databasePath = AppPaths.GetSongsDatabasePath();
-                AppPaths.EnsureDirectory(Path.GetDirectoryName(databasePath) ?? "");
-                bool success = await _songManager.InitializeDatabaseServiceAsync(databasePath, false).ConfigureAwait(false);
+                var databasePath = GetSongsDatabasePath();
+                EnsureDirectory(Path.GetDirectoryName(databasePath) ?? "");
+                bool success = await InitializeDatabaseServiceCoreAsync(databasePath).ConfigureAwait(false);
                 System.Diagnostics.Debug.WriteLine($"Database service initialization: {(success ? "SUCCESS" : "FAILED")}");
             }
             catch (Exception ex)
@@ -510,7 +602,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             try
             {
-                bool success = await _songManager.LoadScoreCacheAsync(_songPaths).ConfigureAwait(false);
+                bool success = await LoadScoreCacheCoreAsync(_songPaths).ConfigureAwait(false);
                 System.Diagnostics.Debug.WriteLine($"Score cache loading: {(success ? "SUCCESS" : "FAILED - enumeration needed")}");
             }
             catch (Exception ex)
@@ -529,7 +621,7 @@ namespace DTXMania.Game.Lib.Stage
                 System.Diagnostics.Debug.WriteLine("Checking filesystem for changes...");
                 
                 // Perform detailed filesystem change detection and cache the result
-                _needsEnumeration = await _songManager.NeedsEnumerationAsync(_songPaths, _forceEnumeration).ConfigureAwait(false);
+                _needsEnumeration = await NeedsEnumerationCoreAsync(_songPaths, _forceEnumeration).ConfigureAwait(false);
                 
                 if (_needsEnumeration.Value)
                 {
@@ -589,7 +681,7 @@ namespace DTXMania.Game.Lib.Stage
                     }
                 });
 
-                int songCount = await _songManager.EnumerateSongsOnlyAsync(_songPaths, progressReporter, _cancellationTokenSource.Token).ConfigureAwait(false);
+                int songCount = await EnumerateSongsOnlyCoreAsync(_songPaths, progressReporter, _cancellationTokenSource.Token).ConfigureAwait(false);
                 System.Diagnostics.Debug.WriteLine($"Song enumeration complete: {songCount} songs found");
             }
             catch (OperationCanceledException)
@@ -617,7 +709,7 @@ namespace DTXMania.Game.Lib.Stage
                 await CallBuildSongListFromDatabaseAsync().ConfigureAwait(false);
                 
                 // Verify the results
-                int songCount = _songManager.RootSongs.Count;
+                int songCount = GetRootSongCount();
                 System.Diagnostics.Debug.WriteLine($"Song lists building complete: {songCount} root nodes loaded");
             }
             catch (Exception ex)
@@ -633,9 +725,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             try
             {
-                // We need to use reflection or create a public method to call BuildSongListFromDatabaseAsync
-                // For now, let's add a public wrapper method to SongManager
-                await _songManager.BuildSongListFromDatabasePublicAsync(_songPaths).ConfigureAwait(false);
+                await BuildSongListFromDatabaseCoreAsync(_songPaths).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -650,13 +740,13 @@ namespace DTXMania.Game.Lib.Stage
         {
             try
             {
-                bool success = await _songManager.SaveSongsDBAsync().ConfigureAwait(false);
+                bool success = await SaveSongsDatabaseCoreAsync().ConfigureAwait(false);
                 
                 // Mark SongManager as fully initialized after successful save
                 if (success)
                 {
-                    _songManager.SetInitialized();
-                    int songCount = _songManager.RootSongs.Count;
+                    MarkSongManagerInitialized();
+                    int songCount = GetRootSongCount();
                     System.Diagnostics.Debug.WriteLine($"SongManager fully initialized: {songCount} root nodes loaded");
                 }
                 
@@ -696,7 +786,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             // Draw version info in top-right corner (DTXMania pattern)
             const string versionText = "DTXManiaCX v1.0.0 - MonoGame Edition";
-            var viewport = _game.GraphicsDevice.Viewport;
+            var viewport = GetViewportCore();
 
             if (_bitmapFont?.IsLoaded == true)
             {
@@ -755,7 +845,7 @@ namespace DTXMania.Game.Lib.Stage
             string progressText = $"{_startupPhase} ({(overallProgress * 100):F1}%)";
 
             // Draw progress bar
-            var viewport = _game.GraphicsDevice.Viewport;
+            var viewport = GetViewportCore();
             int progressBarX = (viewport.Width - PROGRESS_BAR_WIDTH) / 2; // Center horizontally
             int progressBarY = viewport.Height - PROGRESS_BAR_BOTTOM_MARGIN;
 
@@ -774,7 +864,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (_whitePixel != null)
             {
-                _spriteBatch.Draw(_whitePixel, new Rectangle(x, y, width, height), color);
+                DrawSolidRectCore(_spriteBatch, _whitePixel, new Rectangle(x, y, width, height), color);
             }
         }
         #endregion

--- a/DTXMania.Game/Lib/Stage/StartupStage.cs
+++ b/DTXMania.Game/Lib/Stage/StartupStage.cs
@@ -117,7 +117,7 @@ namespace DTXMania.Game.Lib.Stage
 
         protected virtual Viewport GetViewportCore()
         {
-            return _game.GraphicsDevice.Viewport;
+            return GetGraphicsDeviceCore().Viewport;
         }
 
         protected virtual SpriteBatch CreateSpriteBatchCore(GraphicsDevice graphicsDevice)

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -56,6 +56,8 @@ namespace DTXMania.Game.Lib.UI
         /// </summary>
         public ITexture GenerateSongBarBackground(int width, int height, bool isSelected = false, bool isCenter = false)
         {
+            ValidateDimensions(width, height);
+
             var cacheKey = $"SongBar_{width}x{height}_{isSelected}_{isCenter}";
 
             if (_generatedTextures.TryGetValue(cacheKey, out var cached))
@@ -101,6 +103,8 @@ namespace DTXMania.Game.Lib.UI
         /// </summary>
         public ITexture GenerateBarTypeBackground(int width, int height, BarType barType, bool isSelected = false, bool isCenter = false)
         {
+            ValidateDimensions(width, height);
+
             var cacheKey = $"BarType_{width}x{height}_{barType}_{isSelected}_{isCenter}";
 
             if (_generatedTextures.TryGetValue(cacheKey, out var cached))
@@ -116,6 +120,8 @@ namespace DTXMania.Game.Lib.UI
         /// </summary>
         public ITexture GeneratePanelBackground(int width, int height, bool withBorder = true)
         {
+            ValidateDimensions(width, height);
+
             var cacheKey = $"Panel_{width}x{height}_{withBorder}";
 
             if (_generatedTextures.TryGetValue(cacheKey, out var cached))
@@ -131,6 +137,8 @@ namespace DTXMania.Game.Lib.UI
         /// </summary>
         public ITexture GenerateBPMBackground(int width, int height, bool withLabels = true)
         {
+            ValidateDimensions(width, height);
+
             var cacheKey = $"BPMBackground_{width}x{height}_{withLabels}";
 
             if (_generatedTextures.TryGetValue(cacheKey, out var cached))
@@ -146,6 +154,8 @@ namespace DTXMania.Game.Lib.UI
         /// </summary>
         public ITexture GenerateButton(int width, int height, bool isPressed = false)
         {
+            ValidateDimensions(width, height);
+
             var cacheKey = $"Button_{width}x{height}_{isPressed}";
 
             if (_generatedTextures.TryGetValue(cacheKey, out var cached))
@@ -183,6 +193,15 @@ namespace DTXMania.Game.Lib.UI
         protected virtual ITexture CreateGeneratedTexture(string sourcePath)
         {
             return new ManagedTexture(_graphicsDevice, _renderTarget, sourcePath);
+        }
+
+        private static void ValidateDimensions(int width, int height)
+        {
+            if (width <= 0)
+                throw new ArgumentOutOfRangeException(nameof(width));
+
+            if (height <= 0)
+                throw new ArgumentOutOfRangeException(nameof(height));
         }
 
         private ITexture CreateSongBarTexture(int width, int height, bool isSelected, bool isCenter)

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -415,11 +415,13 @@ namespace DTXMania.Game.Lib.UI
                 // For now, we'll create placeholder areas where text would go
                 
                 // Length label area (top portion)
-                var lengthLabelRect = new Rectangle(5, 5, width - 10, height / 2 - 5);
+                var labelWidth = Math.Max(0, width - 10);
+                var labelHeight = Math.Max(0, height / 2 - 5);
+                var lengthLabelRect = new Rectangle(5, 5, labelWidth, labelHeight);
                 DrawSolidRectangle(lengthLabelRect, Color.Black * 0.2f);
                 
                 // BPM label area (bottom portion)
-                var bpmLabelRect = new Rectangle(5, height / 2, width - 10, height / 2 - 5);
+                var bpmLabelRect = new Rectangle(5, height / 2, labelWidth, labelHeight);
                 DrawSolidRectangle(bpmLabelRect, Color.Black * 0.2f);
             }
 

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -183,7 +183,8 @@ namespace DTXMania.Game.Lib.UI
                 GeneratePanelBackground(panelWidth, panelHeight, true);
             }
 
-            // Bar backgrounds for the most common states (unselected, selected, center)
+            // Bar backgrounds for all (isSelected, isCenter) combinations so draw-time
+            // always hits the cache, even for the selected center bar.
             if (barWidth > 0 && barHeight > 0)
             {
                 foreach (BarType barType in Enum.GetValues(typeof(BarType)))
@@ -191,6 +192,7 @@ namespace DTXMania.Game.Lib.UI
                     GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: false, isCenter: false);
                     GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: true, isCenter: false);
                     GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: false, isCenter: true);
+                    GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: true, isCenter: true);
                 }
             }
         }

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -175,6 +175,26 @@ namespace DTXMania.Game.Lib.UI
             _graphicsDevice.Clear(color);
         }
 
+        /// <summary>
+        /// Sets the shared render target as the active render target and returns
+        /// the previous render targets for restoration. Call before drawing.
+        /// </summary>
+        protected virtual RenderTargetBinding[] SetRenderTarget()
+        {
+            var previousTargets = _graphicsDevice.GetRenderTargets();
+            _graphicsDevice.SetRenderTarget(_renderTarget);
+            return previousTargets;
+        }
+
+        /// <summary>
+        /// Restores the previous render targets. Call after drawing and before
+        /// CreateGeneratedTexture (which reads from the render target).
+        /// </summary>
+        protected virtual void RestoreRenderTargets(RenderTargetBinding[] previousTargets)
+        {
+            _graphicsDevice.SetRenderTargets(previousTargets);
+        }
+
         protected virtual void BeginSpriteBatch()
         {
             _spriteBatch.Begin();
@@ -190,9 +210,21 @@ namespace DTXMania.Game.Lib.UI
             _spriteBatch.Draw(_whitePixel, destination, color);
         }
 
+        /// <summary>
+        /// Captures the current render target contents into a new immutable Texture2D,
+        /// then wraps it in a ManagedTexture for caching. This ensures each cached
+        /// texture has its own independent backing texture rather than sharing
+        /// the single reusable _renderTarget.
+        /// </summary>
         protected virtual ITexture CreateGeneratedTexture(string sourcePath)
         {
-            return new ManagedTexture(_graphicsDevice, _renderTarget, sourcePath);
+            // Copy render target data into a dedicated Texture2D so cached textures
+            // don't all reference the same shared render target
+            var texture = new Texture2D(_graphicsDevice, _renderTarget.Width, _renderTarget.Height);
+            var data = new Color[_renderTarget.Width * _renderTarget.Height];
+            _renderTarget.GetData(data);
+            texture.SetData(data);
+            return new ManagedTexture(_graphicsDevice, texture, sourcePath);
         }
 
         private static void ValidateDimensions(int width, int height)
@@ -206,33 +238,41 @@ namespace DTXMania.Game.Lib.UI
 
         private ITexture CreateSongBarTexture(int width, int height, bool isSelected, bool isCenter)
         {
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
-
-            // Base color
-            var baseColor = DTXManiaVisualTheme.SongSelection.SongBarBackground;
-            if (isCenter)
-                baseColor = DTXManiaVisualTheme.SongSelection.SongBarCenter;
-            else if (isSelected)
-                baseColor = DTXManiaVisualTheme.SongSelection.SongBarSelected;
-
-            // Draw background with gradient effect
-            DrawGradientRectangle(new Rectangle(0, 0, width, height),
-                                baseColor, Color.Lerp(baseColor, Color.Black, 0.3f));
-
-            // Draw border for selected items
-            if (isSelected || isCenter)
+            var previousTargets = SetRenderTarget();
+            try
             {
-                var borderColor = isCenter ? Color.Yellow : Color.White;
-                var borderThickness = isCenter ? 2 : 1;
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-                // Top border
-                DrawSolidRectangle(new Rectangle(0, 0, width, borderThickness), borderColor);
-                // Bottom border
-                DrawSolidRectangle(new Rectangle(0, height - borderThickness, width, borderThickness), borderColor);
+                // Base color
+                var baseColor = DTXManiaVisualTheme.SongSelection.SongBarBackground;
+                if (isCenter)
+                    baseColor = DTXManiaVisualTheme.SongSelection.SongBarCenter;
+                else if (isSelected)
+                    baseColor = DTXManiaVisualTheme.SongSelection.SongBarSelected;
+
+                // Draw background with gradient effect
+                DrawGradientRectangle(new Rectangle(0, 0, width, height),
+                                    baseColor, Color.Lerp(baseColor, Color.Black, 0.3f));
+
+                // Draw border for selected items
+                if (isSelected || isCenter)
+                {
+                    var borderColor = isCenter ? Color.Yellow : Color.White;
+                    var borderThickness = isCenter ? 2 : 1;
+
+                    // Top border
+                    DrawSolidRectangle(new Rectangle(0, 0, width, borderThickness), borderColor);
+                    // Bottom border
+                    DrawSolidRectangle(new Rectangle(0, height - borderThickness, width, borderThickness), borderColor);
+                }
+
+                EndSpriteBatch();
             }
-
-            EndSpriteBatch();
+            finally
+            {
+                RestoreRenderTargets(previousTargets);
+            }
 
             return CreateGeneratedTexture($"Generated_SongBar_{width}x{height}");
         }
@@ -242,64 +282,88 @@ namespace DTXMania.Game.Lib.UI
             var width = DTXManiaVisualTheme.Layout.ClearLampWidth;
             var height = DTXManiaVisualTheme.Layout.ClearLampHeight;
 
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
+            var previousTargets = SetRenderTarget();
+            try
+            {
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-            var lampColor = DTXManiaVisualTheme.GetDifficultyColor(difficulty);
-            if (!hasCleared)
-                lampColor = Color.Lerp(lampColor, Color.Gray, 0.7f);
+                var lampColor = DTXManiaVisualTheme.GetDifficultyColor(difficulty);
+                if (!hasCleared)
+                    lampColor = Color.Lerp(lampColor, Color.Gray, 0.7f);
 
-            // Draw lamp with gradient effect
-            DrawGradientRectangle(new Rectangle(0, 0, width, height),
-                                lampColor, Color.Lerp(lampColor, Color.Black, 0.5f));
+                // Draw lamp with gradient effect
+                DrawGradientRectangle(new Rectangle(0, 0, width, height),
+                                    lampColor, Color.Lerp(lampColor, Color.Black, 0.5f));
 
-            // Draw border
-            var borderColor = hasCleared ? Color.White : Color.Gray;
-            DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 1);
+                // Draw border
+                var borderColor = hasCleared ? Color.White : Color.Gray;
+                DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 1);
 
-            EndSpriteBatch();
+                EndSpriteBatch();
+            }
+            finally
+            {
+                RestoreRenderTargets(previousTargets);
+            }
 
             return CreateGeneratedTexture($"Generated_ClearLamp_{difficulty}_{hasCleared}");
         }
 
         private ITexture CreatePanelTexture(int width, int height, bool withBorder)
         {
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
-
-            // Draw background
-            var bgColor = DTXManiaVisualTheme.SongSelection.PanelBackground;
-            DrawSolidRectangle(new Rectangle(0, 0, width, height), bgColor);
-
-            // Draw border if requested
-            if (withBorder)
+            var previousTargets = SetRenderTarget();
+            try
             {
-                var borderColor = DTXManiaVisualTheme.SongSelection.PanelBorder;
-                DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 2);
-            }
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-            EndSpriteBatch();
+                // Draw background
+                var bgColor = DTXManiaVisualTheme.SongSelection.PanelBackground;
+                DrawSolidRectangle(new Rectangle(0, 0, width, height), bgColor);
+
+                // Draw border if requested
+                if (withBorder)
+                {
+                    var borderColor = DTXManiaVisualTheme.SongSelection.PanelBorder;
+                    DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 2);
+                }
+
+                EndSpriteBatch();
+            }
+            finally
+            {
+                RestoreRenderTargets(previousTargets);
+            }
 
             return CreateGeneratedTexture($"Generated_Panel_{width}x{height}");
         }
 
         private ITexture CreateButtonTexture(int width, int height, bool isPressed)
         {
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
+            var previousTargets = SetRenderTarget();
+            try
+            {
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-            var baseColor = new Color(60, 80, 120);
-            if (isPressed)
-                baseColor = Color.Lerp(baseColor, Color.White, 0.3f);
+                var baseColor = new Color(60, 80, 120);
+                if (isPressed)
+                    baseColor = Color.Lerp(baseColor, Color.White, 0.3f);
 
-            // Draw button with gradient effect
-            DrawGradientRectangle(new Rectangle(0, 0, width, height),
-                                Color.Lerp(baseColor, Color.White, 0.2f), baseColor);
+                // Draw button with gradient effect
+                DrawGradientRectangle(new Rectangle(0, 0, width, height),
+                                    Color.Lerp(baseColor, Color.White, 0.2f), baseColor);
 
-            // Draw border
-            DrawRectangleBorder(new Rectangle(0, 0, width, height), Color.White, 1);
+                // Draw border
+                DrawRectangleBorder(new Rectangle(0, 0, width, height), Color.White, 1);
 
-            EndSpriteBatch();
+                EndSpriteBatch();
+            }
+            finally
+            {
+                RestoreRenderTargets(previousTargets);
+            }
 
             return CreateGeneratedTexture($"Generated_Button_{width}x{height}");
         }
@@ -330,121 +394,145 @@ namespace DTXMania.Game.Lib.UI
 
         private ITexture CreateEnhancedClearLampTexture(int difficulty, ClearStatus clearStatus)
         {
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
-
-            // Get base color for difficulty
-            var difficultyColors = DTXManiaVisualTheme.SongSelection.DifficultyColors;
-            var baseColor = difficulty < difficultyColors.Length ? difficultyColors[difficulty] : Color.Gray;
-
-            // Modify color based on clear status
-            Color lampColor = clearStatus switch
+            var previousTargets = SetRenderTarget();
+            try
             {
-                ClearStatus.FullCombo => Color.Gold,
-                ClearStatus.Clear => baseColor,
-                ClearStatus.Failed => baseColor * 0.5f,
-                ClearStatus.NotPlayed => Color.Gray * 0.3f,
-                _ => Color.Gray * 0.3f
-            };
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-            // Draw lamp with gradient effect
-            DrawGradientRectangle(new Rectangle(0, 0, 8, 24),
-                                Color.Lerp(lampColor, Color.White, 0.3f), lampColor);
+                // Get base color for difficulty
+                var difficultyColors = DTXManiaVisualTheme.SongSelection.DifficultyColors;
+                var baseColor = difficulty < difficultyColors.Length ? difficultyColors[difficulty] : Color.Gray;
 
-            // Add border for better definition
-            if (clearStatus != ClearStatus.NotPlayed)
-            {
-                DrawRectangleBorder(new Rectangle(0, 0, 8, 24), Color.White * 0.8f, 1);
+                // Modify color based on clear status
+                Color lampColor = clearStatus switch
+                {
+                    ClearStatus.FullCombo => Color.Gold,
+                    ClearStatus.Clear => baseColor,
+                    ClearStatus.Failed => baseColor * 0.5f,
+                    ClearStatus.NotPlayed => Color.Gray * 0.3f,
+                    _ => Color.Gray * 0.3f
+                };
+
+                // Draw lamp with gradient effect
+                DrawGradientRectangle(new Rectangle(0, 0, 8, 24),
+                                    Color.Lerp(lampColor, Color.White, 0.3f), lampColor);
+
+                // Add border for better definition
+                if (clearStatus != ClearStatus.NotPlayed)
+                {
+                    DrawRectangleBorder(new Rectangle(0, 0, 8, 24), Color.White * 0.8f, 1);
+                }
+
+                EndSpriteBatch();
             }
-
-            EndSpriteBatch();
+            finally
+            {
+                RestoreRenderTargets(previousTargets);
+            }
 
             return CreateGeneratedTexture($"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}");
         }
 
         private ITexture CreateBarTypeTexture(int width, int height, BarType barType, bool isSelected, bool isCenter)
         {
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
-
-            // Get base color based on bar type
-            Color baseColor = barType switch
+            var previousTargets = SetRenderTarget();
+            try
             {
-                BarType.Score => DTXManiaVisualTheme.SongSelection.SongBarBackground,
-                BarType.Box => DTXManiaVisualTheme.SongSelection.FolderBackground,
-                BarType.Other => DTXManiaVisualTheme.SongSelection.SpecialBackground,
-                _ => DTXManiaVisualTheme.SongSelection.SongBarBackground
-            };
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-            // Apply selection highlighting
-            if (isCenter)
-                baseColor = DTXManiaVisualTheme.SongSelection.SongBarCenter;
-            else if (isSelected)
-                baseColor = DTXManiaVisualTheme.SongSelection.SongBarSelected;
+                // Get base color based on bar type
+                Color baseColor = barType switch
+                {
+                    BarType.Score => DTXManiaVisualTheme.SongSelection.SongBarBackground,
+                    BarType.Box => DTXManiaVisualTheme.SongSelection.FolderBackground,
+                    BarType.Other => DTXManiaVisualTheme.SongSelection.SpecialBackground,
+                    _ => DTXManiaVisualTheme.SongSelection.SongBarBackground
+                };
 
-            // Draw background with gradient effect
-            DrawGradientRectangle(new Rectangle(0, 0, width, height),
-                                baseColor, Color.Lerp(baseColor, Color.Black, 0.3f));
+                // Apply selection highlighting
+                if (isCenter)
+                    baseColor = DTXManiaVisualTheme.SongSelection.SongBarCenter;
+                else if (isSelected)
+                    baseColor = DTXManiaVisualTheme.SongSelection.SongBarSelected;
 
-            // Draw border for selected items
-            if (isSelected || isCenter)
-            {
-                var borderColor = isCenter ? Color.Yellow : Color.White;
-                var borderThickness = isCenter ? 2 : 1;
-                DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, borderThickness);
+                // Draw background with gradient effect
+                DrawGradientRectangle(new Rectangle(0, 0, width, height),
+                                    baseColor, Color.Lerp(baseColor, Color.Black, 0.3f));
+
+                // Draw border for selected items
+                if (isSelected || isCenter)
+                {
+                    var borderColor = isCenter ? Color.Yellow : Color.White;
+                    var borderThickness = isCenter ? 2 : 1;
+                    DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, borderThickness);
+                }
+
+                // Add special effects for different bar types
+                if (barType == BarType.Box)
+                {
+                    // Add folder icon indicator (simple rectangle on left side)
+                    var iconRect = new Rectangle(2, height / 4, 4, height / 2);
+                    DrawSolidRectangle(iconRect, Color.Cyan * 0.7f);
+                }
+                else if (barType == BarType.Other)
+                {
+                    // Add special indicator (diamond pattern)
+                    var centerY = height / 2;
+                    var indicatorRect = new Rectangle(width - 8, centerY - 2, 4, 4);
+                    DrawSolidRectangle(indicatorRect, Color.Magenta * 0.8f);
+                }
+
+                EndSpriteBatch();
             }
-
-            // Add special effects for different bar types
-            if (barType == BarType.Box)
+            finally
             {
-                // Add folder icon indicator (simple rectangle on left side)
-                var iconRect = new Rectangle(2, height / 4, 4, height / 2);
-                DrawSolidRectangle(iconRect, Color.Cyan * 0.7f);
+                RestoreRenderTargets(previousTargets);
             }
-            else if (barType == BarType.Other)
-            {
-                // Add special indicator (diamond pattern)
-                var centerY = height / 2;
-                var indicatorRect = new Rectangle(width - 8, centerY - 2, 4, 4);
-                DrawSolidRectangle(indicatorRect, Color.Magenta * 0.8f);
-            }
-
-            EndSpriteBatch();
 
             return CreateGeneratedTexture($"Generated_BarType_{barType}_{width}x{height}");
         }
 
         private ITexture CreateBPMBackgroundTexture(int width, int height, bool withLabels)
         {
-            ClearGraphics(Color.Transparent);
-            BeginSpriteBatch();
-
-            // Draw background with DTXManiaNX-style panel appearance
-            var bgColor = DTXManiaVisualTheme.SongSelection.PanelBackground;
-            DrawGradientRectangle(new Rectangle(0, 0, width, height),
-                                Color.Lerp(bgColor, Color.White, 0.1f), bgColor);
-
-            // Draw border
-            var borderColor = DTXManiaVisualTheme.SongSelection.PanelBorder;
-            DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 2);
-
-            if (withLabels)
+            var previousTargets = SetRenderTarget();
+            try
             {
-                // Note: We would need a font system to draw text labels
-                // For now, we'll create placeholder areas where text would go
-                
-                // Length label area (top portion)
-                var labelWidth = Math.Max(0, width - 10);
-                var labelHeight = Math.Max(0, height / 2 - 5);
-                var lengthLabelRect = new Rectangle(5, 5, labelWidth, labelHeight);
-                DrawSolidRectangle(lengthLabelRect, Color.Black * 0.2f);
-                
-                // BPM label area (bottom portion)
-                var bpmLabelRect = new Rectangle(5, height / 2, labelWidth, labelHeight);
-                DrawSolidRectangle(bpmLabelRect, Color.Black * 0.2f);
-            }
+                ClearGraphics(Color.Transparent);
+                BeginSpriteBatch();
 
-            EndSpriteBatch();
+                // Draw background with DTXManiaNX-style panel appearance
+                var bgColor = DTXManiaVisualTheme.SongSelection.PanelBackground;
+                DrawGradientRectangle(new Rectangle(0, 0, width, height),
+                                    Color.Lerp(bgColor, Color.White, 0.1f), bgColor);
+
+                // Draw border
+                var borderColor = DTXManiaVisualTheme.SongSelection.PanelBorder;
+                DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 2);
+
+                if (withLabels)
+                {
+                    // Note: We would need a font system to draw text labels
+                    // For now, we'll create placeholder areas where text would go
+                    
+                    // Length label area (top portion)
+                    var labelWidth = Math.Max(0, width - 10);
+                    var labelHeight = Math.Max(0, height / 2 - 5);
+                    var lengthLabelRect = new Rectangle(5, 5, labelWidth, labelHeight);
+                    DrawSolidRectangle(lengthLabelRect, Color.Black * 0.2f);
+                    
+                    // BPM label area (bottom portion)
+                    var bpmLabelRect = new Rectangle(5, height / 2, labelWidth, labelHeight);
+                    DrawSolidRectangle(bpmLabelRect, Color.Black * 0.2f);
+                }
+
+                EndSpriteBatch();
+            }
+            finally
+            {
+                RestoreRenderTargets(previousTargets);
+            }
 
             return CreateGeneratedTexture($"Generated_BPMBackground_{width}x{height}");
         }

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -211,18 +211,19 @@ namespace DTXMania.Game.Lib.UI
         }
 
         /// <summary>
-        /// Captures the current render target contents into a new immutable Texture2D,
+        /// Captures a region of the render target into a new immutable Texture2D,
         /// then wraps it in a ManagedTexture for caching. This ensures each cached
         /// texture has its own independent backing texture rather than sharing
-        /// the single reusable _renderTarget.
+        /// the single reusable _renderTarget, and crops to only the generated region
+        /// instead of copying the full render target.
         /// </summary>
-        protected virtual ITexture CreateGeneratedTexture(string sourcePath)
+        protected virtual ITexture CreateGeneratedTexture(string sourcePath, int width, int height)
         {
-            // Copy render target data into a dedicated Texture2D so cached textures
-            // don't all reference the same shared render target
-            var texture = new Texture2D(_graphicsDevice, _renderTarget.Width, _renderTarget.Height);
-            var data = new Color[_renderTarget.Width * _renderTarget.Height];
-            _renderTarget.GetData(data);
+            // Copy only the generated region from the render target into a cropped Texture2D
+            var region = new Rectangle(0, 0, width, height);
+            var texture = new Texture2D(_graphicsDevice, width, height);
+            var data = new Color[width * height];
+            _renderTarget.GetData(0, region, data, 0, data.Length);
             texture.SetData(data);
             return new ManagedTexture(_graphicsDevice, texture, sourcePath);
         }
@@ -274,7 +275,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_SongBar_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_SongBar_{width}x{height}", width, height);
         }
 
         private ITexture CreateClearLampTexture(int difficulty, bool hasCleared)
@@ -307,7 +308,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_ClearLamp_{difficulty}_{hasCleared}");
+            return CreateGeneratedTexture($"Generated_ClearLamp_{difficulty}_{hasCleared}", width, height);
         }
 
         private ITexture CreatePanelTexture(int width, int height, bool withBorder)
@@ -336,7 +337,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_Panel_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_Panel_{width}x{height}", width, height);
         }
 
         private ITexture CreateButtonTexture(int width, int height, bool isPressed)
@@ -365,7 +366,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_Button_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_Button_{width}x{height}", width, height);
         }
 
         private void DrawGradientRectangle(Rectangle bounds, Color topColor, Color bottomColor)
@@ -431,7 +432,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}");
+            return CreateGeneratedTexture($"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}", 8, 24);
         }
 
         private ITexture CreateBarTypeTexture(int width, int height, BarType barType, bool isSelected, bool isCenter)
@@ -491,7 +492,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_BarType_{barType}_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_BarType_{barType}_{width}x{height}", width, height);
         }
 
         private ITexture CreateBPMBackgroundTexture(int width, int height, bool withLabels)
@@ -534,7 +535,7 @@ namespace DTXMania.Game.Lib.UI
                 RestoreRenderTargets(previousTargets);
             }
 
-            return CreateGeneratedTexture($"Generated_BPMBackground_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_BPMBackground_{width}x{height}", width, height);
         }
 
         #endregion

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -216,8 +216,9 @@ namespace DTXMania.Game.Lib.UI
         }
 
         /// <summary>
-        /// Restores the previous render targets. Call after drawing and before
-        /// CreateGeneratedTexture (which reads from the render target).
+        /// Restores the previous render targets after drawing is complete.
+        /// RenderTarget2D.GetData reads from the texture's backing memory, so it
+        /// remains accessible after the target is unbound from the GPU.
         /// </summary>
         protected virtual void RestoreRenderTargets(RenderTargetBinding[] previousTargets)
         {
@@ -298,13 +299,12 @@ namespace DTXMania.Game.Lib.UI
                 }
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_SongBar_{width}x{height}", width, height);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_SongBar_{width}x{height}", width, height);
         }
 
         private ITexture CreateClearLampTexture(int difficulty, bool hasCleared)
@@ -331,13 +331,12 @@ namespace DTXMania.Game.Lib.UI
                 DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 1);
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_ClearLamp_{difficulty}_{hasCleared}", width, height);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_ClearLamp_{difficulty}_{hasCleared}", width, height);
         }
 
         private ITexture CreatePanelTexture(int width, int height, bool withBorder)
@@ -360,13 +359,12 @@ namespace DTXMania.Game.Lib.UI
                 }
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_Panel_{width}x{height}", width, height);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_Panel_{width}x{height}", width, height);
         }
 
         private ITexture CreateButtonTexture(int width, int height, bool isPressed)
@@ -389,13 +387,12 @@ namespace DTXMania.Game.Lib.UI
                 DrawRectangleBorder(new Rectangle(0, 0, width, height), Color.White, 1);
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_Button_{width}x{height}", width, height);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_Button_{width}x{height}", width, height);
         }
 
         private void DrawGradientRectangle(Rectangle bounds, Color topColor, Color bottomColor)
@@ -455,13 +452,12 @@ namespace DTXMania.Game.Lib.UI
                 }
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}", 8, 24);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}", 8, 24);
         }
 
         private ITexture CreateBarTypeTexture(int width, int height, BarType barType, bool isSelected, bool isCenter)
@@ -515,13 +511,12 @@ namespace DTXMania.Game.Lib.UI
                 }
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_BarType_{barType}_{width}x{height}", width, height);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_BarType_{barType}_{width}x{height}", width, height);
         }
 
         private ITexture CreateBPMBackgroundTexture(int width, int height, bool withLabels)
@@ -558,13 +553,12 @@ namespace DTXMania.Game.Lib.UI
                 }
 
                 EndSpriteBatch();
+                return CreateGeneratedTexture($"Generated_BPMBackground_{width}x{height}", width, height);
             }
             finally
             {
                 RestoreRenderTargets(previousTargets);
             }
-
-            return CreateGeneratedTexture($"Generated_BPMBackground_{width}x{height}", width, height);
         }
 
         #endregion

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -166,6 +166,35 @@ namespace DTXMania.Game.Lib.UI
             return texture;
         }
 
+        /// <summary>
+        /// Pre-generate common texture sizes so that draw-time calls hit the cache
+        /// and never need to switch render targets during an active SpriteBatch.
+        /// Call this during initialization, BEFORE any draw pass.
+        /// </summary>
+        /// <param name="panelWidth">Width for panel background pre-generation (0 to skip).</param>
+        /// <param name="panelHeight">Height for panel background pre-generation (0 to skip).</param>
+        /// <param name="barWidth">Width for song bar pre-generation (0 to skip).</param>
+        /// <param name="barHeight">Height for song bar pre-generation (0 to skip).</param>
+        public void PreGenerateCommonTextures(int panelWidth, int panelHeight, int barWidth, int barHeight)
+        {
+            // Panel background for status panel
+            if (panelWidth > 0 && panelHeight > 0)
+            {
+                GeneratePanelBackground(panelWidth, panelHeight, true);
+            }
+
+            // Bar backgrounds for the most common states (unselected, selected, center)
+            if (barWidth > 0 && barHeight > 0)
+            {
+                foreach (BarType barType in Enum.GetValues(typeof(BarType)))
+                {
+                    GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: false, isCenter: false);
+                    GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: true, isCenter: false);
+                    GenerateBarTypeBackground(barWidth, barHeight, barType, isSelected: false, isCenter: true);
+                }
+            }
+        }
+
         #endregion
 
         #region Private Methods

--- a/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
+++ b/DTXMania.Game/Lib/UI/DefaultGraphicsGenerator.cs
@@ -160,14 +160,35 @@ namespace DTXMania.Game.Lib.UI
 
         #region Private Methods
 
+        protected virtual void ClearGraphics(Color color)
+        {
+            _graphicsDevice.Clear(color);
+        }
+
+        protected virtual void BeginSpriteBatch()
+        {
+            _spriteBatch.Begin();
+        }
+
+        protected virtual void EndSpriteBatch()
+        {
+            _spriteBatch.End();
+        }
+
+        protected virtual void DrawSolidRectangle(Rectangle destination, Color color)
+        {
+            _spriteBatch.Draw(_whitePixel, destination, color);
+        }
+
+        protected virtual ITexture CreateGeneratedTexture(string sourcePath)
+        {
+            return new ManagedTexture(_graphicsDevice, _renderTarget, sourcePath);
+        }
+
         private ITexture CreateSongBarTexture(int width, int height, bool isSelected, bool isCenter)
         {
-            // Always use the provided single RenderTarget
-            var renderTarget = _renderTarget;
-
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             // Base color
             var baseColor = DTXManiaVisualTheme.SongSelection.SongBarBackground;
@@ -177,7 +198,7 @@ namespace DTXMania.Game.Lib.UI
                 baseColor = DTXManiaVisualTheme.SongSelection.SongBarSelected;
 
             // Draw background with gradient effect
-            DrawGradientRectangle(_spriteBatch, new Rectangle(0, 0, width, height),
+            DrawGradientRectangle(new Rectangle(0, 0, width, height),
                                 baseColor, Color.Lerp(baseColor, Color.Black, 0.3f));
 
             // Draw border for selected items
@@ -187,86 +208,84 @@ namespace DTXMania.Game.Lib.UI
                 var borderThickness = isCenter ? 2 : 1;
 
                 // Top border
-                _spriteBatch.Draw(_whitePixel, new Rectangle(0, 0, width, borderThickness), borderColor);
+                DrawSolidRectangle(new Rectangle(0, 0, width, borderThickness), borderColor);
                 // Bottom border
-                _spriteBatch.Draw(_whitePixel, new Rectangle(0, height - borderThickness, width, borderThickness), borderColor);
+                DrawSolidRectangle(new Rectangle(0, height - borderThickness, width, borderThickness), borderColor);
             }
 
-            _spriteBatch.End();
+            EndSpriteBatch();
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_SongBar_{width}x{height}");
-        }        private ITexture CreateClearLampTexture(int difficulty, bool hasCleared)
+            return CreateGeneratedTexture($"Generated_SongBar_{width}x{height}");
+        }
+
+        private ITexture CreateClearLampTexture(int difficulty, bool hasCleared)
         {
             var width = DTXManiaVisualTheme.Layout.ClearLampWidth;
             var height = DTXManiaVisualTheme.Layout.ClearLampHeight;
-            var renderTarget = _renderTarget;
 
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             var lampColor = DTXManiaVisualTheme.GetDifficultyColor(difficulty);
             if (!hasCleared)
                 lampColor = Color.Lerp(lampColor, Color.Gray, 0.7f);
 
             // Draw lamp with gradient effect
-            DrawGradientRectangle(_spriteBatch, new Rectangle(0, 0, width, height),
+            DrawGradientRectangle(new Rectangle(0, 0, width, height),
                                 lampColor, Color.Lerp(lampColor, Color.Black, 0.5f));
 
             // Draw border
             var borderColor = hasCleared ? Color.White : Color.Gray;
-            DrawRectangleBorder(_spriteBatch, new Rectangle(0, 0, width, height), borderColor, 1);
+            DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 1);
 
-            _spriteBatch.End();
+            EndSpriteBatch();
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_ClearLamp_{difficulty}_{hasCleared}");
-        }        private ITexture CreatePanelTexture(int width, int height, bool withBorder)
+            return CreateGeneratedTexture($"Generated_ClearLamp_{difficulty}_{hasCleared}");
+        }
+
+        private ITexture CreatePanelTexture(int width, int height, bool withBorder)
         {
-            var renderTarget = _renderTarget;
-
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             // Draw background
             var bgColor = DTXManiaVisualTheme.SongSelection.PanelBackground;
-            _spriteBatch.Draw(_whitePixel, new Rectangle(0, 0, width, height), bgColor);
+            DrawSolidRectangle(new Rectangle(0, 0, width, height), bgColor);
 
             // Draw border if requested
             if (withBorder)
             {
                 var borderColor = DTXManiaVisualTheme.SongSelection.PanelBorder;
-                DrawRectangleBorder(_spriteBatch, new Rectangle(0, 0, width, height), borderColor, 2);
+                DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 2);
             }
 
-            _spriteBatch.End();
+            EndSpriteBatch();
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_Panel_{width}x{height}");
-        }        private ITexture CreateButtonTexture(int width, int height, bool isPressed)
+            return CreateGeneratedTexture($"Generated_Panel_{width}x{height}");
+        }
+
+        private ITexture CreateButtonTexture(int width, int height, bool isPressed)
         {
-            var renderTarget = _renderTarget;
-
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             var baseColor = new Color(60, 80, 120);
             if (isPressed)
                 baseColor = Color.Lerp(baseColor, Color.White, 0.3f);
 
             // Draw button with gradient effect
-            DrawGradientRectangle(_spriteBatch, new Rectangle(0, 0, width, height),
+            DrawGradientRectangle(new Rectangle(0, 0, width, height),
                                 Color.Lerp(baseColor, Color.White, 0.2f), baseColor);
 
             // Draw border
-            DrawRectangleBorder(_spriteBatch, new Rectangle(0, 0, width, height), Color.White, 1);
+            DrawRectangleBorder(new Rectangle(0, 0, width, height), Color.White, 1);
 
-            _spriteBatch.End();
+            EndSpriteBatch();
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_Button_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_Button_{width}x{height}");
         }
 
-        private void DrawGradientRectangle(SpriteBatch spriteBatch, Rectangle bounds, Color topColor, Color bottomColor)
+        private void DrawGradientRectangle(Rectangle bounds, Color topColor, Color bottomColor)
         {
             // Simple vertical gradient using multiple horizontal lines
             for (int y = 0; y < bounds.Height; y++)
@@ -274,27 +293,26 @@ namespace DTXMania.Game.Lib.UI
                 float ratio = (float)y / bounds.Height;
                 var color = Color.Lerp(topColor, bottomColor, ratio);
                 var lineRect = new Rectangle(bounds.X, bounds.Y + y, bounds.Width, 1);
-                spriteBatch.Draw(_whitePixel, lineRect, color);
+                DrawSolidRectangle(lineRect, color);
             }
         }
 
-        private void DrawRectangleBorder(SpriteBatch spriteBatch, Rectangle bounds, Color color, int thickness)
+        private void DrawRectangleBorder(Rectangle bounds, Color color, int thickness)
         {
             // Top
-            spriteBatch.Draw(_whitePixel, new Rectangle(bounds.X, bounds.Y, bounds.Width, thickness), color);
+            DrawSolidRectangle(new Rectangle(bounds.X, bounds.Y, bounds.Width, thickness), color);
             // Bottom
-            spriteBatch.Draw(_whitePixel, new Rectangle(bounds.X, bounds.Bottom - thickness, bounds.Width, thickness), color);
+            DrawSolidRectangle(new Rectangle(bounds.X, bounds.Bottom - thickness, bounds.Width, thickness), color);
             // Left
-            spriteBatch.Draw(_whitePixel, new Rectangle(bounds.X, bounds.Y, thickness, bounds.Height), color);
+            DrawSolidRectangle(new Rectangle(bounds.X, bounds.Y, thickness, bounds.Height), color);
             // Right
-            spriteBatch.Draw(_whitePixel, new Rectangle(bounds.Right - thickness, bounds.Y, thickness, bounds.Height), color);
-        }        private ITexture CreateEnhancedClearLampTexture(int difficulty, ClearStatus clearStatus)
+            DrawSolidRectangle(new Rectangle(bounds.Right - thickness, bounds.Y, thickness, bounds.Height), color);
+        }
+
+        private ITexture CreateEnhancedClearLampTexture(int difficulty, ClearStatus clearStatus)
         {
-            var renderTarget = _renderTarget;
-
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             // Get base color for difficulty
             var difficultyColors = DTXManiaVisualTheme.SongSelection.DifficultyColors;
@@ -311,25 +329,24 @@ namespace DTXMania.Game.Lib.UI
             };
 
             // Draw lamp with gradient effect
-            DrawGradientRectangle(_spriteBatch, new Rectangle(0, 0, 8, 24),
+            DrawGradientRectangle(new Rectangle(0, 0, 8, 24),
                                 Color.Lerp(lampColor, Color.White, 0.3f), lampColor);
 
             // Add border for better definition
             if (clearStatus != ClearStatus.NotPlayed)
             {
-                DrawRectangleBorder(_spriteBatch, new Rectangle(0, 0, 8, 24), Color.White * 0.8f, 1);
+                DrawRectangleBorder(new Rectangle(0, 0, 8, 24), Color.White * 0.8f, 1);
             }
 
-            _spriteBatch.End();
+            EndSpriteBatch();
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}");
-        }        private ITexture CreateBarTypeTexture(int width, int height, BarType barType, bool isSelected, bool isCenter)
+            return CreateGeneratedTexture($"Generated_EnhancedClearLamp_{difficulty}_{clearStatus}");
+        }
+
+        private ITexture CreateBarTypeTexture(int width, int height, BarType barType, bool isSelected, bool isCenter)
         {
-            var renderTarget = _renderTarget;
-
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             // Get base color based on bar type
             Color baseColor = barType switch
@@ -347,7 +364,7 @@ namespace DTXMania.Game.Lib.UI
                 baseColor = DTXManiaVisualTheme.SongSelection.SongBarSelected;
 
             // Draw background with gradient effect
-            DrawGradientRectangle(_spriteBatch, new Rectangle(0, 0, width, height),
+            DrawGradientRectangle(new Rectangle(0, 0, width, height),
                                 baseColor, Color.Lerp(baseColor, Color.Black, 0.3f));
 
             // Draw border for selected items
@@ -355,7 +372,7 @@ namespace DTXMania.Game.Lib.UI
             {
                 var borderColor = isCenter ? Color.Yellow : Color.White;
                 var borderThickness = isCenter ? 2 : 1;
-                DrawRectangleBorder(_spriteBatch, new Rectangle(0, 0, width, height), borderColor, borderThickness);
+                DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, borderThickness);
             }
 
             // Add special effects for different bar types
@@ -363,35 +380,34 @@ namespace DTXMania.Game.Lib.UI
             {
                 // Add folder icon indicator (simple rectangle on left side)
                 var iconRect = new Rectangle(2, height / 4, 4, height / 2);
-                _spriteBatch.Draw(_whitePixel, iconRect, Color.Cyan * 0.7f);
+                DrawSolidRectangle(iconRect, Color.Cyan * 0.7f);
             }
             else if (barType == BarType.Other)
             {
                 // Add special indicator (diamond pattern)
                 var centerY = height / 2;
                 var indicatorRect = new Rectangle(width - 8, centerY - 2, 4, 4);
-                _spriteBatch.Draw(_whitePixel, indicatorRect, Color.Magenta * 0.8f);
-            }            _spriteBatch.End();
+                DrawSolidRectangle(indicatorRect, Color.Magenta * 0.8f);
+            }
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_BarType_{barType}_{width}x{height}");
+            EndSpriteBatch();
+
+            return CreateGeneratedTexture($"Generated_BarType_{barType}_{width}x{height}");
         }
 
         private ITexture CreateBPMBackgroundTexture(int width, int height, bool withLabels)
         {
-            var renderTarget = _renderTarget;
-
-            _graphicsDevice.Clear(Color.Transparent);
-
-            _spriteBatch.Begin();
+            ClearGraphics(Color.Transparent);
+            BeginSpriteBatch();
 
             // Draw background with DTXManiaNX-style panel appearance
             var bgColor = DTXManiaVisualTheme.SongSelection.PanelBackground;
-            DrawGradientRectangle(_spriteBatch, new Rectangle(0, 0, width, height),
+            DrawGradientRectangle(new Rectangle(0, 0, width, height),
                                 Color.Lerp(bgColor, Color.White, 0.1f), bgColor);
 
             // Draw border
             var borderColor = DTXManiaVisualTheme.SongSelection.PanelBorder;
-            DrawRectangleBorder(_spriteBatch, new Rectangle(0, 0, width, height), borderColor, 2);
+            DrawRectangleBorder(new Rectangle(0, 0, width, height), borderColor, 2);
 
             if (withLabels)
             {
@@ -400,16 +416,16 @@ namespace DTXMania.Game.Lib.UI
                 
                 // Length label area (top portion)
                 var lengthLabelRect = new Rectangle(5, 5, width - 10, height / 2 - 5);
-                _spriteBatch.Draw(_whitePixel, lengthLabelRect, Color.Black * 0.2f);
+                DrawSolidRectangle(lengthLabelRect, Color.Black * 0.2f);
                 
                 // BPM label area (bottom portion)
                 var bpmLabelRect = new Rectangle(5, height / 2, width - 10, height / 2 - 5);
-                _spriteBatch.Draw(_whitePixel, bpmLabelRect, Color.Black * 0.2f);
+                DrawSolidRectangle(bpmLabelRect, Color.Black * 0.2f);
             }
 
-            _spriteBatch.End();
+            EndSpriteBatch();
 
-            return new ManagedTexture(_graphicsDevice, renderTarget, $"Generated_BPMBackground_{width}x{height}");
+            return CreateGeneratedTexture($"Generated_BPMBackground_{width}x{height}");
         }
 
         #endregion

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -6,6 +6,7 @@ using DTXMania.Game;
 using DTXMania.Game.Lib;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Graphics;
+using DTXMania.Game.Lib.JsonRpc;
 using DTXMania.Test.TestData;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xna.Framework;
@@ -114,6 +115,46 @@ namespace DTXMania.Test
             await task;
 
             Assert.True(task.IsCompletedSuccessfully);
+        }
+
+        [Fact]
+        public async Task StartGameApiServerAsync_WhenCancellationAlreadyRequested_ShouldSwallowOperationCanceledException()
+        {
+            var game = CreateGameForLifecycle(new ConfigData { GameApiPort = 12345 });
+            var gameApi = new Mock<IGameApi>();
+            gameApi.SetupGet(api => api.IsRunning).Returns(true);
+            using var server = new JsonRpcServer(gameApi.Object, port: 12345);
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            ReflectionHelpers.SetPrivateField(game, "_jsonRpcServer", server);
+            ReflectionHelpers.SetPrivateField(game, "_gameApiCancellation", cancellation);
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(game, "StartGameApiServerAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.False(server.IsRunning);
+        }
+
+        [Fact]
+        public async Task StartGameApiServerAsync_WhenServerStartThrows_ShouldSwallowException()
+        {
+            var game = CreateGameForLifecycle(new ConfigData { GameApiPort = 12346 });
+            var gameApi = new Mock<IGameApi>();
+            gameApi.SetupGet(api => api.IsRunning).Returns(true);
+            var server = new JsonRpcServer(gameApi.Object, port: 12346);
+            server.Dispose();
+            using var cancellation = new CancellationTokenSource();
+
+            ReflectionHelpers.SetPrivateField(game, "_jsonRpcServer", server);
+            ReflectionHelpers.SetPrivateField(game, "_gameApiCancellation", cancellation);
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(game, "StartGameApiServerAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.False(server.IsRunning);
         }
 
         [Fact]

--- a/DTXMania.Test/DTXMania.Test.Mac.csproj
+++ b/DTXMania.Test/DTXMania.Test.Mac.csproj
@@ -30,7 +30,7 @@
 
   <!-- Include all source files except problematic graphics tests -->
   <ItemGroup>
-    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongBarRendererLogicTests.cs;UI/SongStatusPanelTests.cs;UI/SongStatusPanelLogicTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Stage/Performance/PerformanceRendererStateTests.cs;Stage/Performance/PooledEffectsManagerTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs" />
+    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongBarRendererLogicTests.cs;UI/SongStatusPanelTests.cs;UI/SongStatusPanelLogicTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Stage/Performance/PooledEffectsManagerTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs" />
   </ItemGroup>
 
   <!-- Include xunit configuration if it exists -->

--- a/DTXMania.Test/DTXMania.Test.Mac.csproj
+++ b/DTXMania.Test/DTXMania.Test.Mac.csproj
@@ -30,7 +30,7 @@
 
   <!-- Include all source files except problematic graphics tests -->
   <ItemGroup>
-    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongBarRendererLogicTests.cs;UI/SongStatusPanelTests.cs;UI/SongStatusPanelLogicTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Stage/Performance/PooledEffectsManagerTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs" />
+    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongBarRendererLogicTests.cs;UI/SongStatusPanelTests.cs;UI/SongStatusPanelLogicTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Stage/Performance/PerformanceRendererStateTests.cs;Stage/Performance/PooledEffectsManagerTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs" />
   </ItemGroup>
 
   <!-- Include xunit configuration if it exists -->

--- a/DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs
+++ b/DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Graphics;
 using DTXMania.Test.TestData;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,7 +16,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void Constructor_WithNullGame_ShouldThrowArgumentNullException()
     {
-        var exception = Assert.Throws<ArgumentNullException>(() => new GraphicsManager(null!, CreateUninitialized<GraphicsDeviceManager>()));
+        var exception = Assert.Throws<ArgumentNullException>(() => new GraphicsManager(null!, ReflectionHelpers.CreateUninitialized<GraphicsDeviceManager>()));
 
         Assert.Equal("game", exception.ParamName);
     }
@@ -33,7 +32,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void Settings_ShouldReturnCloneOfCurrentSettings()
     {
-        var manager = CreateManager(fixture, new GraphicsSettings
+        var manager = CreateManager(new GraphicsSettings
         {
             Width = 1280,
             Height = 720,
@@ -51,7 +50,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void ApplySettings_WithNullSettings_ShouldThrowArgumentNullException()
     {
-        var manager = CreateManager(fixture);
+        var manager = CreateManager();
 
         var exception = Assert.Throws<ArgumentNullException>(() => manager.ApplySettings(null!));
 
@@ -61,7 +60,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void ApplySettings_WithInvalidSettings_ShouldReturnFalse()
     {
-        var manager = CreateManager(fixture);
+        var manager = CreateManager();
 
         var result = manager.ApplySettings(new GraphicsSettings { Width = 0, Height = 720 });
 
@@ -72,7 +71,7 @@ public class GraphicsManagerLogicTests
     public void ApplySettings_WhenSettingsMatchCurrent_ShouldReturnTrue()
     {
         var current = new GraphicsSettings { Width = 1280, Height = 720, IsFullscreen = false, VSync = true };
-        var manager = CreateManager(fixture, current);
+        var manager = CreateManager(current);
 
         var result = manager.ApplySettings(current.Clone());
 
@@ -82,7 +81,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void ChangeResolution_WhenDimensionsAreInvalid_ShouldReturnFalse()
     {
-        var manager = CreateManager(fixture);
+        var manager = CreateManager();
 
         Assert.False(manager.ChangeResolution(-1, 720));
         Assert.False(manager.ChangeResolution(1280, 5000));
@@ -91,7 +90,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void SetFullscreen_WhenRequestedStateMatchesCurrent_ShouldReturnTrue()
     {
-        var manager = CreateManager(fixture, new GraphicsSettings
+        var manager = CreateManager(new GraphicsSettings
         {
             Width = 1280,
             Height = 720,
@@ -107,7 +106,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void SetVSync_WhenRequestedStateMatchesCurrent_ShouldReturnTrue()
     {
-        var manager = CreateManager(fixture, new GraphicsSettings
+        var manager = CreateManager(new GraphicsSettings
         {
             Width = 1280,
             Height = 720,
@@ -123,7 +122,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void IsResolutionSupported_WithInvalidDimensions_ShouldReturnFalse()
     {
-        var manager = CreateManager(fixture);
+        var manager = CreateManager();
 
         Assert.False(manager.IsResolutionSupported(0, 720));
         Assert.False(manager.IsResolutionSupported(1280, -1));
@@ -133,7 +132,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void OnDeviceLost_ShouldRaiseDeviceLostEvent()
     {
-        var manager = CreateManager(fixture);
+        var manager = CreateManager();
         var raised = false;
         manager.DeviceLost += (_, _) => raised = true;
 
@@ -145,7 +144,7 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void OnDeviceReset_ShouldRaiseDeviceResetEvent()
     {
-        var manager = CreateManager(fixture, renderTargetManager: CreateEmptyRenderTargetManager());
+        var manager = CreateManager(renderTargetManager: CreateEmptyRenderTargetManager());
         var raised = false;
         manager.DeviceReset += (_, _) => raised = true;
 
@@ -158,7 +157,7 @@ public class GraphicsManagerLogicTests
     public void Dispose_ShouldDisposeRenderTargetManagerAndMarkDisposed()
     {
         var renderTargetManager = CreateEmptyRenderTargetManager();
-        var manager = CreateManager(fixture, renderTargetManager: renderTargetManager);
+        var manager = CreateManager(renderTargetManager: renderTargetManager);
 
         manager.Dispose();
 
@@ -169,18 +168,16 @@ public class GraphicsManagerLogicTests
     [Fact]
     public void ResetDevice_WhenDeviceManagerIsUnavailable_ShouldReturnFalse()
     {
-        var manager = CreateManager(fixture);
+        var manager = CreateManager();
 
         Assert.False(manager.ResetDevice());
     }
 
-    private readonly object fixture = new();
-
-    private static GraphicsManager CreateManager(object _, GraphicsSettings? currentSettings = null, RenderTargetManager? renderTargetManager = null)
+    private static GraphicsManager CreateManager(GraphicsSettings? currentSettings = null, RenderTargetManager? renderTargetManager = null)
     {
-        var manager = CreateUninitialized<GraphicsManager>();
+        var manager = ReflectionHelpers.CreateUninitialized<GraphicsManager>();
         ReflectionHelpers.SetPrivateField(manager, "_game", null);
-        ReflectionHelpers.SetPrivateField(manager, "_deviceManager", CreateUninitialized<GraphicsDeviceManager>());
+        ReflectionHelpers.SetPrivateField(manager, "_deviceManager", ReflectionHelpers.CreateUninitialized<GraphicsDeviceManager>());
         ReflectionHelpers.SetPrivateField(manager, "_logger", NullLogger<GraphicsManager>.Instance);
         ReflectionHelpers.SetPrivateField(manager, "_currentSettings", currentSettings ?? new GraphicsSettings());
         ReflectionHelpers.SetPrivateField(manager, "_renderTargetManager", renderTargetManager);
@@ -190,8 +187,8 @@ public class GraphicsManagerLogicTests
 
     private static RenderTargetManager CreateEmptyRenderTargetManager()
     {
-        var manager = CreateUninitialized<RenderTargetManager>();
-        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", CreateUninitialized<GraphicsDevice>());
+        var manager = ReflectionHelpers.CreateUninitialized<RenderTargetManager>();
+        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", ReflectionHelpers.CreateUninitialized<GraphicsDevice>());
         ReflectionHelpers.SetPrivateField(manager, "_renderTargets", CreateRenderTargetDictionary());
         ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
         return manager;
@@ -204,8 +201,4 @@ public class GraphicsManagerLogicTests
         return Activator.CreateInstance(dictionaryType)!;
     }
 
-    private static T CreateUninitialized<T>() where T : class
-    {
-        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
-    }
 }

--- a/DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs
+++ b/DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using DTXMania.Game.Lib.Graphics;
+using DTXMania.Test.TestData;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Xunit;
+
+namespace DTXMania.Test.Graphics;
+
+[Trait("Category", "Unit")]
+public class GraphicsManagerLogicTests
+{
+    [Fact]
+    public void Constructor_WithNullGame_ShouldThrowArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new GraphicsManager(null!, CreateUninitialized<GraphicsDeviceManager>()));
+
+        Assert.Equal("game", exception.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithNullDeviceManager_ShouldThrowArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => new GraphicsManager(ReflectionHelpers.CreateGame(), null!));
+
+        Assert.Equal("deviceManager", exception.ParamName);
+    }
+
+    [Fact]
+    public void Settings_ShouldReturnCloneOfCurrentSettings()
+    {
+        var manager = CreateManager(fixture, new GraphicsSettings
+        {
+            Width = 1280,
+            Height = 720,
+            IsFullscreen = false,
+            VSync = true
+        });
+
+        var snapshot = manager.Settings;
+        snapshot.Width = 1920;
+
+        Assert.Equal(1280, manager.Settings.Width);
+        Assert.NotSame(snapshot, manager.Settings);
+    }
+
+    [Fact]
+    public void ApplySettings_WithNullSettings_ShouldThrowArgumentNullException()
+    {
+        var manager = CreateManager(fixture);
+
+        var exception = Assert.Throws<ArgumentNullException>(() => manager.ApplySettings(null!));
+
+        Assert.Equal("settings", exception.ParamName);
+    }
+
+    [Fact]
+    public void ApplySettings_WithInvalidSettings_ShouldReturnFalse()
+    {
+        var manager = CreateManager(fixture);
+
+        var result = manager.ApplySettings(new GraphicsSettings { Width = 0, Height = 720 });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ApplySettings_WhenSettingsMatchCurrent_ShouldReturnTrue()
+    {
+        var current = new GraphicsSettings { Width = 1280, Height = 720, IsFullscreen = false, VSync = true };
+        var manager = CreateManager(fixture, current);
+
+        var result = manager.ApplySettings(current.Clone());
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ChangeResolution_WhenDimensionsAreInvalid_ShouldReturnFalse()
+    {
+        var manager = CreateManager(fixture);
+
+        Assert.False(manager.ChangeResolution(-1, 720));
+        Assert.False(manager.ChangeResolution(1280, 5000));
+    }
+
+    [Fact]
+    public void SetFullscreen_WhenRequestedStateMatchesCurrent_ShouldReturnTrue()
+    {
+        var manager = CreateManager(fixture, new GraphicsSettings
+        {
+            Width = 1280,
+            Height = 720,
+            IsFullscreen = false,
+            VSync = true
+        });
+
+        var result = manager.SetFullscreen(false);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void SetVSync_WhenRequestedStateMatchesCurrent_ShouldReturnTrue()
+    {
+        var manager = CreateManager(fixture, new GraphicsSettings
+        {
+            Width = 1280,
+            Height = 720,
+            IsFullscreen = false,
+            VSync = true
+        });
+
+        var result = manager.SetVSync(true);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void IsResolutionSupported_WithInvalidDimensions_ShouldReturnFalse()
+    {
+        var manager = CreateManager(fixture);
+
+        Assert.False(manager.IsResolutionSupported(0, 720));
+        Assert.False(manager.IsResolutionSupported(1280, -1));
+        Assert.False(manager.IsResolutionSupported(8000, 720));
+    }
+
+    [Fact]
+    public void OnDeviceLost_ShouldRaiseDeviceLostEvent()
+    {
+        var manager = CreateManager(fixture);
+        var raised = false;
+        manager.DeviceLost += (_, _) => raised = true;
+
+        ReflectionHelpers.InvokePrivateMethod(manager, "OnDeviceLost", null!, EventArgs.Empty);
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void OnDeviceReset_ShouldRaiseDeviceResetEvent()
+    {
+        var manager = CreateManager(fixture, renderTargetManager: CreateEmptyRenderTargetManager());
+        var raised = false;
+        manager.DeviceReset += (_, _) => raised = true;
+
+        ReflectionHelpers.InvokePrivateMethod(manager, "OnDeviceReset", null!, EventArgs.Empty);
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void Dispose_ShouldDisposeRenderTargetManagerAndMarkDisposed()
+    {
+        var renderTargetManager = CreateEmptyRenderTargetManager();
+        var manager = CreateManager(fixture, renderTargetManager: renderTargetManager);
+
+        manager.Dispose();
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderTargetManager, "_disposed"));
+    }
+
+    [Fact]
+    public void ResetDevice_WhenDeviceManagerIsUnavailable_ShouldReturnFalse()
+    {
+        var manager = CreateManager(fixture);
+
+        Assert.False(manager.ResetDevice());
+    }
+
+    private readonly object fixture = new();
+
+    private static GraphicsManager CreateManager(object _, GraphicsSettings? currentSettings = null, RenderTargetManager? renderTargetManager = null)
+    {
+        var manager = CreateUninitialized<GraphicsManager>();
+        ReflectionHelpers.SetPrivateField(manager, "_game", null);
+        ReflectionHelpers.SetPrivateField(manager, "_deviceManager", CreateUninitialized<GraphicsDeviceManager>());
+        ReflectionHelpers.SetPrivateField(manager, "_logger", NullLogger<GraphicsManager>.Instance);
+        ReflectionHelpers.SetPrivateField(manager, "_currentSettings", currentSettings ?? new GraphicsSettings());
+        ReflectionHelpers.SetPrivateField(manager, "_renderTargetManager", renderTargetManager);
+        ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
+        return manager;
+    }
+
+    private static RenderTargetManager CreateEmptyRenderTargetManager()
+    {
+        var manager = CreateUninitialized<RenderTargetManager>();
+        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", CreateUninitialized<GraphicsDevice>());
+        ReflectionHelpers.SetPrivateField(manager, "_renderTargets", CreateRenderTargetDictionary());
+        ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
+        return manager;
+    }
+
+    private static object CreateRenderTargetDictionary()
+    {
+        var infoType = typeof(RenderTargetManager).GetNestedType("RenderTargetInfo", BindingFlags.NonPublic)!;
+        var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), infoType);
+        return Activator.CreateInstance(dictionaryType)!;
+    }
+
+    private static T CreateUninitialized<T>() where T : class
+    {
+        return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+    }
+}

--- a/DTXMania.Test/Graphics/RenderTargetManagerTests.cs
+++ b/DTXMania.Test/Graphics/RenderTargetManagerTests.cs
@@ -4,10 +4,10 @@ using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace DTXMania.Test.Graphics;
 
+[Trait("Category", "Unit")]
 public class RenderTargetManagerTests
 {
     [Fact]
@@ -107,8 +107,8 @@ public class RenderTargetManagerTests
 
     private static RenderTargetManager CreateManagerWithTargets(params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
     {
-        var manager = (RenderTargetManager)RuntimeHelpers.GetUninitializedObject(typeof(RenderTargetManager));
-        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice)));
+        var manager = ReflectionHelpers.CreateUninitialized<RenderTargetManager>();
+        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", ReflectionHelpers.CreateUninitialized<GraphicsDevice>());
         ReflectionHelpers.SetPrivateField(manager, "_renderTargets", CreateRenderTargetDictionary(entries));
         ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
         return manager;
@@ -138,7 +138,7 @@ public class RenderTargetManagerTests
 
     private static TrackingRenderTarget2D CreateTrackingRenderTarget()
     {
-        return (TrackingRenderTarget2D)RuntimeHelpers.GetUninitializedObject(typeof(TrackingRenderTarget2D));
+        return ReflectionHelpers.CreateUninitialized<TrackingRenderTarget2D>();
     }
 
     private sealed class TrackingRenderTarget2D : RenderTarget2D

--- a/DTXMania.Test/Graphics/RenderTargetManagerTests.cs
+++ b/DTXMania.Test/Graphics/RenderTargetManagerTests.cs
@@ -53,6 +53,102 @@ public class RenderTargetManagerTests
         var result = manager.GetOrCreateRenderTarget("scene", 640, 480, SurfaceFormat.Color, DepthFormat.Depth24, 2);
 
         Assert.Same(target, result);
+        Assert.Equal(0, manager.CreateRenderTargetCallCount);
+    }
+
+    [Fact]
+    public void GetOrCreateRenderTarget_WhenTargetDoesNotExist_ShouldCreateAndStoreTarget()
+    {
+        var created = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets((w, h, f, d, msaa) =>
+        {
+            Assert.Equal(1024, w);
+            Assert.Equal(576, h);
+            Assert.Equal(SurfaceFormat.Color, f);
+            Assert.Equal(DepthFormat.Depth24, d);
+            Assert.Equal(0, msaa);
+            return created;
+        });
+
+        var result = manager.GetOrCreateRenderTarget("new-target", 1024, 576, SurfaceFormat.Color, DepthFormat.Depth24, 0);
+
+        Assert.Same(created, result);
+        Assert.Same(created, manager.GetRenderTarget("new-target"));
+        Assert.Equal(1, manager.CreateRenderTargetCallCount);
+    }
+
+    [Theory]
+    [InlineData(800, 480, SurfaceFormat.Color, DepthFormat.Depth24)]
+    [InlineData(640, 480, SurfaceFormat.Bgr565, DepthFormat.Depth24)]
+    [InlineData(640, 480, SurfaceFormat.Color, DepthFormat.Depth16)]
+    public void GetOrCreateRenderTarget_WhenExistingTargetParametersDiffer_ShouldDisposeAndReplaceTarget(
+        int width,
+        int height,
+        SurfaceFormat format,
+        DepthFormat depthFormat)
+    {
+        var existing = CreateTrackingRenderTarget();
+        var replacement = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(
+            (w, h, f, d, msaa) =>
+            {
+                Assert.Equal(width, w);
+                Assert.Equal(height, h);
+                Assert.Equal(format, f);
+                Assert.Equal(depthFormat, d);
+                Assert.Equal(2, msaa);
+                return replacement;
+            },
+            ("scene", existing, 640, 480, SurfaceFormat.Color, DepthFormat.Depth24, 2));
+
+        var result = manager.GetOrCreateRenderTarget("scene", width, height, format, depthFormat, 2);
+
+        Assert.Same(replacement, result);
+        Assert.True(existing.WasDisposed);
+        Assert.Same(replacement, manager.GetRenderTarget("scene"));
+        Assert.Equal(1, manager.CreateRenderTargetCallCount);
+    }
+
+    [Fact]
+    public void GetOrCreateRenderTarget_WhenExistingTargetIsDisposed_ShouldCreateReplacement()
+    {
+        var existing = CreateTrackingRenderTarget();
+        existing.SimulatedIsDisposed = true;
+        var replacement = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(
+            (w, h, f, d, msaa) => replacement,
+            ("scene", existing, 640, 480, SurfaceFormat.Color, DepthFormat.Depth24, 2));
+
+        var result = manager.GetOrCreateRenderTarget("scene", 640, 480, SurfaceFormat.Color, DepthFormat.Depth24, 2);
+
+        Assert.Same(replacement, result);
+        Assert.True(existing.WasDisposed);
+        Assert.Same(replacement, manager.GetRenderTarget("scene"));
+        Assert.Equal(1, manager.CreateRenderTargetCallCount);
+    }
+
+    [Fact]
+    public void RecreateAllRenderTargets_ShouldDisposeAndReplaceTargetsUsingFactory()
+    {
+        var existing = CreateTrackingRenderTarget();
+        var replacement = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(
+            (w, h, f, d, msaa) =>
+            {
+                Assert.Equal(320, w);
+                Assert.Equal(240, h);
+                Assert.Equal(SurfaceFormat.Color, f);
+                Assert.Equal(DepthFormat.Depth16, d);
+                Assert.Equal(4, msaa);
+                return replacement;
+            },
+            ("overlay", existing, 320, 240, SurfaceFormat.Color, DepthFormat.Depth16, 4));
+
+        manager.RecreateAllRenderTargets();
+
+        Assert.True(existing.WasDisposed);
+        Assert.Same(replacement, manager.GetRenderTarget("overlay"));
+        Assert.Equal(1, manager.CreateRenderTargetCallCount);
     }
 
     [Fact]
@@ -105,40 +201,81 @@ public class RenderTargetManagerTests
         Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
     }
 
-    private static RenderTargetManager CreateManagerWithTargets(params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
+    private static TestRenderTargetManager CreateManagerWithTargets(
+        params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
     {
-        var manager = ReflectionHelpers.CreateUninitialized<RenderTargetManager>();
-        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", ReflectionHelpers.CreateUninitialized<GraphicsDevice>());
-        ReflectionHelpers.SetPrivateField(manager, "_renderTargets", CreateRenderTargetDictionary(entries));
-        ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
-        return manager;
+        return CreateManagerWithTargets(null, entries);
     }
 
-    private static object CreateRenderTargetDictionary(params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
+    private static TestRenderTargetManager CreateManagerWithTargets(
+        Func<int, int, SurfaceFormat, DepthFormat, int, RenderTarget2D>? factory,
+        params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
     {
-        var infoType = typeof(RenderTargetManager).GetNestedType("RenderTargetInfo", BindingFlags.NonPublic)!;
-        var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), infoType);
-        var dictionary = Activator.CreateInstance(dictionaryType)!;
+        var manager = new TestRenderTargetManager(factory);
+        var dictionary = ReflectionHelpers.GetPrivateField<object>(manager, "_renderTargets")!;
+        var dictionaryType = dictionary.GetType();
         var addMethod = dictionaryType.GetMethod("Add")!;
 
         foreach (var entry in entries)
         {
-            var info = Activator.CreateInstance(infoType, nonPublic: true)!;
-            infoType.GetProperty("RenderTarget")!.SetValue(info, entry.Target);
-            infoType.GetProperty("Width")!.SetValue(info, entry.Width);
-            infoType.GetProperty("Height")!.SetValue(info, entry.Height);
-            infoType.GetProperty("Format")!.SetValue(info, entry.Format);
-            infoType.GetProperty("DepthFormat")!.SetValue(info, entry.DepthFormat);
-            infoType.GetProperty("MultiSampleCount")!.SetValue(info, entry.MultiSampleCount);
+            var info = CreateRenderTargetInfo(entry.Target, entry.Width, entry.Height, entry.Format, entry.DepthFormat, entry.MultiSampleCount);
             addMethod.Invoke(dictionary, new object[] { entry.Name, info });
         }
 
-        return dictionary;
+        return manager;
+    }
+
+    private static object CreateRenderTargetInfo(
+        RenderTarget2D target,
+        int width,
+        int height,
+        SurfaceFormat format,
+        DepthFormat depthFormat,
+        int multiSampleCount)
+    {
+        var infoType = typeof(RenderTargetManager).GetNestedType("RenderTargetInfo", BindingFlags.NonPublic)!;
+        var info = Activator.CreateInstance(infoType, nonPublic: true)!;
+        infoType.GetProperty("RenderTarget")!.SetValue(info, target);
+        infoType.GetProperty("Width")!.SetValue(info, width);
+        infoType.GetProperty("Height")!.SetValue(info, height);
+        infoType.GetProperty("Format")!.SetValue(info, format);
+        infoType.GetProperty("DepthFormat")!.SetValue(info, depthFormat);
+        infoType.GetProperty("MultiSampleCount")!.SetValue(info, multiSampleCount);
+        return info;
     }
 
     private static TrackingRenderTarget2D CreateTrackingRenderTarget()
     {
         return ReflectionHelpers.CreateUninitialized<TrackingRenderTarget2D>();
+    }
+
+    private sealed class TestRenderTargetManager : RenderTargetManager
+    {
+        private readonly Func<int, int, SurfaceFormat, DepthFormat, int, RenderTarget2D> _factory;
+
+        public TestRenderTargetManager(Func<int, int, SurfaceFormat, DepthFormat, int, RenderTarget2D>? factory)
+            : base(ReflectionHelpers.CreateUninitialized<GraphicsDevice>())
+        {
+            _factory = factory ?? ((_, _, _, _, _) => CreateTrackingRenderTarget());
+        }
+
+        public int CreateRenderTargetCallCount { get; private set; }
+
+        protected override RenderTarget2D CreateRenderTarget(
+            int width,
+            int height,
+            SurfaceFormat format,
+            DepthFormat depthFormat,
+            int multiSampleCount)
+        {
+            CreateRenderTargetCallCount++;
+            return _factory(width, height, format, depthFormat, multiSampleCount);
+        }
+
+        protected override bool IsRenderTargetDisposed(RenderTarget2D renderTarget)
+        {
+            return renderTarget is TrackingRenderTarget2D tracking && tracking.SimulatedIsDisposed;
+        }
     }
 
     private sealed class TrackingRenderTarget2D : RenderTarget2D
@@ -148,10 +285,12 @@ public class RenderTargetManagerTests
         }
 
         public bool WasDisposed { get; private set; }
+        public bool SimulatedIsDisposed { get; set; }
 
         protected override void Dispose(bool disposing)
         {
             WasDisposed = true;
+            SimulatedIsDisposed = true;
         }
     }
 }

--- a/DTXMania.Test/Graphics/RenderTargetManagerTests.cs
+++ b/DTXMania.Test/Graphics/RenderTargetManagerTests.cs
@@ -1,4 +1,10 @@
 using DTXMania.Game.Lib.Graphics;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework.Graphics;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace DTXMania.Test.Graphics;
 
@@ -11,8 +17,141 @@ public class RenderTargetManagerTests
         Assert.Throws<ArgumentNullException>(() => new RenderTargetManager(null!));
     }
 
-    // Note: Most RenderTargetManager tests require a real GraphicsDevice instance
-    // which is difficult to create in unit tests without a full MonoGame context.
-    // The constructor null check test above covers the main validation logic.
-    // Integration tests would be more appropriate for testing the full functionality.
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void GetOrCreateRenderTarget_WithNullOrEmptyName_ShouldThrowArgumentException(string? name)
+    {
+        var manager = CreateManagerWithTargets();
+
+        Assert.Throws<ArgumentException>(() => manager.GetOrCreateRenderTarget(name!, 1280, 720));
+    }
+
+    [Fact]
+    public void GetRenderTarget_WhenTargetDoesNotExist_ShouldReturnNull()
+    {
+        var manager = CreateManagerWithTargets();
+
+        Assert.Null(manager.GetRenderTarget("missing"));
+    }
+
+    [Fact]
+    public void GetRenderTarget_WhenTargetExistsAndIsActive_ShouldReturnTarget()
+    {
+        var target = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(("main", target, 1280, 720, SurfaceFormat.Color, DepthFormat.None, 0));
+
+        Assert.Same(target, manager.GetRenderTarget("main"));
+    }
+
+    [Fact]
+    public void GetOrCreateRenderTarget_WhenMatchingTargetAlreadyExists_ShouldReturnExistingTarget()
+    {
+        var target = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(("scene", target, 640, 480, SurfaceFormat.Color, DepthFormat.Depth24, 2));
+
+        var result = manager.GetOrCreateRenderTarget("scene", 640, 480, SurfaceFormat.Color, DepthFormat.Depth24, 2);
+
+        Assert.Same(target, result);
+    }
+
+    [Fact]
+    public void RemoveRenderTarget_WhenTargetExists_ShouldDisposeAndRemoveTarget()
+    {
+        var target = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(("overlay", target, 320, 240, SurfaceFormat.Color, DepthFormat.None, 0));
+
+        manager.RemoveRenderTarget("overlay");
+
+        Assert.True(target.WasDisposed);
+        Assert.Equal(0, manager.Count);
+        Assert.Null(manager.GetRenderTarget("overlay"));
+    }
+
+    [Fact]
+    public void RemoveRenderTarget_WhenTargetDoesNotExist_ShouldReturnWithoutThrowing()
+    {
+        var manager = CreateManagerWithTargets();
+
+        var exception = Record.Exception(() => manager.RemoveRenderTarget("missing"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Count_ShouldReflectManagedRenderTargets()
+    {
+        var manager = CreateManagerWithTargets(
+            ("primary", CreateTrackingRenderTarget(), 1280, 720, SurfaceFormat.Color, DepthFormat.None, 0),
+            ("secondary", CreateTrackingRenderTarget(), 640, 360, SurfaceFormat.Color, DepthFormat.Depth24, 0));
+
+        Assert.Equal(2, manager.Count);
+    }
+
+    [Fact]
+    public void Dispose_ShouldDisposeManagedTargetsAndClearDictionary()
+    {
+        var targetA = CreateTrackingRenderTarget();
+        var targetB = CreateTrackingRenderTarget();
+        var manager = CreateManagerWithTargets(
+            ("a", targetA, 800, 600, SurfaceFormat.Color, DepthFormat.None, 0),
+            ("b", targetB, 400, 300, SurfaceFormat.Color, DepthFormat.None, 0));
+
+        manager.Dispose();
+
+        Assert.True(targetA.WasDisposed);
+        Assert.True(targetB.WasDisposed);
+        Assert.Equal(0, manager.Count);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
+    }
+
+    private static RenderTargetManager CreateManagerWithTargets(params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
+    {
+        var manager = (RenderTargetManager)RuntimeHelpers.GetUninitializedObject(typeof(RenderTargetManager));
+        ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice)));
+        ReflectionHelpers.SetPrivateField(manager, "_renderTargets", CreateRenderTargetDictionary(entries));
+        ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
+        return manager;
+    }
+
+    private static object CreateRenderTargetDictionary(params (string Name, RenderTarget2D Target, int Width, int Height, SurfaceFormat Format, DepthFormat DepthFormat, int MultiSampleCount)[] entries)
+    {
+        var infoType = typeof(RenderTargetManager).GetNestedType("RenderTargetInfo", BindingFlags.NonPublic)!;
+        var dictionaryType = typeof(Dictionary<,>).MakeGenericType(typeof(string), infoType);
+        var dictionary = Activator.CreateInstance(dictionaryType)!;
+        var addMethod = dictionaryType.GetMethod("Add")!;
+
+        foreach (var entry in entries)
+        {
+            var info = Activator.CreateInstance(infoType, nonPublic: true)!;
+            infoType.GetProperty("RenderTarget")!.SetValue(info, entry.Target);
+            infoType.GetProperty("Width")!.SetValue(info, entry.Width);
+            infoType.GetProperty("Height")!.SetValue(info, entry.Height);
+            infoType.GetProperty("Format")!.SetValue(info, entry.Format);
+            infoType.GetProperty("DepthFormat")!.SetValue(info, entry.DepthFormat);
+            infoType.GetProperty("MultiSampleCount")!.SetValue(info, entry.MultiSampleCount);
+            addMethod.Invoke(dictionary, new object[] { entry.Name, info });
+        }
+
+        return dictionary;
+    }
+
+    private static TrackingRenderTarget2D CreateTrackingRenderTarget()
+    {
+        return (TrackingRenderTarget2D)RuntimeHelpers.GetUninitializedObject(typeof(TrackingRenderTarget2D));
+    }
+
+    private sealed class TrackingRenderTarget2D : RenderTarget2D
+    {
+        public TrackingRenderTarget2D() : base(null!, 1, 1)
+        {
+        }
+
+        public bool WasDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            WasDisposed = true;
+        }
+    }
 }

--- a/DTXMania.Test/JsonRpc/JsonRpcServerIntegrationTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerIntegrationTests.cs
@@ -1,4 +1,5 @@
 using DTXMania.Game.Lib;
+using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.JsonRpc;
 using Moq;
 using System;
@@ -138,6 +139,34 @@ namespace DTXMania.Test.JsonRpc
             var body = await response.Content.ReadAsStringAsync();
 
             Assert.Contains("-32601", body);
+        }
+
+        [Fact]
+        public async Task JsonRpcEndpoint_WithNotification_ShouldReturnEmptyBody()
+        {
+            using var client = await StartServerAsync(NextPort());
+            var request = new { jsonrpc = "2.0", method = "ping" };
+            using var response = await client.PostAsync("/jsonrpc", RpcBody(request));
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.True(response.IsSuccessStatusCode);
+            Assert.Equal(string.Empty, body);
+        }
+
+        [Fact]
+        public async Task JsonRpcEndpoint_WhenPayloadTooLarge_ShouldReturnRequestTooLarge()
+        {
+            using var client = await StartServerAsync(NextPort());
+            using var content = new StringContent(
+                new string('a', (int)GameConstants.JsonRpc.MaxRequestBodyBytes + 1),
+                Encoding.UTF8,
+                "application/json");
+
+            using var response = await client.PostAsync("/jsonrpc", content);
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Equal(System.Net.HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+            Assert.Contains("Request payload too large", body);
         }
 
         #endregion

--- a/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib;
+using DTXMania.Game.Lib.JsonRpc;
+using DTXMania.Test.TestData;
+using Microsoft.Extensions.Hosting;
+using Moq;
+
+namespace DTXMania.Test.JsonRpc;
+
+[Trait("Category", "Unit")]
+public class JsonRpcServerInternalTests
+{
+    [Fact]
+    public async Task HandleGetGameState_WhenGameIsRunning_ShouldReturnSuccessResponse()
+    {
+        var gameApi = CreateGameApi();
+        gameApi
+            .Setup(api => api.GetGameStateAsync())
+            .ReturnsAsync(new GameState { Score = 42, CurrentStage = "Title" });
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleGetGameState",
+            new JsonRpcRequest { Id = 7, Method = "getGameState" });
+
+        Assert.Null(response!.Error);
+        Assert.Equal(7, response.Id);
+        using var resultDocument = JsonDocument.Parse(JsonSerializer.Serialize(response.Result));
+        Assert.Equal(42, resultDocument.RootElement.GetProperty("Score").GetInt32());
+        Assert.Equal("Title", resultDocument.RootElement.GetProperty("CurrentStage").GetString());
+    }
+
+    [Fact]
+    public async Task HandleGetWindowInfo_WhenGameIsRunning_ShouldReturnSuccessResponse()
+    {
+        var gameApi = CreateGameApi();
+        gameApi
+            .Setup(api => api.GetWindowInfoAsync())
+            .ReturnsAsync(new GameWindowInfo { Width = 1280, Height = 720, Title = "DTXManiaCX" });
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleGetWindowInfo",
+            new JsonRpcRequest { Id = 11, Method = "getWindowInfo" });
+
+        Assert.Null(response!.Error);
+        Assert.Equal(11, response.Id);
+        using var resultDocument = JsonDocument.Parse(JsonSerializer.Serialize(response.Result));
+        Assert.Equal(1280, resultDocument.RootElement.GetProperty("Width").GetInt32());
+        Assert.Equal("DTXManiaCX", resultDocument.RootElement.GetProperty("Title").GetString());
+    }
+
+    [Fact]
+    public async Task HandleSendInput_WhenParamsAreMissing_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleSendInput",
+            new JsonRpcRequest { Id = 3, Method = "sendInput" });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("Input parameters are required", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandleSendInput_WhenParamsAreNotJsonElement_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleSendInput",
+            new JsonRpcRequest { Id = 4, Method = "sendInput", Params = new object() });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("Invalid input format", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandleSendInput_WhenGameInputJsonIsInvalid_ShouldReturnInvalidParams()
+    {
+        using var jsonDocument = JsonDocument.Parse("{\"type\":\"bad\",\"data\":\"Enter\"}");
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleSendInput",
+            new JsonRpcRequest { Id = 4, Method = "sendInput", Params = jsonDocument.RootElement.Clone() });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Contains("Invalid input format", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandleTakeScreenshot_WhenCaptureFails_ShouldReturnInternalError()
+    {
+        var gameApi = CreateGameApi();
+        gameApi.Setup(api => api.TakeScreenshotAsync()).ReturnsAsync((byte[]?)null);
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleTakeScreenshot",
+            new JsonRpcRequest { Id = 5, Method = "takeScreenshot" });
+
+        Assert.Equal(JsonRpcErrorCodes.InternalError, response!.Error!.Code);
+        Assert.Contains("Screenshot capture failed", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandleTakeScreenshot_WhenCaptureSucceeds_ShouldReturnBase64EncodedPng()
+    {
+        var gameApi = CreateGameApi();
+        gameApi.Setup(api => api.TakeScreenshotAsync()).ReturnsAsync(new byte[] { 1, 2, 3 });
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleTakeScreenshot",
+            new JsonRpcRequest { Id = 6, Method = "takeScreenshot" });
+
+        Assert.Null(response!.Error);
+        var resultJson = JsonSerializer.Serialize(response.Result);
+        Assert.Contains("\"imageData\":\"AQID\"", resultJson);
+        Assert.Contains("\"mimeType\":\"image/png\"", resultJson);
+    }
+
+    [Fact]
+    public async Task HandleChangeStage_WhenParamsAreMissing_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandleChangeStage",
+            new JsonRpcRequest { Id = 9, Method = "changeStage" });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("stageName parameter is required", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task RouteMethodCall_WhenMethodIsPing_ShouldReturnPong()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "RouteMethodCall",
+            new JsonRpcRequest { Id = 15, Method = "ping" });
+
+        Assert.Null(response!.Error);
+        Assert.Equal(15, response.Id);
+        var resultJson = JsonSerializer.Serialize(response.Result);
+        Assert.Contains("\"pong\":true", resultJson);
+        Assert.Contains("\"timestamp\":", resultJson);
+    }
+
+    [Fact]
+    public async Task RouteMethodCall_WhenHandlerThrows_ShouldReturnInternalErrorWithCorrelationId()
+    {
+        var gameApi = CreateGameApi();
+        gameApi
+            .Setup(api => api.GetGameStateAsync())
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "RouteMethodCall",
+            new JsonRpcRequest { Id = 17, Method = "getGameState" });
+
+        Assert.Equal(JsonRpcErrorCodes.InternalError, response!.Error!.Code);
+        Assert.Contains("CorrelationId:", response.Error.Message);
+    }
+
+    [Theory]
+    [InlineData("secret", "secret", true)]
+    [InlineData("secret", "public", false)]
+    [InlineData("secret", "secret-value", false)]
+    public void ConstantTimeEquals_ShouldRespectLengthAndContent(string left, string right, bool expected)
+    {
+        var result = InvokePrivateStatic<bool>("ConstantTimeEquals", left, right);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void CancelNoThrow_WithDisposedTokenSource_ShouldSuppressObjectDisposedException()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Dispose();
+
+        var exception = Record.Exception(() => InvokePrivateStatic("CancelNoThrow", cancellation));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void CancelNoThrow_WithThrowingCallback_ShouldSuppressAggregateException()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Token.Register(() => throw new InvalidOperationException("boom"));
+
+        var exception = Record.Exception(() => InvokePrivateStatic("CancelNoThrow", cancellation));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DisposeManagedResourcesSynchronously_NoLock_ShouldDisposeHostAndClearState()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        var host = new Mock<IHost>();
+        using var cancellation = new CancellationTokenSource();
+        ReflectionHelpers.SetPrivateField(server, "_host", host.Object);
+        ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
+        ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
+
+        InvokePrivateInstance(server, "DisposeManagedResourcesSynchronously_NoLock");
+
+        host.Verify(value => value.Dispose(), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_host"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_cancellationTokenSource"));
+        Assert.False(server.IsRunning);
+    }
+
+    [Fact]
+    public async Task StopAndDisposeHostAsync_NoLock_ShouldStopDisposeHostAndClearState()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        var host = new Mock<IHost>();
+        host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        using var cancellation = new CancellationTokenSource();
+        ReflectionHelpers.SetPrivateField(server, "_host", host.Object);
+        ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
+        ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
+
+        var task = (Task)ReflectionHelpers.InvokePrivateMethod(server, "StopAndDisposeHostAsync_NoLock")!;
+        await task;
+
+        host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        host.Verify(value => value.Dispose(), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_host"));
+        Assert.False(server.IsRunning);
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenRunning_ShouldStopDisposeHostAndClearState()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        var host = new Mock<IHost>();
+        using var cancellation = new CancellationTokenSource();
+        var cancelled = false;
+        cancellation.Token.Register(() => cancelled = true);
+        host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        ReflectionHelpers.SetPrivateField(server, "_host", host.Object);
+        ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
+        ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
+
+        await server.StopAsync();
+
+        Assert.True(cancelled);
+        host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        host.Verify(value => value.Dispose(), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_host"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_cancellationTokenSource"));
+        Assert.False(server.IsRunning);
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenHostDisposeThrows_ShouldSwallowDisposeExceptionAndClearState()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        var host = new Mock<IHost>();
+        using var cancellation = new CancellationTokenSource();
+        host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        host.Setup(value => value.Dispose()).Throws(new InvalidOperationException("dispose failed"));
+        ReflectionHelpers.SetPrivateField(server, "_host", host.Object);
+        ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
+        ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
+
+        var exception = await Record.ExceptionAsync(() => server.StopAsync());
+
+        Assert.Null(exception);
+        host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        host.Verify(value => value.Dispose(), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_host"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_cancellationTokenSource"));
+        Assert.False(server.IsRunning);
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenHostStopThrows_ShouldRethrowAfterCleanup()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        var host = new Mock<IHost>();
+        using var cancellation = new CancellationTokenSource();
+        host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("stop failed"));
+        ReflectionHelpers.SetPrivateField(server, "_host", host.Object);
+        ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
+        ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => server.StopAsync());
+
+        Assert.Equal("stop failed", exception.Message);
+        host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+        host.Verify(value => value.Dispose(), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_host"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_cancellationTokenSource"));
+        Assert.False(server.IsRunning);
+    }
+
+    [Fact]
+    public void DisposeLifecycleSemaphoreOnce_WhenCalledTwice_ShouldBeIdempotent()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var exception = Record.Exception(() =>
+        {
+            InvokePrivateInstance(server, "DisposeLifecycleSemaphoreOnce");
+            InvokePrivateInstance(server, "DisposeLifecycleSemaphoreOnce");
+        });
+
+        Assert.Null(exception);
+        Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(server, "_lifecycleSemaphoreDisposed"));
+    }
+
+    private static Mock<IGameApi> CreateGameApi()
+    {
+        var gameApi = new Mock<IGameApi>();
+        gameApi.SetupGet(api => api.IsRunning).Returns(true);
+        return gameApi;
+    }
+
+    private static void InvokePrivateInstance(object target, string methodName, params object?[] args)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(target, args);
+    }
+
+    private static void InvokePrivateStatic(string methodName, params object?[] args)
+    {
+        var method = typeof(JsonRpcServer).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(null, args);
+    }
+
+    private static T InvokePrivateStatic<T>(string methodName, params object?[] args)
+    {
+        var method = typeof(JsonRpcServer).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(null, args)!;
+    }
+}

--- a/DTXMania.Test/JsonRpc/JsonRpcServerTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerTests.cs
@@ -1,7 +1,10 @@
 using DTXMania.Game.Lib;
 using DTXMania.Game.Lib.JsonRpc;
+using DTXMania.Test.TestData;
 using Moq;
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -151,6 +154,41 @@ namespace DTXMania.Test.JsonRpc
             Assert.False(_server.IsRunning);
         }
 
+        [Fact]
+        public async Task StartAsync_WhenPortAlreadyInUse_ShouldThrowAndCleanupState()
+        {
+            var port = GetAvailablePort();
+            await using var firstServer = new JsonRpcServer(_mockGameApi.Object, port);
+            await firstServer.StartAsync();
+            var secondServer = new JsonRpcServer(_mockGameApi.Object, port);
+
+            try
+            {
+                await Assert.ThrowsAnyAsync<Exception>(() => secondServer.StartAsync());
+                Assert.False(secondServer.IsRunning);
+                Assert.Null(ReflectionHelpers.GetPrivateField<object>(secondServer, "_host"));
+                Assert.Null(ReflectionHelpers.GetPrivateField<object>(secondServer, "_cancellationTokenSource"));
+            }
+            finally
+            {
+                await secondServer.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task StopAsync_WhenRunning_ShouldStopAndClearHostedResources()
+        {
+            var port = GetAvailablePort();
+            _server = new JsonRpcServer(_mockGameApi.Object, port);
+            await _server.StartAsync();
+
+            await _server.StopAsync();
+
+            Assert.False(_server.IsRunning);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(_server, "_host"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(_server, "_cancellationTokenSource"));
+        }
+
         #endregion
 
         #region Dispose Tests
@@ -177,6 +215,20 @@ namespace DTXMania.Test.JsonRpc
         }
 
         [Fact]
+        public async Task Dispose_WhenRunningServer_ShouldStopAndDisposeResources()
+        {
+            var port = GetAvailablePort();
+            var server = new JsonRpcServer(_mockGameApi.Object, port);
+            await server.StartAsync();
+
+            server.Dispose();
+
+            Assert.False(server.IsRunning);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_host"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(server, "_cancellationTokenSource"));
+        }
+
+        [Fact]
         public async Task StopAsync_AfterDisposeAsync_ShouldThrowObjectDisposedException()
         {
             var server = new JsonRpcServer(_mockGameApi.Object);
@@ -200,6 +252,13 @@ namespace DTXMania.Test.JsonRpc
         }
 
         #endregion
+
+        private static int GetAvailablePort()
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            return ((IPEndPoint)listener.LocalEndpoint).Port;
+        }
 
     }
 

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -334,7 +334,7 @@ namespace DTXMania.Test.Resources
         [Fact]
         public void ExistingTextureConstructor_WhenTextureIsNull_ShouldThrowArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => new ManagedTexture(null!, null!, "source"));
+            Assert.Throws<ArgumentNullException>(() => new ManagedTexture(null!, (Texture2D)null!, "source"));
         }
 
         [Fact]

--- a/DTXMania.Test/Resources/ManagedTextureTests.cs
+++ b/DTXMania.Test/Resources/ManagedTextureTests.cs
@@ -3,7 +3,9 @@ using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -16,6 +18,230 @@ namespace DTXMania.Test.Resources
     [Trait("Category", "Unit")]
     public class ManagedTextureTests : IDisposable
     {
+        private sealed record VectorDrawCall(Vector2 Position, Color Color, Rectangle? SourceRectangle);
+        private sealed record RectangleDrawCall(Rectangle Destination, Rectangle? SourceRectangle, Color Color, float Rotation, Vector2 Origin, SpriteEffects Effects, float LayerDepth);
+        private sealed record TransformDrawCall(Vector2 Position, Color Color, float Rotation, Vector2 Origin, Vector2 Scale, SpriteEffects Effects, float LayerDepth);
+
+        private sealed class ConstructorProbeManagedTexture : ManagedTexture
+        {
+            public static int WidthOverride { get; set; } = 2;
+            public static int HeightOverride { get; set; } = 2;
+            public static Color[] CurrentColorData { get; set; } = Array.Empty<Color>();
+            public static List<Color[]> SetColorDataCalls { get; } = new();
+            public static Exception? LoadException { get; set; }
+
+            public ConstructorProbeManagedTexture(GraphicsDevice graphicsDevice, string filePath, string sourcePath, TextureCreationParams? creationParams = null)
+                : base(graphicsDevice, filePath, sourcePath, creationParams)
+            {
+            }
+
+            public static void Reset(Color[]? initialColorData = null, Exception? loadException = null)
+            {
+                WidthOverride = 2;
+                HeightOverride = 2;
+                CurrentColorData = initialColorData?.ToArray() ?? Array.Empty<Color>();
+                SetColorDataCalls.Clear();
+                LoadException = loadException;
+            }
+
+            protected override int GetTextureWidthCore()
+            {
+                return WidthOverride;
+            }
+
+            protected override int GetTextureHeightCore()
+            {
+                return HeightOverride;
+            }
+
+            protected override Stream OpenReadCore(string filePath)
+            {
+                return new MemoryStream(new byte[] { 1, 2, 3, 4 });
+            }
+
+            protected override Texture2D LoadTextureFromStreamCore(GraphicsDevice graphicsDevice, Stream stream)
+            {
+                if (LoadException != null)
+                {
+                    throw LoadException;
+                }
+
+                return (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            }
+
+            protected override void GetTextureDataCore(Texture2D texture, Color[] data)
+            {
+                Array.Copy(CurrentColorData, data, Math.Min(CurrentColorData.Length, data.Length));
+            }
+
+            protected override void SetTextureDataCore(Texture2D texture, Color[] data)
+            {
+                CurrentColorData = data.ToArray();
+                SetColorDataCalls.Add(data.ToArray());
+            }
+        }
+
+        private sealed class TestableManagedTexture : ManagedTexture
+        {
+            public List<VectorDrawCall> VectorDrawCalls { get; } = new();
+            public List<RectangleDrawCall> RectangleDrawCalls { get; } = new();
+            public List<TransformDrawCall> TransformDrawCalls { get; } = new();
+            public List<Color[]> SetColorDataCalls { get; } = new();
+            public Color[] ColorDataToReturn { get; set; } = Array.Empty<Color>();
+            public int WidthOverride { get; set; } = 2;
+            public int HeightOverride { get; set; } = 2;
+            public GraphicsDevice GraphicsDeviceOverride { get; set; } = CreateGraphicsDeviceStub();
+            public Texture2D CreatedTexture { get; set; } = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            public string? CreatedFilePath { get; private set; }
+            public (int Width, int Height)? SavedSize { get; private set; }
+            public bool ThrowOnSave { get; set; }
+            public bool ThrowOnCreateFile { get; set; }
+
+            public TestableManagedTexture(Texture2D texture, string sourcePath)
+                : base(null!, texture, sourcePath)
+            {
+            }
+
+            protected override int GetTextureWidthCore()
+            {
+                return WidthOverride;
+            }
+
+            protected override int GetTextureHeightCore()
+            {
+                return HeightOverride;
+            }
+
+            protected override GraphicsDevice GetGraphicsDeviceCore(Texture2D texture)
+            {
+                return GraphicsDeviceOverride;
+            }
+
+            protected override void DrawTextureCore(SpriteBatch spriteBatch, Vector2 position, Color color)
+            {
+                VectorDrawCalls.Add(new VectorDrawCall(position, color, null));
+            }
+
+            protected override void DrawTextureCore(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle, Color color)
+            {
+                VectorDrawCalls.Add(new VectorDrawCall(position, color, sourceRectangle));
+            }
+
+            protected override void DrawTextureCore(SpriteBatch spriteBatch, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
+            {
+                RectangleDrawCalls.Add(new RectangleDrawCall(destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth));
+            }
+
+            protected override void DrawTextureCore(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+            {
+                TransformDrawCalls.Add(new TransformDrawCall(position, color, rotation, origin, scale, effects, layerDepth));
+            }
+
+            protected override Texture2D CreateTextureCore(GraphicsDevice graphicsDevice, int width, int height)
+            {
+                return CreatedTexture;
+            }
+
+            protected override void GetTextureDataCore(Texture2D texture, Color[] data)
+            {
+                Array.Copy(ColorDataToReturn, data, Math.Min(ColorDataToReturn.Length, data.Length));
+            }
+
+            protected override void SetTextureDataCore(Texture2D texture, Color[] data)
+            {
+                SetColorDataCalls.Add(data.ToArray());
+            }
+
+            protected override Stream CreateFileCore(string filePath)
+            {
+                if (ThrowOnCreateFile)
+                {
+                    throw new IOException("create failed");
+                }
+
+                CreatedFilePath = filePath;
+                return new MemoryStream();
+            }
+
+            protected override void SaveTextureAsPngCore(Texture2D texture, Stream stream, int width, int height)
+            {
+                if (ThrowOnSave)
+                {
+                    throw new IOException("save failed");
+                }
+
+                SavedSize = (width, height);
+            }
+        }
+
+        private sealed class BaseHookManagedTexture : ManagedTexture
+        {
+            public BaseHookManagedTexture(Texture2D texture, string sourcePath)
+                : base(null!, texture, sourcePath)
+            {
+            }
+
+            public GraphicsDevice CallBaseGetGraphicsDevice(Texture2D texture)
+            {
+                return base.GetGraphicsDeviceCore(texture);
+            }
+
+            public void CallBaseDraw(SpriteBatch spriteBatch, Vector2 position, Color color)
+            {
+                base.DrawTextureCore(spriteBatch, position, color);
+            }
+
+            public void CallBaseDraw(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle, Color color)
+            {
+                base.DrawTextureCore(spriteBatch, position, sourceRectangle, color);
+            }
+
+            public void CallBaseDraw(SpriteBatch spriteBatch, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
+            {
+                base.DrawTextureCore(spriteBatch, destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth);
+            }
+
+            public void CallBaseDraw(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, Vector2 scale, SpriteEffects effects, float layerDepth)
+            {
+                base.DrawTextureCore(spriteBatch, position, sourceRectangle, color, rotation, origin, scale, effects, layerDepth);
+            }
+
+            public Texture2D CallBaseCreateTexture(GraphicsDevice graphicsDevice, int width, int height)
+            {
+                return base.CreateTextureCore(graphicsDevice, width, height);
+            }
+
+            public void CallBaseGetTextureData(Texture2D texture, Color[] data)
+            {
+                base.GetTextureDataCore(texture, data);
+            }
+
+            public void CallBaseSetTextureData(Texture2D texture, Color[] data)
+            {
+                base.SetTextureDataCore(texture, data);
+            }
+
+            public Stream CallBaseOpenRead(string filePath)
+            {
+                return base.OpenReadCore(filePath);
+            }
+
+            public Stream CallBaseCreateFile(string filePath)
+            {
+                return base.CreateFileCore(filePath);
+            }
+
+            public Texture2D CallBaseLoadTextureFromStream(GraphicsDevice graphicsDevice, Stream stream)
+            {
+                return base.LoadTextureFromStreamCore(graphicsDevice, stream);
+            }
+
+            public void CallBaseSaveTextureAsPng(Texture2D texture, Stream stream, int width, int height)
+            {
+                base.SaveTextureAsPngCore(texture, stream, width, height);
+            }
+        }
+
         private readonly string _testImagePath;
 
         public ManagedTextureTests()
@@ -86,6 +312,15 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
+        public void FilePathConstructor_WhenFilePathIsNullOrEmpty_ShouldThrowArgumentException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            Assert.Throws<ArgumentException>(() => new ManagedTexture(graphicsDevice, (string)null!, "source"));
+            Assert.Throws<ArgumentException>(() => new ManagedTexture(graphicsDevice, string.Empty, "source"));
+        }
+
+        [Fact]
         public void ExistingTextureConstructor_WhenSourcePathIsNull_ShouldFallbackToUnknown()
         {
             var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
@@ -94,6 +329,12 @@ namespace DTXMania.Test.Resources
 
             Assert.Same(texture, managedTexture.Texture);
             Assert.Equal("Unknown", managedTexture.SourcePath);
+        }
+
+        [Fact]
+        public void ExistingTextureConstructor_WhenTextureIsNull_ShouldThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ManagedTexture(null!, null!, "source"));
         }
 
         [Fact]
@@ -126,10 +367,29 @@ namespace DTXMania.Test.Resources
             managedTexture.ScaleRatio = new Vector3(2f, 3f, 1f);
             managedTexture.AdditiveBlending = true;
 
+            Assert.Equal(0, managedTexture.Width);
+            Assert.Equal(0, managedTexture.Height);
+            Assert.Equal(Vector2.Zero, managedTexture.Size);
             Assert.Equal(0L, managedTexture.MemoryUsage);
             Assert.Equal(1.25f, managedTexture.ZAxisRotation);
             Assert.Equal(new Vector3(2f, 3f, 1f), managedTexture.ScaleRatio);
             Assert.True(managedTexture.AdditiveBlending);
+        }
+
+        [Fact]
+        public void Properties_WhenTextureDimensionsAreAvailable_ShouldExposeSizeAndMemoryUsage()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "SizedTexture")
+            {
+                WidthOverride = 3,
+                HeightOverride = 4
+            };
+
+            Assert.Equal(3, managedTexture.Width);
+            Assert.Equal(4, managedTexture.Height);
+            Assert.Equal(new Vector2(3, 4), managedTexture.Size);
+            Assert.Equal(48L, managedTexture.MemoryUsage);
         }
 
         [Theory]
@@ -164,6 +424,42 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
+        public void DrawOverloads_WhenTextureExists_ShouldUseConfiguredColorsAndTransforms()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "DrawableTexture")
+            {
+                Transparency = 128,
+                ScaleRatio = new Vector3(2f, 3f, 1f),
+                ZAxisRotation = 0.5f
+            };
+            var spriteBatch = (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+            var sourceRectangle = new Rectangle(1, 2, 3, 4);
+
+            managedTexture.Draw(spriteBatch, new Vector2(10f, 20f));
+            managedTexture.Draw(spriteBatch, new Vector2(30f, 40f), sourceRectangle);
+            managedTexture.Draw(spriteBatch, new Rectangle(5, 6, 7, 8), sourceRectangle, Color.Blue, 0.25f, new Vector2(1f, 2f), SpriteEffects.FlipHorizontally, 0.75f);
+            managedTexture.Draw(spriteBatch, new Vector2(50f, 60f), new Vector2(4f, 5f), 0.75f, new Vector2(2f, 3f));
+
+            Assert.Equal(2, managedTexture.VectorDrawCalls.Count);
+            Assert.Equal(Color.White * (128 / 255f), managedTexture.VectorDrawCalls[0].Color);
+            Assert.Equal(sourceRectangle, managedTexture.VectorDrawCalls[1].SourceRectangle);
+
+            var rectangleDraw = Assert.Single(managedTexture.RectangleDrawCalls);
+            Assert.Equal(Color.Blue * (128 / 255f), rectangleDraw.Color);
+            Assert.Equal(0.25f, rectangleDraw.Rotation);
+            Assert.Equal(SpriteEffects.FlipHorizontally, rectangleDraw.Effects);
+            Assert.Equal(0.75f, rectangleDraw.LayerDepth);
+
+            var transformDraw = Assert.Single(managedTexture.TransformDrawCalls);
+            Assert.Equal(Color.White * (128 / 255f), transformDraw.Color);
+            Assert.Equal(1.25f, transformDraw.Rotation);
+            Assert.Equal(new Vector2(8f, 15f), transformDraw.Scale);
+            Assert.Equal(SpriteEffects.None, transformDraw.Effects);
+            Assert.Equal(0f, transformDraw.LayerDepth);
+        }
+
+        [Fact]
         public void CloneAndColorOperations_WhenTextureIsMissing_ShouldThrowObjectDisposedException()
         {
             var managedTexture = CreateManagedTexture();
@@ -180,6 +476,189 @@ namespace DTXMania.Test.Resources
             {
                 if (File.Exists(tempPath))
                     File.Delete(tempPath);
+            }
+        }
+
+        [Fact]
+        public void Clone_ShouldCopyColorDataAndVisualProperties()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var createdTexture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "CloneSource")
+            {
+                WidthOverride = 2,
+                HeightOverride = 2,
+                ColorDataToReturn = new[] { Color.Red, Color.Green, Color.Blue, Color.White },
+                CreatedTexture = createdTexture,
+                Transparency = 200,
+                ScaleRatio = new Vector3(1.5f, 2.5f, 1f),
+                ZAxisRotation = 0.75f,
+                AdditiveBlending = true
+            };
+
+            var clone = (ManagedTexture)managedTexture.Clone();
+
+            Assert.Single(managedTexture.SetColorDataCalls);
+            Assert.Equal(managedTexture.ColorDataToReturn, managedTexture.SetColorDataCalls[0]);
+            Assert.Same(createdTexture, clone.Texture);
+            Assert.Equal("CloneSource_clone", clone.SourcePath);
+            Assert.Equal(200, clone.Transparency);
+            Assert.Equal(new Vector3(1.5f, 2.5f, 1f), clone.ScaleRatio);
+            Assert.Equal(0.75f, clone.ZAxisRotation);
+            Assert.True(clone.AdditiveBlending);
+        }
+
+        [Fact]
+        public void GetAndSetColorData_ShouldUseTextureAccessors()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "ColorTexture")
+            {
+                WidthOverride = 2,
+                HeightOverride = 2,
+                ColorDataToReturn = new[] { Color.Red, Color.Green, Color.Blue, Color.White }
+            };
+            var newData = new[] { Color.Black, Color.Yellow, Color.Magenta, Color.Cyan };
+
+            var colorData = managedTexture.GetColorData();
+            managedTexture.SetColorData(newData);
+
+            Assert.Equal(managedTexture.ColorDataToReturn, colorData);
+            Assert.Single(managedTexture.SetColorDataCalls);
+            Assert.Equal(newData, managedTexture.SetColorDataCalls[0]);
+        }
+
+        [Fact]
+        public void SetColorData_WhenArrayLengthDoesNotMatchTextureDimensions_ShouldThrowArgumentException()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "ColorTexture")
+            {
+                WidthOverride = 2,
+                HeightOverride = 2
+            };
+
+            Assert.Throws<ArgumentException>(() => managedTexture.SetColorData(new[] { Color.Red }));
+        }
+
+        [Fact]
+        public void SaveToFile_WhenSuccessful_ShouldCreateFileAndSaveTexture()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "SaveTexture")
+            {
+                WidthOverride = 3,
+                HeightOverride = 4
+            };
+
+            managedTexture.SaveToFile("save-target.png");
+
+            Assert.Equal("save-target.png", managedTexture.CreatedFilePath);
+            Assert.Equal((3, 4), managedTexture.SavedSize);
+        }
+
+        [Fact]
+        public void SaveToFile_WhenSavingFails_ShouldWrapInvalidOperationException()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "SaveTexture")
+            {
+                ThrowOnSave = true
+            };
+
+            var exception = Assert.Throws<InvalidOperationException>(() => managedTexture.SaveToFile("save-target.png"));
+
+            Assert.Equal("Failed to save texture to save-target.png", exception.Message);
+            Assert.IsType<IOException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void SaveToFile_WhenFilePathIsNullOrEmpty_ShouldThrowArgumentException()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new TestableManagedTexture(texture, "SaveTexture");
+
+            Assert.Throws<ArgumentException>(() => managedTexture.SaveToFile(null!));
+            Assert.Throws<ArgumentException>(() => managedTexture.SaveToFile(string.Empty));
+        }
+
+        [Fact]
+        public void FilePathConstructor_WhenCreationParamsRequestTransparencyAndPremultiplication_ShouldProcessColorData()
+        {
+            ConstructorProbeManagedTexture.Reset(new[]
+            {
+                Color.Magenta,
+                new Color(100, 50, 200, 128),
+                new Color(10, 20, 30, 255),
+                new Color(5, 5, 5, 0)
+            });
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            var managedTexture = new ConstructorProbeManagedTexture(
+                graphicsDevice,
+                _testImagePath,
+                "ConstructorSource",
+                new TextureCreationParams
+                {
+                    EnableTransparency = true,
+                    TransparencyColor = Color.Magenta,
+                    PremultiplyAlpha = true
+                });
+
+            Assert.Equal("ConstructorSource", managedTexture.SourcePath);
+            Assert.Equal(2, ConstructorProbeManagedTexture.SetColorDataCalls.Count);
+            Assert.Equal(Color.Transparent, ConstructorProbeManagedTexture.SetColorDataCalls[0][0]);
+            Assert.Equal(new Color(50, 25, 100, 128), ConstructorProbeManagedTexture.SetColorDataCalls[1][1]);
+            Assert.Equal(new Color(0, 0, 0, 0), ConstructorProbeManagedTexture.SetColorDataCalls[1][3]);
+        }
+
+        [Fact]
+        public void FilePathConstructor_WhenTextureLoadFails_ShouldWrapTextureLoadException()
+        {
+            ConstructorProbeManagedTexture.Reset(loadException: new InvalidOperationException("load failed"));
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            var exception = Assert.Throws<TextureLoadException>(() =>
+                new ConstructorProbeManagedTexture(graphicsDevice, _testImagePath, "BadTexture"));
+
+            Assert.Equal("BadTexture", exception.TexturePath);
+            Assert.Equal("Failed to load texture from " + _testImagePath, exception.Message);
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void BaseHooks_ShouldReachUnderlyingMonoGameDelegates()
+        {
+            var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            var managedTexture = new BaseHookManagedTexture(texture, "BaseHooks");
+            var tempOutputPath = Path.Combine(Path.GetTempPath(), $"managed-texture-base-{Guid.NewGuid():N}.tmp");
+
+            try
+            {
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseGetGraphicsDevice(null!)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseDraw(null!, Vector2.Zero, Color.White)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseDraw(null!, Vector2.Zero, null, Color.White)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseDraw(null!, new Rectangle(0, 0, 1, 1), null, Color.White, 0f, Vector2.Zero, SpriteEffects.None, 0f)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseDraw(null!, Vector2.Zero, null, Color.White, 0f, Vector2.Zero, Vector2.One, SpriteEffects.None, 0f)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseCreateTexture(null!, 1, 1)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseGetTextureData(null!, Array.Empty<Color>())));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseSetTextureData(null!, Array.Empty<Color>())));
+
+                using var input = managedTexture.CallBaseOpenRead(_testImagePath);
+                Assert.NotNull(input);
+
+                using var output = managedTexture.CallBaseCreateFile(tempOutputPath);
+                Assert.True(File.Exists(tempOutputPath));
+
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseLoadTextureFromStream(null!, Stream.Null)));
+                Assert.NotNull(Record.Exception(() => managedTexture.CallBaseSaveTextureAsPng(null!, Stream.Null, 1, 1)));
+            }
+            finally
+            {
+                if (File.Exists(tempOutputPath))
+                {
+                    File.Delete(tempOutputPath);
+                }
             }
         }
 
@@ -214,6 +693,11 @@ namespace DTXMania.Test.Resources
             ReflectionHelpers.SetPrivateField(managedTexture, "_additiveBlending", false);
 
             return managedTexture;
+        }
+
+        private static GraphicsDevice CreateGraphicsDeviceStub()
+        {
+            return (GraphicsDevice)RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice));
         }
     }
 }

--- a/DTXMania.Test/Resources/ResourceManagerLogicTests.cs
+++ b/DTXMania.Test/Resources/ResourceManagerLogicTests.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Utilities;
 using Moq;
@@ -13,6 +14,50 @@ namespace DTXMania.Test.Resources
     [Trait("Category", "Unit")]
     public class ResourceManagerLogicTests : IDisposable
     {
+        private sealed class TestableResourceManager : ResourceManager
+        {
+            public Func<string, string, TextureCreationParams, ITexture>? CreateTextureCoreHandler { get; set; }
+            public Func<string, int, FontStyle, IFont>? CreateFontCoreHandler { get; set; }
+            public Func<string, string, ISound>? CreateSoundCoreHandler { get; set; }
+            public Func<Color, string, ITexture>? CreateColorTextureCoreHandler { get; set; }
+            public Func<string, ITexture>? CreateFallbackTextureHandler { get; set; }
+            public Func<string, int, FontStyle, IFont>? CreateFallbackFontHandler { get; set; }
+            public Func<string, ISound>? CreateFallbackSoundHandler { get; set; }
+
+            public TestableResourceManager()
+                : base((GraphicsDevice)FormatterServices.GetUninitializedObject(typeof(GraphicsDevice)))
+            {
+            }
+
+            protected override ITexture CreateTextureCore(string resolvedPath, string originalPath, TextureCreationParams creationParams)
+                => CreateTextureCoreHandler?.Invoke(resolvedPath, originalPath, creationParams)
+                    ?? throw new InvalidOperationException("CreateTextureCoreHandler was not configured.");
+
+            protected override IFont CreateFontCore(string normalizedPath, int size, FontStyle style)
+                => CreateFontCoreHandler?.Invoke(normalizedPath, size, style)
+                    ?? throw new InvalidOperationException("CreateFontCoreHandler was not configured.");
+
+            protected override ISound CreateSoundCore(string resolvedPath, string originalPath)
+                => CreateSoundCoreHandler?.Invoke(resolvedPath, originalPath)
+                    ?? throw new InvalidOperationException("CreateSoundCoreHandler was not configured.");
+
+            protected override ITexture CreateColorTextureCore(Color color, string cacheKey)
+                => CreateColorTextureCoreHandler?.Invoke(color, cacheKey)
+                    ?? throw new InvalidOperationException("CreateColorTextureCoreHandler was not configured.");
+
+            protected override ITexture CreateFallbackTexture(string originalPath)
+                => CreateFallbackTextureHandler?.Invoke(originalPath)
+                    ?? throw new InvalidOperationException("CreateFallbackTextureHandler was not configured.");
+
+            protected override IFont CreateFallbackFont(string originalPath, int size, FontStyle style)
+                => CreateFallbackFontHandler?.Invoke(originalPath, size, style)
+                    ?? throw new InvalidOperationException("CreateFallbackFontHandler was not configured.");
+
+            protected override ISound CreateFallbackSound(string originalPath)
+                => CreateFallbackSoundHandler?.Invoke(originalPath)
+                    ?? throw new InvalidOperationException("CreateFallbackSoundHandler was not configured.");
+        }
+
         private readonly string _testDataPath;
         private readonly string _defaultSkinRoot;
         private readonly string _customSkinRoot;
@@ -126,6 +171,81 @@ namespace DTXMania.Test.Resources
             Assert.Equal(0, GetPrivateField<int>(resourceManager, "_cacheMisses"));
         }
 
+        [Fact]
+        public void LoadTexture_WhenCachedTextureDisposed_ShouldReloadUsingFallbackSkin()
+        {
+            var resourceManager = CreateTestableResourceManager(_customSkinRoot, _defaultSkinRoot);
+            var textureCache = GetPrivateField<ConcurrentDictionary<string, ITexture>>(resourceManager, "_textureCache");
+            var disposedTexture = CreateTextureMock();
+            var reloadedTexture = CreateTextureMock();
+            var fallbackPath = Path.GetFullPath(Path.Combine(_defaultSkinRoot, "Graphics", "Fallback_Only.png"));
+            string? resolvedPath = null;
+            TextureCreationParams? creationParams = null;
+
+            disposedTexture.Setup(x => x.AddReference()).Throws(new ObjectDisposedException("ITexture"));
+            resourceManager.CreateTextureCoreHandler = (resolved, _, parameters) =>
+            {
+                resolvedPath = resolved;
+                creationParams = parameters;
+                return reloadedTexture.Object;
+            };
+            textureCache["graphics/fallback_only.png|False"] = disposedTexture.Object;
+
+            var loadedTexture = resourceManager.LoadTexture("Graphics/Fallback_Only.png");
+
+            Assert.Same(reloadedTexture.Object, loadedTexture);
+            Assert.Equal(fallbackPath, resolvedPath);
+            Assert.NotNull(creationParams);
+            Assert.False(creationParams!.EnableTransparency);
+            disposedTexture.Verify(x => x.AddReference(), Times.Once);
+            reloadedTexture.Verify(x => x.AddReference(), Times.Once);
+            Assert.Equal(0, GetPrivateField<int>(resourceManager, "_cacheHits"));
+            Assert.Equal(1, GetPrivateField<int>(resourceManager, "_cacheMisses"));
+            Assert.Same(reloadedTexture.Object, textureCache["graphics/fallback_only.png|False"]);
+        }
+
+        [Fact]
+        public void LoadTexture_WhenTextureMissingInAllSkins_ShouldRaiseEventAndReturnFallbackTexture()
+        {
+            var resourceManager = CreateTestableResourceManager(_customSkinRoot, _defaultSkinRoot);
+            var fallbackTexture = CreateTextureMock();
+            ResourceLoadFailedEventArgs? eventArgs = null;
+
+            resourceManager.CreateFallbackTextureHandler = _ => fallbackTexture.Object;
+            resourceManager.ResourceLoadFailed += (_, args) => eventArgs = args;
+
+            var loadedTexture = resourceManager.LoadTexture("Graphics/missing.png");
+
+            Assert.Same(fallbackTexture.Object, loadedTexture);
+            Assert.NotNull(eventArgs);
+            Assert.Equal("Graphics/missing.png", eventArgs!.Path);
+            Assert.IsType<FileNotFoundException>(eventArgs.Exception);
+            Assert.Contains("Texture not found", eventArgs.ErrorMessage);
+            Assert.Empty(GetPrivateField<ConcurrentDictionary<string, ITexture>>(resourceManager, "_textureCache"));
+        }
+
+        [Fact]
+        public void LoadTexture_WhenTextureCreationThrows_ShouldRaiseEventAndReturnFallbackTexture()
+        {
+            var resourceManager = CreateTestableResourceManager(_customSkinRoot, _defaultSkinRoot);
+            var fallbackTexture = CreateTextureMock();
+            var texturePath = Path.Combine(_customSkinRoot, "Graphics", "throws.png");
+            ResourceLoadFailedEventArgs? eventArgs = null;
+
+            File.WriteAllText(texturePath, "current");
+            resourceManager.CreateTextureCoreHandler = (_, _, _) => throw new InvalidOperationException("load failed");
+            resourceManager.CreateFallbackTextureHandler = _ => fallbackTexture.Object;
+            resourceManager.ResourceLoadFailed += (_, args) => eventArgs = args;
+
+            var loadedTexture = resourceManager.LoadTexture("Graphics/throws.png");
+
+            Assert.Same(fallbackTexture.Object, loadedTexture);
+            Assert.NotNull(eventArgs);
+            Assert.IsType<InvalidOperationException>(eventArgs!.Exception);
+            Assert.Equal("load failed", eventArgs.Exception.Message);
+            Assert.Contains("Failed to load texture", eventArgs.ErrorMessage);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData(null)]
@@ -150,6 +270,60 @@ namespace DTXMania.Test.Resources
             cachedFont.Verify(x => x.AddReference(), Times.Once);
             Assert.Equal(1, GetPrivateField<int>(resourceManager, "_cacheHits"));
             Assert.Equal(0, GetPrivateField<int>(resourceManager, "_cacheMisses"));
+        }
+
+        [Fact]
+        public void LoadFont_WhenCachedFontDisposed_ShouldReloadAndReplaceCacheEntry()
+        {
+            var resourceManager = CreateTestableResourceManager();
+            var fontCache = GetPrivateField<ConcurrentDictionary<string, IFont>>(resourceManager, "_fontCache");
+            var disposedFont = CreateFontMock();
+            var reloadedFont = CreateFontMock();
+            string? normalizedPath = null;
+            int size = 0;
+            FontStyle? style = null;
+
+            disposedFont.Setup(x => x.AddReference()).Throws(new ObjectDisposedException("IFont"));
+            resourceManager.CreateFontCoreHandler = (path, fontSize, fontStyle) =>
+            {
+                normalizedPath = path;
+                size = fontSize;
+                style = fontStyle;
+                return reloadedFont.Object;
+            };
+            fontCache["fonts/test.ttf|24|Bold"] = disposedFont.Object;
+
+            var loadedFont = resourceManager.LoadFont("Fonts/Test.ttf", 24, FontStyle.Bold);
+
+            Assert.Same(reloadedFont.Object, loadedFont);
+            Assert.Equal("fonts/test.ttf", normalizedPath);
+            Assert.Equal(24, size);
+            Assert.Equal(FontStyle.Bold, style);
+            disposedFont.Verify(x => x.AddReference(), Times.Once);
+            reloadedFont.Verify(x => x.AddReference(), Times.Once);
+            Assert.Equal(0, GetPrivateField<int>(resourceManager, "_cacheHits"));
+            Assert.Equal(1, GetPrivateField<int>(resourceManager, "_cacheMisses"));
+            Assert.Same(reloadedFont.Object, fontCache["fonts/test.ttf|24|Bold"]);
+        }
+
+        [Fact]
+        public void LoadFont_WhenCreationThrows_ShouldRaiseEventAndReturnFallbackFont()
+        {
+            var resourceManager = CreateTestableResourceManager();
+            var fallbackFont = CreateFontMock();
+            ResourceLoadFailedEventArgs? eventArgs = null;
+
+            resourceManager.CreateFontCoreHandler = (_, _, _) => throw new InvalidOperationException("font failed");
+            resourceManager.CreateFallbackFontHandler = (_, _, _) => fallbackFont.Object;
+            resourceManager.ResourceLoadFailed += (_, args) => eventArgs = args;
+
+            var loadedFont = resourceManager.LoadFont("Fonts/Test.ttf", 18, FontStyle.Italic);
+
+            Assert.Same(fallbackFont.Object, loadedFont);
+            Assert.NotNull(eventArgs);
+            Assert.IsType<InvalidOperationException>(eventArgs!.Exception);
+            Assert.Equal("font failed", eventArgs.Exception.Message);
+            Assert.Contains("Failed to load font", eventArgs.ErrorMessage);
         }
 
         [Theory]
@@ -179,6 +353,82 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
+        public void LoadSound_WhenCachedSoundDisposed_ShouldReloadUsingFallbackSkin()
+        {
+            var resourceManager = CreateTestableResourceManager(_customSkinRoot, _defaultSkinRoot);
+            var soundCache = GetPrivateField<ConcurrentDictionary<string, ISound>>(resourceManager, "_soundCache");
+            var disposedSound = CreateSoundMock();
+            var reloadedSound = CreateSoundMock();
+            var fallbackPath = Path.GetFullPath(Path.Combine(_defaultSkinRoot, "Sounds", "Fallback_Only.ogg"));
+            string? resolvedPath = null;
+
+            Directory.CreateDirectory(Path.Combine(_defaultSkinRoot, "Sounds"));
+            File.WriteAllText(fallbackPath, "fallback");
+
+            disposedSound.Setup(x => x.AddReference()).Throws(new ObjectDisposedException("ISound"));
+            resourceManager.CreateSoundCoreHandler = (resolved, _) =>
+            {
+                resolvedPath = resolved;
+                return reloadedSound.Object;
+            };
+            soundCache["sounds/fallback_only.ogg"] = disposedSound.Object;
+
+            var loadedSound = resourceManager.LoadSound("Sounds/Fallback_Only.ogg");
+
+            Assert.Same(reloadedSound.Object, loadedSound);
+            Assert.Equal(fallbackPath, resolvedPath);
+            disposedSound.Verify(x => x.AddReference(), Times.Once);
+            reloadedSound.Verify(x => x.AddReference(), Times.Once);
+            Assert.Equal(0, GetPrivateField<int>(resourceManager, "_cacheHits"));
+            Assert.Equal(1, GetPrivateField<int>(resourceManager, "_cacheMisses"));
+            Assert.Same(reloadedSound.Object, soundCache["sounds/fallback_only.ogg"]);
+        }
+
+        [Fact]
+        public void LoadSound_WhenSoundMissingInAllSkins_ShouldRaiseEventAndReturnFallbackSound()
+        {
+            var resourceManager = CreateTestableResourceManager(_customSkinRoot, _defaultSkinRoot);
+            var fallbackSound = CreateSoundMock();
+            ResourceLoadFailedEventArgs? eventArgs = null;
+
+            resourceManager.CreateFallbackSoundHandler = _ => fallbackSound.Object;
+            resourceManager.ResourceLoadFailed += (_, args) => eventArgs = args;
+
+            var loadedSound = resourceManager.LoadSound("Sounds/missing.ogg");
+
+            Assert.Same(fallbackSound.Object, loadedSound);
+            Assert.NotNull(eventArgs);
+            Assert.Equal("Sounds/missing.ogg", eventArgs!.Path);
+            Assert.IsType<FileNotFoundException>(eventArgs.Exception);
+            Assert.Contains("Sound not found", eventArgs.ErrorMessage);
+            Assert.Empty(GetPrivateField<ConcurrentDictionary<string, ISound>>(resourceManager, "_soundCache"));
+        }
+
+        [Fact]
+        public void LoadSound_WhenSoundCreationThrows_ShouldRaiseEventAndReturnFallbackSound()
+        {
+            var resourceManager = CreateTestableResourceManager(_customSkinRoot, _defaultSkinRoot);
+            var fallbackSound = CreateSoundMock();
+            var soundPath = Path.Combine(_customSkinRoot, "Sounds", "throws.ogg");
+            ResourceLoadFailedEventArgs? eventArgs = null;
+
+            Directory.CreateDirectory(Path.Combine(_customSkinRoot, "Sounds"));
+            File.WriteAllText(soundPath, "current");
+
+            resourceManager.CreateSoundCoreHandler = (_, _) => throw new InvalidOperationException("sound failed");
+            resourceManager.CreateFallbackSoundHandler = _ => fallbackSound.Object;
+            resourceManager.ResourceLoadFailed += (_, args) => eventArgs = args;
+
+            var loadedSound = resourceManager.LoadSound("Sounds/throws.ogg");
+
+            Assert.Same(fallbackSound.Object, loadedSound);
+            Assert.NotNull(eventArgs);
+            Assert.IsType<InvalidOperationException>(eventArgs!.Exception);
+            Assert.Equal("sound failed", eventArgs.Exception.Message);
+            Assert.Contains("Failed to load sound", eventArgs.ErrorMessage);
+        }
+
+        [Fact]
         public void CreateTextureFromColor_WhenCachedTextureExists_ShouldAddReferenceIncrementHitsAndReturnCachedTexture()
         {
             var resourceManager = CreateResourceManager();
@@ -192,6 +442,36 @@ namespace DTXMania.Test.Resources
             Assert.Same(cachedTexture.Object, createdTexture);
             cachedTexture.Verify(x => x.AddReference(), Times.Once);
             Assert.Equal(1, GetPrivateField<int>(resourceManager, "_cacheHits"));
+        }
+
+        [Fact]
+        public void CreateTextureFromColor_WhenCachedTextureDisposed_ShouldReplaceCacheEntry()
+        {
+            var resourceManager = CreateTestableResourceManager();
+            var textureCache = GetPrivateField<ConcurrentDictionary<string, ITexture>>(resourceManager, "_textureCache");
+            var disposedTexture = CreateTextureMock();
+            var createdTexture = CreateTextureMock();
+            var cacheKey = $"__Color|{Color.CornflowerBlue.PackedValue}";
+            string? createdCacheKey = null;
+            Color? createdColor = null;
+
+            disposedTexture.Setup(x => x.AddReference()).Throws(new ObjectDisposedException("ITexture"));
+            resourceManager.CreateColorTextureCoreHandler = (color, key) =>
+            {
+                createdColor = color;
+                createdCacheKey = key;
+                return createdTexture.Object;
+            };
+            textureCache[cacheKey] = disposedTexture.Object;
+
+            var texture = resourceManager.CreateTextureFromColor(Color.CornflowerBlue);
+
+            Assert.Same(createdTexture.Object, texture);
+            Assert.Equal(Color.CornflowerBlue, createdColor);
+            Assert.Equal(cacheKey, createdCacheKey);
+            disposedTexture.Verify(x => x.AddReference(), Times.Once);
+            createdTexture.Verify(x => x.AddReference(), Times.Once);
+            Assert.Same(createdTexture.Object, textureCache[cacheKey]);
         }
 
         [Theory]
@@ -448,6 +728,24 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
+        public void SetSkinPath_WithInvalidSkin_ShouldStillRaiseSkinChanged()
+        {
+            var invalidSkin = Path.Combine(_testDataPath, "InvalidSkin");
+            var resourceManager = CreateResourceManager(_customSkinRoot, _defaultSkinRoot);
+            SkinChangedEventArgs? eventArgs = null;
+
+            Directory.CreateDirectory(invalidSkin);
+            resourceManager.SkinChanged += (_, args) => eventArgs = args;
+
+            resourceManager.SetSkinPath(invalidSkin);
+
+            Assert.Equal(NormalizeDirectory(invalidSkin), resourceManager.GetCurrentEffectiveSkinPath());
+            Assert.NotNull(eventArgs);
+            Assert.Equal(NormalizeDirectory(_customSkinRoot), eventArgs!.OldSkinPath);
+            Assert.Equal(NormalizeDirectory(invalidSkin), eventArgs.NewSkinPath);
+        }
+
+        [Fact]
         public void InitializeDefaultSkinPath_WhenValidationFails_ShouldStillUseDefaultPathAndCreateStructure()
         {
             var nonExistentRoot = Path.Combine(_testDataPath, "MissingSystem");
@@ -475,6 +773,44 @@ namespace DTXMania.Test.Resources
             Assert.True(Directory.Exists(expectedSystemPath), "System directory should be created");
             Assert.True(Directory.Exists(Path.Combine(expectedSystemPath, "Graphics")), "Graphics subdirectory should be created");
             Assert.True(Directory.Exists(Path.Combine(expectedSystemPath, "Fonts")), "Fonts subdirectory should be created");
+        }
+
+        [Fact]
+        public void InitializeDefaultSkinPath_WhenValidationSucceeds_ShouldUseValidatedSystemPath()
+        {
+            var appDataRoot = Path.Combine(_testDataPath, "ValidDefaultRoot");
+            var systemRoot = Path.Combine(appDataRoot, "System");
+            var graphicsRoot = Path.Combine(systemRoot, "Graphics");
+            var resourceManager = CreateResourceManagerWithoutInitialization();
+
+            Directory.CreateDirectory(graphicsRoot);
+            File.WriteAllText(Path.Combine(graphicsRoot, "1_background.jpg"), "background");
+            SetPrivateField(resourceManager, "_currentSkinPath", string.Empty);
+            SetPrivateField(resourceManager, "_fallbackSkinPath", string.Empty);
+            SetPrivateField(resourceManager, "_cachedAppDataRoot", appDataRoot);
+
+            InvokePrivateMethod(resourceManager, "InitializeDefaultSkinPath");
+
+            var expectedPath = NormalizeDirectory(systemRoot);
+            Assert.Equal(expectedPath, GetPrivateField<string>(resourceManager, "_currentSkinPath"));
+            Assert.Equal(expectedPath, GetPrivateField<string>(resourceManager, "_fallbackSkinPath"));
+        }
+
+        [Fact]
+        public void CreateDefaultSkinStructure_WhenDirectoryCreationThrows_ShouldSwallowException()
+        {
+            var appDataRoot = Path.Combine(_testDataPath, "BrokenDefaultRoot");
+            var resourceManager = CreateResourceManagerWithoutInitialization();
+            var systemFilePath = Path.Combine(appDataRoot, "System");
+
+            Directory.CreateDirectory(appDataRoot);
+            File.WriteAllText(systemFilePath, "not a directory");
+            SetPrivateField(resourceManager, "_cachedAppDataRoot", appDataRoot);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(resourceManager, "CreateDefaultSkinStructure"));
+
+            Assert.Null(exception);
+            Assert.True(File.Exists(systemFilePath));
         }
 
         public void Dispose()
@@ -516,6 +852,28 @@ namespace DTXMania.Test.Resources
             SetPrivateField(resourceManager, "_useBoxDefSkin", true);
             SetPrivateField(resourceManager, "_disposed", false);
 
+            return resourceManager;
+        }
+
+        private static TestableResourceManager CreateTestableResourceManager(string? currentSkinPath = null, string? fallbackSkinPath = null)
+        {
+#pragma warning disable SYSLIB0050
+            var resourceManager = (TestableResourceManager)FormatterServices.GetUninitializedObject(typeof(TestableResourceManager));
+            var graphicsDevice = (GraphicsDevice)FormatterServices.GetUninitializedObject(typeof(GraphicsDevice));
+#pragma warning restore SYSLIB0050
+
+            SetPrivateField(resourceManager, "_graphicsDevice", graphicsDevice);
+            SetPrivateField(resourceManager, "_textureCache", new ConcurrentDictionary<string, ITexture>());
+            SetPrivateField(resourceManager, "_fontCache", new ConcurrentDictionary<string, IFont>());
+            SetPrivateField(resourceManager, "_soundCache", new ConcurrentDictionary<string, ISound>());
+            SetPrivateField(resourceManager, "_lockObject", new object());
+            SetPrivateField(resourceManager, "_cachedAppDataRoot", AppPaths.GetAppDataRoot());
+            SetPrivateField(resourceManager, "_totalLoadTime", new Stopwatch());
+            SetPrivateField(resourceManager, "_boxDefSkinPath", string.Empty);
+            SetPrivateField(resourceManager, "_useBoxDefSkin", true);
+            SetPrivateField(resourceManager, "_disposed", false);
+            SetPrivateField(resourceManager, "_currentSkinPath", NormalizeDirectory(currentSkinPath ?? AppPaths.GetDefaultSystemSkinRoot()));
+            SetPrivateField(resourceManager, "_fallbackSkinPath", NormalizeDirectory(fallbackSkinPath ?? currentSkinPath ?? AppPaths.GetDefaultSystemSkinRoot()));
             return resourceManager;
         }
 

--- a/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
@@ -602,7 +602,7 @@ namespace DTXMania.Test.Stage.Performance
 
         private sealed class TrackingManagedFont : ManagedFont
         {
-            public TrackingManagedFont() : base((SpriteFont)null!, "tracking", 1)
+            private TrackingManagedFont() : base((SpriteFont)null!, "tracking", 1)
             {
             }
 
@@ -616,7 +616,7 @@ namespace DTXMania.Test.Stage.Performance
 
         private sealed class TrackingTexture2D : Texture2D
         {
-            public TrackingTexture2D() : base(null!, 1, 1)
+            private TrackingTexture2D() : base(null!, 1, 1)
             {
             }
 

--- a/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
@@ -2,8 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage.Performance;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
 using Xunit;
 
 namespace DTXMania.Test.Stage.Performance
@@ -17,6 +20,70 @@ namespace DTXMania.Test.Stage.Performance
     [Trait("Category", "Performance")]
     public class DisplayComponentStateTests
     {
+        #region Constructor Guard Tests
+
+        [Fact]
+        public void ComboDisplay_Constructor_WithNullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new ComboDisplay(null!, graphicsDevice));
+
+            Assert.Equal("resourceManager", ex.ParamName);
+        }
+
+        [Fact]
+        public void ComboDisplay_Constructor_WithNullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new ComboDisplay(resourceManager.Object, null!));
+
+            Assert.Equal("graphicsDevice", ex.ParamName);
+        }
+
+        [Fact]
+        public void GaugeDisplay_Constructor_WithNullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new GaugeDisplay(null!, graphicsDevice));
+
+            Assert.Equal("resourceManager", ex.ParamName);
+        }
+
+        [Fact]
+        public void GaugeDisplay_Constructor_WithNullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new GaugeDisplay(resourceManager.Object, null!));
+
+            Assert.Equal("graphicsDevice", ex.ParamName);
+        }
+
+        [Fact]
+        public void ScoreDisplay_Constructor_WithNullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new ScoreDisplay(null!, graphicsDevice));
+
+            Assert.Equal("resourceManager", ex.ParamName);
+        }
+
+        [Fact]
+        public void ScoreDisplay_Constructor_WithNullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => new ScoreDisplay(resourceManager.Object, null!));
+
+            Assert.Equal("graphicsDevice", ex.ParamName);
+        }
+
+        #endregion
+
         #region ComboDisplay State Tests
 
         [Fact]
@@ -159,6 +226,66 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal("999", comboText);
         }
 
+        [Fact]
+        public void ComboDisplay_Update_WhenDisposed_ShouldLeaveAnimationStateUnchanged()
+        {
+            var display = CreateUninitialized<ComboDisplay>();
+            SetPrivateField(display, "_disposed", true);
+            SetPrivateField(display, "_scale", 1.25f);
+            SetPrivateField(display, "_targetScale", 1.5f);
+            SetPrivateField(display, "_scaleVelocity", 0.75f);
+
+            display.Update(0.1);
+
+            Assert.Equal(1.25f, GetPrivateField<float>(display, "_scale"));
+            Assert.Equal(1.5f, GetPrivateField<float>(display, "_targetScale"));
+            Assert.Equal(0.75f, GetPrivateField<float>(display, "_scaleVelocity"));
+        }
+
+        [Fact]
+        public void ComboDisplay_Update_WhenActive_ShouldAdvanceAnimationTowardRestingScale()
+        {
+            var display = CreateUninitialized<ComboDisplay>();
+            SetPrivateField(display, "_scale", 1.0f);
+            SetPrivateField(display, "_targetScale", 1.5f);
+            SetPrivateField(display, "_scaleVelocity", 0.0f);
+
+            display.Update(0.1);
+
+            Assert.True(GetPrivateField<float>(display, "_scale") > 1.0f);
+            Assert.True(GetPrivateField<float>(display, "_scaleVelocity") > 0.0f);
+            Assert.True(GetPrivateField<float>(display, "_targetScale") < 1.5f);
+        }
+
+        [Fact]
+        public void ComboDisplay_Draw_WhenSpriteBatchIsNull_ShouldReturnWithoutThrowing()
+        {
+            var display = CreateUninitialized<ComboDisplay>();
+            SetPrivateField(display, "_visible", true);
+
+            var exception = Record.Exception(() => display.Draw(null!));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ComboDisplay_Dispose_ShouldDisposeFontsAndClearReferences()
+        {
+            var display = CreateUninitialized<ComboDisplay>();
+            var comboFont = CreateTrackingManagedFont();
+            var labelFont = CreateTrackingManagedFont();
+            SetPrivateField(display, "_comboFont", comboFont);
+            SetPrivateField(display, "_labelFont", labelFont);
+
+            display.Dispose();
+
+            Assert.Equal(1, comboFont.DisposeCount);
+            Assert.Equal(1, labelFont.DisposeCount);
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_comboFont"));
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_labelFont"));
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+        }
+
         #endregion
 
         #region GaugeDisplay State Tests
@@ -240,6 +367,40 @@ namespace DTXMania.Test.Stage.Performance
 
             display.BackgroundColor = Color.Black;
             Assert.Equal(Color.Black, display.BackgroundColor);
+        }
+
+        [Fact]
+        public void GaugeDisplay_Update_ShouldNotThrow()
+        {
+            var display = CreateUninitialized<GaugeDisplay>();
+
+            var exception = Record.Exception(() => display.Update(0.016));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void GaugeDisplay_Draw_WhenSpriteBatchIsNull_ShouldReturnWithoutThrowing()
+        {
+            var display = CreateUninitialized<GaugeDisplay>();
+
+            var exception = Record.Exception(() => display.Draw(null!));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void GaugeDisplay_Dispose_ShouldDisposeWhiteTextureAndClearReference()
+        {
+            var display = CreateUninitialized<GaugeDisplay>();
+            var whiteTexture = CreateTrackingTexture2D();
+            SetPrivateField(display, "_whiteTexture", whiteTexture);
+
+            display.Dispose();
+
+            Assert.True(whiteTexture.WasDisposed);
+            Assert.Null(GetPrivateField<Texture2D?>(display, "_whiteTexture"));
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
         }
 
         #endregion
@@ -340,9 +501,75 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(new Vector2(1, 1), display.ShadowOffset);
         }
 
+        [Fact]
+        public void ScoreDisplay_ShadowColor_ShouldBeSettable()
+        {
+            var display = CreateUninitialized<ScoreDisplay>();
+
+            display.ShadowColor = Color.DarkSlateBlue;
+
+            Assert.Equal(Color.DarkSlateBlue, display.ShadowColor);
+        }
+
+        [Fact]
+        public void ScoreDisplay_Update_ShouldNotThrow()
+        {
+            var display = CreateUninitialized<ScoreDisplay>();
+
+            var exception = Record.Exception(() => display.Update(0.016));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ScoreDisplay_Draw_WhenSpriteBatchIsNull_ShouldReturnWithoutThrowing()
+        {
+            var display = CreateUninitialized<ScoreDisplay>();
+
+            var exception = Record.Exception(() => display.Draw(null!));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ScoreDisplay_Dispose_ShouldDisposeFontAndClearReference()
+        {
+            var display = CreateUninitialized<ScoreDisplay>();
+            var scoreFont = CreateTrackingManagedFont();
+            SetPrivateField(display, "_scoreFont", scoreFont);
+
+            display.Dispose();
+
+            Assert.Equal(1, scoreFont.DisposeCount);
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_scoreFont"));
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+        }
+
         #endregion
 
         #region Helper Methods
+
+        private static T CreateUninitialized<T>() where T : class
+        {
+#pragma warning disable SYSLIB0050
+            return (T)FormatterServices.GetUninitializedObject(typeof(T));
+#pragma warning restore SYSLIB0050
+        }
+
+        private static GraphicsDevice CreateGraphicsDeviceStub()
+        {
+            return CreateUninitialized<GraphicsDevice>();
+        }
+
+        private static TrackingManagedFont CreateTrackingManagedFont()
+        {
+            return CreateUninitialized<TrackingManagedFont>();
+        }
+
+        private static TrackingTexture2D CreateTrackingTexture2D()
+        {
+            return CreateUninitialized<TrackingTexture2D>();
+        }
 
         private static T? GetPrivateField<T>(object target, string fieldName)
         {
@@ -371,6 +598,34 @@ namespace DTXMania.Test.Stage.Performance
                 type = type.BaseType;
             }
             throw new InvalidOperationException($"Field '{fieldName}' not found on {target.GetType().Name}");
+        }
+
+        private sealed class TrackingManagedFont : ManagedFont
+        {
+            public TrackingManagedFont() : base((SpriteFont)null!, "tracking", 1)
+            {
+            }
+
+            public int DisposeCount { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+            }
+        }
+
+        private sealed class TrackingTexture2D : Texture2D
+        {
+            public TrackingTexture2D() : base(null!, 1, 1)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupLogicTests.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
 
 namespace DTXMania.Test.Stage.Performance;
 
@@ -157,18 +158,14 @@ public class JudgementTextPopupLogicTests
         Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
     }
 
-    // Uses FormatterServices.GetUninitializedObject to bypass JudgementTextPopupManager's
-    // constructor, which requires GraphicsDevice and IResourceManager unavailable in unit tests.
-    // Private fields (_activePopups, _disposed) are injected via ReflectionHelpers.SetPrivateField.
     private static JudgementTextPopupManager CreateManager(bool disposed = false)
     {
-#pragma warning disable SYSLIB0050
-        var manager = (JudgementTextPopupManager)FormatterServices.GetUninitializedObject(typeof(JudgementTextPopupManager));
-#pragma warning restore SYSLIB0050
-
-        ReflectionHelpers.SetPrivateField(manager, "_activePopups", new List<JudgementTextPopup>());
-        ReflectionHelpers.SetPrivateField(manager, "_disposed", disposed);
-        return manager;
+        return JudgementTextPopupManager.CreateForTesting(
+            ReflectionHelpers.CreateUninitialized<GraphicsDevice>(),
+            new Mock<IResourceManager>().Object,
+            font: null,
+            activePopups: null,
+            disposed: disposed);
     }
 
     private static List<JudgementTextPopup> GetActivePopups(JudgementTextPopupManager manager)

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
@@ -9,6 +9,7 @@ using DTXMania.Test.TestData;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace DTXMania.Test.Stage.Performance
 {
@@ -192,6 +193,24 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(expectedText, popup.Text);
         }
 
+        [Fact]
+        public void JudgementTextPopupManager_LoadJudgementFont_WhenBitmapFontIsNotLoaded_ShouldReturnNull()
+        {
+            var loadMethod = typeof(JudgementTextPopupManager).GetMethod("LoadJudgementFont", BindingFlags.Static | BindingFlags.NonPublic);
+
+            Assert.NotNull(loadMethod);
+
+            var result = loadMethod!.Invoke(
+                null,
+                new object[]
+                {
+                    ReflectionHelpers.CreateUninitialized<GraphicsDevice>(),
+                    CreateMockResourceManager().Object
+                });
+
+            Assert.Null(result);
+        }
+
         #endregion
 
         #region Integration Tests
@@ -294,15 +313,14 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void JudgementTextPopupManager_Update_WhenDisposed_ShouldLeaveExistingPopupsUntouched()
+        public void JudgementTextPopupManager_CreateForTesting_WhenDisposed_ShouldRunRealDisposeLogic()
         {
-            var popup = new JudgementTextPopup("Perfect", Vector2.Zero);
-            var manager = CreateManager(activePopups: [popup], disposed: true);
+            var trackingFont = ReflectionHelpers.CreateUninitialized<TrackingBitmapFont>();
+            var manager = CreateManager(font: trackingFont, activePopups: [new JudgementTextPopup("Perfect", Vector2.Zero)], disposed: true);
 
-            manager.Update(0.7);
-
-            Assert.Single(GetActivePopups(manager));
-            Assert.True(popup.IsActive);
+            Assert.Empty(GetActivePopups(manager));
+            Assert.Equal(1, trackingFont.DisposeCount);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
@@ -9,7 +9,6 @@ using DTXMania.Test.TestData;
 using Moq;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 
 namespace DTXMania.Test.Stage.Performance
 {
@@ -17,6 +16,7 @@ namespace DTXMania.Test.Stage.Performance
     /// Unit tests for JudgementText popup system
     /// Tests the popup animation, manager lifecycle, and integration with JudgementEvents
     /// </summary>
+    [Trait("Category", "Graphics")]
     public class JudgementTextPopupTests
     {
         #region Test Helpers
@@ -276,8 +276,7 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void JudgementTextPopupManager_SpawnPopup_WhenDisposed_ShouldIgnoreJudgement()
         {
-            var manager = CreateManager();
-            ReflectionHelpers.SetPrivateField(manager, "_disposed", true);
+            var manager = CreateManager(disposed: true);
 
             manager.SpawnPopup(new JudgementEvent(1, 1, 0.0, JudgementType.Just));
 
@@ -297,10 +296,8 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void JudgementTextPopupManager_Update_WhenDisposed_ShouldLeaveExistingPopupsUntouched()
         {
-            var manager = CreateManager();
             var popup = new JudgementTextPopup("Perfect", Vector2.Zero);
-            GetActivePopups(manager).Add(popup);
-            ReflectionHelpers.SetPrivateField(manager, "_disposed", true);
+            var manager = CreateManager(activePopups: [popup], disposed: true);
 
             manager.Update(0.7);
 
@@ -337,12 +334,14 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(new Color(r, g, b), color);
         }
 
-        [Fact]
-        public void JudgementTextPopupManager_GetLaneCenterPosition_WithInvalidLane_ShouldReturnScreenCenter()
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(PerformanceUILayout.LaneCount)]
+        public void JudgementTextPopupManager_GetLaneCenterPosition_WithInvalidLane_ShouldReturnScreenCenter(int laneIndex)
         {
             var manager = CreateManager();
 
-            var position = ReflectionHelpers.InvokePrivateMethod<Vector2>(manager, "GetLaneCenterPosition", -1);
+            var position = ReflectionHelpers.InvokePrivateMethod<Vector2>(manager, "GetLaneCenterPosition", laneIndex);
 
             Assert.Equal(new Vector2(PerformanceUILayout.ScreenWidth / 2, PerformanceUILayout.JudgementLineY - 50), position);
         }
@@ -350,10 +349,8 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void JudgementTextPopupManager_Dispose_ShouldClearPopupsDisposeFontAndMarkDisposed()
         {
-            var manager = CreateManager();
-            var trackingFont = (TrackingBitmapFont)RuntimeHelpers.GetUninitializedObject(typeof(TrackingBitmapFont));
-            GetActivePopups(manager).Add(new JudgementTextPopup("Perfect", Vector2.Zero));
-            ReflectionHelpers.SetPrivateField(manager, "_font", trackingFont);
+            var trackingFont = ReflectionHelpers.CreateUninitialized<TrackingBitmapFont>();
+            var manager = CreateManager(font: trackingFont, activePopups: [new JudgementTextPopup("Perfect", Vector2.Zero)]);
 
             manager.Dispose();
 
@@ -362,15 +359,17 @@ namespace DTXMania.Test.Stage.Performance
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
         }
 
-        private static JudgementTextPopupManager CreateManager()
+        private static JudgementTextPopupManager CreateManager(
+            BitmapFont? font = null,
+            List<JudgementTextPopup>? activePopups = null,
+            bool disposed = false)
         {
-            var manager = (JudgementTextPopupManager)RuntimeHelpers.GetUninitializedObject(typeof(JudgementTextPopupManager));
-            ReflectionHelpers.SetPrivateField(manager, "_activePopups", new List<JudgementTextPopup>());
-            ReflectionHelpers.SetPrivateField(manager, "_font", null);
-            ReflectionHelpers.SetPrivateField(manager, "_resourceManager", new Mock<IResourceManager>().Object);
-            ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice)));
-            ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
-            return manager;
+            return JudgementTextPopupManager.CreateForTesting(
+                ReflectionHelpers.CreateUninitialized<GraphicsDevice>(),
+                new Mock<IResourceManager>().Object,
+                font,
+                activePopups,
+                disposed);
         }
 
         private static List<JudgementTextPopup> GetActivePopups(JudgementTextPopupManager manager)

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
@@ -4,8 +4,12 @@ using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.TestData;
 using Moq;
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace DTXMania.Test.Stage.Performance
 {
@@ -151,39 +155,41 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void JudgementTextPopupManager_SpawnPopup_CreatesPopupForValidJudgement()
         {
-            // Arrange
-            var mockResourceManager = CreateMockResourceManager();
-            
-            // This test would need a proper GraphicsDevice setup in a real test environment
-            // For now, we'll test the logic flow
-            
+            var manager = CreateManager();
             var judgementEvent = new JudgementEvent(1, 3, 10.0, JudgementType.Just);
 
-            // Act & Assert would involve creating the manager and testing popup spawning
-            // This requires proper GraphicsDevice mocking which is complex in unit tests
+            manager.SpawnPopup(judgementEvent);
+
+            var popup = Assert.Single(GetActivePopups(manager));
+            Assert.Equal("Perfect", popup.Text);
+            Assert.Equal(new Vector2(PerformanceUILayout.GetLaneX(3), PerformanceUILayout.JudgementLineY - 50), popup.CurrentPosition);
         }
 
         [Fact]
         public void JudgementTextPopupManager_SpawnPopup_IgnoresNullJudgement()
         {
-            // Arrange
-            var mockResourceManager = CreateMockResourceManager();
-            
-            // This test verifies null safety in the spawn method
-            // Implementation would check that no exception is thrown when null is passed
+            var manager = CreateManager();
+
+            manager.SpawnPopup(null!);
+
+            Assert.Empty(GetActivePopups(manager));
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, "JUST")]
-        [InlineData(JudgementType.Great, "GREAT")]
-        [InlineData(JudgementType.Good, "GOOD")]
-        [InlineData(JudgementType.Poor, "POOR")]
-        [InlineData(JudgementType.Miss, "MISS")]
+        [InlineData(JudgementType.Just, "Perfect")]
+        [InlineData(JudgementType.Great, "Great")]
+        [InlineData(JudgementType.Good, "Good")]
+        [InlineData(JudgementType.Poor, "OK")]
+        [InlineData(JudgementType.Miss, "Miss")]
         public void JudgementTextPopupManager_SpawnPopup_CreatesCorrectTextForJudgementType(
             JudgementType judgementType, string expectedText)
         {
-            // This test would verify that the correct text is generated for each judgement type
-            // Implementation would create judgement events of each type and verify the popup text
+            var manager = CreateManager();
+
+            manager.SpawnPopup(new JudgementEvent(1, 2, 0.0, judgementType));
+
+            var popup = Assert.Single(GetActivePopups(manager));
+            Assert.Equal(expectedText, popup.Text);
         }
 
         #endregion
@@ -239,20 +245,151 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void JudgementTextPopupManager_MultiplePopups_HandlesSimultaneousPopups()
         {
-            // This test would verify that multiple popups can be active simultaneously
-            // without performance issues or incorrect behavior
-            
-            // Would create multiple judgement events rapidly and verify:
-            // 1. All popups are created
-            // 2. They animate independently
-            // 3. They are properly cleaned up when complete
+            var manager = CreateManager();
+
+            manager.SpawnPopup(new JudgementEvent(1, 0, 0.0, JudgementType.Just));
+            manager.SpawnPopup(new JudgementEvent(1, 4, 0.0, JudgementType.Great));
+            manager.SpawnPopup(new JudgementEvent(1, 8, 0.0, JudgementType.Miss));
+
+            Assert.Equal(3, manager.ActivePopupCount);
         }
 
         [Fact]
         public void JudgementTextPopupManager_Update_RemovesCompletedPopups()
         {
-            // This test would verify that completed popups are properly removed
-            // from the active list to prevent memory leaks
+            var manager = CreateManager();
+            var expiredPopup = new JudgementTextPopup("Perfect", Vector2.Zero);
+            expiredPopup.Update(0.55);
+            GetActivePopups(manager).Add(expiredPopup);
+            GetActivePopups(manager).Add(new JudgementTextPopup("Great", Vector2.One));
+
+            manager.Update(0.1);
+
+            var remainingPopup = Assert.Single(GetActivePopups(manager));
+            Assert.Equal("Great", remainingPopup.Text);
+        }
+
+        #endregion
+
+        #region Hostless Manager Logic Tests
+
+        [Fact]
+        public void JudgementTextPopupManager_SpawnPopup_WhenDisposed_ShouldIgnoreJudgement()
+        {
+            var manager = CreateManager();
+            ReflectionHelpers.SetPrivateField(manager, "_disposed", true);
+
+            manager.SpawnPopup(new JudgementEvent(1, 1, 0.0, JudgementType.Just));
+
+            Assert.Empty(GetActivePopups(manager));
+        }
+
+        [Fact]
+        public void JudgementTextPopupManager_SpawnPopup_WithUnknownJudgementType_ShouldNotCreatePopup()
+        {
+            var manager = CreateManager();
+
+            manager.SpawnPopup(new JudgementEvent(1, 1, 0.0, (JudgementType)999));
+
+            Assert.Empty(GetActivePopups(manager));
+        }
+
+        [Fact]
+        public void JudgementTextPopupManager_Update_WhenDisposed_ShouldLeaveExistingPopupsUntouched()
+        {
+            var manager = CreateManager();
+            var popup = new JudgementTextPopup("Perfect", Vector2.Zero);
+            GetActivePopups(manager).Add(popup);
+            ReflectionHelpers.SetPrivateField(manager, "_disposed", true);
+
+            manager.Update(0.7);
+
+            Assert.Single(GetActivePopups(manager));
+            Assert.True(popup.IsActive);
+        }
+
+        [Fact]
+        public void JudgementTextPopupManager_ClearAll_ShouldRemoveEveryPopup()
+        {
+            var manager = CreateManager();
+            GetActivePopups(manager).Add(new JudgementTextPopup("Perfect", Vector2.Zero));
+            GetActivePopups(manager).Add(new JudgementTextPopup("Great", Vector2.One));
+
+            manager.ClearAll();
+
+            Assert.Empty(GetActivePopups(manager));
+            Assert.Equal(0, manager.ActivePopupCount);
+        }
+
+        [Theory]
+        [InlineData("Perfect", 255, 255, 0)]
+        [InlineData("Great", 144, 238, 144)]
+        [InlineData("Good", 173, 216, 230)]
+        [InlineData("OK", 255, 165, 0)]
+        [InlineData("Miss", 255, 0, 0)]
+        [InlineData("Unknown", 255, 255, 255)]
+        public void JudgementTextPopupManager_GetJudgementColor_ShouldReturnExpectedColor(string text, byte r, byte g, byte b)
+        {
+            var manager = CreateManager();
+
+            var color = ReflectionHelpers.InvokePrivateMethod<Color>(manager, "GetJudgementColor", text);
+
+            Assert.Equal(new Color(r, g, b), color);
+        }
+
+        [Fact]
+        public void JudgementTextPopupManager_GetLaneCenterPosition_WithInvalidLane_ShouldReturnScreenCenter()
+        {
+            var manager = CreateManager();
+
+            var position = ReflectionHelpers.InvokePrivateMethod<Vector2>(manager, "GetLaneCenterPosition", -1);
+
+            Assert.Equal(new Vector2(PerformanceUILayout.ScreenWidth / 2, PerformanceUILayout.JudgementLineY - 50), position);
+        }
+
+        [Fact]
+        public void JudgementTextPopupManager_Dispose_ShouldClearPopupsDisposeFontAndMarkDisposed()
+        {
+            var manager = CreateManager();
+            var trackingFont = (TrackingBitmapFont)RuntimeHelpers.GetUninitializedObject(typeof(TrackingBitmapFont));
+            GetActivePopups(manager).Add(new JudgementTextPopup("Perfect", Vector2.Zero));
+            ReflectionHelpers.SetPrivateField(manager, "_font", trackingFont);
+
+            manager.Dispose();
+
+            Assert.Empty(GetActivePopups(manager));
+            Assert.Equal(1, trackingFont.DisposeCount);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(manager, "_disposed"));
+        }
+
+        private static JudgementTextPopupManager CreateManager()
+        {
+            var manager = (JudgementTextPopupManager)RuntimeHelpers.GetUninitializedObject(typeof(JudgementTextPopupManager));
+            ReflectionHelpers.SetPrivateField(manager, "_activePopups", new List<JudgementTextPopup>());
+            ReflectionHelpers.SetPrivateField(manager, "_font", null);
+            ReflectionHelpers.SetPrivateField(manager, "_resourceManager", new Mock<IResourceManager>().Object);
+            ReflectionHelpers.SetPrivateField(manager, "_graphicsDevice", RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice)));
+            ReflectionHelpers.SetPrivateField(manager, "_disposed", false);
+            return manager;
+        }
+
+        private static List<JudgementTextPopup> GetActivePopups(JudgementTextPopupManager manager)
+        {
+            return ReflectionHelpers.GetPrivateField<List<JudgementTextPopup>>(manager, "_activePopups")!;
+        }
+
+        private sealed class TrackingBitmapFont : BitmapFont
+        {
+            public TrackingBitmapFont() : base(new Mock<IResourceManager>().Object, new BitmapFontConfig(), true)
+            {
+            }
+
+            public int DisposeCount { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                DisposeCount++;
+            }
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/PadRendererTests.cs
+++ b/DTXMania.Test/Stage/Performance/PadRendererTests.cs
@@ -4,6 +4,8 @@ using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Moq;
 using Xunit;
 
@@ -16,11 +18,51 @@ namespace DTXMania.Test.Stage.Performance
     [Trait("Category", "Performance")]
     public class PadRendererTests
     {
+        private sealed record SpriteSheetDrawCall(Rectangle Destination, Rectangle Source, Color Tint);
+        private sealed record FallbackDrawCall(Rectangle Destination, Color Color);
+
+        private sealed class TestablePadRenderer : PadRenderer
+        {
+            public List<SpriteSheetDrawCall> SpriteSheetDrawCalls { get; } = new();
+            public List<FallbackDrawCall> FallbackDrawCalls { get; } = new();
+            public int CreateFallbackTextureCalls { get; private set; }
+            public Texture2D? NextFallbackTexture { get; set; }
+
+            public TestablePadRenderer(GraphicsDevice graphicsDevice, IResourceManager resourceManager)
+                : base(graphicsDevice, resourceManager)
+            {
+            }
+
+            protected override void DrawPadSpriteCore(ITexture texture, SpriteBatch spriteBatch, Rectangle destination, Rectangle source, Color tint)
+            {
+                SpriteSheetDrawCalls.Add(new SpriteSheetDrawCall(destination, source, tint));
+            }
+
+            protected override Texture2D CreateFallbackTextureCore()
+            {
+                CreateFallbackTextureCalls++;
+                return NextFallbackTexture ?? (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+            }
+
+            protected override void DrawFallbackTextureCore(SpriteBatch spriteBatch, Texture2D texture, Rectangle destination, Color color)
+            {
+                FallbackDrawCalls.Add(new FallbackDrawCall(destination, color));
+            }
+        }
+
         [Fact]
         public void Constructor_NullGraphicsDevice_ThrowsArgumentNullException()
         {
             // Arrange, Act & Assert
             Assert.Throws<ArgumentNullException>(() => new PadRenderer(null, null));
+        }
+
+        [Fact]
+        public void Constructor_NullResourceManager_ThrowsArgumentNullException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            Assert.Throws<ArgumentNullException>(() => new PadRenderer(graphicsDevice, null!));
         }
 
         [Fact]
@@ -118,6 +160,49 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
+        public void Draw_WhenSpriteBatchIsNull_ShouldReturnWithoutThrowing()
+        {
+            var renderer = CreateRenderer();
+
+            var exception = Record.Exception(() => renderer.Draw(null!));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Constructor_WhenAlternateTexturePathSucceeds_ShouldLoadSpriteSheetAndCalculateCells()
+        {
+            var resourceManager = new Mock<IResourceManager>(MockBehavior.Strict);
+            var spriteSheet = new Mock<ITexture>();
+            spriteSheet.SetupGet(x => x.Width).Returns(400);
+            spriteSheet.SetupGet(x => x.Height).Returns(150);
+            resourceManager.SetupSequence(x => x.LoadTexture(It.IsAny<string>()))
+                .Returns((ITexture)null!)
+                .Returns(spriteSheet.Object);
+
+            var renderer = new PadRenderer(CreateGraphicsDeviceStub(), resourceManager.Object);
+
+            Assert.Same(spriteSheet.Object, ReflectionHelpers.GetPrivateField<ITexture>(renderer, "_padSpriteSheet"));
+            Assert.Equal(4, ReflectionHelpers.GetPrivateField<int>(renderer, "_spriteColumns"));
+            Assert.Equal(100, ReflectionHelpers.GetPrivateField<int>(renderer, "_cellWidth"));
+            Assert.Equal(50, ReflectionHelpers.GetPrivateField<int>(renderer, "_cellHeight"));
+            resourceManager.Verify(x => x.LoadTexture("Graphics/7_pads.png"), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void Constructor_WhenCalculateCellDimensionsThrows_ShouldClearSpriteSheet()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var spriteSheet = new Mock<ITexture>();
+            spriteSheet.SetupGet(x => x.Width).Throws(new InvalidOperationException("width failed"));
+            resourceManager.Setup(x => x.LoadTexture(It.IsAny<string>())).Returns(spriteSheet.Object);
+
+            var renderer = new PadRenderer(CreateGraphicsDeviceStub(), resourceManager.Object);
+
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture>(renderer, "_padSpriteSheet"));
+        }
+
+        [Fact]
         public void CalculateCellDimensions_WhenSpriteSheetLoaded_ShouldUseExpectedGrid()
         {
             var renderer = CreateRenderer();
@@ -169,6 +254,74 @@ namespace DTXMania.Test.Stage.Performance
             spriteSheet.Verify(x => x.RemoveReference(), Times.Once);
             Assert.Null(ReflectionHelpers.GetPrivateField<ITexture?>(renderer, "_padSpriteSheet"));
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderer, "_disposed"));
+        }
+
+        [Fact]
+        public void Draw_WhenSpriteSheetAvailable_ShouldDrawSpriteSheetPadsForAllLanes()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager.Setup(x => x.LoadTexture(It.IsAny<string>())).Returns((ITexture)null!);
+            var renderer = new TestablePadRenderer(CreateGraphicsDeviceStub(), resourceManager.Object);
+            var spriteSheet = new Mock<ITexture>();
+            var spriteBatch = (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+            ReflectionHelpers.SetPrivateField(renderer, "_padSpriteSheet", spriteSheet.Object);
+            ReflectionHelpers.SetPrivateField(renderer, "_cellWidth", 100);
+            ReflectionHelpers.SetPrivateField(renderer, "_cellHeight", 50);
+            ReflectionHelpers.SetPrivateField(renderer, "_spriteColumns", 4);
+            GetPadVisuals(renderer)[0].State = PadState.Pressed;
+
+            renderer.Draw(spriteBatch);
+
+            Assert.Equal(PerformanceUILayout.LaneCount, renderer.SpriteSheetDrawCalls.Count);
+            Assert.Empty(renderer.FallbackDrawCalls);
+            Assert.Equal(new Rectangle(0, 0, 100, 50), renderer.SpriteSheetDrawCalls[0].Source);
+            Assert.Equal(Color.White * 1.5f, renderer.SpriteSheetDrawCalls[0].Tint);
+            Assert.Equal(new Rectangle(PerformanceUILayout.GetLaneLeftX(1), 670, PerformanceUILayout.GetLaneWidth(1), 60), renderer.SpriteSheetDrawCalls[1].Destination);
+        }
+
+        [Fact]
+        public void Draw_WhenCellDimensionsInvalid_ShouldUseFallbackPads()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager.Setup(x => x.LoadTexture(It.IsAny<string>())).Returns((ITexture)null!);
+            var renderer = new TestablePadRenderer(CreateGraphicsDeviceStub(), resourceManager.Object)
+            {
+                NextFallbackTexture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D))
+            };
+            var spriteSheet = new Mock<ITexture>();
+            var spriteBatch = (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+            ReflectionHelpers.SetPrivateField(renderer, "_padSpriteSheet", spriteSheet.Object);
+            ReflectionHelpers.SetPrivateField(renderer, "_cellWidth", 0);
+            ReflectionHelpers.SetPrivateField(renderer, "_cellHeight", 0);
+
+            renderer.Draw(spriteBatch);
+
+            Assert.Empty(renderer.SpriteSheetDrawCalls);
+            Assert.Equal(PerformanceUILayout.LaneCount, renderer.FallbackDrawCalls.Count);
+            Assert.Equal(1, renderer.CreateFallbackTextureCalls);
+        }
+
+        [Fact]
+        public void Draw_WhenSpriteSheetMissing_ShouldDrawFallbackPadsForAllLanes()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager.Setup(x => x.LoadTexture(It.IsAny<string>())).Returns((ITexture)null!);
+            var renderer = new TestablePadRenderer(CreateGraphicsDeviceStub(), resourceManager.Object)
+            {
+                NextFallbackTexture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D))
+            };
+            var spriteBatch = (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+            GetPadVisuals(renderer)[2].State = PadState.Pressed;
+
+            renderer.Draw(spriteBatch);
+
+            Assert.Empty(renderer.SpriteSheetDrawCalls);
+            Assert.Equal(PerformanceUILayout.LaneCount, renderer.FallbackDrawCalls.Count);
+            Assert.Equal(1, renderer.CreateFallbackTextureCalls);
+            Assert.Equal(Color.Red, renderer.FallbackDrawCalls[2].Color);
+            Assert.Equal(Color.Yellow, renderer.FallbackDrawCalls[0].Color);
         }
 
         private static PadRenderer CreateRenderer()

--- a/DTXMania.Test/Stage/Performance/PerformanceRendererStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceRendererStateTests.cs
@@ -1,0 +1,572 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    [Trait("Category", "Performance")]
+    public class PerformanceRendererStateTests
+    {
+        #region BackgroundRenderer
+
+        [Fact]
+        public void BackgroundRenderer_Constructor_WithNullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new BackgroundRenderer(null!));
+
+            Assert.Equal("resourceManager", exception.ParamName);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task LoadBackgroundAsync_WhenLoadSucceeds_ShouldMarkBackgroundReady()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var texture = CreateManagedTexture(width: 320, height: 180, sourcePath: "Graphics/7_background.jpg");
+            resourceManager
+                .Setup(manager => manager.LoadTexture(TexturePath.PerformanceBackground))
+                .Returns(texture);
+
+            var renderer = new BackgroundRenderer(resourceManager.Object);
+
+            await renderer.LoadBackgroundAsync();
+
+            Assert.False(renderer.IsLoading);
+            Assert.False(renderer.LoadingFailed);
+            Assert.True(renderer.IsReady);
+            Assert.Same(texture, ReflectionHelpers.GetPrivateField<ITexture>(renderer, "_backgroundTexture"));
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task LoadBackgroundAsync_WhenLoadFails_ShouldRecordFailureState()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(manager => manager.LoadTexture(TexturePath.PerformanceBackground))
+                .Throws(new InvalidOperationException("load failed"));
+
+            var renderer = new BackgroundRenderer(resourceManager.Object);
+
+            await renderer.LoadBackgroundAsync();
+
+            Assert.False(renderer.IsLoading);
+            Assert.True(renderer.LoadingFailed);
+            Assert.False(renderer.IsReady);
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture>(renderer, "_backgroundTexture"));
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task LoadBackgroundAsync_WhenRendererIsDisposed_ShouldReturnWithoutLoading()
+        {
+            var resourceManager = new Mock<IResourceManager>(MockBehavior.Strict);
+            var renderer = new BackgroundRenderer(resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(renderer, "_disposed", true);
+
+            await renderer.LoadBackgroundAsync();
+
+            Assert.False(renderer.IsLoading);
+            Assert.False(renderer.IsReady);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task LoadBackgroundAsync_WhenAlreadyLoading_ShouldKeepCurrentState()
+        {
+            var resourceManager = new Mock<IResourceManager>(MockBehavior.Strict);
+            var renderer = new BackgroundRenderer(resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(renderer, "_isLoading", true);
+
+            await renderer.LoadBackgroundAsync();
+
+            Assert.True(renderer.IsLoading);
+            Assert.False(renderer.LoadingFailed);
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task LoadBackgroundAsync_WhenTextureAlreadyLoaded_ShouldSkipReload()
+        {
+            var resourceManager = new Mock<IResourceManager>(MockBehavior.Strict);
+            var existingTexture = CreateManagedTexture(width: 64, height: 64, sourcePath: "existing.png");
+            var renderer = new BackgroundRenderer(resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(renderer, "_backgroundTexture", existingTexture);
+
+            await renderer.LoadBackgroundAsync();
+
+            Assert.True(renderer.IsReady);
+            Assert.Same(existingTexture, ReflectionHelpers.GetPrivateField<ITexture>(renderer, "_backgroundTexture"));
+        }
+
+        [Fact]
+        public void BackgroundRenderer_Draw_WhenSpriteBatchIsNull_ShouldReturnWithoutThrowing()
+        {
+            var renderer = new BackgroundRenderer(new Mock<IResourceManager>().Object);
+
+            var exception = Record.Exception(() => renderer.Draw(null!, new Rectangle(0, 0, 100, 100)));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void BackgroundRenderer_Dispose_ShouldReleaseLoadedTextureAndResetFlags()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var renderer = new BackgroundRenderer(resourceManager.Object);
+            var texture = new TrackingTextureResource();
+            ReflectionHelpers.SetPrivateField(renderer, "_backgroundTexture", texture);
+            ReflectionHelpers.SetPrivateField(renderer, "_isLoading", true);
+            ReflectionHelpers.SetPrivateField(renderer, "_loadingFailed", true);
+
+            renderer.Dispose();
+
+            Assert.Equal(1, texture.RemoveReferenceCount);
+            Assert.Null(ReflectionHelpers.GetPrivateField<ITexture>(renderer, "_backgroundTexture"));
+            Assert.False(renderer.IsLoading);
+            Assert.False(renderer.LoadingFailed);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderer, "_disposed"));
+        }
+
+        #endregion
+
+        #region LaneBackgroundRenderer
+
+        [Fact]
+        public void LaneBackgroundRenderer_Constructor_WithNullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new LaneBackgroundRenderer(null!));
+
+            Assert.Equal("resourceManager", exception.ParamName);
+        }
+
+        [Fact]
+        public void LaneBackgroundRenderer_Constructor_WhenWhiteTextureCreationFails_ShouldWrapException()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(manager => manager.CreateTextureFromColor(It.IsAny<Color>()))
+                .Throws(new InvalidOperationException("failed"));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => new LaneBackgroundRenderer(resourceManager.Object));
+
+            Assert.Contains("white texture could not be created", exception.Message);
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Fact]
+        public void LaneBackgroundRenderer_Update_ShouldNotThrow()
+        {
+            var renderer = CreateUninitialized<LaneBackgroundRenderer>();
+
+            var exception = Record.Exception(() => renderer.Update(0.016));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void LaneBackgroundRenderer_Draw_WithNullSpriteBatch_ShouldReturnWithoutThrowing()
+        {
+            var renderer = CreateUninitialized<LaneBackgroundRenderer>();
+
+            var exception = Record.Exception(() => renderer.Draw(null!));
+
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(PerformanceUILayout.LaneCount)]
+        public void LaneBackgroundRenderer_DrawLane_WithInvalidLaneIndex_ShouldReturnWithoutThrowing(int laneIndex)
+        {
+            var renderer = CreateUninitialized<LaneBackgroundRenderer>();
+
+            var exception = Record.Exception(() => renderer.DrawLane(null!, laneIndex));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void LaneBackgroundRenderer_Dispose_ShouldReleaseWhiteTextureAndMarkDisposed()
+        {
+            var texture = new TrackingTextureResource();
+            var renderer = CreateUninitialized<LaneBackgroundRenderer>();
+            ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", texture);
+
+            renderer.Dispose();
+
+            Assert.Equal(1, texture.RemoveReferenceCount);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderer, "_disposed"));
+        }
+
+        #endregion
+
+        #region JudgementLineRenderer
+
+        [Fact]
+        public void JudgementLineRenderer_Constructor_WithNullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => new JudgementLineRenderer(null!));
+
+            Assert.Equal("graphicsDevice", exception.ParamName);
+        }
+
+        [Fact]
+        public void JudgementLineRenderer_PropertySetters_ShouldClampAndStoreValues()
+        {
+            var renderer = CreateUninitialized<JudgementLineRenderer>();
+
+            renderer.LineColor = Color.CornflowerBlue;
+            renderer.LineThickness = -5;
+            renderer.Alpha = 2.5f;
+
+            Assert.Equal(Color.CornflowerBlue, renderer.LineColor);
+            Assert.Equal(1, renderer.LineThickness);
+            Assert.Equal(1.0f, renderer.Alpha);
+
+            renderer.Alpha = -1.0f;
+
+            Assert.Equal(0.0f, renderer.Alpha);
+        }
+
+        [Fact]
+        public void JudgementLineRenderer_GetJudgementLineRectangle_ShouldUseLaneBoundsAndThickness()
+        {
+            var renderer = CreateUninitialized<JudgementLineRenderer>();
+            renderer.LineThickness = 4;
+
+            var rectangle = ReflectionHelpers.InvokePrivateMethod<Rectangle>(renderer, "GetJudgementLineRectangle");
+
+            var leftX = PerformanceUILayout.GetLaneLeftX(0);
+            var rightX = PerformanceUILayout.GetLaneRightX(PerformanceUILayout.LaneCount - 1);
+            Assert.Equal(leftX, rectangle.X);
+            Assert.Equal(PerformanceUILayout.JudgementLineY, rectangle.Y);
+            Assert.Equal(rightX - leftX, rectangle.Width);
+            Assert.Equal(4, rectangle.Height);
+        }
+
+        [Fact]
+        public void JudgementLineRenderer_DrawOverloads_WhenSpriteBatchIsNull_ShouldReturnWithoutThrowing()
+        {
+            var renderer = CreateUninitialized<JudgementLineRenderer>();
+            ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", CreateTrackingTexture(1, 1));
+
+            var exception = Record.Exception(() =>
+            {
+                renderer.Draw(null!);
+                renderer.Draw(null!, Color.Red);
+                renderer.Draw(null!, Color.Red, 0.5f);
+            });
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void JudgementLineRenderer_CreateWhiteTexture_WhenGraphicsDeviceIsMissing_ShouldClearTextureAndThrow()
+        {
+            var renderer = CreateUninitialized<JudgementLineRenderer>();
+            ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", CreateTrackingTexture(1, 1));
+            ReflectionHelpers.SetPrivateField(renderer, "_graphicsDevice", null);
+
+            var exception = Assert.ThrowsAny<Exception>(() => ReflectionHelpers.InvokePrivateMethod(renderer, "CreateWhiteTexture"));
+
+            Assert.NotNull(exception);
+            Assert.Null(ReflectionHelpers.GetPrivateField<Texture2D>(renderer, "_whiteTexture"));
+        }
+
+        [Fact]
+        public void JudgementLineRenderer_Dispose_ShouldReleaseTextureAndClearGraphicsDevice()
+        {
+            var renderer = CreateUninitialized<JudgementLineRenderer>();
+            var texture = CreateTrackingTexture(1, 1);
+            ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", texture);
+            ReflectionHelpers.SetPrivateField(renderer, "_graphicsDevice", CreateGraphicsDeviceStub());
+
+            renderer.Dispose();
+
+            Assert.True(texture.WasDisposed);
+            Assert.Null(ReflectionHelpers.GetPrivateField<Texture2D>(renderer, "_whiteTexture"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<GraphicsDevice>(renderer, "_graphicsDevice"));
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderer, "_disposed"));
+        }
+
+        #endregion
+
+        #region EffectsManager
+
+        [Fact]
+        public void EffectsManager_Constructor_WithNullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => new EffectsManager(null!, resourceManager.Object));
+
+            Assert.Equal("graphicsDevice", exception.ParamName);
+        }
+
+        [Fact]
+        public void EffectsManager_Constructor_WithNullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var graphicsDevice = CreateGraphicsDeviceStub();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => new EffectsManager(graphicsDevice, null!));
+
+            Assert.Equal("resourceManager", exception.ParamName);
+        }
+
+        [Fact]
+        public void EffectsManager_Constructor_WithValidTexture_ShouldEnableEffects()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(fixture.Manager, "_effectsEnabled"));
+            Assert.NotNull(ReflectionHelpers.GetPrivateField<ManagedSpriteTexture>(fixture.Manager, "_hitEffectTexture"));
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            Assert.Empty(activeEffects!.Cast<object>());
+        }
+
+        [Fact]
+        public void SpawnHitEffect_WhenEffectsAreEnabled_ShouldAddEffectAtLanePosition()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+
+            fixture.Manager.SpawnHitEffect(2);
+
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            var effect = Assert.Single(activeEffects!.Cast<object>());
+            var position = (Vector2)effect.GetType().GetProperty("Position")!.GetValue(effect)!;
+            Assert.Equal(new Vector2(PerformanceUILayout.GetLaneX(2), PerformanceUILayout.JudgementLineY), position);
+        }
+
+        [Fact]
+        public void SpawnHitEffect_WhenEffectsAreDisabled_ShouldNotAddEffects()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+            ReflectionHelpers.SetPrivateField(fixture.Manager, "_effectsEnabled", false);
+
+            fixture.Manager.SpawnHitEffect(1);
+
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            Assert.Empty(activeEffects!.Cast<object>());
+        }
+
+        [Fact]
+        public void Update_WhenEffectsAreDisabled_ShouldLeaveActiveEffectsUntouched()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+            fixture.Manager.SpawnHitEffect(0);
+            ReflectionHelpers.SetPrivateField(fixture.Manager, "_effectsEnabled", false);
+
+            fixture.Manager.Update(1.0);
+
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            Assert.Single(activeEffects!.Cast<object>());
+        }
+
+        [Fact]
+        public void Update_WhenEffectsExpire_ShouldRemoveThemFromActiveList()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 2);
+            fixture.Manager.SpawnHitEffect(0);
+
+            fixture.Manager.Update(1.0);
+
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            Assert.Empty(activeEffects!.Cast<object>());
+        }
+
+        [Fact]
+        public void ClearAllEffects_ShouldRemoveEveryActiveEffect()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+            fixture.Manager.SpawnHitEffect(0);
+            fixture.Manager.SpawnHitEffect(1);
+
+            fixture.Manager.ClearAllEffects();
+
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            Assert.Empty(activeEffects!.Cast<object>());
+        }
+
+        [Fact]
+        public void Draw_WhenEffectsAreDisabled_ShouldReturnWithoutThrowing()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+            ReflectionHelpers.SetPrivateField(fixture.Manager, "_effectsEnabled", false);
+
+            var exception = Record.Exception(() => fixture.Manager.Draw(null!));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Dispose_ShouldDisposeHitTextureAndClearActiveEffects()
+        {
+            using var fixture = new EffectsManagerFixture(totalSprites: 4);
+            fixture.Manager.SpawnHitEffect(0);
+
+            fixture.Manager.Dispose();
+
+            var activeEffects = ReflectionHelpers.GetPrivateField<System.Collections.IList>(fixture.Manager, "_activeEffects");
+            Assert.Null(ReflectionHelpers.GetPrivateField<ManagedSpriteTexture>(fixture.Manager, "_hitEffectTexture"));
+            Assert.Empty(activeEffects!.Cast<object>());
+            Assert.True(fixture.HitTexture.WasDisposed);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static T CreateUninitialized<T>() where T : class
+        {
+            return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+        }
+
+        private static GraphicsDevice CreateGraphicsDeviceStub()
+        {
+            return CreateUninitialized<GraphicsDevice>();
+        }
+
+        private static ManagedTexture CreateManagedTexture(int width, int height, string sourcePath)
+        {
+            return CreateManagedTexture(width, height, sourcePath, out _);
+        }
+
+        private static ManagedTexture CreateManagedTexture(int width, int height, string sourcePath, out TrackingTexture2D trackingTexture)
+        {
+            trackingTexture = CreateTrackingTexture(width, height);
+            return new ManagedTexture(CreateGraphicsDeviceStub(), trackingTexture, sourcePath);
+        }
+
+        private static TrackingTexture2D CreateTrackingTexture(int width, int height)
+        {
+            var texture = CreateUninitialized<TrackingTexture2D>();
+            ReflectionHelpers.SetPrivateField(texture, "width", width);
+            ReflectionHelpers.SetPrivateField(texture, "height", height);
+            ReflectionHelpers.SetPrivateField(texture, "<TexelWidth>k__BackingField", 1f / width);
+            ReflectionHelpers.SetPrivateField(texture, "<TexelHeight>k__BackingField", 1f / height);
+            return texture;
+        }
+
+        private sealed class EffectsManagerFixture : IDisposable
+        {
+            public EffectsManagerFixture(int totalSprites)
+            {
+                HitTexture = CreateTrackingTexture(width: 8 * totalSprites, height: 32);
+                var graphicsDevice = CreateGraphicsDeviceStub();
+                var loadedTexture = new ManagedTexture(graphicsDevice, HitTexture, "Graphics/hit_fx.png");
+                var resourceManager = new Mock<IResourceManager>();
+                resourceManager
+                    .Setup(manager => manager.LoadTexture("Graphics/hit_fx.png"))
+                    .Returns(loadedTexture);
+
+                Manager = new EffectsManager(graphicsDevice, resourceManager.Object);
+            }
+
+            public EffectsManager Manager { get; }
+
+            public TrackingTexture2D HitTexture { get; }
+
+            public void Dispose()
+            {
+                Manager.Dispose();
+            }
+        }
+
+        private sealed class TrackingTexture2D : Texture2D
+        {
+            public TrackingTexture2D() : base(null!, 1, 1)
+            {
+            }
+
+            public bool WasDisposed { get; private set; }
+
+            protected override void Dispose(bool disposing)
+            {
+                WasDisposed = true;
+            }
+        }
+
+        private sealed class TrackingTextureResource : ITexture
+        {
+            public Texture2D Texture => null!;
+
+            public string SourcePath => "tracking";
+
+            public int Width => 1;
+
+            public int Height => 1;
+
+            public Vector2 Size => Vector2.One;
+
+            public bool IsDisposed { get; private set; }
+
+            public int ReferenceCount => 0;
+
+            public long MemoryUsage => 0;
+
+            public int Transparency { get; set; } = 255;
+
+            public Vector3 ScaleRatio { get; set; } = Vector3.One;
+
+            public float ZAxisRotation { get; set; }
+
+            public bool AdditiveBlending { get; set; }
+
+            public int RemoveReferenceCount { get; private set; }
+
+            public void AddReference()
+            {
+            }
+
+            public ITexture Clone()
+            {
+                return this;
+            }
+
+            public Color[] GetColorData()
+            {
+                return Array.Empty<Color>();
+            }
+
+            public void RemoveReference()
+            {
+                RemoveReferenceCount++;
+            }
+
+            public void SetColorData(Color[] colorData)
+            {
+            }
+
+            public void SaveToFile(string filePath)
+            {
+            }
+
+            public void Draw(SpriteBatch spriteBatch, Vector2 position)
+            {
+            }
+
+            public void Draw(SpriteBatch spriteBatch, Vector2 position, Rectangle? sourceRectangle)
+            {
+            }
+
+            public void Draw(SpriteBatch spriteBatch, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
+            {
+            }
+
+            public void Draw(SpriteBatch spriteBatch, Vector2 position, Vector2 scale, float rotation, Vector2 origin)
+            {
+            }
+
+            public void Dispose()
+            {
+                IsDisposed = true;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -110,6 +110,53 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void CheckSongInitializationCompletion_WhenTaskStillRunning_ShouldLeaveStateUnchanged()
+        {
+            var pendingTask = new TaskCompletionSource<List<SongListNode>>();
+            var stage = CreateStage();
+            var currentSongs = new List<SongListNode> { CreateScoreNode("Existing") };
+            var display = new SongListDisplay
+            {
+                CurrentList = [currentSongs[0]]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", currentSongs);
+            SetPrivateField(stage, "_songInitializationTask", pendingTask.Task);
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.False(GetPrivateField<bool>(stage, "_songInitializationProcessed"));
+            Assert.Same(pendingTask.Task, GetPrivateField<Task<List<SongListNode>>>(stage, "_songInitializationTask"));
+            Assert.Same(currentSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Same(currentSongs[0], display.CurrentList[0]);
+        }
+
+        [Fact]
+        public void CheckSongInitializationCompletion_WhenAlreadyProcessed_ShouldLeaveCompletedTaskUntouched()
+        {
+            var songs = new List<SongListNode> { CreateScoreNode("Existing") };
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [songs[0]]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", songs);
+            SetPrivateField(stage, "_songInitializationTask", Task.FromResult(new List<SongListNode> { CreateScoreNode("Loaded") }));
+            SetPrivateField(stage, "_songInitializationProcessed", true);
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.True(GetPrivateField<bool>(stage, "_songInitializationProcessed"));
+            Assert.NotNull(GetPrivateField<Task<List<SongListNode>>>(stage, "_songInitializationTask"));
+            Assert.Same(songs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Same(songs[0], display.CurrentList[0]);
+        }
+
+        [Fact]
         public void OnSongSelectionChanged_WhenScoreAndScrollIncomplete_ShouldUpdateLightweightUiOnly()
         {
             var stage = CreateStage();
@@ -247,6 +294,30 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void NavigateIntoBox_WhenChildrenMissing_ShouldLeaveStateUnchanged()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("Root Song")]
+            };
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root Song") };
+            var box = CreateBoxNode("Folder");
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", rootSongs);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root");
+
+            InvokePrivateMethod(stage, "NavigateIntoBox", box);
+
+            Assert.Same(rootSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Empty(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+            Assert.Single(display.CurrentList);
+            Assert.Equal("Root Song", display.CurrentList[0].Title);
+        }
+
+        [Fact]
         public void NavigateBack_ShouldRestorePreviousState()
         {
             var stage = CreateStage();
@@ -266,6 +337,28 @@ namespace DTXMania.Test.Stage
             Assert.Single(display.CurrentList);
             Assert.Same(rootSongs[0], display.CurrentList[0]);
             Assert.Empty(stack);
+        }
+
+        [Fact]
+        public void NavigateBack_WhenStackEmpty_ShouldLeaveCurrentStateUnchanged()
+        {
+            var stage = CreateStage();
+            var songs = new List<SongListNode> { CreateScoreNode("Root Song") };
+            var display = new SongListDisplay
+            {
+                CurrentList = [songs[0]]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", songs);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root");
+
+            InvokePrivateMethod(stage, "NavigateBack");
+
+            Assert.Same(songs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Empty(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+            Assert.Same(songs[0], display.CurrentList[0]);
         }
 
         [Fact]
@@ -398,6 +491,51 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void HandleSongActivation_WhenScoreNodeProvided_ShouldSelectSong()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var song = CreateScoreNode("Song", songId: 21);
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "HandleSongActivation", song);
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.IsAny<IStageTransition>(),
+                    It.Is<Dictionary<string, object>>(sharedData => ReferenceEquals(sharedData["selectedSong"], song))),
+                Times.Once);
+        }
+
+        [Fact]
+        public void HandleSongActivation_WhenRandomNodeProvided_ShouldSelectRandomSong()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var song = CreateScoreNode("Song", songId: 22);
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode>
+            {
+                song,
+                new SongListNode { Type = NodeType.Random, Title = "Random" }
+            });
+
+            InvokePrivateMethod(stage, "HandleSongActivation", new SongListNode { Type = NodeType.Random, Title = "Random" });
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.IsAny<IStageTransition>(),
+                    It.Is<Dictionary<string, object>>(sharedData => ReferenceEquals(sharedData["selectedSong"], song))),
+                Times.Once);
+        }
+
+        [Fact]
         public void UpdateBreadcrumb_ShouldUseRootFallbackAndCurrentBreadcrumb()
         {
             var stage = CreateStage();
@@ -523,6 +661,24 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ExecuteInputCommand_MoveLeftOutsideStatusPanel_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentDifficulty", 3);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveLeft, 0.0));
+
+            Assert.Equal(3, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal("A", display.SelectedSong!.Title);
+        }
+
+        [Fact]
         public void ExecuteInputCommand_MoveRightInStatusPanel_ShouldUseSongListDifficultyCycling()
         {
             var stage = CreateStage();
@@ -549,6 +705,24 @@ namespace DTXMania.Test.Stage
             Assert.Equal(2, display.CurrentDifficulty);
             Assert.Equal(2, GetPrivateField<int>(statusPanel, "_currentDifficulty"));
             cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveRightOutsideStatusPanel_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentDifficulty", 1);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveRight, 0.0));
+
+            Assert.Equal(1, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal("A", display.SelectedSong!.Title);
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -660,8 +660,10 @@ namespace DTXMania.Test.Stage
             cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
         }
 
-        [Fact]
-        public void ExecuteInputCommand_MoveLeftOutsideStatusPanel_ShouldDoNothing()
+        [Theory]
+        [InlineData(InputCommandType.MoveLeft, 3)]
+        [InlineData(InputCommandType.MoveRight, 1)]
+        public void ExecuteInputCommand_MoveOutsideStatusPanel_ShouldDoNothing(InputCommandType command, int initialDifficulty)
         {
             var stage = CreateStage();
             var display = new SongListDisplay
@@ -670,11 +672,11 @@ namespace DTXMania.Test.Stage
             };
 
             AttachCoreUi(stage, display: display);
-            SetPrivateField(stage, "_currentDifficulty", 3);
+            SetPrivateField(stage, "_currentDifficulty", initialDifficulty);
 
-            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveLeft, 0.0));
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(command, 0.0));
 
-            Assert.Equal(3, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal(initialDifficulty, GetPrivateField<int>(stage, "_currentDifficulty"));
             Assert.Equal("A", display.SelectedSong!.Title);
         }
 
@@ -705,24 +707,6 @@ namespace DTXMania.Test.Stage
             Assert.Equal(2, display.CurrentDifficulty);
             Assert.Equal(2, GetPrivateField<int>(statusPanel, "_currentDifficulty"));
             cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
-        }
-
-        [Fact]
-        public void ExecuteInputCommand_MoveRightOutsideStatusPanel_ShouldDoNothing()
-        {
-            var stage = CreateStage();
-            var display = new SongListDisplay
-            {
-                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
-            };
-
-            AttachCoreUi(stage, display: display);
-            SetPrivateField(stage, "_currentDifficulty", 1);
-
-            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveRight, 0.0));
-
-            Assert.Equal(1, GetPrivateField<int>(stage, "_currentDifficulty"));
-            Assert.Equal("A", display.SelectedSong!.Title);
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/StartupStageLogicTests.cs
+++ b/DTXMania.Test/Stage/StartupStageLogicTests.cs
@@ -1,13 +1,18 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Moq;
 
 namespace DTXMania.Test.Stage
@@ -334,6 +339,114 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public async Task InitializeDatabaseServiceAsync_WhenSongOperationsSucceed_ShouldUseOverriddenDatabasePath()
+        {
+            var stage = CreateControlledStage();
+            stage.DatabasePath = Path.Combine(Path.GetTempPath(), "StartupStageLogicTests", Guid.NewGuid().ToString("N"), "songs.db");
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "InitializeDatabaseServiceAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.InitializeDatabaseCalls);
+            Assert.Equal(stage.DatabasePath, stage.LastDatabasePath);
+            Assert.Equal(Path.GetDirectoryName(stage.DatabasePath), stage.LastEnsuredDirectoryPath);
+        }
+
+        [Fact]
+        public async Task LoadScoreCacheAsync_WhenSongOperationsSucceed_ShouldPassSongPathsToWrapper()
+        {
+            var songPaths = new[] { "SongsA", "SongsB" };
+            var stage = CreateControlledStage(songPaths: songPaths);
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "LoadScoreCacheAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.LoadScoreCacheCalls);
+            Assert.Equal(songPaths, stage.LastSongPaths);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CheckFilesystemChangesAsync_WhenSongOperationsSucceed_ShouldCacheEnumerationResult(bool needsEnumeration)
+        {
+            var songPaths = new[] { "SongsRoot" };
+            var stage = CreateControlledStage(songPaths: songPaths);
+            stage.NextNeedsEnumerationResult = needsEnumeration;
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "CheckFilesystemChangesAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.NeedsEnumerationCalls);
+            Assert.Equal(songPaths, stage.LastSongPaths);
+            Assert.Equal(needsEnumeration, ReflectionHelpers.GetPrivateField<bool?>(stage, "_needsEnumeration"));
+        }
+
+        [Fact]
+        public async Task EnumerateSongsAsync_WhenEnumerationNeeded_ShouldUseProgressReporterAndCancellationToken()
+        {
+            var songPaths = new[] { "SongsRoot" };
+            var stage = CreateControlledStage(songPaths: songPaths);
+            stage.ReportedEnumerationProgress = new EnumerationProgress
+            {
+                CurrentFile = Path.Combine("SongsRoot", "test-song.dtx"),
+                ProcessedCount = 3,
+                DiscoveredSongs = 2
+            };
+            stage.NextEnumerationCount = 7;
+            ReflectionHelpers.SetPrivateField(stage, "_needsEnumeration", true);
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "EnumerateSongsAsync")!;
+            await task;
+
+            SpinWait.SpinUntil(
+                () => (ReflectionHelpers.GetPrivateField<string>(stage, "_currentProgressMessage") ?? string.Empty).Contains("test-song.dtx", StringComparison.Ordinal),
+                TimeSpan.FromSeconds(1));
+
+            var progressMessage = ReflectionHelpers.GetPrivateField<string>(stage, "_currentProgressMessage");
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.EnumerateSongsCalls);
+            Assert.Equal(songPaths, stage.LastSongPaths);
+            Assert.True(stage.LastEnumerationToken.CanBeCanceled);
+            Assert.Contains("test-song.dtx", progressMessage);
+            Assert.Contains("3 processed", progressMessage);
+            Assert.Contains("2 songs", progressMessage);
+        }
+
+        [Fact]
+        public async Task BuildSongListsAsync_WhenSongOperationsSucceed_ShouldBuildFromDatabaseUsingCurrentSongPaths()
+        {
+            var songPaths = new[] { "SongsRoot" };
+            var stage = CreateControlledStage(songPaths: songPaths);
+            stage.RootSongCount = 12;
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "BuildSongListsAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.BuildSongListCalls);
+            Assert.Equal(songPaths, stage.LastSongPaths);
+        }
+
+        [Fact]
+        public async Task SaveSongsDbAsync_WhenSaveSucceeds_ShouldMarkSongManagerInitialized()
+        {
+            var stage = CreateControlledStage();
+            stage.NextSaveResult = true;
+            stage.RootSongCount = 5;
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "SaveSongsDBAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.SaveSongsDatabaseCalls);
+            Assert.True(stage.MarkSongManagerInitializedCalled);
+        }
+
+        [Fact]
         public void OnUpdate_WhenCompletePhaseDurationElapsed_ShouldRequestTitleStageTransition()
         {
             var stageManager = new Mock<IStageManager>();
@@ -383,6 +496,73 @@ namespace DTXMania.Test.Stage
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_disposed"));
         }
 
+        [Fact]
+        public void OnActivate_ShouldInitializeGraphicsStateAndResetProgress()
+        {
+            var game = ReflectionHelpers.CreateGame();
+            var resourceManager = new Mock<IResourceManager>();
+            ReflectionHelpers.SetPrivateField(game, "<ResourceManager>k__BackingField", resourceManager.Object);
+            var stage = new GraphicsControlledStartupStage(game);
+            ReflectionHelpers.SetPrivateField(stage, "_progressMessages", new List<string> { "stale" });
+            ReflectionHelpers.SetPrivateField(stage, "_startupPhase", StartupPhase.BuildSongLists);
+            ReflectionHelpers.SetPrivateField(stage, "_elapsedTime", 12.0);
+            ReflectionHelpers.SetPrivateField(stage, "_phaseStartTime", 4.0);
+            ReflectionHelpers.SetPrivateField(stage, "_currentAsyncTask", Task.CompletedTask);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnActivate");
+
+            Assert.Same(stage.SpriteBatchStub, ReflectionHelpers.GetPrivateField<SpriteBatch>(stage, "_spriteBatch"));
+            Assert.Same(stage.WhitePixelStub, ReflectionHelpers.GetPrivateField<Texture2D>(stage, "_whitePixel"));
+            Assert.Same(resourceManager.Object, ReflectionHelpers.GetPrivateField<IResourceManager>(stage, "_resourceManager"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<BitmapFont>(stage, "_bitmapFont"));
+            Assert.Equal(StartupPhase.SystemSounds, ReflectionHelpers.GetPrivateField<StartupPhase>(stage, "_startupPhase"));
+            Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_elapsedTime"));
+            Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_phaseStartTime"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<Task>(stage, "_currentAsyncTask"));
+            Assert.Equal(new[] { "DTXMania powered by YAMAHA Silent Session Drums" }, ReflectionHelpers.GetPrivateField<List<string>>(stage, "_progressMessages"));
+        }
+
+        [Fact]
+        public void OnDraw_WhenSpriteBatchMissing_ShouldReturnWithoutRendering()
+        {
+            var stage = new GraphicsControlledStartupStage(ReflectionHelpers.CreateGame());
+
+            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", null);
+
+            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "OnDraw", 0.016));
+
+            Assert.Null(exception);
+            Assert.Empty(stage.DrawCalls);
+            Assert.Equal(0, stage.BeginCalls);
+            Assert.Equal(0, stage.EndCalls);
+        }
+
+        [Fact]
+        public void OnDraw_WhenUsingFallbackRendering_ShouldDrawBackgroundMessagesAndProgress()
+        {
+            var stage = new GraphicsControlledStartupStage(ReflectionHelpers.CreateGame());
+            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", stage.SpriteBatchStub);
+            ReflectionHelpers.SetPrivateField(stage, "_whitePixel", stage.WhitePixelStub);
+            ReflectionHelpers.SetPrivateField(stage, "_bitmapFont", null);
+            ReflectionHelpers.SetPrivateField(stage, "_progressMessages", new List<string> { "message one", "message two" });
+            ReflectionHelpers.SetPrivateField(stage, "_currentProgressMessage", "current");
+            ReflectionHelpers.SetPrivateField(stage, "_startupPhase", StartupPhase.LoadScoreFiles);
+            ReflectionHelpers.SetPrivateField(stage, "_phaseInfo", CreatePhaseInfo());
+            ReflectionHelpers.SetPrivateField(stage, "_elapsedTime", 0.35);
+            ReflectionHelpers.SetPrivateField(stage, "_phaseStartTime", 0.0);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnDraw", 0.016);
+
+            Assert.Equal(1, stage.BeginCalls);
+            Assert.Equal(1, stage.EndCalls);
+            Assert.Contains(stage.DrawCalls, call => call.Color == new Color(16, 16, 32));
+            Assert.Contains(stage.DrawCalls, call => call.Color == Color.White);
+            Assert.Contains(stage.DrawCalls, call => call.Color == Color.Yellow);
+            Assert.Contains(stage.DrawCalls, call => call.Color == Color.DarkGray);
+            Assert.Contains(stage.DrawCalls, call => call.Color == Color.LightGreen);
+            Assert.True(stage.DrawCalls.Count >= 6);
+        }
+
         private static StartupStage CreateStage(
             StartupPhase phase = StartupPhase.SystemSounds,
             double elapsedTime = 0.0,
@@ -413,6 +593,25 @@ namespace DTXMania.Test.Stage
             ReflectionHelpers.SetPrivateField(stage, "_phaseInfo", CreatePhaseInfo());
             ReflectionHelpers.SetPrivateField(stage, "_phaseStartTime", phaseStartTime);
             ReflectionHelpers.SetPrivateField(stage, "_elapsedTime", elapsedTime);
+
+            return stage;
+        }
+
+        private static ControlledStartupStage CreateControlledStage(string[]? songPaths = null, ConfigData? configData = null)
+        {
+            var game = ReflectionHelpers.CreateGame();
+            ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", CreateConfigManager(configData ?? new ConfigData
+            {
+                DTXPath = "Songs",
+                ScreenWidth = 1280,
+                ScreenHeight = 720
+            }));
+
+            var stage = new ControlledStartupStage(game);
+            if (songPaths != null)
+            {
+                ReflectionHelpers.SetPrivateField(stage, "_songPaths", songPaths);
+            }
 
             return stage;
         }
@@ -451,6 +650,177 @@ namespace DTXMania.Test.Stage
                 modifiers: null);
             Assert.NotNull(method);
             method!.Invoke(stage, new object[] { disposing });
+        }
+
+        private class ControlledStartupStage : StartupStage
+        {
+            public ControlledStartupStage(BaseGame game) : base(game)
+            {
+            }
+
+            public string DatabasePath { get; set; } = Path.Combine(Path.GetTempPath(), "controlled-startup-stage", "songs.db");
+
+            public string? LastDatabasePath { get; private set; }
+
+            public string? LastEnsuredDirectoryPath { get; private set; }
+
+            public string[]? LastSongPaths { get; private set; }
+
+            public CancellationToken LastEnumerationToken { get; private set; }
+
+            public int InitializeDatabaseCalls { get; private set; }
+
+            public int LoadScoreCacheCalls { get; private set; }
+
+            public int NeedsEnumerationCalls { get; private set; }
+
+            public int EnumerateSongsCalls { get; private set; }
+
+            public int BuildSongListCalls { get; private set; }
+
+            public int SaveSongsDatabaseCalls { get; private set; }
+
+            public bool NextNeedsEnumerationResult { get; set; } = true;
+
+            public int NextEnumerationCount { get; set; }
+
+            public int RootSongCount { get; set; }
+
+            public bool NextSaveResult { get; set; }
+
+            public bool MarkSongManagerInitializedCalled { get; private set; }
+
+            public EnumerationProgress? ReportedEnumerationProgress { get; set; }
+
+            protected override string GetSongsDatabasePath()
+            {
+                return DatabasePath;
+            }
+
+            protected override void EnsureDirectory(string path)
+            {
+                LastEnsuredDirectoryPath = path;
+            }
+
+            protected override Task<bool> InitializeDatabaseServiceCoreAsync(string databasePath)
+            {
+                InitializeDatabaseCalls++;
+                LastDatabasePath = databasePath;
+                return Task.FromResult(true);
+            }
+
+            protected override Task<bool> LoadScoreCacheCoreAsync(string[] songPaths)
+            {
+                LoadScoreCacheCalls++;
+                LastSongPaths = songPaths;
+                return Task.FromResult(true);
+            }
+
+            protected override Task<bool> NeedsEnumerationCoreAsync(string[] songPaths, bool forceEnumeration)
+            {
+                NeedsEnumerationCalls++;
+                LastSongPaths = songPaths;
+                return Task.FromResult(NextNeedsEnumerationResult);
+            }
+
+            protected override Task<int> EnumerateSongsOnlyCoreAsync(string[] songPaths, IProgress<EnumerationProgress> progressReporter, CancellationToken cancellationToken)
+            {
+                EnumerateSongsCalls++;
+                LastSongPaths = songPaths;
+                LastEnumerationToken = cancellationToken;
+                if (ReportedEnumerationProgress != null)
+                {
+                    progressReporter.Report(ReportedEnumerationProgress);
+                }
+
+                return Task.FromResult(NextEnumerationCount);
+            }
+
+            protected override Task BuildSongListFromDatabaseCoreAsync(string[] songPaths)
+            {
+                BuildSongListCalls++;
+                LastSongPaths = songPaths;
+                return Task.CompletedTask;
+            }
+
+            protected override int GetRootSongCount()
+            {
+                return RootSongCount;
+            }
+
+            protected override Task<bool> SaveSongsDatabaseCoreAsync()
+            {
+                SaveSongsDatabaseCalls++;
+                return Task.FromResult(NextSaveResult);
+            }
+
+            protected override void MarkSongManagerInitialized()
+            {
+                MarkSongManagerInitializedCalled = true;
+            }
+        }
+
+        private sealed record DrawCall(Rectangle Destination, Color Color);
+
+        private sealed class GraphicsControlledStartupStage : StartupStage
+        {
+            public GraphicsControlledStartupStage(BaseGame game) : base(game)
+            {
+            }
+
+            public GraphicsDevice GraphicsDeviceStub { get; } = (GraphicsDevice)RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice));
+
+            public SpriteBatch SpriteBatchStub { get; } = (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+            public Texture2D WhitePixelStub { get; } = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+
+            public Viewport ViewportValue { get; set; } = new(0, 0, 1280, 720);
+
+            public int BeginCalls { get; private set; }
+
+            public int EndCalls { get; private set; }
+
+            public List<DrawCall> DrawCalls { get; } = new();
+
+            protected override GraphicsDevice GetGraphicsDeviceCore()
+            {
+                return GraphicsDeviceStub;
+            }
+
+            protected override Viewport GetViewportCore()
+            {
+                return ViewportValue;
+            }
+
+            protected override SpriteBatch CreateSpriteBatchCore(GraphicsDevice graphicsDevice)
+            {
+                return SpriteBatchStub;
+            }
+
+            protected override Texture2D CreateWhitePixelCore(GraphicsDevice graphicsDevice)
+            {
+                return WhitePixelStub;
+            }
+
+            protected override BitmapFont CreateBitmapFontCore(GraphicsDevice graphicsDevice, IResourceManager resourceManager, BitmapFont.BitmapFontConfig config)
+            {
+                return null!;
+            }
+
+            protected override void BeginSpriteBatchCore(SpriteBatch spriteBatch)
+            {
+                BeginCalls++;
+            }
+
+            protected override void EndSpriteBatchCore(SpriteBatch spriteBatch)
+            {
+                EndCalls++;
+            }
+
+            protected override void DrawSolidRectCore(SpriteBatch spriteBatch, Texture2D texture, Rectangle destination, Color color)
+            {
+                DrawCalls.Add(new DrawCall(destination, color));
+            }
         }
     }
 }

--- a/DTXMania.Test/Stage/StartupStageLogicTests.cs
+++ b/DTXMania.Test/Stage/StartupStageLogicTests.cs
@@ -447,6 +447,20 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public async Task SaveSongsDbAsync_WhenSaveFails_ShouldNotMarkSongManagerInitialized()
+        {
+            var stage = CreateControlledStage();
+            stage.NextSaveResult = false;
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "SaveSongsDBAsync")!;
+            await task;
+
+            Assert.True(task.IsCompletedSuccessfully);
+            Assert.Equal(1, stage.SaveSongsDatabaseCalls);
+            Assert.False(stage.MarkSongManagerInitializedCalled);
+        }
+
+        [Fact]
         public void OnUpdate_WhenCompletePhaseDurationElapsed_ShouldRequestTitleStageTransition()
         {
             var stageManager = new Mock<IStageManager>();

--- a/DTXMania.Test/TestData/ReflectionHelpers.cs
+++ b/DTXMania.Test/TestData/ReflectionHelpers.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
 using DTXMania.Game;
@@ -29,6 +30,11 @@ namespace DTXMania.Test.TestData
 #pragma warning restore SYSLIB0050
             SetPrivateField(game, "<ResourceManager>k__BackingField", resourceManager);
             return game;
+        }
+
+        internal static T CreateUninitialized<T>() where T : class
+        {
+            return (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
         }
 
         internal static T? GetPrivateField<T>(object target, string fieldName)

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -22,6 +22,8 @@ public class DefaultGraphicsGeneratorLogicTests
         public List<DrawCall> DrawCalls { get; } = new();
         public int BeginCount { get; private set; }
         public int EndCount { get; private set; }
+        public int SetRenderTargetCount { get; private set; }
+        public int RestoreRenderTargetsCount { get; private set; }
         public Func<string, ITexture>? CreateGeneratedTextureHandler { get; set; }
 
         public TestableDefaultGraphicsGenerator()
@@ -39,6 +41,17 @@ public class DefaultGraphicsGeneratorLogicTests
 
         protected override void DrawSolidRectangle(Rectangle destination, Color color)
             => DrawCalls.Add(new DrawCall(destination, color));
+
+        protected override RenderTargetBinding[] SetRenderTarget()
+        {
+            SetRenderTargetCount++;
+            return Array.Empty<RenderTargetBinding>();
+        }
+
+        protected override void RestoreRenderTargets(RenderTargetBinding[] previousTargets)
+        {
+            RestoreRenderTargetsCount++;
+        }
 
         protected override ITexture CreateGeneratedTexture(string sourcePath)
             => CreateGeneratedTextureHandler?.Invoke(sourcePath)
@@ -101,6 +114,8 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal([Color.Transparent], generator.ClearColors);
         Assert.Equal(1, generator.BeginCount);
         Assert.Equal(1, generator.EndCount);
+        Assert.Equal(1, generator.SetRenderTargetCount);
+        Assert.Equal(1, generator.RestoreRenderTargetsCount);
         Assert.Equal("Generated_SongBar_4x3", result.SourcePath);
         Assert.Equal(5, generator.DrawCalls.Count);
         Assert.Equal(new Rectangle(0, 0, 4, 2), generator.DrawCalls[3].Destination);
@@ -138,6 +153,8 @@ public class DefaultGraphicsGeneratorLogicTests
 
         Assert.Same(texture.Object, result);
         Assert.Equal("Generated_ClearLamp_3_False", result.SourcePath);
+        Assert.Equal(1, generator.SetRenderTargetCount);
+        Assert.Equal(1, generator.RestoreRenderTargetsCount);
         Assert.Equal(DTXManiaVisualTheme.Layout.ClearLampHeight + 4, generator.DrawCalls.Count);
         Assert.All(generator.DrawCalls[^4..], drawCall => Assert.Equal(Color.Gray, drawCall.Color));
         Assert.Same(texture.Object, GetTextureCache(generator)["ClearLamp_3_False"]);

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.UI;
 using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Moq;
 
@@ -12,6 +14,37 @@ namespace DTXMania.Test.UI;
 [Trait("Category", "Unit")]
 public class DefaultGraphicsGeneratorLogicTests
 {
+    private sealed record DrawCall(Rectangle Destination, Color Color);
+
+    private sealed class TestableDefaultGraphicsGenerator : DefaultGraphicsGenerator
+    {
+        public List<Color> ClearColors { get; } = new();
+        public List<DrawCall> DrawCalls { get; } = new();
+        public int BeginCount { get; private set; }
+        public int EndCount { get; private set; }
+        public Func<string, ITexture>? CreateGeneratedTextureHandler { get; set; }
+
+        public TestableDefaultGraphicsGenerator()
+            : base(
+                (GraphicsDevice)RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice)),
+                (RenderTarget2D)RuntimeHelpers.GetUninitializedObject(typeof(RenderTarget2D)))
+        {
+        }
+
+        protected override void ClearGraphics(Color color) => ClearColors.Add(color);
+
+        protected override void BeginSpriteBatch() => BeginCount++;
+
+        protected override void EndSpriteBatch() => EndCount++;
+
+        protected override void DrawSolidRectangle(Rectangle destination, Color color)
+            => DrawCalls.Add(new DrawCall(destination, color));
+
+        protected override ITexture CreateGeneratedTexture(string sourcePath)
+            => CreateGeneratedTextureHandler?.Invoke(sourcePath)
+                ?? throw new InvalidOperationException("CreateGeneratedTextureHandler was not configured.");
+    }
+
     [Fact]
     public void Constructor_WhenGraphicsDeviceIsNull_ShouldThrowArgumentNullException()
     {
@@ -35,6 +68,170 @@ public class DefaultGraphicsGeneratorLogicTests
         var generator = CreateGenerator(graphicsDevice);
 
         Assert.Same(graphicsDevice, generator.GraphicsDevice);
+    }
+
+    [Fact]
+    public void GenerateSongBarBackground_WhenCenterNotCached_ShouldDrawGradientCenterBordersAndCacheTexture()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_SongBar_4x3");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateSongBarBackground(4, 3, isSelected: false, isCenter: true);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal([Color.Transparent], generator.ClearColors);
+        Assert.Equal(1, generator.BeginCount);
+        Assert.Equal(1, generator.EndCount);
+        Assert.Equal("Generated_SongBar_4x3", result.SourcePath);
+        Assert.Equal(5, generator.DrawCalls.Count);
+        Assert.Equal(new Rectangle(0, 0, 4, 2), generator.DrawCalls[3].Destination);
+        Assert.Equal(Color.Yellow, generator.DrawCalls[3].Color);
+        Assert.Equal(new Rectangle(0, 1, 4, 2), generator.DrawCalls[4].Destination);
+        Assert.Equal(Color.Yellow, generator.DrawCalls[4].Color);
+        Assert.Same(texture.Object, GetTextureCache(generator)["SongBar_4x3_False_True"]);
+    }
+
+    [Fact]
+    public void GenerateSongBarBackground_WhenSelectedNotCached_ShouldDrawWhiteBorders()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_SongBar_5x2");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateSongBarBackground(5, 2, isSelected: true, isCenter: false);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal(4, generator.DrawCalls.Count);
+        Assert.Equal(new Rectangle(0, 0, 5, 1), generator.DrawCalls[2].Destination);
+        Assert.Equal(Color.White, generator.DrawCalls[2].Color);
+        Assert.Equal(new Rectangle(0, 1, 5, 1), generator.DrawCalls[3].Destination);
+        Assert.Equal(Color.White, generator.DrawCalls[3].Color);
+    }
+
+    [Fact]
+    public void GenerateClearLamp_WhenNotCleared_ShouldUseGrayBorderAndCacheTexture()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_ClearLamp_3_False");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateClearLamp(3, hasCleared: false);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_ClearLamp_3_False", result.SourcePath);
+        Assert.Equal(DTXManiaVisualTheme.Layout.ClearLampHeight + 4, generator.DrawCalls.Count);
+        Assert.All(generator.DrawCalls[^4..], drawCall => Assert.Equal(Color.Gray, drawCall.Color));
+        Assert.Same(texture.Object, GetTextureCache(generator)["ClearLamp_3_False"]);
+    }
+
+    [Fact]
+    public void GenerateEnhancedClearLamp_WhenNotPlayed_ShouldSkipBorder()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_EnhancedClearLamp_1_NotPlayed");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateEnhancedClearLamp(1, ClearStatus.NotPlayed);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_EnhancedClearLamp_1_NotPlayed", result.SourcePath);
+        Assert.Equal(24, generator.DrawCalls.Count);
+        Assert.Same(texture.Object, GetTextureCache(generator)["EnhancedClearLamp_1_NotPlayed"]);
+    }
+
+    [Fact]
+    public void GenerateEnhancedClearLamp_WhenStatusUnknown_ShouldUseDefaultBranchAndDrawBorder()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_EnhancedClearLamp_9_999");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateEnhancedClearLamp(9, (ClearStatus)999);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_EnhancedClearLamp_9_999", result.SourcePath);
+        Assert.Equal(28, generator.DrawCalls.Count);
+        Assert.Equal(Color.White * 0.8f, generator.DrawCalls[^1].Color);
+    }
+
+    [Fact]
+    public void GenerateBarTypeBackground_WhenBoxSelected_ShouldDrawBorderAndFolderIndicator()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_BarType_Box_10x8");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateBarTypeBackground(10, 8, BarType.Box, isSelected: true, isCenter: false);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_BarType_Box_10x8", result.SourcePath);
+        Assert.Equal(13, generator.DrawCalls.Count);
+        Assert.Equal(Color.Cyan * 0.7f, generator.DrawCalls[^1].Color);
+        Assert.Equal(new Rectangle(2, 2, 4, 4), generator.DrawCalls[^1].Destination);
+    }
+
+    [Fact]
+    public void GenerateBarTypeBackground_WhenOtherCentered_ShouldDrawCenterBorderAndSpecialIndicator()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_BarType_Other_12x8");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateBarTypeBackground(12, 8, BarType.Other, isSelected: false, isCenter: true);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_BarType_Other_12x8", result.SourcePath);
+        Assert.Equal(13, generator.DrawCalls.Count);
+        Assert.Equal(Color.Magenta * 0.8f, generator.DrawCalls[^1].Color);
+        Assert.Equal(new Rectangle(4, 2, 4, 4), generator.DrawCalls[^1].Destination);
+        Assert.Equal(Color.Yellow, generator.DrawCalls[8].Color);
+    }
+
+    [Fact]
+    public void GeneratePanelBackground_WhenBorderDisabled_ShouldOnlyDrawBackgroundAndCacheTexture()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_Panel_20x8");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GeneratePanelBackground(20, 8, withBorder: false);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_Panel_20x8", result.SourcePath);
+        Assert.Single(generator.DrawCalls);
+        Assert.Equal(new Rectangle(0, 0, 20, 8), generator.DrawCalls[0].Destination);
+    }
+
+    [Fact]
+    public void GenerateBPMBackground_WhenLabelsEnabled_ShouldDrawPlaceholderAreas()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_BPMBackground_10x8");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateBPMBackground(10, 8, withLabels: true);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_BPMBackground_10x8", result.SourcePath);
+        Assert.Equal(14, generator.DrawCalls.Count);
+        Assert.Equal(new Rectangle(5, 5, 0, -1), generator.DrawCalls[^2].Destination);
+        Assert.Equal(new Rectangle(5, 4, 0, -1), generator.DrawCalls[^1].Destination);
+    }
+
+    [Fact]
+    public void GenerateButton_WhenPressed_ShouldDrawGradientAndBorder()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_Button_6x3");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        var result = generator.GenerateButton(6, 3, isPressed: true);
+
+        Assert.Same(texture.Object, result);
+        Assert.Equal("Generated_Button_6x3", result.SourcePath);
+        Assert.Equal(7, generator.DrawCalls.Count);
+        Assert.Equal(Color.White, generator.DrawCalls[^1].Color);
     }
 
     [Fact]
@@ -166,15 +363,36 @@ public class DefaultGraphicsGeneratorLogicTests
         return generator;
     }
 
+    private static TestableDefaultGraphicsGenerator CreateTestableGenerator()
+    {
+        var generator = (TestableDefaultGraphicsGenerator)RuntimeHelpers.GetUninitializedObject(typeof(TestableDefaultGraphicsGenerator));
+        ReflectionHelpers.SetPrivateField(generator, "_graphicsDevice", (GraphicsDevice)RuntimeHelpers.GetUninitializedObject(typeof(GraphicsDevice)));
+        ReflectionHelpers.SetPrivateField(generator, "_generatedTextures", new Dictionary<string, ITexture>());
+        ReflectionHelpers.SetPrivateField(generator, "_renderTarget", (RenderTarget2D)RuntimeHelpers.GetUninitializedObject(typeof(RenderTarget2D)));
+        ReflectionHelpers.SetPrivateField(generator, "_spriteBatch", null);
+        ReflectionHelpers.SetPrivateField(generator, "_whitePixel", null);
+        ReflectionHelpers.SetPrivateField(generator, "_disposed", false);
+        SetAutoProperty(generator, "ClearColors", new List<Color>());
+        SetAutoProperty(generator, "DrawCalls", new List<DrawCall>());
+        return generator;
+    }
+
     private static Dictionary<string, ITexture> GetTextureCache(DefaultGraphicsGenerator generator)
     {
         return ReflectionHelpers.GetPrivateField<Dictionary<string, ITexture>>(generator, "_generatedTextures")!;
     }
 
-    private static Mock<ITexture> CreateTextureMock()
+    private static Mock<ITexture> CreateTextureMock(string sourcePath = "generated")
     {
         var texture = new Mock<ITexture>();
-        texture.SetupGet(x => x.SourcePath).Returns("generated");
+        texture.SetupGet(x => x.SourcePath).Returns(sourcePath);
         return texture;
+    }
+
+    private static void SetAutoProperty(object target, string propertyName, object value)
+    {
+        var field = target.GetType().GetField($"<{propertyName}>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+        field!.SetValue(target, value);
     }
 }

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -203,21 +203,21 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal(new Rectangle(0, 0, 20, 8), generator.DrawCalls[0].Destination);
     }
 
-    [Fact]
-    public void GenerateBPMBackground_WhenLabelsEnabled_ShouldDrawPlaceholderAreas()
-    {
-        var generator = CreateTestableGenerator();
-        var texture = CreateTextureMock("Generated_BPMBackground_10x8");
-        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+        [Fact]
+        public void GenerateBPMBackground_WhenLabelsEnabled_ShouldDrawPlaceholderAreas()
+        {
+            var generator = CreateTestableGenerator();
+            var texture = CreateTextureMock("Generated_BPMBackground_8x8");
+            generator.CreateGeneratedTextureHandler = _ => texture.Object;
 
-        var result = generator.GenerateBPMBackground(10, 8, withLabels: true);
+            var result = generator.GenerateBPMBackground(8, 8, withLabels: true);
 
-        Assert.Same(texture.Object, result);
-        Assert.Equal("Generated_BPMBackground_10x8", result.SourcePath);
-        Assert.Equal(14, generator.DrawCalls.Count);
-        Assert.Equal(new Rectangle(5, 5, 0, -1), generator.DrawCalls[^2].Destination);
-        Assert.Equal(new Rectangle(5, 4, 0, -1), generator.DrawCalls[^1].Destination);
-    }
+            Assert.Same(texture.Object, result);
+            Assert.Equal("Generated_BPMBackground_8x8", result.SourcePath);
+            Assert.Equal(14, generator.DrawCalls.Count);
+            Assert.Equal(new Rectangle(5, 5, 0, 0), generator.DrawCalls[^2].Destination);
+            Assert.Equal(new Rectangle(5, 4, 0, 0), generator.DrawCalls[^1].Destination);
+        }
 
     [Fact]
     public void GenerateButton_WhenPressed_ShouldDrawGradientAndBorder()

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -477,14 +477,14 @@ public class DefaultGraphicsGeneratorLogicTests
 
         generator.PreGenerateCommonTextures(panelWidth: 0, panelHeight: 0, barWidth: 510, barHeight: 48);
 
-        // 3 BarType values x 3 states = 9 bar textures, no panel
-        Assert.Equal(9, generator.CreateGeneratedTextureCalls.Count);
+        // 3 BarType values x 4 (isSelected, isCenter) states = 12 bar textures, no panel
+        Assert.Equal(12, generator.CreateGeneratedTextureCalls.Count);
         Assert.All(generator.CreateGeneratedTextureCalls, call =>
         {
             Assert.Equal(510, call.Width);
             Assert.Equal(48, call.Height);
         });
-        Assert.Equal(9, generator.SetRenderTargetCount);
+        Assert.Equal(12, generator.SetRenderTargetCount);
 
         // Verify subsequent draw-time calls hit cache
         var countBefore = generator.SetRenderTargetCount;
@@ -506,9 +506,9 @@ public class DefaultGraphicsGeneratorLogicTests
 
         generator.PreGenerateCommonTextures(panelWidth: 580, panelHeight: 320, barWidth: 510, barHeight: 48);
 
-        // 1 panel + 3 BarType x 3 states = 10 total
-        Assert.Equal(10, generator.CreateGeneratedTextureCalls.Count);
-        Assert.Equal(10, generator.SetRenderTargetCount);
+        // 1 panel + 3 BarType x 4 (isSelected, isCenter) states = 13 total
+        Assert.Equal(13, generator.CreateGeneratedTextureCalls.Count);
+        Assert.Equal(13, generator.SetRenderTargetCount);
     }
 
     [Fact]

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -442,6 +442,87 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Single(textures);
     }
 
+    [Fact]
+    public void PreGenerateCommonTextures_WhenPanelDimensionsProvided_ShouldCachePanelBackground()
+    {
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock("Generated_Panel_580x320");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        generator.PreGenerateCommonTextures(panelWidth: 580, panelHeight: 320, barWidth: 0, barHeight: 0);
+
+        // Only panel background should be generated (bar dimensions are 0)
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(("Generated_Panel_580x320", 580, 320), generator.CreateGeneratedTextureCalls[0]);
+        Assert.Equal(1, generator.SetRenderTargetCount);
+        Assert.Equal(1, generator.RestoreRenderTargetsCount);
+
+        // Verify cached so subsequent draw-time calls don't trigger additional SetRenderTarget
+        var countBefore = generator.SetRenderTargetCount;
+        var cachedResult = generator.GeneratePanelBackground(580, 320, true);
+        Assert.Same(texture.Object, cachedResult);
+        Assert.Equal(countBefore, generator.SetRenderTargetCount);
+    }
+
+    [Fact]
+    public void PreGenerateCommonTextures_WhenBarDimensionsProvided_ShouldCacheAllBarTypesAndStates()
+    {
+        var generator = CreateTestableGenerator();
+        var textureIdx = 0;
+        generator.CreateGeneratedTextureHandler = _ =>
+        {
+            var t = CreateTextureMock($"Generated_{textureIdx++}");
+            return t.Object;
+        };
+
+        generator.PreGenerateCommonTextures(panelWidth: 0, panelHeight: 0, barWidth: 510, barHeight: 48);
+
+        // 3 BarType values x 3 states = 9 bar textures, no panel
+        Assert.Equal(9, generator.CreateGeneratedTextureCalls.Count);
+        Assert.All(generator.CreateGeneratedTextureCalls, call =>
+        {
+            Assert.Equal(510, call.Width);
+            Assert.Equal(48, call.Height);
+        });
+        Assert.Equal(9, generator.SetRenderTargetCount);
+
+        // Verify subsequent draw-time calls hit cache
+        var countBefore = generator.SetRenderTargetCount;
+        var cachedResult = generator.GenerateBarTypeBackground(510, 48, BarType.Score, false, false);
+        Assert.NotNull(cachedResult);
+        Assert.Equal(countBefore, generator.SetRenderTargetCount);
+    }
+
+    [Fact]
+    public void PreGenerateCommonTextures_WhenBothDimensionsProvided_ShouldGenerateAllTextures()
+    {
+        var generator = CreateTestableGenerator();
+        var textureIdx = 0;
+        generator.CreateGeneratedTextureHandler = _ =>
+        {
+            var t = CreateTextureMock($"Generated_{textureIdx++}");
+            return t.Object;
+        };
+
+        generator.PreGenerateCommonTextures(panelWidth: 580, panelHeight: 320, barWidth: 510, barHeight: 48);
+
+        // 1 panel + 3 BarType x 3 states = 10 total
+        Assert.Equal(10, generator.CreateGeneratedTextureCalls.Count);
+        Assert.Equal(10, generator.SetRenderTargetCount);
+    }
+
+    [Fact]
+    public void PreGenerateCommonTextures_WhenAllDimensionsZero_ShouldNotGenerateAnything()
+    {
+        var generator = CreateTestableGenerator();
+        generator.CreateGeneratedTextureHandler = _ => CreateTextureMock().Object;
+
+        generator.PreGenerateCommonTextures(panelWidth: 0, panelHeight: 0, barWidth: 0, barHeight: 0);
+
+        Assert.Empty(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(0, generator.SetRenderTargetCount);
+    }
+
     private static DefaultGraphicsGenerator CreateGenerator(GraphicsDevice? graphicsDevice = null)
     {
         var generator = (DefaultGraphicsGenerator)RuntimeHelpers.GetUninitializedObject(typeof(DefaultGraphicsGenerator));

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -25,6 +25,7 @@ public class DefaultGraphicsGeneratorLogicTests
         public int SetRenderTargetCount { get; private set; }
         public int RestoreRenderTargetsCount { get; private set; }
         public Func<string, ITexture>? CreateGeneratedTextureHandler { get; set; }
+        public List<(string SourcePath, int Width, int Height)> CreateGeneratedTextureCalls { get; } = new();
 
         public TestableDefaultGraphicsGenerator()
             : base(
@@ -53,9 +54,12 @@ public class DefaultGraphicsGeneratorLogicTests
             RestoreRenderTargetsCount++;
         }
 
-        protected override ITexture CreateGeneratedTexture(string sourcePath)
-            => CreateGeneratedTextureHandler?.Invoke(sourcePath)
+        protected override ITexture CreateGeneratedTexture(string sourcePath, int width, int height)
+        {
+            CreateGeneratedTextureCalls.Add((sourcePath, width, height));
+            return CreateGeneratedTextureHandler?.Invoke(sourcePath)
                 ?? throw new InvalidOperationException("CreateGeneratedTextureHandler was not configured.");
+        }
     }
 
     [Fact]
@@ -123,6 +127,8 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal(new Rectangle(0, 1, 4, 2), generator.DrawCalls[4].Destination);
         Assert.Equal(Color.Yellow, generator.DrawCalls[4].Color);
         Assert.Same(texture.Object, GetTextureCache(generator)["SongBar_4x3_False_True"]);
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(("Generated_SongBar_4x3", 4, 3), generator.CreateGeneratedTextureCalls[0]);
     }
 
     [Fact]
@@ -158,6 +164,9 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal(DTXManiaVisualTheme.Layout.ClearLampHeight + 4, generator.DrawCalls.Count);
         Assert.All(generator.DrawCalls[^4..], drawCall => Assert.Equal(Color.Gray, drawCall.Color));
         Assert.Same(texture.Object, GetTextureCache(generator)["ClearLamp_3_False"]);
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(DTXManiaVisualTheme.Layout.ClearLampWidth, generator.CreateGeneratedTextureCalls[0].Width);
+        Assert.Equal(DTXManiaVisualTheme.Layout.ClearLampHeight, generator.CreateGeneratedTextureCalls[0].Height);
     }
 
     [Fact]
@@ -173,6 +182,8 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal("Generated_EnhancedClearLamp_1_NotPlayed", result.SourcePath);
         Assert.Equal(24, generator.DrawCalls.Count);
         Assert.Same(texture.Object, GetTextureCache(generator)["EnhancedClearLamp_1_NotPlayed"]);
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(("Generated_EnhancedClearLamp_1_NotPlayed", 8, 24), generator.CreateGeneratedTextureCalls[0]);
     }
 
     [Fact]
@@ -204,6 +215,8 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal(13, generator.DrawCalls.Count);
         Assert.Equal(Color.Cyan * 0.7f, generator.DrawCalls[^1].Color);
         Assert.Equal(new Rectangle(2, 2, 4, 4), generator.DrawCalls[^1].Destination);
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(("Generated_BarType_Box_10x8", 10, 8), generator.CreateGeneratedTextureCalls[0]);
     }
 
     [Fact]
@@ -236,6 +249,8 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal("Generated_Panel_20x8", result.SourcePath);
         Assert.Single(generator.DrawCalls);
         Assert.Equal(new Rectangle(0, 0, 20, 8), generator.DrawCalls[0].Destination);
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(("Generated_Panel_20x8", 20, 8), generator.CreateGeneratedTextureCalls[0]);
     }
 
         [Fact]
@@ -252,6 +267,8 @@ public class DefaultGraphicsGeneratorLogicTests
             Assert.Equal(14, generator.DrawCalls.Count);
             Assert.Equal(new Rectangle(5, 5, 0, 0), generator.DrawCalls[^2].Destination);
             Assert.Equal(new Rectangle(5, 4, 0, 0), generator.DrawCalls[^1].Destination);
+            Assert.Single(generator.CreateGeneratedTextureCalls);
+            Assert.Equal(("Generated_BPMBackground_8x8", 8, 8), generator.CreateGeneratedTextureCalls[0]);
         }
 
     [Fact]
@@ -267,6 +284,45 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Equal("Generated_Button_6x3", result.SourcePath);
         Assert.Equal(7, generator.DrawCalls.Count);
         Assert.Equal(Color.White, generator.DrawCalls[^1].Color);
+    }
+
+    [Theory]
+    [InlineData(187, 67, "BPMBackground")]
+    [InlineData(800, 48, "SongBar")]
+    [InlineData(640, 96, "BarType")]
+    [InlineData(200, 80, "Panel")]
+    [InlineData(7, 41, "ClearLamp")]
+    public void CreateGeneratedTexture_ShouldPassRequestedDimensions_NotRenderTargetSize(int width, int height, string method)
+    {
+        // Verifies the fix for the bug where CreateGeneratedTexture copied the
+        // full 1024x1024 render target instead of cropping to requested size.
+        var generator = CreateTestableGenerator();
+        var texture = CreateTextureMock($"Generated_{method}_{width}x{height}");
+        generator.CreateGeneratedTextureHandler = _ => texture.Object;
+
+        switch (method)
+        {
+            case "SongBar":
+                generator.GenerateSongBarBackground(width, height);
+                break;
+            case "BarType":
+                generator.GenerateBarTypeBackground(width, height, BarType.Score);
+                break;
+            case "Panel":
+                generator.GeneratePanelBackground(width, height);
+                break;
+            case "BPMBackground":
+                generator.GenerateBPMBackground(width, height);
+                break;
+            case "ClearLamp":
+                // ClearLamp uses fixed dimensions from layout, not caller-specified
+                generator.GenerateClearLamp(0);
+                return;
+        }
+
+        Assert.Single(generator.CreateGeneratedTextureCalls);
+        Assert.Equal(width, generator.CreateGeneratedTextureCalls[0].Width);
+        Assert.Equal(height, generator.CreateGeneratedTextureCalls[0].Height);
     }
 
     [Fact]
@@ -409,6 +465,7 @@ public class DefaultGraphicsGeneratorLogicTests
         ReflectionHelpers.SetPrivateField(generator, "_disposed", false);
         SetAutoProperty(generator, "ClearColors", new List<Color>());
         SetAutoProperty(generator, "DrawCalls", new List<DrawCall>());
+        SetAutoProperty(generator, "CreateGeneratedTextureCalls", new List<(string, int, int)>());
         return generator;
     }
 

--- a/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
+++ b/DTXMania.Test/UI/DefaultGraphicsGeneratorLogicTests.cs
@@ -70,6 +70,24 @@ public class DefaultGraphicsGeneratorLogicTests
         Assert.Same(graphicsDevice, generator.GraphicsDevice);
     }
 
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(1, 0)]
+    [InlineData(-1, 1)]
+    [InlineData(1, -1)]
+    [InlineData(0, 0)]
+    [InlineData(-1, -1)]
+    public void GenerateMethods_WhenDimensionsAreNonPositive_ShouldThrowArgumentOutOfRangeException(int width, int height)
+    {
+        var generator = CreateTestableGenerator();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => generator.GenerateSongBarBackground(width, height, isSelected: false, isCenter: false));
+        Assert.Throws<ArgumentOutOfRangeException>(() => generator.GenerateBarTypeBackground(width, height, BarType.Score, isSelected: false, isCenter: false));
+        Assert.Throws<ArgumentOutOfRangeException>(() => generator.GeneratePanelBackground(width, height, withBorder: true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => generator.GenerateBPMBackground(width, height, withLabels: true));
+        Assert.Throws<ArgumentOutOfRangeException>(() => generator.GenerateButton(width, height, isPressed: false));
+    }
+
     [Fact]
     public void GenerateSongBarBackground_WhenCenterNotCached_ShouldDrawGradientCenterBordersAndCacheTexture()
     {

--- a/DTXMania.Test/UI/UIContainerAdditionalTests.cs
+++ b/DTXMania.Test/UI/UIContainerAdditionalTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
 using DTXMania.Game.Lib.UI;
 using Xunit;
 using System;
@@ -356,6 +358,94 @@ namespace DTXMania.Test.UI
             Assert.True(child.IsActive);
         }
 
+        [Fact]
+        public void Update_WhenActiveChildExists_ShouldUpdateChild()
+        {
+            var container = new UIContainer();
+            var child = new TrackingUIElement();
+            container.AddChild(child);
+            container.Activate();
+
+            container.Update(0.016);
+
+            Assert.Equal(1, child.UpdateCallCount);
+        }
+
+        [Fact]
+        public void Draw_WhenActiveVisibleChildExists_ShouldDrawChild()
+        {
+            var container = new UIContainer();
+            var child = new DrawTrackingElement();
+            container.AddChild(child);
+            container.Activate();
+
+            container.Draw(null!, 0.016);
+
+            Assert.Equal(1, child.DrawCallCount);
+        }
+
+        [Fact]
+        public void HandleInput_WhenTopMostChildHandles_ShouldStopTraversal()
+        {
+            var container = new UIContainer();
+            var lowerChild = new InputTrackingElement { ShouldHandleInput = true };
+            var topMostChild = new InputTrackingElement { ShouldHandleInput = true };
+            container.AddChild(lowerChild);
+            container.AddChild(topMostChild);
+            container.Activate();
+
+            var inputState = new Mock<IInputState>();
+            inputState.Setup(state => state.IsMouseButtonPressed(MouseButton.Left)).Returns(false);
+
+            var handled = container.HandleInput(inputState.Object);
+
+            Assert.True(handled);
+            Assert.Equal(0, lowerChild.HandleInputCallCount);
+            Assert.Equal(1, topMostChild.HandleInputCallCount);
+        }
+
+        [Fact]
+        public void HandleInput_WhenNoChildHandles_ShouldReturnFalseAfterCheckingEachChild()
+        {
+            var container = new UIContainer();
+            var firstChild = new InputTrackingElement();
+            var secondChild = new InputTrackingElement();
+            container.AddChild(firstChild);
+            container.AddChild(secondChild);
+            container.Activate();
+
+            var inputState = new Mock<IInputState>();
+            inputState.Setup(state => state.IsMouseButtonPressed(MouseButton.Left)).Returns(false);
+
+            var handled = container.HandleInput(inputState.Object);
+
+            Assert.False(handled);
+            Assert.Equal(1, firstChild.HandleInputCallCount);
+            Assert.Equal(1, secondChild.HandleInputCallCount);
+        }
+
         #endregion
+
+        private sealed class DrawTrackingElement : UIElement
+        {
+            public int DrawCallCount { get; private set; }
+
+            protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
+            {
+                DrawCallCount++;
+            }
+        }
+
+        private sealed class InputTrackingElement : UIElement
+        {
+            public int HandleInputCallCount { get; private set; }
+            public bool ShouldHandleInput { get; set; }
+
+            protected override bool OnHandleInput(IInputState inputState)
+            {
+                HandleInputCallCount++;
+                return ShouldHandleInput;
+            }
+        }
     }
 }

--- a/DTXMania.Test/UI/UIContainerAdditionalTests.cs
+++ b/DTXMania.Test/UI/UIContainerAdditionalTests.cs
@@ -384,12 +384,19 @@ namespace DTXMania.Test.UI
             Assert.Equal(1, child.DrawCallCount);
         }
 
-        [Fact]
-        public void HandleInput_WhenTopMostChildHandles_ShouldStopTraversal()
+        [Theory]
+        [InlineData(true, true, true, 0, 1)]
+        [InlineData(false, false, false, 1, 1)]
+        public void HandleInput_ShouldRespectChildTraversalOrder(
+            bool lowerChildHandles,
+            bool topMostChildHandles,
+            bool expectedHandled,
+            int expectedLowerCalls,
+            int expectedTopMostCalls)
         {
             var container = new UIContainer();
-            var lowerChild = new InputTrackingElement { ShouldHandleInput = true };
-            var topMostChild = new InputTrackingElement { ShouldHandleInput = true };
+            var lowerChild = new InputTrackingElement { ShouldHandleInput = lowerChildHandles };
+            var topMostChild = new InputTrackingElement { ShouldHandleInput = topMostChildHandles };
             container.AddChild(lowerChild);
             container.AddChild(topMostChild);
             container.Activate();
@@ -399,29 +406,23 @@ namespace DTXMania.Test.UI
 
             var handled = container.HandleInput(inputState.Object);
 
-            Assert.True(handled);
-            Assert.Equal(0, lowerChild.HandleInputCallCount);
-            Assert.Equal(1, topMostChild.HandleInputCallCount);
+            Assert.Equal(expectedHandled, handled);
+            Assert.Equal(expectedLowerCalls, lowerChild.HandleInputCallCount);
+            Assert.Equal(expectedTopMostCalls, topMostChild.HandleInputCallCount);
         }
 
         [Fact]
-        public void HandleInput_WhenNoChildHandles_ShouldReturnFalseAfterCheckingEachChild()
+        public void HandleInput_WhenInputStateIsNull_ShouldReturnFalseWithoutVisitingChildren()
         {
             var container = new UIContainer();
-            var firstChild = new InputTrackingElement();
-            var secondChild = new InputTrackingElement();
-            container.AddChild(firstChild);
-            container.AddChild(secondChild);
+            var child = new InputTrackingElement { ShouldHandleInput = true };
+            container.AddChild(child);
             container.Activate();
 
-            var inputState = new Mock<IInputState>();
-            inputState.Setup(state => state.IsMouseButtonPressed(MouseButton.Left)).Returns(false);
-
-            var handled = container.HandleInput(inputState.Object);
+            var handled = container.HandleInput(null!);
 
             Assert.False(handled);
-            Assert.Equal(1, firstChild.HandleInputCallCount);
-            Assert.Equal(1, secondChild.HandleInputCallCount);
+            Assert.Equal(0, child.HandleInputCallCount);
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- Add protected virtual methods (hooks) to `ManagedTexture`, `ResourceManager`, `PadRenderer`, `StartupStage`, and `DefaultGraphicsGenerator` so core logic can be tested without a real `GraphicsDevice`
- Expand unit test coverage across render target management, resource management, pad rendering, startup stage lifecycle, JSON-RPC server, and UI components (21 files changed, +4052 / -184 lines)
- Add 3 new test files: `GraphicsManagerLogicTests`, `JsonRpcServerInternalTests`, `PerformanceRendererStateTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad unit and integration tests across graphics, rendering, resources, staging, and JSON‑RPC to increase coverage and reliability.

* **Chores**
  * Introduced extensibility hooks and safer texture/render target creation paths to allow customization and testing without public API changes.

* **Bug Fixes**
  * Strengthened null/invalid‑input handling, dimension validation, and startup/popups draw paths to avoid crashes and improve robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->