### PR TITLE
test: add comprehensive test coverage for Game1 and performance stage

### DIFF
--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -64,6 +64,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
     private JsonRpcServer? _jsonRpcServer;
     private GameApiImplementation? _gameApiImplementation;
     private CancellationTokenSource? _gameApiCancellation;
+    private Task? _gameApiStartTask;
 
     // Main-thread action queue for thread-safe game API calls
     private readonly ConcurrentQueue<Action> _mainThreadActions = new();
@@ -187,7 +188,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         if (TryInitializeGameApi(config))
         {
             // Start API server with proper error handling
-            _ = StartGameApiServerAsync();
+            _gameApiStartTask = StartGameApiServerAsync();
         }
     }
 
@@ -203,7 +204,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
             return false;
 
         // Security: Validate API key is present when API is enabled
-        if (string.IsNullOrEmpty(config.GameApiKey))
+        if (string.IsNullOrWhiteSpace(config.GameApiKey))
         {
             _logger.LogWarning("Game API is enabled but no API key is configured. " +
                               "API server will not start. Please set GameApiKey in Config.ini or " +
@@ -431,7 +432,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         if (StageManager != null)
         {
             StageManager.Dispose();
-            StageManager = null;
+            StageManager = null!;
         }
 
         // Dispose other managers
@@ -450,6 +451,26 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         if (_gameApiCancellation is not null)
         {
             _gameApiCancellation.Cancel();
+        }
+
+        if (_gameApiStartTask is not null)
+        {
+            try
+            {
+                _gameApiStartTask.GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error waiting for JSON-RPC server startup to complete");
+            }
+            finally
+            {
+                _gameApiStartTask = null;
+            }
+        }
+
+        if (_gameApiCancellation is not null)
+        {
             _gameApiCancellation.Dispose();
             _gameApiCancellation = null;
         }

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -148,8 +148,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         InputManager = new InputManagerCompat(ConfigManager);
 
         // Apply saved system key bindings on top of defaults
-        if (ConfigManager is ConfigManager concreteConfig)
-            concreteConfig.LoadSystemKeyBindings(InputManager);
+        ApplySavedSystemKeyBindings();
 
         // Initialize graphics manager after base initialization
         _graphicsManager.Initialize();
@@ -185,25 +184,37 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         StageManager?.ChangeStage(StageType.Startup);
 
         // Initialize Game API server for MCP communication if enabled
-        if (config.EnableGameApi)
+        if (TryInitializeGameApi(config))
         {
-            // Security: Validate API key is present when API is enabled
-            if (string.IsNullOrEmpty(config.GameApiKey))
-            {
-                _logger.LogWarning("Game API is enabled but no API key is configured. " +
-                                  "API server will not start. Please set GameApiKey in Config.ini or " +
-                                  "delete Config.ini to auto-generate a secure key.");
-            }
-            else
-            {
-                _gameApiImplementation = new GameApiImplementation(this, _loggerFactory.CreateLogger<GameApiImplementation>());
-                _jsonRpcServer = new JsonRpcServer(_gameApiImplementation, config.GameApiPort, config.GameApiKey, _loggerFactory.CreateLogger<JsonRpcServer>());
-                _gameApiCancellation = new CancellationTokenSource();
-                
-                // Start API server with proper error handling
-                _ = StartGameApiServerAsync();
-            }
+            // Start API server with proper error handling
+            _ = StartGameApiServerAsync();
         }
+    }
+
+    private void ApplySavedSystemKeyBindings()
+    {
+        if (ConfigManager is ConfigManager concreteConfig)
+            concreteConfig.LoadSystemKeyBindings(InputManager);
+    }
+
+    private bool TryInitializeGameApi(ConfigData config)
+    {
+        if (!config.EnableGameApi)
+            return false;
+
+        // Security: Validate API key is present when API is enabled
+        if (string.IsNullOrEmpty(config.GameApiKey))
+        {
+            _logger.LogWarning("Game API is enabled but no API key is configured. " +
+                              "API server will not start. Please set GameApiKey in Config.ini or " +
+                              "delete Config.ini to auto-generate a secure key.");
+            return false;
+        }
+
+        _gameApiImplementation = new GameApiImplementation(this, _loggerFactory.CreateLogger<GameApiImplementation>());
+        _jsonRpcServer = new JsonRpcServer(_gameApiImplementation, config.GameApiPort, config.GameApiKey, _loggerFactory.CreateLogger<JsonRpcServer>());
+        _gameApiCancellation = new CancellationTokenSource();
+        return true;
     }
 
     private async Task StartGameApiServerAsync()
@@ -255,7 +266,13 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         // Update stage manager after config is loaded
         StageManager?.Update(gameTime.ElapsedGameTime.TotalSeconds);
 
-        // Drain the main-thread action queue (used by the Game API for stage transitions etc.)
+        DrainMainThreadActions();
+
+        base.Update(gameTime);
+    }
+
+    private void DrainMainThreadActions()
+    {
         // Cap at 64 actions per frame to prevent frame starvation
         const int MaxMainThreadActionsPerFrame = 64;
         int actionsProcessed = 0;
@@ -265,8 +282,6 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
             catch (Exception ex) { _logger.LogError(ex, "Main-thread action from Game API threw an exception"); }
             actionsProcessed++;
         }
-
-        base.Update(gameTime);
     }
 
     protected override void Draw(GameTime gameTime)
@@ -405,67 +420,72 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
     {
         if (disposing)
         {
-            // Dispose StageManager first to properly cleanup all stages
-            if (StageManager != null)
-            {
-                StageManager.Dispose();
-                StageManager = null;
-            }
-
-            // Dispose other managers
-            if (_graphicsManager != null)
-            {
-                _graphicsManager.SettingsChanged -= OnGraphicsSettingsChanged;
-                _graphicsManager.DeviceLost -= OnGraphicsDeviceLost;
-                _graphicsManager.DeviceReset -= OnGraphicsDeviceReset;
-                _graphicsManager.Dispose();
-            }
-
-            // Dispose resource manager
-            ResourceManager?.Dispose();
-
-            // Stop and dispose game API server
-            if (_gameApiCancellation is not null)
-            {
-                _gameApiCancellation.Cancel();
-                _gameApiCancellation.Dispose();
-                _gameApiCancellation = null;
-            }
-
-            if (_jsonRpcServer != null)
-            {
-                try
-                {
-                    // Use GetAwaiter().GetResult() instead of .Wait() to avoid potential deadlocks
-                    // This properly propagates exceptions and is safer in synchronous dispose contexts
-                    // Note: StopAsync has a built-in timeout, so we don't need an external CancellationToken
-                    _jsonRpcServer.StopAsync().GetAwaiter().GetResult();
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Error stopping JSON-RPC server");
-                }
-                finally
-                {
-                    _jsonRpcServer.Dispose();
-                    _jsonRpcServer = null;
-                }
-            }
-
-            // Complete any pending screenshot task to prevent callers from blocking indefinitely
-            var pendingScreenshot = Interlocked.Exchange(ref _pendingScreenshot, null);
-            if (pendingScreenshot != null)
-            {
-                try { pendingScreenshot.TrySetCanceled(); }
-                catch { /* Best effort - task may already be completed */ }
-            }
-
-            // Dispose other resources
-            _spriteBatch?.Dispose();
-            _renderTarget?.Dispose();
-            _loggerFactory.Dispose();
+            DisposeManagedResources();
         }
         base.Dispose(disposing);
+    }
+
+    private void DisposeManagedResources()
+    {
+        // Dispose StageManager first to properly cleanup all stages
+        if (StageManager != null)
+        {
+            StageManager.Dispose();
+            StageManager = null;
+        }
+
+        // Dispose other managers
+        if (_graphicsManager != null)
+        {
+            _graphicsManager.SettingsChanged -= OnGraphicsSettingsChanged;
+            _graphicsManager.DeviceLost -= OnGraphicsDeviceLost;
+            _graphicsManager.DeviceReset -= OnGraphicsDeviceReset;
+            _graphicsManager.Dispose();
+        }
+
+        // Dispose resource manager
+        ResourceManager?.Dispose();
+
+        // Stop and dispose game API server
+        if (_gameApiCancellation is not null)
+        {
+            _gameApiCancellation.Cancel();
+            _gameApiCancellation.Dispose();
+            _gameApiCancellation = null;
+        }
+
+        if (_jsonRpcServer != null)
+        {
+            try
+            {
+                // Use GetAwaiter().GetResult() instead of .Wait() to avoid potential deadlocks
+                // This properly propagates exceptions and is safer in synchronous dispose contexts
+                // Note: StopAsync has a built-in timeout, so we don't need an external CancellationToken
+                _jsonRpcServer.StopAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error stopping JSON-RPC server");
+            }
+            finally
+            {
+                _jsonRpcServer.Dispose();
+                _jsonRpcServer = null;
+            }
+        }
+
+        // Complete any pending screenshot task to prevent callers from blocking indefinitely
+        var pendingScreenshot = Interlocked.Exchange(ref _pendingScreenshot, null);
+        if (pendingScreenshot != null)
+        {
+            try { pendingScreenshot.TrySetCanceled(); }
+            catch { /* Best effort - task may already be completed */ }
+        }
+
+        // Dispose other resources
+        _spriteBatch?.Dispose();
+        _renderTarget?.Dispose();
+        _loggerFactory.Dispose();
     }
 }
 

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -262,38 +262,15 @@ namespace DTXMania.Test
             Assert.Null(exception);
         }
 
-        [Fact]
-        public void TryInitializeGameApi_WhenApiIsDisabled_ShouldLeaveServerStateUnset()
+        [Theory]
+        [InlineData(false, "ignored", "API disabled")]
+        [InlineData(true, null, "API key null")]
+        [InlineData(true, "", "API key empty")]
+        [InlineData(true, "   ", "API key whitespace")]
+        public void TryInitializeGameApi_WhenConfigurationIsInvalid_ShouldLeaveServerStateUnset(
+            bool enableGameApi, string? gameApiKey, string testCase)
         {
-            var config = new ConfigData { EnableGameApi = false, GameApiKey = "ignored", GameApiPort = 12345 };
-            var game = CreateGameForLifecycle(config);
-
-            var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
-
-            Assert.False(initialized);
-            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiImplementation"));
-            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
-            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
-        }
-
-        [Fact]
-        public void TryInitializeGameApi_WhenApiKeyIsMissing_ShouldLeaveServerStateUnset()
-        {
-            var config = new ConfigData { EnableGameApi = true, GameApiKey = string.Empty, GameApiPort = 12345 };
-            var game = CreateGameForLifecycle(config);
-
-            var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
-
-            Assert.False(initialized);
-            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiImplementation"));
-            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
-            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
-        }
-
-        [Fact]
-        public void TryInitializeGameApi_WhenApiKeyIsWhitespace_ShouldLeaveServerStateUnset()
-        {
-            var config = new ConfigData { EnableGameApi = true, GameApiKey = "   ", GameApiPort = 12345 };
+            var config = new ConfigData { EnableGameApi = enableGameApi, GameApiKey = gameApiKey!, GameApiPort = 12345 };
             var game = CreateGameForLifecycle(config);
 
             var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
@@ -501,9 +478,11 @@ namespace DTXMania.Test
             ReflectionHelpers.SetPrivateField(game, "_gameApiStartTask", startTaskSource.Task);
 
             var disposeTask = Task.Run(() => ReflectionHelpers.InvokePrivateMethod(game, "DisposeManagedResources"));
-            await Task.Delay(100);
 
-            Assert.False(disposeTask.IsCompleted);
+            // Give the dispose thread time to reach the blocking GetAwaiter().GetResult() call,
+            // then use WhenAny with a timeout to verify it hasn't completed (still waiting on startTaskSource)
+            var raceResult = await Task.WhenAny(disposeTask, Task.Delay(500));
+            Assert.NotSame(disposeTask, raceResult);
             host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Never);
 
             startTaskSource.SetResult();
@@ -563,12 +542,6 @@ namespace DTXMania.Test
             }
 
             public (string Name, int Width, int Height)? LastRequest { get; private set; }
-
-            public new RenderTarget2D GetOrCreateRenderTarget(string name, int width, int height, SurfaceFormat format = SurfaceFormat.Color, DepthFormat depthFormat = DepthFormat.None, int multiSampleCount = 0)
-            {
-                LastRequest = (name, width, height);
-                return _renderTarget;
-            }
 
             protected override RenderTarget2D CreateRenderTarget(int width, int height, SurfaceFormat format, DepthFormat depthFormat, int multiSampleCount)
             {

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -1,16 +1,22 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
 using DTXMania.Game.Lib;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Graphics;
 using DTXMania.Game.Lib.JsonRpc;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage;
 using DTXMania.Test.TestData;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using Moq;
 
 namespace DTXMania.Test
@@ -225,6 +231,246 @@ namespace DTXMania.Test
             Assert.Null(ex);
         }
 
+        [Fact]
+        public void ApplySavedSystemKeyBindings_WhenConfigManagerIsConcrete_ShouldLoadPersistedBindings()
+        {
+            var configManager = new ConfigManager();
+            configManager.Config.SystemKeyBindings["SystemKey.Activate"] = Keys.F1.ToString();
+            var inputManager = new InputManagerCompat(configManager);
+            var game = ReflectionHelpers.CreateGame();
+            using var loggerFactory = LoggerFactory.Create(builder => { });
+
+            ReflectionHelpers.SetPrivateField(game, "_loggerFactory", loggerFactory);
+            ReflectionHelpers.SetPrivateField(game, "_logger", loggerFactory.CreateLogger<BaseGame>());
+            ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", configManager);
+            ReflectionHelpers.SetPrivateField(game, "<InputManager>k__BackingField", inputManager);
+
+            ReflectionHelpers.InvokePrivateMethod(game, "ApplySavedSystemKeyBindings");
+
+            var snapshot = inputManager.GetKeyMappingSnapshot();
+            Assert.Equal(InputCommandType.Activate, snapshot[Keys.F1]);
+            Assert.DoesNotContain(Keys.Enter, snapshot.Keys);
+        }
+
+        [Fact]
+        public void ApplySavedSystemKeyBindings_WhenConfigManagerIsInterfaceOnly_ShouldDoNothing()
+        {
+            var game = CreateGameForLifecycle();
+
+            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(game, "ApplySavedSystemKeyBindings"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void TryInitializeGameApi_WhenApiIsDisabled_ShouldLeaveServerStateUnset()
+        {
+            var config = new ConfigData { EnableGameApi = false, GameApiKey = "ignored", GameApiPort = 12345 };
+            var game = CreateGameForLifecycle(config);
+
+            var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
+
+            Assert.False(initialized);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiImplementation"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
+        }
+
+        [Fact]
+        public void TryInitializeGameApi_WhenApiKeyIsMissing_ShouldLeaveServerStateUnset()
+        {
+            var config = new ConfigData { EnableGameApi = true, GameApiKey = string.Empty, GameApiPort = 12345 };
+            var game = CreateGameForLifecycle(config);
+
+            var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
+
+            Assert.False(initialized);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiImplementation"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
+        }
+
+        [Fact]
+        public void TryInitializeGameApi_WhenConfigurationIsValid_ShouldCreateServerComponents()
+        {
+            var config = new ConfigData { EnableGameApi = true, GameApiKey = "secret-key", GameApiPort = 12345 };
+            var game = CreateGameForLifecycle(config);
+
+            var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
+
+            Assert.True(initialized);
+            Assert.IsType<GameApiImplementation>(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiImplementation"));
+            Assert.IsType<JsonRpcServer>(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
+
+            var cancellation = ReflectionHelpers.GetPrivateField<CancellationTokenSource>(game, "_gameApiCancellation");
+            Assert.NotNull(cancellation);
+            Assert.False(cancellation!.IsCancellationRequested);
+
+            cancellation.Dispose();
+            (ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer") as IDisposable)?.Dispose();
+        }
+
+        [Fact]
+        public void DrainMainThreadActions_WhenActionsAreQueued_ShouldExecuteThemInOrder()
+        {
+            var game = CreateGameForLifecycle();
+            var context = (IGameContext)game;
+            var executionOrder = new List<int>();
+
+            context.QueueMainThreadAction(() => executionOrder.Add(1));
+            context.QueueMainThreadAction(() => executionOrder.Add(2));
+            context.QueueMainThreadAction(() => executionOrder.Add(3));
+
+            ReflectionHelpers.InvokePrivateMethod(game, "DrainMainThreadActions");
+
+            Assert.Equal(new[] { 1, 2, 3 }, executionOrder);
+            Assert.True(ReflectionHelpers.GetPrivateField<ConcurrentQueue<Action>>(game, "_mainThreadActions")!.IsEmpty);
+        }
+
+        [Fact]
+        public void DrainMainThreadActions_WhenActionThrows_ShouldContinueProcessingRemainingActions()
+        {
+            var game = CreateGameForLifecycle();
+            var context = (IGameContext)game;
+            var executionOrder = new List<int>();
+
+            context.QueueMainThreadAction(() => executionOrder.Add(1));
+            context.QueueMainThreadAction(() => throw new InvalidOperationException("boom"));
+            context.QueueMainThreadAction(() => executionOrder.Add(3));
+
+            ReflectionHelpers.InvokePrivateMethod(game, "DrainMainThreadActions");
+
+            Assert.Equal(new[] { 1, 3 }, executionOrder);
+            Assert.True(ReflectionHelpers.GetPrivateField<ConcurrentQueue<Action>>(game, "_mainThreadActions")!.IsEmpty);
+        }
+
+        [Fact]
+        public void DrainMainThreadActions_WhenMoreThanSixtyFourActionsAreQueued_ShouldLeaveTheRemainderForNextFrame()
+        {
+            var game = CreateGameForLifecycle();
+            var context = (IGameContext)game;
+            var executed = 0;
+
+            for (var i = 0; i < 70; i++)
+            {
+                context.QueueMainThreadAction(() => executed++);
+            }
+
+            ReflectionHelpers.InvokePrivateMethod(game, "DrainMainThreadActions");
+
+            Assert.Equal(64, executed);
+            Assert.Equal(6, ReflectionHelpers.GetPrivateField<ConcurrentQueue<Action>>(game, "_mainThreadActions")!.Count);
+        }
+
+        [Fact]
+        public void OnGraphicsSettingsChanged_WhenRenderTargetRecreationSucceeds_ShouldReplaceRenderTarget()
+        {
+            var config = new ConfigData { ScreenWidth = 640, ScreenHeight = 480, FullScreen = false, VSyncWait = true };
+            var fakeRenderTarget = ReflectionHelpers.CreateUninitialized<RenderTarget2D>();
+            var renderTargetManager = new RecordingRenderTargetManager(fakeRenderTarget);
+            var game = CreateGameForLifecycle(config);
+
+            ReflectionHelpers.SetPrivateField(game, "_graphicsManager", new StubGraphicsManager(isDeviceAvailable: true, renderTargetManager));
+            ReflectionHelpers.SetPrivateField(game, "_renderTarget", null);
+
+            var newSettings = new GraphicsSettings
+            {
+                Width = 1920,
+                Height = 1080,
+                IsFullscreen = true,
+                VSync = false
+            };
+
+            ReflectionHelpers.InvokePrivateMethod(
+                game,
+                "OnGraphicsSettingsChanged",
+                null!,
+                new GraphicsSettingsChangedEventArgs(new GraphicsSettings { Width = 640, Height = 480 }, newSettings));
+
+            Assert.Equal(1920, config.ScreenWidth);
+            Assert.Equal(1080, config.ScreenHeight);
+            Assert.True(config.FullScreen);
+            Assert.False(config.VSyncWait);
+            Assert.Same(fakeRenderTarget, ReflectionHelpers.GetPrivateField<object>(game, "_renderTarget"));
+            Assert.Equal(("MainRenderTarget", 1920, 1080), renderTargetManager.LastRequest);
+        }
+
+        [Fact]
+        public void OnGraphicsDeviceReset_WhenRenderTargetRecreationSucceeds_ShouldReplaceRenderTarget()
+        {
+            var config = new ConfigData { ScreenWidth = 1280, ScreenHeight = 720 };
+            var fakeRenderTarget = ReflectionHelpers.CreateUninitialized<RenderTarget2D>();
+            var renderTargetManager = new RecordingRenderTargetManager(fakeRenderTarget);
+            var game = CreateGameForLifecycle(config);
+
+            ReflectionHelpers.SetPrivateField(game, "_graphicsManager", new StubGraphicsManager(isDeviceAvailable: true, renderTargetManager));
+            ReflectionHelpers.SetPrivateField(game, "_renderTarget", null);
+
+            ReflectionHelpers.InvokePrivateMethod(game, "OnGraphicsDeviceReset", null!, EventArgs.Empty);
+
+            Assert.Same(fakeRenderTarget, ReflectionHelpers.GetPrivateField<object>(game, "_renderTarget"));
+            Assert.Equal(("MainRenderTarget", 1280, 720), renderTargetManager.LastRequest);
+        }
+
+        [Fact]
+        public void DisposeManagedResources_WhenServerStopsSuccessfully_ShouldDisposeCollaboratorsAndCancelPendingScreenshot()
+        {
+            var game = CreateGameForLifecycle();
+            var stageManager = new Mock<IStageManager>();
+            var resourceManager = new Mock<IResourceManager>();
+            var graphicsManager = new StubGraphicsManager(isDeviceAvailable: true, CreateFailingRenderTargetManager());
+            var pendingScreenshot = new TaskCompletionSource<byte[]?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var host = new Mock<IHost>();
+            host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            var cancellation = new CancellationTokenSource();
+            var server = CreateRunningJsonRpcServer(host, cancellation);
+
+            ReflectionHelpers.SetPrivateField(game, "<StageManager>k__BackingField", stageManager.Object);
+            ReflectionHelpers.SetPrivateField(game, "<ResourceManager>k__BackingField", resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(game, "_graphicsManager", graphicsManager);
+            ReflectionHelpers.SetPrivateField(game, "_pendingScreenshot", pendingScreenshot);
+            ReflectionHelpers.SetPrivateField(game, "_jsonRpcServer", server);
+            ReflectionHelpers.SetPrivateField(game, "_gameApiCancellation", cancellation);
+
+            ReflectionHelpers.InvokePrivateMethod(game, "DisposeManagedResources");
+
+            stageManager.Verify(value => value.Dispose(), Times.Once);
+            resourceManager.Verify(value => value.Dispose(), Times.Once);
+            host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+            host.Verify(value => value.Dispose(), Times.Once);
+            Assert.True(graphicsManager.DisposeCalled);
+            Assert.Equal(1, graphicsManager.SettingsChangedRemoveCount);
+            Assert.Equal(1, graphicsManager.DeviceLostRemoveCount);
+            Assert.Equal(1, graphicsManager.DeviceResetRemoveCount);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "<StageManager>k__BackingField"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
+            Assert.True(pendingScreenshot.Task.IsCanceled);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_pendingScreenshot"));
+        }
+
+        [Fact]
+        public void DisposeManagedResources_WhenServerStopThrows_ShouldStillDisposeServerAndClearState()
+        {
+            var game = CreateGameForLifecycle();
+            var host = new Mock<IHost>();
+            host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException("stop failed"));
+            var cancellation = new CancellationTokenSource();
+            var server = CreateRunningJsonRpcServer(host, cancellation);
+
+            ReflectionHelpers.SetPrivateField(game, "_graphicsManager", new StubGraphicsManager(isDeviceAvailable: true, CreateFailingRenderTargetManager()));
+            ReflectionHelpers.SetPrivateField(game, "_jsonRpcServer", server);
+            ReflectionHelpers.SetPrivateField(game, "_gameApiCancellation", cancellation);
+
+            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(game, "DisposeManagedResources"));
+
+            Assert.Null(exception);
+            host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+            host.Verify(value => value.Dispose(), Times.Once);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
+        }
+
         private static BaseGame CreateGameForLifecycle(ConfigData? config = null)
         {
             var game = ReflectionHelpers.CreateGame();
@@ -235,6 +481,18 @@ namespace DTXMania.Test
             ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", CreateConfigManager(config ?? new ConfigData()));
 
             return game;
+        }
+
+        private static JsonRpcServer CreateRunningJsonRpcServer(Mock<IHost> host, CancellationTokenSource cancellation)
+        {
+            var gameApi = new Mock<IGameApi>();
+            gameApi.SetupGet(api => api.IsRunning).Returns(true);
+
+            var server = new JsonRpcServer(gameApi.Object, port: 12345);
+            ReflectionHelpers.SetPrivateField(server, "_host", host.Object);
+            ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
+            ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
+            return server;
         }
 
         private static IConfigManager CreateConfigManager(ConfigData config)
@@ -252,6 +510,31 @@ namespace DTXMania.Test
             return new RenderTargetManager(graphicsDevice);
         }
 
+        private sealed class RecordingRenderTargetManager : RenderTargetManager
+        {
+            private readonly RenderTarget2D _renderTarget;
+
+            public RecordingRenderTargetManager(RenderTarget2D renderTarget)
+                : base(ReflectionHelpers.CreateUninitialized<GraphicsDevice>())
+            {
+                _renderTarget = renderTarget;
+            }
+
+            public (string Name, int Width, int Height)? LastRequest { get; private set; }
+
+            public new RenderTarget2D GetOrCreateRenderTarget(string name, int width, int height, SurfaceFormat format = SurfaceFormat.Color, DepthFormat depthFormat = DepthFormat.None, int multiSampleCount = 0)
+            {
+                LastRequest = (name, width, height);
+                return _renderTarget;
+            }
+
+            protected override RenderTarget2D CreateRenderTarget(int width, int height, SurfaceFormat format, DepthFormat depthFormat, int multiSampleCount)
+            {
+                LastRequest = ("MainRenderTarget", width, height);
+                return _renderTarget;
+            }
+        }
+
         private sealed class StubGraphicsManager : IGraphicsManager
         {
             public StubGraphicsManager(bool isDeviceAvailable, RenderTargetManager renderTargetManager)
@@ -265,10 +548,43 @@ namespace DTXMania.Test
             public bool IsDeviceAvailable { get; }
             public RenderTargetManager RenderTargetManager { get; }
             public bool DisposeCalled { get; private set; }
+            public int SettingsChangedRemoveCount { get; private set; }
+            public int DeviceLostRemoveCount { get; private set; }
+            public int DeviceResetRemoveCount { get; private set; }
 
-            public event EventHandler<GraphicsSettingsChangedEventArgs>? SettingsChanged;
-            public event EventHandler? DeviceLost;
-            public event EventHandler? DeviceReset;
+            private event EventHandler<GraphicsSettingsChangedEventArgs>? _settingsChanged;
+            private event EventHandler? _deviceLost;
+            private event EventHandler? _deviceReset;
+
+            public event EventHandler<GraphicsSettingsChangedEventArgs>? SettingsChanged
+            {
+                add => _settingsChanged += value;
+                remove
+                {
+                    SettingsChangedRemoveCount++;
+                    _settingsChanged -= value;
+                }
+            }
+
+            public event EventHandler? DeviceLost
+            {
+                add => _deviceLost += value;
+                remove
+                {
+                    DeviceLostRemoveCount++;
+                    _deviceLost -= value;
+                }
+            }
+
+            public event EventHandler? DeviceReset
+            {
+                add => _deviceReset += value;
+                remove
+                {
+                    DeviceResetRemoveCount++;
+                    _deviceReset -= value;
+                }
+            }
 
             public void Initialize()
             {

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -291,6 +291,20 @@ namespace DTXMania.Test
         }
 
         [Fact]
+        public void TryInitializeGameApi_WhenApiKeyIsWhitespace_ShouldLeaveServerStateUnset()
+        {
+            var config = new ConfigData { EnableGameApi = true, GameApiKey = "   ", GameApiPort = 12345 };
+            var game = CreateGameForLifecycle(config);
+
+            var initialized = Assert.IsType<bool>(ReflectionHelpers.InvokePrivateMethod(game, "TryInitializeGameApi", config));
+
+            Assert.False(initialized);
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiImplementation"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
+        }
+
+        [Fact]
         public void TryInitializeGameApi_WhenConfigurationIsValid_ShouldCreateServerComponents()
         {
             var config = new ConfigData { EnableGameApi = true, GameApiKey = "secret-key", GameApiPort = 12345 };
@@ -469,6 +483,34 @@ namespace DTXMania.Test
             host.Verify(value => value.Dispose(), Times.Once);
             Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_jsonRpcServer"));
             Assert.Null(ReflectionHelpers.GetPrivateField<object>(game, "_gameApiCancellation"));
+        }
+
+        [Fact]
+        public async Task DisposeManagedResources_WhenServerStartupIsStillRunning_ShouldWaitBeforeStoppingServer()
+        {
+            var game = CreateGameForLifecycle();
+            var host = new Mock<IHost>();
+            host.Setup(value => value.StopAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            var cancellation = new CancellationTokenSource();
+            var server = CreateRunningJsonRpcServer(host, cancellation);
+            var startTaskSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            ReflectionHelpers.SetPrivateField(game, "_graphicsManager", new StubGraphicsManager(isDeviceAvailable: true, CreateFailingRenderTargetManager()));
+            ReflectionHelpers.SetPrivateField(game, "_jsonRpcServer", server);
+            ReflectionHelpers.SetPrivateField(game, "_gameApiCancellation", cancellation);
+            ReflectionHelpers.SetPrivateField(game, "_gameApiStartTask", startTaskSource.Task);
+
+            var disposeTask = Task.Run(() => ReflectionHelpers.InvokePrivateMethod(game, "DisposeManagedResources"));
+            await Task.Delay(100);
+
+            Assert.False(disposeTask.IsCompleted);
+            host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Never);
+
+            startTaskSource.SetResult();
+            await disposeTask;
+
+            host.Verify(value => value.StopAsync(It.IsAny<CancellationToken>()), Times.Once);
+            host.Verify(value => value.Dispose(), Times.Once);
         }
 
         private static BaseGame CreateGameForLifecycle(ConfigData? config = null)

--- a/DTXMania.Test/Resources/ManagedFontLogicTests.cs
+++ b/DTXMania.Test/Resources/ManagedFontLogicTests.cs
@@ -345,6 +345,21 @@ public class ManagedFontLogicTests
     }
 
     [Fact]
+    public void DefaultCharacter_WhenSpriteFontExists_ShouldUpdateSpriteFontDefaultCharacter()
+    {
+        var spriteFont = CreateSpriteFont(
+            [('A', 10), ('?', 8)],
+            lineSpacing: 16,
+            defaultCharacter: '?');
+        var font = new ManagedFont(spriteFont, "SpriteFont", 16);
+
+        font.DefaultCharacter = 'A';
+
+        Assert.Equal('A', font.DefaultCharacter);
+        Assert.Equal('A', spriteFont.DefaultCharacter);
+    }
+
+    [Fact]
     public void MeasureString_WhenUsingCustomGlyphs_ShouldRespectGlyphWidthsAndNewlines()
     {
         var font = CreateManagedFont(
@@ -370,6 +385,36 @@ public class ManagedFontLogicTests
 
         ReflectionHelpers.SetPrivateField(font, "_disposed", true);
         Assert.Equal(Vector2.Zero, font.MeasureString("text"));
+    }
+
+    [Fact]
+    public void MeasureStringWrapped_WhenSpriteFontExists_ShouldReturnWrappedDimensions()
+    {
+        var spriteFont = CreateSpriteFont(
+            [('A', 10), ('B', 10), ('C', 10), (' ', 8)],
+            lineSpacing: 16);
+        var font = new ManagedFont(spriteFont, "SpriteFont", 16);
+
+        var size = font.MeasureStringWrapped("AA BB CCC", 30f);
+
+        Assert.Equal(new Vector2(30, 48), size);
+    }
+
+    [Fact]
+    public void GetCharacterBounds_WhenSpriteFontExists_ShouldTrackCharacterPositionsAndLineBreaks()
+    {
+        var spriteFont = CreateSpriteFont(
+            [('A', 10), ('B', 12), ('C', 8)],
+            lineSpacing: 16);
+        var font = new ManagedFont(spriteFont, "SpriteFont", 16);
+
+        var bounds = font.GetCharacterBounds("AB\nC");
+
+        Assert.Equal(4, bounds.Length);
+        Assert.Equal(new Rectangle(0, 0, 10, 16), bounds[0]);
+        Assert.Equal(new Rectangle(10, 0, 12, 16), bounds[1]);
+        Assert.Equal(Rectangle.Empty, bounds[2]);
+        Assert.Equal(new Rectangle(0, 16, 8, 16), bounds[3]);
     }
 
     [Fact]
@@ -472,6 +517,16 @@ public class ManagedFontLogicTests
         var font = CreateManagedFont();
 
         var exception = Assert.Throws<InvalidOperationException>(() => font.CreateTextTexture(null!, "text", new TextRenderOptions()));
+        Assert.Contains("shared RenderTarget", exception.Message);
+    }
+
+    [Fact]
+    public void CreateTextTexture_WithColorOverload_ShouldThrowInvalidOperationException()
+    {
+        var font = CreateManagedFont();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => font.CreateTextTexture(null!, "text", Color.White));
+
         Assert.Contains("shared RenderTarget", exception.Message);
     }
 
@@ -884,6 +939,32 @@ public class ManagedFontLogicTests
         cacheField!.SetValue(font, Activator.CreateInstance(cacheField.FieldType));
 
         return font;
+    }
+
+    private static SpriteFont CreateSpriteFont((char character, int width)[] glyphs, int lineSpacing = 16, char? defaultCharacter = null)
+    {
+        var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+        var glyphBounds = new List<Rectangle>();
+        var cropping = new List<Rectangle>();
+        var characters = new List<char>();
+        var kerning = new List<Vector3>();
+        var x = 0;
+
+        foreach (var (character, width) in glyphs.OrderBy(glyph => glyph.character))
+        {
+            glyphBounds.Add(new Rectangle(x, 0, width, lineSpacing));
+            cropping.Add(new Rectangle(0, 0, width, lineSpacing));
+            characters.Add(character);
+            kerning.Add(new Vector3(0, width, 0));
+            x += width;
+        }
+
+        return (SpriteFont)Activator.CreateInstance(
+            typeof(SpriteFont),
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: [texture, glyphBounds, cropping, characters, lineSpacing, 0f, kerning, defaultCharacter],
+            culture: null)!;
     }
 
     private static SpriteFont CreateUninitializedSpriteFont(int lineSpacing = 0)

--- a/DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+
+namespace DTXMania.Test.Stage.Performance;
+
+[Trait("Category", "Unit")]
+public class NoteRendererLogicTests
+{
+    [Fact]
+    public void SetScrollSpeed_WhenValueIsInvalid_ShouldThrowArgumentException()
+    {
+        var renderer = CreateRenderer();
+
+        Assert.Throws<ArgumentException>(() => renderer.SetScrollSpeed(0));
+    }
+
+    [Fact]
+    public void SetScrollSpeed_WhenValueIsValid_ShouldUpdateLookAheadAndPixelsPerMs()
+    {
+        var renderer = CreateRenderer();
+
+        renderer.SetScrollSpeed(200);
+
+        Assert.Equal(750.0, renderer.EffectiveLookAheadMs, 3);
+        Assert.Equal(renderer.JudgementY / 750.0, renderer.ScrollPixelsPerMs, 3);
+    }
+
+    [Fact]
+    public void SetBpm_WhenValueIsInvalid_ShouldThrowArgumentException()
+    {
+        var renderer = CreateRenderer();
+
+        Assert.Throws<ArgumentException>(() => renderer.SetBpm(0));
+    }
+
+    [Fact]
+    public void SetBpm_WhenValueIsValid_ShouldUpdateProperty()
+    {
+        var renderer = CreateRenderer();
+
+        renderer.SetBpm(180.0);
+
+        Assert.Equal(180.0, renderer.Bpm);
+    }
+
+    [Fact]
+    public void FilterVisibleNotes_WhenNotesAreNull_ShouldReturnEmpty()
+    {
+        var renderer = CreateRenderer();
+
+        var result = renderer.FilterVisibleNotes(null!, 1000.0);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterVisibleNotes_ShouldReturnOnlyNotesWithinVisibleWindow()
+    {
+        var renderer = CreateRenderer();
+        var notes = new[]
+        {
+            new Note { TimeMs = 799.0 },
+            new Note { TimeMs = 800.0 },
+            new Note { TimeMs = 2000.0 },
+            new Note { TimeMs = 2600.0 }
+        };
+
+        var result = renderer.FilterVisibleNotes(notes, 1000.0, 1000.0).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Contains(notes[1], result);
+        Assert.Contains(notes[2], result);
+    }
+
+    [Fact]
+    public void GetNoteScreenY_AndShouldDropNote_ShouldUseConfiguredScrollSpeed()
+    {
+        var renderer = CreateRenderer();
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 0.5);
+        var note = new Note { TimeMs = 1000.0 };
+
+        var y = renderer.GetNoteScreenY(1000.0, 900.0);
+
+        Assert.Equal(renderer.JudgementY - 50.0, y, 3);
+        Assert.False(renderer.ShouldDropNote(note, 1000.0));
+        Assert.True(renderer.ShouldDropNote(note, 1200.0));
+    }
+
+    [Fact]
+    public void Update_ShouldAdvanceAnimationAndDecayFlashAlpha()
+    {
+        var renderer = CreateReadyRenderer();
+        var flashAlpha = new[] { 1.0f, 0.005f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+        ReflectionHelpers.SetPrivateField(renderer, "_laneFlashAlpha", flashAlpha);
+
+        renderer.Update(0.1);
+
+        Assert.Equal(100.0, ReflectionHelpers.GetPrivateField<double>(renderer, "_animationTimeMs"), 3);
+        Assert.InRange(flashAlpha[0], 0.44f, 0.46f);
+        Assert.Equal(0.0f, flashAlpha[1]);
+    }
+
+    [Fact]
+    public void TriggerLaneFlash_WhenLaneIsValid_ShouldSetLaneAlphaToOne()
+    {
+        var renderer = CreateRenderer();
+        var flashAlpha = ReflectionHelpers.GetPrivateField<float[]>(renderer, "_laneFlashAlpha");
+
+        renderer.TriggerLaneFlash(3);
+
+        Assert.Equal(1.0f, flashAlpha[3]);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(PerformanceUILayout.LaneCount)]
+    public void TriggerLaneFlash_WhenLaneIsInvalid_ShouldLeaveFlashAlphaUnchanged(int laneIndex)
+    {
+        var renderer = CreateRenderer();
+        var flashAlpha = ReflectionHelpers.GetPrivateField<float[]>(renderer, "_laneFlashAlpha");
+        flashAlpha[0] = 0.25f;
+
+        renderer.TriggerLaneFlash(laneIndex);
+
+        Assert.Equal(0.25f, flashAlpha[0]);
+    }
+
+    [Fact]
+    public void DrawNotes_WhenRendererIsNotReady_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateRenderer();
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNotes((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { new Note() }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNote_WhenLaneIndexIsInvalid_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRenderer();
+        var note = new Note { LaneIndex = -1, TimeMs = 1000.0 };
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNote((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), note, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData(2500.0)]
+    [InlineData(-4000.0)]
+    public void DrawNote_WhenNoteIsOutsideVisibleRange_ShouldReturnWithoutThrowing(double currentSongTimeMs)
+    {
+        var renderer = CreateReadyRenderer();
+        var note = new Note { LaneIndex = 0, TimeMs = 1000.0 };
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNote((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), note, currentSongTimeMs));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNote_WhenTextureUnavailableAndFallbackTextureMissing_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRenderer();
+        var note = new Note { LaneIndex = 0, Channel = 0x13, TimeMs = 1000.0 };
+        ReflectionHelpers.SetPrivateField(renderer, "_drumChipsTexture", null);
+        ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", null);
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNote((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), note, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNote_WhenSpriteColumnIsInvalidAndFallbackTextureMissing_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRendererWithValidSpriteTexture();
+        var note = new Note { LaneIndex = 0, Channel = 0x99, TimeMs = 1000.0 };
+        ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", null);
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNote((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), note, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNoteOverlays_WhenRendererIsNotReady_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateRenderer();
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNoteOverlays((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { new Note() }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNoteOverlays_WhenNoteUsesSnareOrTomOverlay_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRenderer();
+        var note = new Note { LaneIndex = 3, Channel = 0x12, TimeMs = 1000.0 };
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNoteOverlays((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { note }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNoteOverlays_WhenLaneIndexIsInvalid_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRenderer();
+        var note = new Note { LaneIndex = -1, Channel = 0x13, TimeMs = 1000.0 };
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNoteOverlays((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { note }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNoteOverlays_WhenTextureUnavailable_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRenderer();
+        var note = new Note { LaneIndex = 0, Channel = 0x13, TimeMs = 1000.0 };
+        ReflectionHelpers.SetPrivateField(renderer, "_drumChipsTexture", null);
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNoteOverlays((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { note }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawNoteOverlays_WhenSpriteColumnIsInvalid_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRendererWithValidSpriteTexture();
+        var note = new Note { LaneIndex = 0, Channel = 0x99, TimeMs = 1000.0 };
+
+        var exception = Record.Exception(() =>
+            renderer.DrawNoteOverlays((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { note }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawOverlayEffect_WhenRendererIsNotReady_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateRenderer();
+
+        var exception = Record.Exception(() =>
+            renderer.DrawOverlayEffect((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), 0, 0, Vector2.Zero));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawOverlayEffect_WhenOverlayFrameIndexIsInvalid_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRendererWithValidSpriteTexture();
+
+        var exception = Record.Exception(() =>
+            renderer.DrawOverlayEffect((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), 0, -1, Vector2.Zero));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawOverlayEffect_WhenLaneIndexIsInvalid_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRendererWithValidSpriteTexture();
+
+        var exception = Record.Exception(() =>
+            renderer.DrawOverlayEffect((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), PerformanceUILayout.LaneCount, 0, Vector2.Zero));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void CheckAndReloadResources_WhenDrumTextureIsMissing_ShouldAttemptReloadAndLeaveTextureNull()
+    {
+        var renderer = CreateRenderer();
+        var resourceManager = new Mock<IResourceManager>();
+        resourceManager.Setup(manager => manager.LoadTexture(It.IsAny<string>())).Returns((ITexture?)null);
+        ReflectionHelpers.SetPrivateField(renderer, "_resourceManager", resourceManager.Object);
+        ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D)));
+        ReflectionHelpers.SetPrivateField(renderer, "_drumChipsTexture", null);
+
+        ReflectionHelpers.InvokePrivateMethod(renderer, "CheckAndReloadResources");
+
+        Assert.Null(ReflectionHelpers.GetPrivateField<ManagedSpriteTexture>(renderer, "_drumChipsTexture"));
+        resourceManager.Verify(manager => manager.LoadTexture(TexturePath.DrumChips), Times.Once);
+    }
+
+    [Fact]
+    public void CreateWhiteTexture_WhenGraphicsDeviceIsMissing_ShouldThrowInvalidOperationException()
+    {
+        var renderer = CreateRenderer();
+        ReflectionHelpers.SetPrivateField(renderer, "_graphicsDevice", null);
+
+        var exception = Assert.Throws<TargetInvocationException>(() => ReflectionHelpers.InvokePrivateMethod(renderer, "CreateWhiteTexture"));
+
+        Assert.IsType<InvalidOperationException>(exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData(0x13, 0)]
+    [InlineData(0x19, 1)]
+    [InlineData(0x12, 2)]
+    [InlineData(0x14, 3)]
+    [InlineData(0x15, 4)]
+    [InlineData(0x17, 5)]
+    [InlineData(0x16, 6)]
+    [InlineData(0x11, 7)]
+    [InlineData(0x1C, 8)]
+    [InlineData(0x1A, 9)]
+    [InlineData(0x18, 10)]
+    [InlineData(0x1B, 11)]
+    [InlineData(0x99, -1)]
+    public void GetSpriteColumnForChannel_ShouldReturnExpectedMapping(int channel, int expectedColumn)
+    {
+        var renderer = CreateRenderer();
+
+        var result = ReflectionHelpers.InvokePrivateMethod<int>(renderer, "GetSpriteColumnForChannel", channel);
+
+        Assert.Equal(expectedColumn, result);
+    }
+
+    [Theory]
+    [InlineData(0, 9)]
+    [InlineData(1, 10)]
+    [InlineData(2, 11)]
+    [InlineData(3, 2)]
+    [InlineData(4, 3)]
+    [InlineData(5, 0)]
+    [InlineData(6, 4)]
+    [InlineData(7, 5)]
+    [InlineData(8, 1)]
+    [InlineData(9, 6)]
+    [InlineData(99, -1)]
+    public void GetSpriteColumnForLane_ShouldReturnExpectedMapping(int laneIndex, int expectedColumn)
+    {
+        var renderer = CreateRenderer();
+
+        var result = ReflectionHelpers.InvokePrivateMethod<int>(renderer, "GetSpriteColumnForLane", laneIndex);
+
+        Assert.Equal(expectedColumn, result);
+    }
+
+    [Theory]
+    [InlineData(0, 70)]
+    [InlineData(1, 58)]
+    [InlineData(2, 64)]
+    [InlineData(3, 56)]
+    [InlineData(4, 56)]
+    [InlineData(5, 56)]
+    [InlineData(6, 74)]
+    [InlineData(7, 48)]
+    [InlineData(8, 58)]
+    [InlineData(9, 74)]
+    [InlineData(10, 48)]
+    [InlineData(11, 58)]
+    [InlineData(99, 64)]
+    public void GetSpriteWidthForColumn_ShouldReturnExpectedWidths(int columnIndex, int expectedWidth)
+    {
+        var renderer = CreateRenderer();
+
+        var result = ReflectionHelpers.InvokePrivateMethod<int>(renderer, "GetSpriteWidthForColumn", columnIndex);
+
+        Assert.Equal(expectedWidth, result);
+    }
+
+    [Theory]
+    [InlineData(0x12, true)]
+    [InlineData(0x14, true)]
+    [InlineData(0x15, true)]
+    [InlineData(0x17, true)]
+    [InlineData(0x13, false)]
+    public void IsSnareOrTomChannel_ShouldMatchExpectedChannels(int channel, bool expected)
+    {
+        var renderer = CreateRenderer();
+
+        var result = ReflectionHelpers.InvokePrivateMethod<bool>(renderer, "IsSnareOrTomChannel", channel);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(3, true)]
+    [InlineData(4, true)]
+    [InlineData(6, true)]
+    [InlineData(7, true)]
+    [InlineData(0, false)]
+    public void IsSnareOrTomLane_ShouldMatchExpectedLanes(int laneIndex, bool expected)
+    {
+        var renderer = CreateRenderer();
+
+        var result = ReflectionHelpers.InvokePrivateMethod<bool>(renderer, "IsSnareOrTomLane", laneIndex);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(-1, 0, 64)]
+    [InlineData(0, 0, 70)]
+    [InlineData(1, 70, 58)]
+    [InlineData(2, 128, 64)]
+    [InlineData(11, 662, 58)]
+    public void GetCustomSpriteSourceRectangleForColumn_ShouldUseExpectedOffsetsAndWidths(int columnIndex, int expectedX, int expectedWidth)
+    {
+        var renderer = CreateRenderer();
+
+        var result = ReflectionHelpers.InvokePrivateMethod<Rectangle>(renderer, "GetCustomSpriteSourceRectangleForColumn", columnIndex);
+
+        Assert.Equal(expectedX, result.X);
+        Assert.Equal(expectedWidth, result.Width);
+    }
+
+    [Fact]
+    public void Dispose_WhenRendererHasNoResources_ShouldMarkDisposed()
+    {
+        var renderer = CreateRenderer();
+
+        renderer.Dispose();
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(renderer, "_disposed"));
+    }
+
+    private static NoteRenderer CreateRenderer()
+    {
+        var renderer = ReflectionHelpers.CreateUninitialized<NoteRenderer>();
+        ReflectionHelpers.SetPrivateField(renderer, "_lanePositions", new Vector2[PerformanceUILayout.LaneCount]);
+        ReflectionHelpers.SetPrivateField(renderer, "_laneColors", Enumerable.Repeat(Color.White, PerformanceUILayout.LaneCount).ToArray());
+        ReflectionHelpers.SetPrivateField(renderer, "_laneFlashAlpha", new float[PerformanceUILayout.LaneCount]);
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 0.5);
+        ReflectionHelpers.SetPrivateField(renderer, "<EffectiveLookAheadMs>k__BackingField", 1200.0);
+        ReflectionHelpers.SetPrivateField(renderer, "_disposed", false);
+        return renderer;
+    }
+
+    private static NoteRenderer CreateReadyRenderer()
+    {
+        var renderer = CreateRenderer();
+        ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D)));
+        ReflectionHelpers.SetPrivateField(renderer, "_drumChipsTexture", (ManagedSpriteTexture)RuntimeHelpers.GetUninitializedObject(typeof(ManagedSpriteTexture)));
+        return renderer;
+    }
+
+    private static NoteRenderer CreateReadyRendererWithValidSpriteTexture()
+    {
+        var renderer = CreateRenderer();
+        ReflectionHelpers.SetPrivateField(renderer, "_drumChipsTexture", CreateSpriteTexture());
+        return renderer;
+    }
+
+    private static ManagedSpriteTexture CreateSpriteTexture()
+    {
+        var texture = (Texture2D)RuntimeHelpers.GetUninitializedObject(typeof(Texture2D));
+        var spriteTexture = (ManagedSpriteTexture)RuntimeHelpers.GetUninitializedObject(typeof(ManagedSpriteTexture));
+        ReflectionHelpers.SetPrivateField(spriteTexture, "_texture", texture);
+        return spriteTexture;
+    }
+}

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -1,0 +1,898 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Test.Helpers;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Moq;
+
+namespace DTXMania.Test.Stage.Performance;
+
+[Trait("Category", "Unit")]
+public class PerformanceStageDeterministicTests
+{
+    [Fact]
+    public void ExtractSharedData_WhenSharedDataMissing_ShouldLeaveStageDataUnchanged()
+    {
+        var stage = CreateStage();
+
+        ReflectionHelpers.SetPrivateField(stage, "_sharedData", null);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ExtractSharedData");
+
+        Assert.Null(ReflectionHelpers.GetPrivateField<SongListNode>(stage, "_selectedSong"));
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedDifficulty"));
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_songId"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ParsedChart>(stage, "_parsedChart"));
+    }
+
+    [Fact]
+    public void ExtractSharedData_WhenValidValuesExist_ShouldAssignAllFields()
+    {
+        var stage = CreateStage();
+        var selectedSong = new SongListNode { Title = "Song" };
+        var parsedChart = new ParsedChart("test.dtx");
+        var sharedData = new Dictionary<string, object>
+        {
+            ["selectedSong"] = selectedSong,
+            ["selectedDifficulty"] = 3,
+            ["songId"] = 42,
+            ["parsedChart"] = parsedChart
+        };
+
+        ReflectionHelpers.SetPrivateField(stage, "_sharedData", sharedData);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ExtractSharedData");
+
+        Assert.Same(selectedSong, ReflectionHelpers.GetPrivateField<SongListNode>(stage, "_selectedSong"));
+        Assert.Equal(3, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedDifficulty"));
+        Assert.Equal(42, ReflectionHelpers.GetPrivateField<int>(stage, "_songId"));
+        Assert.Same(parsedChart, ReflectionHelpers.GetPrivateField<ParsedChart>(stage, "_parsedChart"));
+    }
+
+    [Fact]
+    public void InitializeAutoPlay_WhenConfigEnablesAutoPlay_ShouldEnableAndResetIndex()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), CreateConfigManager(new ConfigData { AutoPlay = true }));
+        var stage = CreateStage(game);
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayEnabled", false);
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayNoteIndex", 19);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "InitializeAutoPlay");
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_autoPlayEnabled"));
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+    }
+
+    [Fact]
+    public void InitializeAutoPlay_WhenConfigManagerMissing_ShouldDisableAutoPlayAndResetIndex()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), null);
+        var stage = CreateStage(game);
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayEnabled", true);
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayNoteIndex", 7);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "InitializeAutoPlay");
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_autoPlayEnabled"));
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+    }
+
+    [Fact]
+    public void OnScoreChanged_WhenDisplayExists_ShouldPropagateCurrentScore()
+    {
+        var stage = CreateStage();
+        var scoreDisplay = CreateScoreDisplay();
+        ReflectionHelpers.SetPrivateField(stage, "_scoreDisplay", scoreDisplay);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnScoreChanged", null, new ScoreChangedEventArgs { CurrentScore = 123456 });
+
+        Assert.Equal(123456, scoreDisplay.Score);
+    }
+
+    [Fact]
+    public void OnComboChanged_WhenDisplayExists_ShouldPropagateCurrentCombo()
+    {
+        var stage = CreateStage();
+        var comboDisplay = CreateComboDisplay();
+        ReflectionHelpers.SetPrivateField(stage, "_comboDisplay", comboDisplay);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnComboChanged", null, new ComboChangedEventArgs { CurrentCombo = 87 });
+
+        Assert.Equal(87, comboDisplay.Combo);
+    }
+
+    [Theory]
+    [InlineData(75f, 0.75f, false)]
+    [InlineData(15f, 0.15f, true)]
+    public void OnGaugeChanged_ShouldNormalizeGaugeAndUpdateDangerState(float life, float expectedGauge, bool expectedDanger)
+    {
+        var stage = CreateStage();
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnGaugeChanged", null, new GaugeChangedEventArgs { CurrentLife = life });
+
+        Assert.Equal(expectedGauge, ReflectionHelpers.GetPrivateField<float>(stage, "_currentGaugeValue"));
+        Assert.Equal(expectedDanger, ReflectionHelpers.GetPrivateField<bool>(stage, "_isDanger"));
+    }
+
+    [Fact]
+    public void OnLaneHitForPadFeedback_WhenPadRendererExists_ShouldMarkLanePressed()
+    {
+        var stage = CreateStage();
+        var padRenderer = CreatePadRenderer();
+        ReflectionHelpers.SetPrivateField(stage, "_padRenderer", padRenderer);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnLaneHitForPadFeedback", null, new LaneHitEventArgs(4, new ButtonState("Key.Z", true)));
+
+        var padVisuals = ReflectionHelpers.GetPrivateField<PadVisual[]>(padRenderer, "_padVisuals");
+        Assert.NotNull(padVisuals);
+        Assert.Equal(PadState.Pressed, padVisuals![4].State);
+        Assert.Equal(0.0, padVisuals[4].TimePressed);
+    }
+
+    [Theory]
+    [InlineData(-100.0, 0.0f)]
+    [InlineData(500.0, 0.25f)]
+    [InlineData(2500.0, 1.0f)]
+    public void UpdateSongProgress_WhenChartDurationExists_ShouldClampProgress(double currentSongTimeMs, float expectedProgress)
+    {
+        var stage = CreateStage();
+        var parsedChart = new ParsedChart("duration-test.dtx") { DurationMs = 2000.0 };
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", parsedChart);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSongProgress", currentSongTimeMs);
+
+        Assert.Equal(expectedProgress, ReflectionHelpers.GetPrivateField<float>(stage, "_currentProgressValue"));
+    }
+
+    [Fact]
+    public void UpdateSongProgress_WhenChartMissingOrDurationNonPositive_ShouldLeaveProgressUnchanged()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_currentProgressValue", 0.42f);
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("zero-duration.dtx") { DurationMs = 0.0 });
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSongProgress", 500.0);
+
+        Assert.Equal(0.42f, ReflectionHelpers.GetPrivateField<float>(stage, "_currentProgressValue"));
+
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", null);
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSongProgress", 800.0);
+
+        Assert.Equal(0.42f, ReflectionHelpers.GetPrivateField<float>(stage, "_currentProgressValue"));
+    }
+
+    [Fact]
+    public void InitializeGameplayManagers_WhenDependenciesExist_ShouldCreateManagersAndInitializeState()
+    {
+        var stage = CreateStage();
+        var inputManager = new MockInputManagerCompat();
+        var chartManager = CreateChartManagerWithSingleNote();
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", inputManager);
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "InitializeGameplayManagers");
+
+        var judgementManager = ReflectionHelpers.GetPrivateField<JudgementManager>(stage, "_judgementManager");
+        Assert.NotNull(judgementManager);
+        Assert.False(judgementManager!.IsActive);
+        Assert.NotNull(ReflectionHelpers.GetPrivateField<ScoreManager>(stage, "_scoreManager"));
+        Assert.NotNull(ReflectionHelpers.GetPrivateField<ComboManager>(stage, "_comboManager"));
+        Assert.NotNull(ReflectionHelpers.GetPrivateField<GaugeManager>(stage, "_gaugeManager"));
+        Assert.Equal(0.5f, ReflectionHelpers.GetPrivateField<float>(stage, "_currentGaugeValue"));
+        Assert.Equal(0.0f, ReflectionHelpers.GetPrivateField<float>(stage, "_currentProgressValue"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isPaused"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isDanger"));
+    }
+
+    [Fact]
+    public void CleanupGameplayManagers_WhenManagersInitialized_ShouldClearAllManagerReferences()
+    {
+        var stage = CreateStage();
+        var inputManager = new MockInputManagerCompat();
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", inputManager);
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+        ReflectionHelpers.InvokePrivateMethod(stage, "InitializeGameplayManagers");
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CleanupGameplayManagers");
+
+        Assert.Null(ReflectionHelpers.GetPrivateField<JudgementManager>(stage, "_judgementManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ScoreManager>(stage, "_scoreManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ComboManager>(stage, "_comboManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<GaugeManager>(stage, "_gaugeManager"));
+    }
+
+    [Fact]
+    public void ProcessBGMEvents_WhenCurrentTimeReachesTolerance_ShouldTriggerAndRemoveElapsedEvents()
+    {
+        var stage = CreateStage();
+        var scheduledEvents = new List<BGMEvent>
+        {
+            new() { WavId = "01", TimeMs = 1000.0 },
+            new() { WavId = "02", TimeMs = 1300.0 }
+        };
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", scheduledEvents);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ProcessBGMEvents", 980.0);
+
+        var remainingEvents = ReflectionHelpers.GetPrivateField<List<BGMEvent>>(stage, "_scheduledBGMEvents");
+        Assert.Single(remainingEvents);
+        Assert.Equal("02", remainingEvents[0].WavId);
+    }
+
+    [Fact]
+    public void UpdateGameplayManagers_WhenAutoPlayDisabled_ShouldStillAdvanceMissDetection()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayEnabled", false);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplayManagers", 1301.0);
+
+        Assert.Equal(1, judgementManager.GetJudgementCount(JudgementType.Miss));
+    }
+
+    [Fact]
+    public void UpdateGameplayManagers_WhenAutoPlayEnabled_ShouldTriggerAutoHitBeforeMissDetection()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var padRenderer = CreatePadRenderer();
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayEnabled", true);
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_padRenderer", padRenderer);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplayManagers", 1000.0);
+        judgementManager.Update(1000.0);
+
+        Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+        Assert.Equal(NoteStatus.Hit, judgementManager.GetNoteRuntimeData(chartManager.AllNotes[0].Id)!.Status);
+        Assert.Equal(PadState.Pressed, ReflectionHelpers.GetPrivateField<PadVisual[]>(padRenderer, "_padVisuals")[0].State);
+    }
+
+    [Fact]
+    public void ProcessAutoPlay_WhenNextNoteIsInFuture_ShouldLeaveIndexUnchanged()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var padRenderer = CreatePadRenderer();
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_padRenderer", padRenderer);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ProcessAutoPlay", 900.0);
+
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+        Assert.Equal(PadState.Idle, ReflectionHelpers.GetPrivateField<PadVisual[]>(padRenderer, "_padVisuals")[0].State);
+    }
+
+    [Fact]
+    public void ProcessAutoPlay_WhenNextNoteIsTooFarInPast_ShouldSkipNote()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ProcessAutoPlay", 1100.0);
+
+        Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+    }
+
+    [Fact]
+    public void ProcessAutoPlay_WhenNextNoteIsWithinWindow_ShouldQueueHitAndPressPad()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var padRenderer = CreatePadRenderer();
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_padRenderer", padRenderer);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ProcessAutoPlay", 1000.0);
+        judgementManager.Update(1000.0);
+
+        Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+        Assert.Equal(PadState.Pressed, ReflectionHelpers.GetPrivateField<PadVisual[]>(padRenderer, "_padVisuals")[0].State);
+        Assert.Equal(NoteStatus.Hit, judgementManager.GetNoteRuntimeData(chartManager.AllNotes[0].Id)!.Status);
+    }
+
+    [Fact]
+    public void OnPlayerFailed_WhenNoFailDisabled_ShouldFinalizePerformanceAndTransitionToResult()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), CreateConfigManager(new ConfigData { NoFail = false }));
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        Dictionary<string, object>? capturedSharedData = null;
+        stageManager
+            .Setup(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, sharedData) => capturedSharedData = sharedData);
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnPlayerFailed", null, new FailureEventArgs { FinalLife = 0.0f, JudgementType = JudgementType.Miss });
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        var summary = Assert.IsType<PerformanceSummary>(capturedSharedData!["performanceSummary"]);
+        Assert.Equal(CompletionReason.PlayerFailed, summary.CompletionReason);
+        Assert.False(summary.ClearFlag);
+        Assert.Equal(1, summary.TotalNotes);
+        stageManager.Verify(x => x.ChangeStage(StageType.Result, It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void CheckStageCompletion_WhenSongEndBufferPassed_ShouldFinalizeAsSongComplete()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        Dictionary<string, object>? capturedSharedData = null;
+        stageManager
+            .Setup(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, sharedData) => capturedSharedData = sharedData);
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("complete-test.dtx") { DurationMs = 1000.0 });
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CheckStageCompletion", 5000.0);
+
+        var summary = Assert.IsType<PerformanceSummary>(capturedSharedData!["performanceSummary"]);
+        Assert.Equal(CompletionReason.SongComplete, summary.CompletionReason);
+        Assert.True(summary.ClearFlag);
+        stageManager.Verify(x => x.ChangeStage(StageType.Result, It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void CleanupComponents_WhenAssetsAndSoundsExist_ShouldResetStateAndReleaseResources()
+    {
+        var stage = CreateStage();
+        var backgroundTexture = CreateTextureMock();
+        var shutterTexture = CreateTextureMock();
+        var laneBgTexture = CreateTextureMock();
+        var laneDividerTexture = CreateTextureMock();
+        var laneFlashTexture = CreateTextureMock();
+        var judgementLineTexture = CreateTextureMock();
+        var gaugeBaseTexture = CreateTextureMock();
+        var gaugeFillTexture = CreateTextureMock();
+        var progressBaseTexture = CreateTextureMock();
+        var progressFillTexture = CreateTextureMock();
+        var comboDigitsTexture = CreateTextureMock();
+        var scoreDigitsTexture = CreateTextureMock();
+        var judgeStringsTexture = CreateTextureMock();
+        var lagNumbersTexture = CreateTextureMock();
+        var pauseOverlayTexture = CreateTextureMock();
+        var dangerOverlayTexture = CreateTextureMock();
+        var skillPanelTexture = CreateTextureMock();
+        var bgmSound = CreateSoundMock();
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", true);
+        ReflectionHelpers.SetPrivateField(stage, "_inputPaused", true);
+        ReflectionHelpers.SetPrivateField(stage, "_totalTime", 12.0);
+        ReflectionHelpers.SetPrivateField(stage, "_stageElapsedTime", 15.0);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.25);
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayNoteIndex", 8);
+        ReflectionHelpers.SetPrivateField(stage, "_backgroundTexture", backgroundTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_shutterTexture", shutterTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_laneBgTexture", laneBgTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_laneDividerTexture", laneDividerTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_laneFlashTexture", laneFlashTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementLineTexture", judgementLineTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeBaseTexture", gaugeBaseTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeFillTexture", gaugeFillTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_progressBaseTexture", progressBaseTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_progressFillTexture", progressFillTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_comboDigitsTexture", comboDigitsTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_scoreDigitsTexture", scoreDigitsTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_judgeStringsTexture", judgeStringsTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_lagNumbersTexture", lagNumbersTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_pauseOverlayTexture", pauseOverlayTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_dangerOverlayTexture", dangerOverlayTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_skillPanelTexture", skillPanelTexture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound> { ["01"] = bgmSound.Object });
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent> { new() { WavId = "01", TimeMs = 1000.0 } });
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("cleanup-test.dtx"));
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CleanupComponents");
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_isLoading"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_totalTime"));
+        Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_stageElapsedTime"));
+        Assert.Equal(1.0, ReflectionHelpers.GetPrivateField<double>(stage, "_readyCountdown"));
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ParsedChart>(stage, "_parsedChart"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ChartManager>(stage, "_chartManager"));
+        backgroundTexture.Verify(x => x.RemoveReference(), Times.Once);
+        shutterTexture.Verify(x => x.RemoveReference(), Times.Once);
+        laneBgTexture.Verify(x => x.RemoveReference(), Times.Once);
+        laneDividerTexture.Verify(x => x.RemoveReference(), Times.Once);
+        laneFlashTexture.Verify(x => x.RemoveReference(), Times.Once);
+        judgementLineTexture.Verify(x => x.RemoveReference(), Times.Once);
+        gaugeBaseTexture.Verify(x => x.RemoveReference(), Times.Once);
+        gaugeFillTexture.Verify(x => x.RemoveReference(), Times.Once);
+        progressBaseTexture.Verify(x => x.RemoveReference(), Times.Once);
+        progressFillTexture.Verify(x => x.RemoveReference(), Times.Once);
+        comboDigitsTexture.Verify(x => x.RemoveReference(), Times.Once);
+        scoreDigitsTexture.Verify(x => x.RemoveReference(), Times.Once);
+        judgeStringsTexture.Verify(x => x.RemoveReference(), Times.Once);
+        lagNumbersTexture.Verify(x => x.RemoveReference(), Times.Once);
+        pauseOverlayTexture.Verify(x => x.RemoveReference(), Times.Once);
+        dangerOverlayTexture.Verify(x => x.RemoveReference(), Times.Once);
+        skillPanelTexture.Verify(x => x.RemoveReference(), Times.Once);
+        bgmSound.Verify(x => x.Dispose(), Times.Once);
+        Assert.Empty(ReflectionHelpers.GetPrivateField<List<BGMEvent>>(stage, "_scheduledBGMEvents"));
+        Assert.Empty(ReflectionHelpers.GetPrivateField<Dictionary<string, ISound>>(stage, "_bgmSounds"));
+    }
+
+    [Fact]
+    public void ReturnToSongSelect_ShouldPauseInputStopTimerAndChangeStage()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote())
+        {
+            IsActive = true
+        };
+
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreateStoppedSongTimer());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        stage.StageManager = stageManager.Object;
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ReturnToSongSelect");
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        Assert.False(judgementManager.IsActive);
+        stageManager.Verify(
+            x => x.ChangeStage(
+                StageType.SongSelect,
+                It.Is<IStageTransition>(transition => transition is DTXManiaFadeTransition),
+                null),
+            Times.Once);
+    }
+
+    [Fact]
+    public void HandleInput_WhenBackActionTriggeredAndTransitionAllowed_ShouldMarkTransitionAndReturnToSongSelect()
+    {
+        var game = ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        var inputManager = new BackActionInputManagerCompat(backTriggered: true);
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote())
+        {
+            IsActive = true
+        };
+
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", inputManager);
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreateStoppedSongTimer());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        stage.StageManager = stageManager.Object;
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        Assert.False(judgementManager.IsActive);
+        Assert.Equal(2.0, ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        stageManager.Verify(
+            x => x.ChangeStage(
+                StageType.SongSelect,
+                It.IsAny<IStageTransition>(),
+                null),
+            Times.Once);
+    }
+
+    [Fact]
+    public void HandleInput_WhenBackActionTriggeredButDebounceBlocks_ShouldNotChangeStage()
+    {
+        var game = ReflectionHelpers.CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0.0);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", new BackActionInputManagerCompat(backTriggered: true));
+        stage.StageManager = stageManager.Object;
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void OnPlayerFailed_WhenNoFailEnabled_ShouldNotFinalizePerformance()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), CreateConfigManager(new ConfigData { NoFail = true }));
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnPlayerFailed", null, new FailureEventArgs { FinalLife = 0.0f, JudgementType = JudgementType.Miss });
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void OnPlayerFailed_WhenStageAlreadyCompleted_ShouldNotTransitionAgain()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), CreateConfigManager(new ConfigData { NoFail = false }));
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnPlayerFailed", null, new FailureEventArgs { FinalLife = 0.0f, JudgementType = JudgementType.Miss });
+
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void UpdateGameplay_WhenStillLoading_ShouldReturnWithoutMutatingReadyCountdown()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", true);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.5);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplay", 0.25);
+
+        Assert.Equal(0.5, ReflectionHelpers.GetPrivateField<double>(stage, "_readyCountdown"));
+    }
+
+    [Fact]
+    public void UpdateGameplay_WhenReadyCountdownStillActive_ShouldDecreaseCountdownWithoutStartingSong()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.75);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplay", 0.25);
+
+        Assert.Equal(0.5, ReflectionHelpers.GetPrivateField<double>(stage, "_readyCountdown"), 3);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+    }
+
+    [Fact]
+    public async Task LoadBGMSoundsAsync_WhenChartHasNoEvents_ShouldLeaveSoundMapEmpty()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("no-bgm.dtx"));
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+
+        var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "LoadBGMSoundsAsync")!;
+        await task;
+
+        Assert.Empty(ReflectionHelpers.GetPrivateField<Dictionary<string, ISound>>(stage, "_bgmSounds"));
+    }
+
+    [Fact]
+    public async Task LoadBGMSoundsAsync_WhenAudioFileIsMissingOrDuplicate_ShouldSkipEntries()
+    {
+        var stage = CreateStage();
+        var parsedChart = new ParsedChart("missing-bgm.dtx");
+        parsedChart.BGMEvents.Add(new BGMEvent { WavId = "01", AudioFilePath = "/tmp/definitely-missing-file.wav" });
+        parsedChart.BGMEvents.Add(new BGMEvent { WavId = "01", AudioFilePath = "/tmp/another-missing-file.wav" });
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", parsedChart);
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+
+        var task = (Task)ReflectionHelpers.InvokePrivateMethod(stage, "LoadBGMSoundsAsync")!;
+        await task;
+
+        Assert.Empty(ReflectionHelpers.GetPrivateField<Dictionary<string, ISound>>(stage, "_bgmSounds"));
+    }
+
+    [Fact]
+    public void TriggerBGMEvent_WhenCreateInstanceReturnsNull_ShouldAttemptPlaybackWithoutThrowing()
+    {
+        var stage = CreateStage();
+        var sound = CreateSoundMock();
+        sound.Setup(x => x.CreateInstance()).Returns((Microsoft.Xna.Framework.Audio.SoundEffectInstance)null!);
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound> { ["01"] = sound.Object });
+
+        var exception = Record.Exception(() =>
+            ReflectionHelpers.InvokePrivateMethod(stage, "TriggerBGMEvent", new BGMEvent { WavId = "01" }));
+
+        Assert.Null(exception);
+        sound.Verify(x => x.CreateInstance(), Times.Once);
+    }
+
+    [Fact]
+    public void TriggerBGMEvent_WhenSoundIsMissing_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+
+        var exception = Record.Exception(() =>
+            ReflectionHelpers.InvokePrivateMethod(stage, "TriggerBGMEvent", new BGMEvent { WavId = "missing" }));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void TriggerBGMEvent_WhenCreateInstanceThrows_ShouldSwallowPlaybackFailure()
+    {
+        var stage = CreateStage();
+        var sound = CreateSoundMock();
+        sound.Setup(x => x.CreateInstance()).Throws(new InvalidOperationException("boom"));
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound> { ["01"] = sound.Object });
+
+        var exception = Record.Exception(() =>
+            ReflectionHelpers.InvokePrivateMethod(stage, "TriggerBGMEvent", new BGMEvent { WavId = "01" }));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void CheckStageCompletion_WhenNoFailEnabledAndGaugeFailed_ShouldNotFinalize()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), CreateConfigManager(new ConfigData { NoFail = true }));
+        var stage = CreateStage(game);
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("nofail-test.dtx") { DurationMs = 5000.0 });
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CheckStageCompletion", 1000.0);
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+    }
+
+    [Fact]
+    public void FinalizePerformance_WhenManagersAreMissing_ShouldBuildZeroedSummaryAndPauseInput()
+    {
+        var stage = CreateStage();
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.SongComplete);
+
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.Equal(0, summary.Score);
+        Assert.Equal(0, summary.TotalNotes);
+        Assert.True(summary.ClearFlag);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+    }
+
+    [Fact]
+    public void TransitionToResultStage_WhenStageManagerMissing_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_performanceSummary", new PerformanceSummary());
+
+        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "TransitionToResultStage"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void LogPerformanceError_WithAndWithoutException_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+
+        var withoutException = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "LogPerformanceError", "plain message", null));
+        var withException = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "LogPerformanceError", "failure", new InvalidOperationException("boom")));
+
+        Assert.Null(withoutException);
+        Assert.Null(withException);
+    }
+
+    [Fact]
+    public void StartSong_WhenPlaybackFailsWithoutBgmEvents_ShouldDisableReadyAndActivateJudgementManager()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        var songTimer = CreateStoppedSongTimer();
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "StartSong");
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.True(judgementManager.IsActive);
+    }
+
+    [Fact]
+    public void StartSong_WhenPlaybackFailsWithBgmEvents_ShouldStillDisableReadyAndActivateJudgementManager()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        var songTimer = CreateStoppedSongTimer();
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent> { new() { WavId = "01", TimeMs = 250.0 } });
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "StartSong");
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.True(judgementManager.IsActive);
+    }
+
+    [Fact]
+    public void InitializeReadyFont_WhenSpriteBatchIsMissing_ShouldLeaveFontNull()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", null);
+        ReflectionHelpers.SetPrivateField(stage, "_resourceManager", new Mock<IResourceManager>().Object);
+
+        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "InitializeReadyFont"));
+
+        Assert.Null(exception);
+        Assert.Null(ReflectionHelpers.GetPrivateField<BitmapFont>(stage, "_readyFont"));
+    }
+
+    [Fact]
+    public void TryLoadTexture_WhenResourceManagerUnavailableOrLoadFails_ShouldReturnNull()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_resourceManager", null);
+
+        var missingManagerResult = ReflectionHelpers.InvokePrivateMethod<ITexture>(stage, "TryLoadTexture", "missing");
+        Assert.Null(missingManagerResult);
+
+        var resourceManager = new Mock<IResourceManager>();
+        resourceManager.Setup(x => x.LoadTexture("throws")).Throws(new InvalidOperationException("boom"));
+        ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+
+        var loadFailureResult = ReflectionHelpers.InvokePrivateMethod<ITexture>(stage, "TryLoadTexture", "throws");
+        Assert.Null(loadFailureResult);
+    }
+
+    [Fact]
+    public void TryLoadTexture_WhenLoadSucceeds_ShouldReturnTexture()
+    {
+        var stage = CreateStage();
+        var texture = CreateTextureMock();
+        var resourceManager = new Mock<IResourceManager>();
+        resourceManager.Setup(x => x.LoadTexture("ok")).Returns(texture.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+
+        var result = ReflectionHelpers.InvokePrivateMethod<ITexture>(stage, "TryLoadTexture", "ok");
+
+        Assert.Same(texture.Object, result);
+    }
+
+    private static PerformanceStage CreateStage(BaseGame? game = null)
+    {
+#pragma warning disable SYSLIB0050
+        var stage = (PerformanceStage)FormatterServices.GetUninitializedObject(typeof(PerformanceStage));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(stage, "_game", game ?? ReflectionHelpers.CreateGame());
+        return stage;
+    }
+
+    private static ScoreDisplay CreateScoreDisplay()
+    {
+#pragma warning disable SYSLIB0050
+        var display = (ScoreDisplay)FormatterServices.GetUninitializedObject(typeof(ScoreDisplay));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(display, "_currentScore", 0);
+        ReflectionHelpers.SetPrivateField(display, "_scoreText", "0000000");
+        return display;
+    }
+
+    private static ComboDisplay CreateComboDisplay()
+    {
+#pragma warning disable SYSLIB0050
+        var display = (ComboDisplay)FormatterServices.GetUninitializedObject(typeof(ComboDisplay));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(display, "_currentCombo", 0);
+        ReflectionHelpers.SetPrivateField(display, "_comboText", "0");
+        ReflectionHelpers.SetPrivateField(display, "_visible", false);
+        ReflectionHelpers.SetPrivateField(display, "_targetScale", 1.0f);
+        return display;
+    }
+
+    private static PadRenderer CreatePadRenderer()
+    {
+#pragma warning disable SYSLIB0050
+        var renderer = (PadRenderer)FormatterServices.GetUninitializedObject(typeof(PadRenderer));
+#pragma warning restore SYSLIB0050
+        var padVisuals = new PadVisual[10];
+        for (var i = 0; i < padVisuals.Length; i++)
+        {
+            padVisuals[i] = new PadVisual();
+        }
+
+        ReflectionHelpers.SetPrivateField(renderer, "_padVisuals", padVisuals);
+        return renderer;
+    }
+
+    private static IConfigManager CreateConfigManager(ConfigData configData)
+    {
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(x => x.Config).Returns(configData);
+        return configManager.Object;
+    }
+
+    private static ChartManager CreateChartManagerWithSingleNote()
+    {
+        var parsedChart = new ParsedChart("performance-stage-test.dtx")
+        {
+            Bpm = 120.0
+        };
+        parsedChart.AddNote(new Note(0, 0, 96, 0x11, "01"));
+        parsedChart.FinalizeChart();
+        return new ChartManager(parsedChart);
+    }
+
+    private static Mock<ITexture> CreateTextureMock()
+    {
+        var texture = new Mock<ITexture>();
+        texture.Setup(x => x.RemoveReference());
+        return texture;
+    }
+
+    private static Mock<ISound> CreateSoundMock()
+    {
+        var sound = new Mock<ISound>();
+        sound.Setup(x => x.Dispose());
+        return sound;
+    }
+
+    private static SongTimer CreateStoppedSongTimer()
+    {
+#pragma warning disable SYSLIB0050
+        var timer = (SongTimer)FormatterServices.GetUninitializedObject(typeof(SongTimer));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(timer, "_disposed", true);
+        return timer;
+    }
+
+    private sealed class BackActionInputManagerCompat : MockInputManagerCompat
+    {
+        private readonly bool _backTriggered;
+
+        public BackActionInputManagerCompat(bool backTriggered)
+        {
+            _backTriggered = backTriggered;
+        }
+
+        public override bool IsBackActionTriggered()
+        {
+            return _backTriggered;
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -609,8 +609,8 @@ public class PerformanceStageDeterministicTests
     {
         var stage = CreateStage();
         var parsedChart = new ParsedChart("missing-bgm.dtx");
-        parsedChart.BGMEvents.Add(new BGMEvent { WavId = "01", AudioFilePath = "/tmp/definitely-missing-file.wav" });
-        parsedChart.BGMEvents.Add(new BGMEvent { WavId = "01", AudioFilePath = "/tmp/another-missing-file.wav" });
+        parsedChart.BGMEvents.Add(new BGMEvent { WavId = "01", AudioFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dtxmania-test-missing-{Guid.NewGuid()}.wav") });
+        parsedChart.BGMEvents.Add(new BGMEvent { WavId = "01", AudioFilePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"dtxmania-test-missing-{Guid.NewGuid()}.wav") });
         ReflectionHelpers.SetPrivateField(stage, "_parsedChart", parsedChart);
         ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
 

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -9,6 +9,7 @@ using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework;
 using Moq;
 using Xunit;
 
@@ -276,6 +277,29 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ExecuteInputCommand_WhenActivateAndTransitionAllowed_ShouldReturnToSongSelect()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var stageManager = new Mock<IStageManager>();
+            var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+
+            SetPrivateField(stage, "_game", game);
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new DTXMania.Game.Lib.Input.InputCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate, 0.0));
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    StageType.SongSelect,
+                    It.Is<IStageTransition>(transition => transition is DTXManiaFadeTransition),
+                    null),
+                Times.Once);
+            Assert.Equal(2.0, DTXMania.Test.TestData.ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
         public void OnUpdate_WhenQueuedBackCommandExists_ShouldProcessInputAndReturnToSongSelect()
         {
             var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
@@ -321,6 +345,19 @@ namespace DTXMania.Test.Stage
                     It.Is<IStageTransition>(transition => transition is DTXManiaFadeTransition),
                     null),
                 Times.Once);
+        }
+
+        [Fact]
+        public void DrawResultLine_WhenTextIsEmpty_ShouldNotAdvanceCurrentY()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var currentY = 120;
+
+            InvokePrivateMethod(stage, "DrawResultLine", string.Empty, 400, currentY, Color.White, 32);
+
+            Assert.Equal(120, currentY);
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -354,10 +354,11 @@ namespace DTXMania.Test.Stage
             var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
 #pragma warning restore SYSLIB0050
             var currentY = 120;
+            object[] args = [string.Empty, 400, currentY, Color.White, 32];
 
-            InvokePrivateMethod(stage, "DrawResultLine", string.Empty, 400, currentY, Color.White, 32);
+            InvokePrivateMethod(stage, "DrawResultLine", args);
 
-            Assert.Equal(120, currentY);
+            Assert.Equal(120, Assert.IsType<int>(args[2]));
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
@@ -740,20 +740,6 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void CreateConfiguredInputManager_WhenConfigManagerIsNotConcrete_ShouldReturnFallbackInputManager()
-        {
-            var game = ReflectionHelpers.CreateGame();
-            var configManager = new Mock<IConfigManager>();
-            ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
-            var stage = CreateStage(game);
-
-            var inputManager = InvokePrivateMethod<InputManager>(stage, "CreateConfiguredInputManager");
-
-            Assert.NotNull(inputManager);
-            Assert.IsType<InputManager>(inputManager);
-        }
-
-        [Fact]
         public void LoadDifficultySprite_WhenBaseTextureHasNoBackingTexture_ShouldLeaveDifficultySpriteNull()
         {
             var stage = CreateStage();

--- a/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongTransitionStageLogicTests.cs
@@ -720,6 +720,58 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void LoadBackground_WhenLoadSucceeds_ShouldReleaseExistingTextureAndStoreNewBackground()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var oldBackground = new Mock<ITexture>();
+            var newBackground = new Mock<ITexture>();
+
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_backgroundTexture", oldBackground.Object);
+            resourceManager
+                .Setup(x => x.LoadTexture(SongTransitionUILayout.Background.DefaultBackgroundPath))
+                .Returns(newBackground.Object);
+
+            InvokePrivateMethod(stage, "LoadBackground");
+
+            oldBackground.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Same(newBackground.Object, ReflectionHelpers.GetPrivateField<ITexture>(stage, "_backgroundTexture"));
+        }
+
+        [Fact]
+        public void CreateConfiguredInputManager_WhenConfigManagerIsNotConcrete_ShouldReturnFallbackInputManager()
+        {
+            var game = ReflectionHelpers.CreateGame();
+            var configManager = new Mock<IConfigManager>();
+            ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+            var stage = CreateStage(game);
+
+            var inputManager = InvokePrivateMethod<InputManager>(stage, "CreateConfiguredInputManager");
+
+            Assert.NotNull(inputManager);
+            Assert.IsType<InputManager>(inputManager);
+        }
+
+        [Fact]
+        public void LoadDifficultySprite_WhenBaseTextureHasNoBackingTexture_ShouldLeaveDifficultySpriteNull()
+        {
+            var stage = CreateStage();
+            var resourceManager = new Mock<IResourceManager>();
+            var baseTexture = new Mock<ITexture>();
+            baseTexture.SetupGet(x => x.Texture).Returns((Texture2D?)null);
+
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            resourceManager
+                .Setup(x => x.LoadTexture(TexturePath.DifficultySprite))
+                .Returns(baseTexture.Object);
+
+            InvokePrivateMethod(stage, "LoadDifficultySprite");
+
+            Assert.Null(ReflectionHelpers.GetPrivateField<ManagedSpriteTexture>(stage, "_difficultySprite"));
+        }
+
+        [Fact]
         public void HandleInput_WhenInputManagerIsNull_ShouldReturnEarly()
         {
             var stage = CreateStage();

--- a/DTXMania.Test/Stage/TitleStageLogicTests.cs
+++ b/DTXMania.Test/Stage/TitleStageLogicTests.cs
@@ -474,6 +474,25 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void HandleMouseInput_WhenClickOccursOutsideMenu_ShouldNotChangeSelection()
+        {
+            var stage = CreateStage();
+            var cursorSound = CreateSoundReturningInstance();
+
+            ReflectionHelpers.SetPrivateField(stage, "_currentMenuIndex", 1);
+            ReflectionHelpers.SetPrivateField(stage, "_hoveredMenuIndex", -1);
+            ReflectionHelpers.SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(0, 0, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(0, 0, 0, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleMouseInput");
+
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentMenuIndex"));
+            Assert.Equal(-1, ReflectionHelpers.GetPrivateField<int>(stage, "_hoveredMenuIndex"));
+            cursorSound.Verify(x => x.Play(It.IsAny<float>()), Times.Never);
+        }
+
+        [Fact]
         public void IsMouseButtonPressed_WhenLeftEdgeTransitionOccurs_ShouldReturnTrue()
         {
             var stage = CreateStage();
@@ -524,6 +543,52 @@ namespace DTXMania.Test.Stage
                 Enum.ToObject(mouseButtonType!, 99));
 
             Assert.False(pressed);
+        }
+
+        [Theory]
+        [InlineData("Left")]
+        [InlineData("Right")]
+        [InlineData("Middle")]
+        public void IsMouseButtonPressed_WhenButtonIsHeld_ShouldReturnFalse(string mouseButtonName)
+        {
+            var stage = CreateStage();
+            var mouseButtonType = typeof(TitleStage).GetNestedType("MouseButton", System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(mouseButtonType);
+
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(0, 0, 0, XnaButtonState.Pressed, XnaButtonState.Pressed, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(0, 0, 0, XnaButtonState.Pressed, XnaButtonState.Pressed, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released));
+
+            var pressed = ReflectionHelpers.InvokePrivateMethod<bool>(
+                stage,
+                "IsMouseButtonPressed",
+                Enum.Parse(mouseButtonType!, mouseButtonName));
+
+            Assert.False(pressed);
+        }
+
+        [Fact]
+        public void OnDeactivate_ShouldResetTransientMenuState()
+        {
+            var stage = CreateStage();
+            var titlePhaseType = ReflectionHelpers.GetPrivateField<object>(stage, "_titlePhase")!.GetType();
+
+            ReflectionHelpers.SetPrivateField(stage, "_elapsedTime", 4.2d);
+            ReflectionHelpers.SetPrivateField(stage, "_currentMenuIndex", 2);
+            ReflectionHelpers.SetPrivateField(stage, "_hoveredMenuIndex", 1);
+            ReflectionHelpers.SetPrivateField(stage, "_titlePhase", Enum.Parse(titlePhaseType, "Normal"));
+            ReflectionHelpers.SetPrivateField(stage, "_previousKeyboardState", new KeyboardState(Keys.Down));
+            ReflectionHelpers.SetPrivateField(stage, "_currentKeyboardState", new KeyboardState(Keys.Enter));
+            ReflectionHelpers.SetPrivateField(stage, "_previousMouseState", new MouseState(10, 10, 0, XnaButtonState.Pressed, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+            ReflectionHelpers.SetPrivateField(stage, "_currentMouseState", new MouseState(20, 20, 0, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released, XnaButtonState.Released));
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnDeactivate");
+
+            Assert.Equal(0d, ReflectionHelpers.GetPrivateField<double>(stage, "_elapsedTime"));
+            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_currentMenuIndex"));
+            Assert.Equal(-1, ReflectionHelpers.GetPrivateField<int>(stage, "_hoveredMenuIndex"));
+            Assert.Equal("FadeIn", ReflectionHelpers.GetPrivateField<object>(stage, "_titlePhase")!.ToString());
+            Assert.False(ReflectionHelpers.GetPrivateField<KeyboardState>(stage, "_currentKeyboardState").IsKeyDown(Keys.Enter));
+            Assert.False(ReflectionHelpers.GetPrivateField<KeyboardState>(stage, "_previousKeyboardState").IsKeyDown(Keys.Down));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for Game1 initialization, dispose, and stage logic
- Expand virtual hooks for testability in BaseGame
- Add NoteRendererLogicTests for deterministic note rendering
- Add PerformanceStageDeterministicTests covering audio/background/effects rendering
- Add logic tests for TitleStage, SongTransitionStage, and ResultStage
- Add ManagedFontLogicTests for character handling edge cases
- Fix pre-generation of common textures at init to avoid render target switches
- Improve render target handling with detailed exception logging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across initialization/API lifecycle, main-thread action draining, graphics/device lifecycle, rendering and note renderer behavior, performance-stage determinism, stage transitions, title/result/song-transition logic, and font/texture handling to improve reliability.
* **Chores**
  * Internal refactor and cleanup to improve resource management, startup/shutdown ordering, and disposal reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->