### PR TITLE
feat: add scroll speed control

### DIFF
--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -134,6 +134,10 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         ConfigManager = new ConfigManager();
         ConfigManager.LoadConfig(AppPaths.GetConfigFilePath());
 
+        // Ensure deferred config writes (e.g. scroll-speed changes) are flushed
+        // even if the normal deactivate path is skipped during abrupt exit.
+        Exiting += OnGameExiting;
+
         // Initialize graphics manager
         _graphicsManager = new GraphicsManager(this, _graphicsDeviceManager, _loggerFactory.CreateLogger<GraphicsManager>());
 
@@ -449,6 +453,21 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         _logger.LogWarning("Graphics device lost");
     }
 
+    private void OnGameExiting(object? sender, EventArgs e)
+    {
+        // Belt-and-suspenders: ensure any deferred config write (e.g. scroll-speed)
+        // is flushed even if the normal stage-deactivation path is skipped.
+        try
+        {
+            if (ConfigManager is ConfigManager concrete)
+                concrete.FlushPendingSave();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to flush pending config save on exit");
+        }
+    }
+
     private void OnGraphicsDeviceReset(object? sender, EventArgs e)
     {
         // Handle device reset scenario
@@ -484,6 +503,9 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
 
     private void DisposeManagedResources()
     {
+        // Unsubscribe from Game.Exiting to avoid double-flush during normal shutdown
+        Exiting -= OnGameExiting;
+
         // Dispose StageManager first to properly cleanup all stages
         if (StageManager != null)
         {

--- a/DTXMania.Game/Lib/Config/ConfigData.cs
+++ b/DTXMania.Game/Lib/Config/ConfigData.cs
@@ -32,7 +32,7 @@ namespace DTXMania.Game.Lib.Config
         public Dictionary<string, string> SystemKeyBindings { get; set; } = new();
 
         // Game settings
-        public int ScrollSpeed { get; set; } = 100;
+        public int ScrollSpeed { get; set; } = ScrollSpeedRange.Default;
         public bool AutoPlay { get; set; } = false;
         public bool NoFail { get; set; } = false;
 

--- a/DTXMania.Game/Lib/Config/ConfigItems.cs
+++ b/DTXMania.Game/Lib/Config/ConfigItems.cs
@@ -128,8 +128,8 @@ namespace DTXMania.Game.Lib.Config
     }
 
     /// <summary>
-    /// Configuration item for integer values with min/max bounds
-    /// Similar to DTXManiaNX Integer type config items
+    /// Configuration item for integer values with min/max bounds.
+    /// Optional valueFormatter customizes the displayed value (default: stringified integer).
     /// </summary>
     public class IntegerConfigItem : BaseConfigItem
     {
@@ -138,9 +138,10 @@ namespace DTXMania.Game.Lib.Config
         private readonly int _minValue;
         private readonly int _maxValue;
         private readonly int _step;
+        private readonly Func<int, string> _valueFormatter;
 
-        public IntegerConfigItem(string name, Func<int> getCurrentValue, Action<int> setValue, 
-            int minValue, int maxValue, int step = 1)
+        public IntegerConfigItem(string name, Func<int> getCurrentValue, Action<int> setValue,
+            int minValue, int maxValue, int step = 1, Func<int, string> valueFormatter = null)
             : base(name)
         {
             _getCurrentValue = getCurrentValue ?? throw new ArgumentNullException(nameof(getCurrentValue));
@@ -148,6 +149,7 @@ namespace DTXMania.Game.Lib.Config
             _minValue = minValue;
             _maxValue = maxValue;
             _step = step;
+            _valueFormatter = valueFormatter;
 
             if (_minValue >= _maxValue)
                 throw new ArgumentException("Min value must be less than max value");
@@ -158,7 +160,8 @@ namespace DTXMania.Game.Lib.Config
         public override string GetDisplayText()
         {
             var currentValue = _getCurrentValue();
-            return $"{Name}: {currentValue}";
+            var formatted = _valueFormatter != null ? _valueFormatter(currentValue) : currentValue.ToString();
+            return $"{Name}: {formatted}";
         }
 
         public override void PreviousValue()

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -197,6 +197,10 @@ namespace DTXMania.Game.Lib.Config
                     {
                         EnsureRequiredSystemKeyBinding(inputManager, command);
                     }
+                    else
+                    {
+                        RemoveSystemKeyBinding(inputManager, command);
+                    }
 
                     continue;
                 }

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -288,7 +288,7 @@ namespace DTXMania.Game.Lib.Config
                     break;
                 case "ScrollSpeed":
                     if (int.TryParse(value, out var scrollSpeed))
-                        Config.ScrollSpeed = scrollSpeed;
+                        Config.ScrollSpeed = ScrollSpeedRange.SnapAndClamp(scrollSpeed);
                     break;
                 case "AutoPlay":
                     if (TryParseBool(value, out var autoPlay))

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Stage.KeyAssign;
 using DTXMania.Game.Lib.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -25,6 +26,16 @@ namespace DTXMania.Game.Lib.Config
             InputCommandType.Activate,
             InputCommandType.Back,
         };
+
+        private static bool IsRequiredSystemCommand(InputCommandType command)
+        {
+            return KeyConflictChecker.IsRequiredCommand(command);
+        }
+
+        private static InputCommandType[] GetRequiredSystemCommands()
+        {
+            return RequiredSystemCommands;
+        }
 
         private readonly ILogger<ConfigManager> _logger;
         public ConfigData Config { get; private set; }
@@ -219,6 +230,8 @@ namespace DTXMania.Game.Lib.Config
                 if (IsRequiredSystemCommand(kvp.Value))
                     continue;
 
+                System.Diagnostics.Debug.WriteLine(
+                    $"[ConfigManager] Evicting system binding: {kvp.Key} -> {kvp.Value} (conflicts with drum key)");
                 inputManager.RemoveKeyMapping(kvp.Key);
             }
         }
@@ -461,7 +474,7 @@ namespace DTXMania.Game.Lib.Config
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to persist ScrollSpeed change to {Path}; in-memory value still updated.", configFilePath);
+                _logger.LogError(ex, "Failed to persist ScrollSpeed change to {Path}; in-memory value still updated.", configFilePath);
             }
 
             ScrollSpeedChanged?.Invoke(this, new ScrollSpeedChangedEventArgs(old, snapped));
@@ -579,16 +592,6 @@ namespace DTXMania.Game.Lib.Config
             }
 
             return explicitlyUnboundButtons;
-        }
-
-        private static bool IsRequiredSystemCommand(InputCommandType command)
-        {
-            return RequiredSystemCommands.Contains(command);
-        }
-
-        private static InputCommandType[] GetRequiredSystemCommands()
-        {
-            return RequiredSystemCommands;
         }
 
         private static bool HasSystemKeyBinding(InputManager inputManager, InputCommandType command)

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -420,7 +420,35 @@ namespace DTXMania.Game.Lib.Config
         {
             Config = new ConfigData();
         }
-        
+
+        public event EventHandler<ScrollSpeedChangedEventArgs>? ScrollSpeedChanged;
+
+        public void SetScrollSpeed(string configFilePath, int percent)
+        {
+            var snapped = ScrollSpeedRange.SnapAndClamp(percent);
+            var old = Config.ScrollSpeed;
+            if (snapped == old)
+                return;
+
+            Config.ScrollSpeed = snapped;
+
+            try
+            {
+                SaveConfig(configFilePath);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to persist ScrollSpeed change to {Path}; in-memory value still updated.", configFilePath);
+            }
+
+            ScrollSpeedChanged?.Invoke(this, new ScrollSpeedChangedEventArgs(old, snapped));
+        }
+
+        public void AdjustScrollSpeed(string configFilePath, int stepDelta)
+        {
+            SetScrollSpeed(configFilePath, Config.ScrollSpeed + stepDelta * ScrollSpeedRange.Step);
+        }
+
         /// <summary>
         /// Helper method for robust boolean parsing
         /// </summary>

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -458,7 +458,11 @@ namespace DTXMania.Game.Lib.Config
                 }
             }
 
-            File.WriteAllText(filePath, sb.ToString(), Encoding.UTF8);
+            // Write atomically via temp-file to avoid truncation on crash/disk-full.
+            // Write to temp first — if it fails, original remains intact.
+            var tempFile = filePath + ".tmp";
+            File.WriteAllText(tempFile, sb.ToString(), Encoding.UTF8);
+            File.Move(tempFile, filePath, overwrite: true);
         }
 
         public void ResetToDefaults()
@@ -495,15 +499,14 @@ namespace DTXMania.Game.Lib.Config
             if (path == null)
                 return;
 
-            _pendingSavePath = null;
-
             try
             {
                 SaveConfig(path);
+                _pendingSavePath = null;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Failed to persist deferred config changes to {Path}; in-memory values are still up to date.", path);
+                _logger.LogError(ex, "Failed to persist deferred config changes to {Path}; in-memory values are still up to date. Will retry on next flush.", path);
             }
         }
 

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -40,6 +40,12 @@ namespace DTXMania.Game.Lib.Config
         private readonly ILogger<ConfigManager> _logger;
         public ConfigData Config { get; private set; }
 
+        /// <summary>
+        /// Path of the config file that has a deferred (debounced) write pending.
+        /// Null when no write is pending.
+        /// </summary>
+        private string? _pendingSavePath;
+
         public ConfigManager(ILogger<ConfigManager>? logger = null)
         {
             _logger = logger ?? NullLogger<ConfigManager>.Instance;
@@ -223,7 +229,7 @@ namespace DTXMania.Game.Lib.Config
         /// Required commands are never evicted; their fallback logic in
         /// <see cref="EnsureRequiredSystemKeyBindings"/> already handles this.
         /// </summary>
-        private static void EvictDrumKeyConflicts(InputManager inputManager, HashSet<Keys> drumKeys)
+        private void EvictDrumKeyConflicts(InputManager inputManager, HashSet<Keys> drumKeys)
         {
             var snapshot = inputManager.GetKeyMappingSnapshot();
             foreach (var kvp in snapshot)
@@ -234,8 +240,7 @@ namespace DTXMania.Game.Lib.Config
                 if (IsRequiredSystemCommand(kvp.Value))
                     continue;
 
-                System.Diagnostics.Debug.WriteLine(
-                    $"[ConfigManager] Evicting system binding: {kvp.Key} -> {kvp.Value} (conflicts with drum key)");
+                _logger.LogDebug("Evicting system binding: {Key} -> {Command} (conflicts with drum key)", kvp.Key, kvp.Value);
                 inputManager.RemoveKeyMapping(kvp.Key);
             }
         }
@@ -472,14 +477,8 @@ namespace DTXMania.Game.Lib.Config
 
             Config.ScrollSpeed = snapped;
 
-            try
-            {
-                SaveConfig(configFilePath);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to persist ScrollSpeed change to {Path}; in-memory value still updated.", configFilePath);
-            }
+            // Defer disk write — mark dirty and flush later via FlushPendingSave.
+            _pendingSavePath = configFilePath;
 
             ScrollSpeedChanged?.Invoke(this, new ScrollSpeedChangedEventArgs(old, snapped));
         }
@@ -487,6 +486,25 @@ namespace DTXMania.Game.Lib.Config
         public void AdjustScrollSpeed(string configFilePath, int stepDelta)
         {
             SetScrollSpeed(configFilePath, Config.ScrollSpeed + stepDelta * ScrollSpeedRange.Step);
+        }
+
+        /// <inheritdoc/>
+        public void FlushPendingSave()
+        {
+            var path = _pendingSavePath;
+            if (path == null)
+                return;
+
+            _pendingSavePath = null;
+
+            try
+            {
+                SaveConfig(path);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to persist deferred config changes to {Path}; in-memory values are still up to date.", path);
+            }
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -198,6 +198,29 @@ namespace DTXMania.Game.Lib.Config
             }
 
             EnsureRequiredSystemKeyBindings(inputManager);
+            EvictDrumKeyConflicts(inputManager, drumKeys);
+        }
+
+        /// <summary>
+        /// Removes non-required system key bindings that collide with drum keys,
+        /// so that a key used for gameplay does not also fire a system command
+        /// (e.g. scroll-speed adjust) during performance.
+        /// Required commands are never evicted; their fallback logic in
+        /// <see cref="EnsureRequiredSystemKeyBindings"/> already handles this.
+        /// </summary>
+        private static void EvictDrumKeyConflicts(InputManager inputManager, HashSet<Keys> drumKeys)
+        {
+            var snapshot = inputManager.GetKeyMappingSnapshot();
+            foreach (var kvp in snapshot)
+            {
+                if (!drumKeys.Contains(kvp.Key))
+                    continue;
+
+                if (IsRequiredSystemCommand(kvp.Value))
+                    continue;
+
+                inputManager.RemoveKeyMapping(kvp.Key);
+            }
         }
 
         public void SaveSystemKeyBindings(InputManager inputManager)

--- a/DTXMania.Game/Lib/Config/IConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/IConfigManager.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace DTXMania.Game.Lib.Config
 {
     public interface IConfigManager
@@ -6,5 +8,25 @@ namespace DTXMania.Game.Lib.Config
         void LoadConfig(string filePath);
         void SaveConfig(string filePath);
         void ResetToDefaults();
+
+        /// <summary>
+        /// Raised when the scroll-speed setting changes via SetScrollSpeed or AdjustScrollSpeed.
+        /// Not raised by direct mutation of Config.ScrollSpeed or by LoadConfig.
+        /// </summary>
+        event EventHandler<ScrollSpeedChangedEventArgs>? ScrollSpeedChanged;
+
+        /// <summary>
+        /// Sets the scroll speed (percent), snapping to the nearest allowed step and
+        /// clamping to the allowed range. Persists to the given file path and raises
+        /// ScrollSpeedChanged when the value actually changes.
+        /// No-op (and no save) if the new value equals the current value.
+        /// </summary>
+        void SetScrollSpeed(string configFilePath, int percent);
+
+        /// <summary>
+        /// Adjusts scroll speed by stepDelta * Step. Equivalent to
+        /// SetScrollSpeed(path, current + stepDelta * Step).
+        /// </summary>
+        void AdjustScrollSpeed(string configFilePath, int stepDelta);
     }
 }

--- a/DTXMania.Game/Lib/Config/IConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/IConfigManager.cs
@@ -30,5 +30,11 @@ namespace DTXMania.Game.Lib.Config
         /// SetScrollSpeed(path, current + stepDelta * Step).
         /// </summary>
         void AdjustScrollSpeed(string configFilePath, int stepDelta);
+
+        /// <summary>
+        /// Flushes any deferred config changes to disk. Call this on stage exit
+        /// or game shutdown to ensure pending writes are persisted.
+        /// </summary>
+        void FlushPendingSave();
     }
 }

--- a/DTXMania.Game/Lib/Config/IConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/IConfigManager.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace DTXMania.Game.Lib.Config

--- a/DTXMania.Game/Lib/Config/ScrollSpeedChangedEventArgs.cs
+++ b/DTXMania.Game/Lib/Config/ScrollSpeedChangedEventArgs.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace DTXMania.Game.Lib.Config
+{
+    public sealed class ScrollSpeedChangedEventArgs : EventArgs
+    {
+        public int OldPercent { get; }
+        public int NewPercent { get; }
+
+        public ScrollSpeedChangedEventArgs(int oldPercent, int newPercent)
+        {
+            OldPercent = oldPercent;
+            NewPercent = newPercent;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Config/ScrollSpeedRange.cs
+++ b/DTXMania.Game/Lib/Config/ScrollSpeedRange.cs
@@ -21,10 +21,10 @@ namespace DTXMania.Game.Lib.Config
         /// </summary>
         public static int SnapAndClamp(int percent)
         {
-            var snapped = (int)Math.Round(percent / (double)Step, MidpointRounding.AwayFromZero) * Step;
+            var snapped = (long)Math.Round(percent / (double)Step, MidpointRounding.AwayFromZero) * Step;
             if (snapped < Min) return Min;
             if (snapped > Max) return Max;
-            return snapped;
+            return (int)snapped;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Config/ScrollSpeedRange.cs
+++ b/DTXMania.Game/Lib/Config/ScrollSpeedRange.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Globalization;
+
+namespace DTXMania.Game.Lib.Config
+{
+    /// <summary>
+    /// Range, step, and formatting for the visual scroll-speed setting.
+    /// Single source of truth used by ConfigManager, ConfigStage, SongSelectionStage,
+    /// and the in-game ScrollSpeedIndicator.
+    /// </summary>
+    public static class ScrollSpeedRange
+    {
+        public const int Min = 50;
+        public const int Max = 400;
+        public const int Step = 50;
+        public const int Default = 100;
+
+        /// <summary>
+        /// Snaps an arbitrary integer percent to the nearest multiple of Step,
+        /// then clamps to [Min, Max].
+        /// </summary>
+        public static int SnapAndClamp(int percent)
+        {
+            var snapped = (int)Math.Round(percent / (double)Step, MidpointRounding.AwayFromZero) * Step;
+            if (snapped < Min) return Min;
+            if (snapped > Max) return Max;
+            return snapped;
+        }
+
+        /// <summary>
+        /// Formats a percent as "x1.0", "x1.5", etc. (one decimal).
+        /// </summary>
+        public static string Format(int percent)
+        {
+            var multiplier = percent / 100.0;
+            return "x" + multiplier.ToString("0.0", CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Input/InputManager.cs
+++ b/DTXMania.Game/Lib/Input/InputManager.cs
@@ -15,7 +15,9 @@ namespace DTXMania.Game.Lib.Input
         MoveLeft,
         MoveRight,
         Activate,
-        Back
+        Back,
+        IncreaseScrollSpeed,
+        DecreaseScrollSpeed
     }
 
     /// <summary>
@@ -99,6 +101,8 @@ namespace DTXMania.Game.Lib.Input
             _keyMapping[Keys.Right] = InputCommandType.MoveRight;
             _keyMapping[Keys.Enter] = InputCommandType.Activate;
             _keyMapping[Keys.Escape] = InputCommandType.Back;
+            _keyMapping[Keys.PageUp] = InputCommandType.IncreaseScrollSpeed;
+            _keyMapping[Keys.PageDown] = InputCommandType.DecreaseScrollSpeed;
         }
 
         public virtual void Update(double deltaTime = 0)

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -338,6 +338,7 @@ namespace DTXMania.Game.Lib.Stage
             _drumPanel._liveSystemMappingProvider = () => new Dictionary<Keys, InputCommandType>(_workingSystemBindings);
             _drumPanel._navigationMappingProvider = () => new Dictionary<Keys, InputCommandType>(_workingSystemBindings);
             _drumPanel._commandPressedProvider = IsPanelCommandPressed;
+            _drumPanel.EvictSystemBinding = key => _workingSystemBindings.Remove(key);
             _drumPanel.Saved += OnPanelSaved;
             _drumPanel.Closed += OnPanelClosed;
 

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -296,11 +296,25 @@ namespace DTXMania.Game.Lib.Stage
                     System.Diagnostics.Debug.WriteLine($"AutoPlay changed to {value}");
                 });
 
+            var scrollSpeedItem = new IntegerConfigItem(
+                "Scroll Speed",
+                () => _workingConfig.ScrollSpeed,
+                value =>
+                {
+                    _workingConfig.ScrollSpeed = ScrollSpeedRange.SnapAndClamp(value);
+                    _hasUnsavedChanges = true;
+                },
+                minValue: ScrollSpeedRange.Min,
+                maxValue: ScrollSpeedRange.Max,
+                step: ScrollSpeedRange.Step,
+                valueFormatter: ScrollSpeedRange.Format);
+
             _configItems.Add(resolutionItem);
             _configItems.Add(fullscreenItem);
             _configItems.Add(vsyncItem);
             _configItems.Add(noFailItem);
             _configItems.Add(autoPlayItem);
+            _configItems.Add(scrollSpeedItem);
 
             // Drum and system key mapping navigation items
             _configItems.Add(new NavigationConfigItem("Drum Key Mapping",
@@ -492,6 +506,7 @@ namespace DTXMania.Game.Lib.Stage
             bool prevVSync = config.VSyncWait;
             bool prevNoFail = config.NoFail;
             bool prevAutoPlay = config.AutoPlay;
+            int prevScrollSpeed = config.ScrollSpeed;
             var prevKeyBindings = new Dictionary<string, int>(config.KeyBindings);
             var prevUnboundLanes = new HashSet<int>(config.UnboundDrumLanes);
             var prevUnboundButtons = new HashSet<string>(config.UnboundDrumButtons);
@@ -504,6 +519,7 @@ namespace DTXMania.Game.Lib.Stage
             config.VSyncWait = _workingConfig.VSyncWait;
             config.NoFail = _workingConfig.NoFail;
             config.AutoPlay = _workingConfig.AutoPlay;
+            config.ScrollSpeed = _workingConfig.ScrollSpeed;
 
             if (_configManager is ConfigManager concreteConfig)
             {
@@ -527,6 +543,7 @@ namespace DTXMania.Game.Lib.Stage
                 config.VSyncWait = prevVSync;
                 config.NoFail = prevNoFail;
                 config.AutoPlay = prevAutoPlay;
+                config.ScrollSpeed = prevScrollSpeed;
                 config.KeyBindings.Clear();
                 foreach (var kvp in prevKeyBindings) config.KeyBindings[kvp.Key] = kvp.Value;
                 config.UnboundDrumLanes.Clear();

--- a/DTXMania.Game/Lib/Stage/KeyAssign/DrumKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/DrumKeyAssignPanel.cs
@@ -135,14 +135,19 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
 
         private void AssignKey(Keys key)
         {
-            var conflict = KeyConflictChecker.CheckAgainstSystemBindings(
-                GetLiveSystemMapping(), key);
+            var systemMapping = GetLiveSystemMapping();
 
-            if (conflict != null)
+            // Reject if the key is bound to a REQUIRED system command (navigation/core)
+            var requiredConflict = KeyConflictChecker.GetRequiredSystemConflict(systemMapping, key);
+            if (requiredConflict != null)
             {
-                ShowConflict(conflict);
+                ShowConflict($"{key} is already bound to system action: {requiredConflict}");
                 return;
             }
+
+            // Auto-evict non-required system binding (e.g. IncreaseScrollSpeed) so the
+            // drum lane can claim this key, mirroring EvictDrumKeyConflicts() at config load.
+            EvictSystemBinding?.Invoke(key);
 
             _workingBindings.BindButton(KeyBindings.CreateKeyButtonId(key), _selectedIndex);
             _state = CaptureState.Browsing;
@@ -186,6 +191,12 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         internal Func<KeyBindings>? _workingBindingsProvider;
         internal Func<IReadOnlyDictionary<Keys, InputCommandType>>? _navigationMappingProvider;
         internal Func<InputCommandType, bool>? _commandPressedProvider;
+
+        /// <summary>
+        /// Injected by ConfigStage. Called to evict a non-required system key binding
+        /// from the working system map when a drum lane claims that key.
+        /// </summary>
+        internal Action<Keys>? EvictSystemBinding;
 
         internal KeyBindings GetWorkingBindingsSnapshot() => _workingBindings.Clone();
 

--- a/DTXMania.Game/Lib/Stage/KeyAssign/DrumKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/DrumKeyAssignPanel.cs
@@ -46,7 +46,7 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         private CaptureState _state;
         private string? _conflictMessage;
         private double _conflictTimer;
-        private HashSet<Keys> _pendingEvictions = new();
+        private readonly HashSet<Keys> _pendingEvictions = new();
 
         public bool IsActive { get; private set; }
         public event EventHandler? Closed;

--- a/DTXMania.Game/Lib/Stage/KeyAssign/DrumKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/DrumKeyAssignPanel.cs
@@ -46,6 +46,7 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         private CaptureState _state;
         private string? _conflictMessage;
         private double _conflictTimer;
+        private HashSet<Keys> _pendingEvictions = new();
 
         public bool IsActive { get; private set; }
         public event EventHandler? Closed;
@@ -66,6 +67,7 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
             _state = CaptureState.Browsing;
             _conflictMessage = null;
             _conflictTimer = 0;
+            _pendingEvictions.Clear();
             IsActive = true;
         }
 
@@ -147,7 +149,9 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
 
             // Auto-evict non-required system binding (e.g. IncreaseScrollSpeed) so the
             // drum lane can claim this key, mirroring EvictDrumKeyConflicts() at config load.
-            EvictSystemBinding?.Invoke(key);
+            // Deferred: the eviction is recorded and only applied when the user saves,
+            // so cancelling the panel does not leave a partially-mutated system map.
+            _pendingEvictions.Add(key);
 
             _workingBindings.BindButton(KeyBindings.CreateKeyButtonId(key), _selectedIndex);
             _state = CaptureState.Browsing;
@@ -155,6 +159,16 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
 
         private void CommitAndClose()
         {
+            // Apply deferred evictions — but only for keys still bound to a drum lane.
+            // If the user assigned a key (triggering an eviction) then cleared that lane,
+            // there is no reason to evict the system binding anymore.
+            foreach (var key in _pendingEvictions)
+            {
+                var buttonId = KeyBindings.CreateKeyButtonId(key);
+                if (_workingBindings.GetLane(buttonId) >= 0)
+                    EvictSystemBinding?.Invoke(key);
+            }
+
             Deactivate();
             Saved?.Invoke(this, EventArgs.Empty);
             Closed?.Invoke(this, EventArgs.Empty);

--- a/DTXMania.Game/Lib/Stage/KeyAssign/KeyConflictChecker.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/KeyConflictChecker.cs
@@ -12,6 +12,26 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
     public static class KeyConflictChecker
     {
         /// <summary>
+        /// System commands that must always remain bound (navigation/core actions).
+        /// Non-required commands (e.g. IncreaseScrollSpeed) can be auto-evicted
+        /// when the user assigns that key to a drum lane.
+        /// </summary>
+        private static readonly HashSet<InputCommandType> RequiredCommands = new()
+        {
+            InputCommandType.MoveUp,
+            InputCommandType.MoveDown,
+            InputCommandType.MoveLeft,
+            InputCommandType.MoveRight,
+            InputCommandType.Activate,
+            InputCommandType.Back,
+        };
+
+        /// <summary>
+        /// Returns true if the command is a required system command that cannot be evicted.
+        /// </summary>
+        public static bool IsRequiredCommand(InputCommandType command) => RequiredCommands.Contains(command);
+
+        /// <summary>
         /// Checks if a candidate key is already mapped as a system navigation key.
         /// Returns a human-readable error message, or null if no conflict.
         /// </summary>
@@ -21,6 +41,22 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         {
             if (systemBindings.TryGetValue(candidate, out var command))
                 return $"{candidate} is already bound to system action: {command}";
+            return null;
+        }
+
+        /// <summary>
+        /// Checks if a candidate key conflicts with a required system command.
+        /// Returns the conflicting command if it is required, or null if the key
+        /// is either not in system bindings or only bound to non-required commands.
+        /// Non-required commands (e.g. IncreaseScrollSpeed) can be auto-evicted
+        /// by the caller when assigning a drum lane.
+        /// </summary>
+        public static InputCommandType? GetRequiredSystemConflict(
+            IReadOnlyDictionary<Keys, InputCommandType> systemBindings,
+            Keys candidate)
+        {
+            if (systemBindings.TryGetValue(candidate, out var command) && IsRequiredCommand(command))
+                return command;
             return null;
         }
 

--- a/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
@@ -124,7 +124,14 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         private void TryUnbindSelectedAction()
         {
             var action = Actions[_selectedIndex];
-            ShowConflict($"{action} must remain bound");
+
+            if (KeyConflictChecker.IsRequiredCommand(action))
+            {
+                ShowConflict($"{action} must remain bound");
+                return;
+            }
+
+            RemoveBindingsForAction(action);
         }
 
         private void HandleKeyCapture(KeyboardState current, KeyboardState previous)

--- a/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
@@ -31,6 +31,8 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
             InputCommandType.MoveRight,
             InputCommandType.Activate,
             InputCommandType.Back,
+            InputCommandType.IncreaseScrollSpeed,
+            InputCommandType.DecreaseScrollSpeed,
         };
 
         private static readonly int ActionCount = Actions.Length;

--- a/DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Brief on-screen toast that displays the current scroll-speed value
+    /// for a short duration after the player adjusts it.
+    /// </summary>
+    public class ScrollSpeedIndicator
+    {
+        private readonly BitmapFont? _font;
+        private string _text = string.Empty;
+        private float _remainingSeconds;
+        private bool _hasShown;
+
+        public ScrollSpeedIndicator(BitmapFont? font)
+        {
+            _font = font;
+        }
+
+        public void Show(int scrollSpeedPercent)
+        {
+            _text = "Scroll Speed " + ScrollSpeedRange.Format(scrollSpeedPercent);
+            _remainingSeconds = PerformanceUILayout.ScrollSpeedIndicatorDurationSeconds;
+            _hasShown = true;
+        }
+
+        public void Update(GameTime gameTime)
+        {
+            if (_remainingSeconds <= 0f)
+                return;
+            _remainingSeconds -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+            if (_remainingSeconds < 0f)
+                _remainingSeconds = 0f;
+        }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (!_hasShown || _remainingSeconds <= 0f || _font == null)
+                return;
+
+            var alpha = ComputeAlpha();
+            var color = Color.White * alpha;
+            _font.DrawText(spriteBatch, _text,
+                PerformanceUILayout.ScrollSpeedIndicatorX,
+                PerformanceUILayout.ScrollSpeedIndicatorY,
+                color, BitmapFont.FontType.Normal, 0.0f);
+        }
+
+        private float ComputeAlpha()
+        {
+            var fade = PerformanceUILayout.ScrollSpeedIndicatorFadeSeconds;
+            if (_remainingSeconds >= fade)
+                return 1f;
+            return _remainingSeconds / fade;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs
@@ -18,6 +18,18 @@ namespace DTXMania.Game.Lib.Stage.Performance
         private float _remainingSeconds;
         private bool _hasShown;
 
+        /// <summary>Current display text (set by Show).</summary>
+        internal string Text => _text;
+
+        /// <summary>Seconds remaining before the indicator hides.</summary>
+        internal float RemainingSeconds => _remainingSeconds;
+
+        /// <summary>Whether the indicator has been shown at least once and is still visible.</summary>
+        internal bool IsVisible => _hasShown && _remainingSeconds > 0f;
+
+        /// <summary>Current alpha value (0..1) used for fade-out near expiry.</summary>
+        internal float Alpha => (!_hasShown || _remainingSeconds <= 0f) ? 0f : ComputeAlpha();
+
         public ScrollSpeedIndicator(BitmapFont? font)
         {
             _font = font;

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -790,12 +790,13 @@ namespace DTXMania.Game.Lib.Stage
                 _readyFont = new BitmapFont(_spriteBatch.GraphicsDevice, _resourceManager, consoleFontConfig);
                 _scrollSpeedIndicator = new ScrollSpeedIndicator(_readyFont);
             }
-            catch (Exception ex)
-            {
-                // Font initialization failed, fallback will be used
-                _readyFont = null;
-                _scrollSpeedIndicator = new ScrollSpeedIndicator(null);
-            }
+    catch (Exception ex)
+    {
+        // Font initialization failed, fallback will be used
+        System.Diagnostics.Debug.WriteLine($"[PerformanceStage] InitializeReadyFont failed: {ex.Message}");
+        _readyFont = null;
+        _scrollSpeedIndicator = new ScrollSpeedIndicator(null);
+    }
         }
         
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -790,13 +790,13 @@ namespace DTXMania.Game.Lib.Stage
                 _readyFont = new BitmapFont(_spriteBatch.GraphicsDevice, _resourceManager, consoleFontConfig);
                 _scrollSpeedIndicator = new ScrollSpeedIndicator(_readyFont);
             }
-    catch (Exception ex)
-    {
-        // Font initialization failed, fallback will be used
-        System.Diagnostics.Debug.WriteLine($"[PerformanceStage] InitializeReadyFont failed: {ex.Message}");
-        _readyFont = null;
-        _scrollSpeedIndicator = new ScrollSpeedIndicator(null);
-    }
+            catch (Exception ex)
+            {
+                // Font initialization failed, fallback will be used
+                System.Diagnostics.Debug.WriteLine($"[PerformanceStage] InitializeReadyFont failed: {ex.Message}");
+                _readyFont = null;
+                _scrollSpeedIndicator = new ScrollSpeedIndicator(null);
+            }
         }
         
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -19,6 +19,7 @@ using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Utilities;
 
 namespace DTXMania.Game.Lib.Stage
 {
@@ -178,10 +179,20 @@ namespace DTXMania.Game.Lib.Stage
             // Start async chart loading and audio preparation
             _ = InitializeGameplayAsync();
 
+            var configManager = _game?.ConfigManager;
+            if (configManager != null)
+            {
+                configManager.ScrollSpeedChanged += OnScrollSpeedChanged;
+            }
         }
 
         protected override void OnDeactivate()
         {
+            var configManager = _game?.ConfigManager;
+            if (configManager != null)
+            {
+                configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+            }
 
             // Clean up components
             CleanupComponents();
@@ -451,10 +462,25 @@ namespace DTXMania.Game.Lib.Stage
             // Only process gameplay input when song is actively playing (not during loading or ready countdown)
             if (_songTimer?.IsPlaying == true && !_inputPaused && !_isLoading && !(_isReady && _readyCountdown > 0))
             {
-                // Input manager is already being updated in OnUpdate(), 
+                // Input manager is already being updated in OnUpdate(),
                 // so we don't need to do anything special here.
                 // The ModularInputManager will automatically trigger lane hit events
                 // which the JudgementManager is subscribed to.
+            }
+
+            // Scroll-speed adjust hotkeys (PageUp/PageDown) — active throughout performance,
+            // not gated on song playback so player can pre-adjust during the ready countdown.
+            var configManager = _game?.ConfigManager;
+            if (configManager != null)
+            {
+                if (_inputManager.IsCommandPressed(InputCommandType.IncreaseScrollSpeed))
+                {
+                    configManager.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), +1);
+                }
+                else if (_inputManager.IsCommandPressed(InputCommandType.DecreaseScrollSpeed))
+                {
+                    configManager.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
+                }
             }
         }
 
@@ -496,6 +522,12 @@ namespace DTXMania.Game.Lib.Stage
                 new DTXManiaFadeTransition(0.5), null);
         }
 
+        private void OnScrollSpeedChanged(object? sender, ScrollSpeedChangedEventArgs e)
+        {
+            _noteRenderer?.SetScrollSpeed(e.NewPercent);
+            // Indicator hookup added in Task 6.
+        }
+
         #endregion
 
         #region Phase 2 - Chart Loading and Gameplay
@@ -535,9 +567,9 @@ namespace DTXMania.Game.Lib.Stage
                 // Set BPM and scroll speed in note renderer
                 _noteRenderer?.SetBpm(_parsedChart.Bpm);
 
-                // Set scroll speed based on user preference
-                // TODO: Get scroll speed from user config
-                var scrollSpeedSetting = 100; // Default scroll speed
+                // Set scroll speed based on user preference (read from config, applied at chart load).
+                // In-game adjustments are handled via ConfigManager.ScrollSpeedChanged subscription.
+                var scrollSpeedSetting = _game?.ConfigManager?.Config?.ScrollSpeed ?? ScrollSpeedRange.Default;
                 _noteRenderer?.SetScrollSpeed(scrollSpeedSetting);
 
                 // Load background audio - ALWAYS needed for SongTimer creation (master clock)

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -86,6 +86,7 @@ namespace DTXMania.Game.Lib.Stage
         // UX components
         private BitmapFont _readyFont = null!;
         private ScrollSpeedIndicator? _scrollSpeedIndicator;
+        private IConfigManager? _subscribedConfigManager;
 
         // Performance UI Assets - initialized in InitializeComponents
         private ITexture _backgroundTexture = null!;
@@ -183,16 +184,18 @@ namespace DTXMania.Game.Lib.Stage
             var configManager = _game?.ConfigManager;
             if (configManager != null)
             {
+                _subscribedConfigManager = configManager;
                 configManager.ScrollSpeedChanged += OnScrollSpeedChanged;
             }
         }
 
         protected override void OnDeactivate()
         {
-            var configManager = _game?.ConfigManager;
-            if (configManager != null)
+            if (_subscribedConfigManager != null)
             {
-                configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+                _subscribedConfigManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+                _subscribedConfigManager.FlushPendingSave();
+                _subscribedConfigManager = null;
             }
 
             // Clean up components

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -85,6 +85,7 @@ namespace DTXMania.Game.Lib.Stage
 
         // UX components
         private BitmapFont _readyFont = null!;
+        private ScrollSpeedIndicator? _scrollSpeedIndicator;
 
         // Performance UI Assets - initialized in InitializeComponents
         private ITexture _backgroundTexture = null!;
@@ -218,6 +219,9 @@ namespace DTXMania.Game.Lib.Stage
             // Update performance components
             UpdateComponents(deltaTime);
 
+            // Update scroll-speed indicator toast
+            _scrollSpeedIndicator?.Update(_currentGameTime);
+
             // Update gameplay state
             UpdateGameplay(deltaTime);
 
@@ -275,7 +279,9 @@ namespace DTXMania.Game.Lib.Stage
 
             // Draw ready state or loading indicator
             DrawGameplayState();
-            
+
+            // Draw scroll-speed indicator toast (on top of everything via depth 0.0)
+            _scrollSpeedIndicator?.Draw(_spriteBatch);
 
             _spriteBatch.End();
 
@@ -525,7 +531,7 @@ namespace DTXMania.Game.Lib.Stage
         private void OnScrollSpeedChanged(object? sender, ScrollSpeedChangedEventArgs e)
         {
             _noteRenderer?.SetScrollSpeed(e.NewPercent);
-            // Indicator hookup added in Task 6.
+            _scrollSpeedIndicator?.Show(e.NewPercent);
         }
 
         #endregion
@@ -782,11 +788,13 @@ namespace DTXMania.Game.Lib.Stage
                 // Create bitmap font for ready text display
                 var consoleFontConfig = BitmapFont.CreateConsoleFontConfig();
                 _readyFont = new BitmapFont(_spriteBatch.GraphicsDevice, _resourceManager, consoleFontConfig);
+                _scrollSpeedIndicator = new ScrollSpeedIndicator(_readyFont);
             }
             catch (Exception ex)
             {
                 // Font initialization failed, fallback will be used
                 _readyFont = null;
+                _scrollSpeedIndicator = new ScrollSpeedIndicator(null);
             }
         }
         

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -796,7 +796,7 @@ namespace DTXMania.Game.Lib.Stage
             catch (Exception ex)
             {
                 // Font initialization failed, fallback will be used
-                System.Diagnostics.Debug.WriteLine($"[PerformanceStage] InitializeReadyFont failed: {ex.Message}");
+                System.Diagnostics.Trace.WriteLine($"[PerformanceStage] InitializeReadyFont failed: {ex.Message}");
                 _readyFont = null;
                 _scrollSpeedIndicator = new ScrollSpeedIndicator(null);
             }

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -18,6 +18,7 @@ using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Utilities;
 
 namespace DTXMania.Game.Lib.Stage
 {
@@ -138,6 +139,11 @@ namespace DTXMania.Game.Lib.Stage
                 _configManager = baseGame.ConfigManager;
             }
 
+            if (_configManager != null)
+            {
+                _configManager.ScrollSpeedChanged += OnScrollSpeedChanged;
+            }
+
             // Initialize graphics resources
             _spriteBatch = new SpriteBatch(_game.GraphicsDevice);
             _resourceManager = _game.ResourceManager;
@@ -202,6 +208,11 @@ namespace DTXMania.Game.Lib.Stage
 
         public override void Deactivate()
         {
+            if (_configManager != null)
+            {
+                _configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+            }
+
             // Cancel any running song initialization task
             _cancellationTokenSource?.Cancel();
 
@@ -828,6 +839,16 @@ namespace DTXMania.Game.Lib.Stage
             // Draw UI (PreviewImagePanel will handle its own drawing including delay)
             _uiManager?.Draw(_spriteBatch, deltaTime);
 
+            // Draw current scroll-speed value as a small label
+            if (_bitmapFont != null && _configManager != null)
+            {
+                var label = "Scroll " + ScrollSpeedRange.Format(_configManager.Config.ScrollSpeed);
+                _bitmapFont.DrawText(_spriteBatch, label,
+                    SongSelectionUILayout.ScrollSpeedLabelX,
+                    SongSelectionUILayout.ScrollSpeedLabelY,
+                    Microsoft.Xna.Framework.Color.White);
+            }
+
             _spriteBatch.End();
         }
 
@@ -964,6 +985,14 @@ namespace DTXMania.Game.Lib.Stage
                             StageManager?.ChangeStage(StageType.Title, new DTXManiaFadeTransition(SongSelectionUILayout.Timing.TransitionDuration));
                         }
                     }
+                    break;
+
+                case InputCommandType.IncreaseScrollSpeed:
+                    _configManager?.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), +1);
+                    break;
+
+                case InputCommandType.DecreaseScrollSpeed:
+                    _configManager?.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
                     break;
             }
         }
@@ -1463,6 +1492,16 @@ namespace DTXMania.Game.Lib.Stage
             {
                 // Game start sound failed, continue
             }
+        }
+
+        #endregion
+
+        #region Scroll Speed
+
+        private void OnScrollSpeedChanged(object? sender, ScrollSpeedChangedEventArgs e)
+        {
+            // Label re-renders each frame from current config; nothing to do here today.
+            // Hook kept for symmetry with PerformanceStage and to make future caching trivial.
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1498,7 +1498,7 @@ namespace DTXMania.Game.Lib.Stage
 
         #region Scroll Speed
 
-        private void OnScrollSpeedChanged(object? sender, ScrollSpeedChangedEventArgs e)
+        private void OnScrollSpeedChanged(object sender, ScrollSpeedChangedEventArgs e)
         {
             // Label re-renders each frame from current config; nothing to do here today.
             // Hook kept for symmetry with PerformanceStage and to make future caching trivial.

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -211,6 +211,7 @@ namespace DTXMania.Game.Lib.Stage
             if (_configManager != null)
             {
                 _configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+                _configManager.FlushPendingSave();
             }
 
             // Cancel any running song initialization task

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -462,7 +462,13 @@ namespace DTXMania.Game.Lib.UI.Layout
         /// </summary>
         public const double NoteDefaultLookAheadMs = 1500.0;
         public const int NoteDefaultScrollSpeed = 100; // Default scroll speed percentage
-        
+
+        // Scroll-speed indicator (in-game toast shown when player adjusts scroll speed)
+        public const float ScrollSpeedIndicatorDurationSeconds = 1.5f;
+        public const float ScrollSpeedIndicatorFadeSeconds = 0.3f;
+        public const int ScrollSpeedIndicatorX = 640; // top-center of 1280-wide screen
+        public const int ScrollSpeedIndicatorY = 40;
+
         #endregion
         
         #region Performance Component Constants

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -466,7 +466,7 @@ namespace DTXMania.Game.Lib.UI.Layout
         // Scroll-speed indicator (in-game toast shown when player adjusts scroll speed)
         public const float ScrollSpeedIndicatorDurationSeconds = 1.5f;
         public const float ScrollSpeedIndicatorFadeSeconds = 0.3f;
-        public const int ScrollSpeedIndicatorX = 640; // top-center of 1280-wide screen
+        public const int ScrollSpeedIndicatorX = 640; // left edge at horizontal center of 1280-wide screen
         public const int ScrollSpeedIndicatorY = 40;
 
         #endregion

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -559,7 +559,7 @@ namespace DTXMania.Game.Lib.UI.Layout
         #endregion
         
         #region Spacing and Offsets
-        
+
         /// <summary>
         /// Common spacing and offset values
         /// </summary>
@@ -570,7 +570,11 @@ namespace DTXMania.Game.Lib.UI.Layout
             public const int BorderThickness = 2;   // Border thickness for panels
             public const int LabelValueSpacing = 5; // Space between label and value text
         }
-        
+
         #endregion
+
+        // Scroll-speed display (e.g., "Scroll x1.5") on song-select panel
+        public const int ScrollSpeedLabelX = 20;
+        public const int ScrollSpeedLabelY = 680; // bottom-left
     }
 }

--- a/DTXMania.Test/Config/ConfigItemTests.cs
+++ b/DTXMania.Test/Config/ConfigItemTests.cs
@@ -365,7 +365,7 @@ namespace DTXMania.Test.Config
                 () => _currentValue,
                 v => _currentValue = v,
                 50, 400, 50,
-                v => "x" + (v / 100.0).ToString("0.0"));
+                v => "x" + (v / 100.0).ToString("0.0", System.Globalization.CultureInfo.InvariantCulture));
 
             var text = item.GetDisplayText();
             Assert.Equal("Scroll Speed: x1.5", text);
@@ -380,7 +380,7 @@ namespace DTXMania.Test.Config
                 () => _currentValue,
                 v => _currentValue = v,
                 50, 400, 50,
-                v => "x" + (v / 100.0).ToString("0.0"));
+                v => "x" + (v / 100.0).ToString("0.0", System.Globalization.CultureInfo.InvariantCulture));
 
             Assert.Equal("Scroll Speed: x1.0", item.GetDisplayText());
         }

--- a/DTXMania.Test/Config/ConfigItemTests.cs
+++ b/DTXMania.Test/Config/ConfigItemTests.cs
@@ -356,6 +356,35 @@ namespace DTXMania.Test.Config
             Assert.Contains("75", text);
         }
 
+        [Fact]
+        public void GetDisplayText_WithFormatter_ShouldUseFormatter()
+        {
+            _currentValue = 150;
+            var item = new IntegerConfigItem(
+                "Scroll Speed",
+                () => _currentValue,
+                v => _currentValue = v,
+                50, 400, 50,
+                v => "x" + (v / 100.0).ToString("0.0"));
+
+            var text = item.GetDisplayText();
+            Assert.Equal("Scroll Speed: x1.5", text);
+        }
+
+        [Fact]
+        public void GetDisplayText_WithFormatterAtBoundary_ShouldFormatCorrectly()
+        {
+            _currentValue = 100;
+            var item = new IntegerConfigItem(
+                "Scroll Speed",
+                () => _currentValue,
+                v => _currentValue = v,
+                50, 400, 50,
+                v => "x" + (v / 100.0).ToString("0.0"));
+
+            Assert.Equal("Scroll Speed: x1.0", item.GetDisplayText());
+        }
+
         #endregion
 
         #region NextValue Tests

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -203,5 +203,52 @@ namespace DTXMania.Test.Config
                     File.Delete(blockerFile);
             }
         }
+
+        [Fact]
+        [Trait("Category", "ConfigManager")]
+        public void FlushPendingSave_FailurePreservesPendingPathForRetry()
+        {
+            // After a failed flush, _pendingSavePath should remain set so the next flush retries.
+            var blockerFile = Path.Combine(Path.GetTempPath(),
+                "dtxmania-scrollspeed-retry-" + Guid.NewGuid().ToString("N"));
+            var badPath = Path.Combine(blockerFile, "sub", "config.ini");
+            File.WriteAllText(blockerFile, "blocker");
+
+            try
+            {
+                var cm = new ConfigManager();
+                cm.Config.ScrollSpeed = 100;
+                cm.SetScrollSpeed(badPath, 200);
+
+                // First flush fails
+                cm.FlushPendingSave();
+
+                // In-memory value is still updated
+                Assert.Equal(200, cm.Config.ScrollSpeed);
+
+                // Remove blocker so the next write can succeed
+                File.Delete(blockerFile);
+
+                // Second flush should succeed — pending path was preserved
+                cm.FlushPendingSave();
+
+                // Verify the value was persisted
+                var roundTrip = new ConfigManager();
+                roundTrip.LoadConfig(badPath);
+                Assert.Equal(200, roundTrip.Config.ScrollSpeed);
+
+                // Cleanup
+                if (File.Exists(badPath))
+                    File.Delete(badPath);
+                var dir = Path.GetDirectoryName(badPath);
+                if (dir != null && Directory.Exists(dir))
+                    Directory.Delete(dir, recursive: true);
+            }
+            finally
+            {
+                if (File.Exists(blockerFile))
+                    File.Delete(blockerFile);
+            }
+        }
     }
 }

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using DTXMania.Game.Lib.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config
+{
+    public class ConfigManagerScrollSpeedTests : IDisposable
+    {
+        private readonly string _tempPath;
+
+        public ConfigManagerScrollSpeedTests()
+        {
+            _tempPath = Path.Combine(Path.GetTempPath(),
+                "dtxmania-scrollspeed-" + Guid.NewGuid().ToString("N") + ".ini");
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_tempPath))
+                File.Delete(_tempPath);
+        }
+
+        [Theory]
+        [InlineData(117, 100)]
+        [InlineData(130, 150)]
+        [InlineData(425, 400)]
+        [InlineData(30, 50)]
+        public void SetScrollSpeed_SnapsToNearestStep(int input, int expected)
+        {
+            var cm = new ConfigManager();
+            cm.SetScrollSpeed(_tempPath, input);
+            Assert.Equal(expected, cm.Config.ScrollSpeed);
+        }
+
+        [Theory]
+        [InlineData(0, 50)]
+        [InlineData(-100, 50)]
+        [InlineData(9999, 400)]
+        public void SetScrollSpeed_ClampsToRange(int input, int expected)
+        {
+            var cm = new ConfigManager();
+            cm.SetScrollSpeed(_tempPath, input);
+            Assert.Equal(expected, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void SetScrollSpeed_RaisesChangedEventWithOldAndNew()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 100;
+
+            ScrollSpeedChangedEventArgs? captured = null;
+            cm.ScrollSpeedChanged += (_, e) => captured = e;
+
+            cm.SetScrollSpeed(_tempPath, 200);
+
+            Assert.NotNull(captured);
+            Assert.Equal(100, captured!.OldPercent);
+            Assert.Equal(200, captured.NewPercent);
+        }
+
+        [Fact]
+        public void SetScrollSpeed_NoOpWhenUnchanged_DoesNotRaiseEvent()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 150;
+            var raised = false;
+            cm.ScrollSpeedChanged += (_, _) => raised = true;
+
+            cm.SetScrollSpeed(_tempPath, 150);
+
+            Assert.False(raised);
+            Assert.False(File.Exists(_tempPath));
+        }
+
+        [Fact]
+        public void SetScrollSpeed_PersistsToConfigIni()
+        {
+            var cm = new ConfigManager();
+            cm.SetScrollSpeed(_tempPath, 250);
+
+            var roundTrip = new ConfigManager();
+            roundTrip.LoadConfig(_tempPath);
+            Assert.Equal(250, roundTrip.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_StepsUp()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 100;
+            cm.AdjustScrollSpeed(_tempPath, +1);
+            Assert.Equal(150, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_StepsDown()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 200;
+            cm.AdjustScrollSpeed(_tempPath, -1);
+            Assert.Equal(150, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_FloorsAtMin()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 50;
+            cm.AdjustScrollSpeed(_tempPath, -1);
+            Assert.Equal(50, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_CeilingsAtMax()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 400;
+            cm.AdjustScrollSpeed(_tempPath, +1);
+            Assert.Equal(400, cm.Config.ScrollSpeed);
+        }
+    }
+}

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -86,6 +86,17 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        public void LoadConfig_SnapsHandEditedScrollSpeedToNearestStep()
+        {
+            File.WriteAllText(_tempPath, "ScrollSpeed=133\n");
+
+            var cm = new ConfigManager();
+            cm.LoadConfig(_tempPath);
+
+            Assert.Equal(150, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
         public void AdjustScrollSpeed_StepsUp()
         {
             var cm = new ConfigManager();

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -120,5 +120,21 @@ namespace DTXMania.Test.Config
             cm.AdjustScrollSpeed(_tempPath, +1);
             Assert.Equal(400, cm.Config.ScrollSpeed);
         }
+
+        [Fact]
+        public void AdjustScrollSpeed_RaisesChangedEventWithOldAndNew()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 100;
+
+            ScrollSpeedChangedEventArgs? captured = null;
+            cm.ScrollSpeedChanged += (_, e) => captured = e;
+
+            cm.AdjustScrollSpeed(_tempPath, +1);
+
+            Assert.NotNull(captured);
+            Assert.Equal(100, captured!.OldPercent);
+            Assert.Equal(150, captured.NewPercent);
+        }
     }
 }

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -26,6 +26,7 @@ namespace DTXMania.Test.Config
         [InlineData(130, 150)]
         [InlineData(425, 400)]
         [InlineData(30, 50)]
+        [Trait("Category", "ConfigManager")]
         public void SetScrollSpeed_SnapsToNearestStep(int input, int expected)
         {
             var cm = new ConfigManager();
@@ -37,6 +38,7 @@ namespace DTXMania.Test.Config
         [InlineData(0, 50)]
         [InlineData(-100, 50)]
         [InlineData(9999, 400)]
+        [Trait("Category", "ConfigManager")]
         public void SetScrollSpeed_ClampsToRange(int input, int expected)
         {
             var cm = new ConfigManager();
@@ -45,6 +47,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void SetScrollSpeed_RaisesChangedEventWithOldAndNew()
         {
             var cm = new ConfigManager();
@@ -61,6 +64,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void SetScrollSpeed_NoOpWhenUnchanged_DoesNotRaiseEvent()
         {
             var cm = new ConfigManager();
@@ -75,6 +79,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void SetScrollSpeed_PersistsToConfigIni()
         {
             var cm = new ConfigManager();
@@ -86,6 +91,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void LoadConfig_SnapsHandEditedScrollSpeedToNearestStep()
         {
             File.WriteAllText(_tempPath, "ScrollSpeed=133\n");
@@ -97,6 +103,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void AdjustScrollSpeed_StepsUp()
         {
             var cm = new ConfigManager();
@@ -106,6 +113,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void AdjustScrollSpeed_StepsDown()
         {
             var cm = new ConfigManager();
@@ -115,6 +123,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void AdjustScrollSpeed_FloorsAtMin()
         {
             var cm = new ConfigManager();
@@ -124,6 +133,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void AdjustScrollSpeed_CeilingsAtMax()
         {
             var cm = new ConfigManager();
@@ -133,6 +143,7 @@ namespace DTXMania.Test.Config
         }
 
         [Fact]
+        [Trait("Category", "ConfigManager")]
         public void AdjustScrollSpeed_RaisesChangedEventWithOldAndNew()
         {
             var cm = new ConfigManager();

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -84,6 +84,7 @@ namespace DTXMania.Test.Config
         {
             var cm = new ConfigManager();
             cm.SetScrollSpeed(_tempPath, 250);
+            cm.FlushPendingSave();
 
             var roundTrip = new ConfigManager();
             roundTrip.LoadConfig(_tempPath);
@@ -161,7 +162,7 @@ namespace DTXMania.Test.Config
 
         [Fact]
         [Trait("Category", "ConfigManager")]
-        public void SetScrollSpeed_SaveFailure_StillUpdatesInMemoryAndFiresEvent()
+        public void FlushPendingSave_FailureStillRetainsInMemoryAndFiredEvent()
         {
             // Create a regular file where a directory would need to be created.
             // When SaveConfig tries Directory.CreateDirectory on a path whose parent
@@ -179,16 +180,22 @@ namespace DTXMania.Test.Config
                 ScrollSpeedChangedEventArgs? captured = null;
                 cm.ScrollSpeedChanged += (_, e) => captured = e;
 
-                // This should NOT throw — the failure is caught internally
+                // SetScrollSpeed defers the write; event fires immediately
                 cm.SetScrollSpeed(badPath, 200);
 
-                // In-memory value should be updated despite save failure
+                // In-memory value should be updated
                 Assert.Equal(200, cm.Config.ScrollSpeed);
 
-                // Event should still fire despite save failure
+                // Event should have fired
                 Assert.NotNull(captured);
                 Assert.Equal(100, captured!.OldPercent);
                 Assert.Equal(200, captured.NewPercent);
+
+                // Flush attempts the write — should NOT throw; failure is caught internally
+                cm.FlushPendingSave();
+
+                // In-memory value should still be updated despite save failure
+                Assert.Equal(200, cm.Config.ScrollSpeed);
             }
             finally
             {

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -163,30 +163,38 @@ namespace DTXMania.Test.Config
         [Trait("Category", "ConfigManager")]
         public void SetScrollSpeed_SaveFailure_StillUpdatesInMemoryAndFiresEvent()
         {
-            // Use an invalid path that cannot be written to (directory that doesn't exist
-            // on a path segment marked read-only isn't reliable cross-platform,
-            // so use a path with illegal characters on Windows / too-long on Unix).
-            // Instead: create a directory where the file should be, making it unwritable.
-            var cm = new ConfigManager();
-            cm.Config.ScrollSpeed = 100;
+            // Create a regular file where a directory would need to be created.
+            // When SaveConfig tries Directory.CreateDirectory on a path whose parent
+            // is a file (not a directory), it throws — exercising the catch block.
+            var blockerFile = Path.Combine(Path.GetTempPath(),
+                "dtxmania-scrollspeed-blocker-" + Guid.NewGuid().ToString("N"));
+            var badPath = Path.Combine(blockerFile, "sub", "config.ini");
+            File.WriteAllText(blockerFile, "blocker");
 
-            ScrollSpeedChangedEventArgs? captured = null;
-            cm.ScrollSpeedChanged += (_, e) => captured = e;
+            try
+            {
+                var cm = new ConfigManager();
+                cm.Config.ScrollSpeed = 100;
 
-            // Use an impossible path — SaveConfig will throw, but in-memory should still update
-            var badPath = Path.Combine(Path.GetTempPath(),
-                "dtxmania-scrollspeed-nonexistent-" + Guid.NewGuid(), "sub", "config.ini");
+                ScrollSpeedChangedEventArgs? captured = null;
+                cm.ScrollSpeedChanged += (_, e) => captured = e;
 
-            // This should NOT throw — the failure is caught internally
-            cm.SetScrollSpeed(badPath, 200);
+                // This should NOT throw — the failure is caught internally
+                cm.SetScrollSpeed(badPath, 200);
 
-            // In-memory value should be updated despite save failure
-            Assert.Equal(200, cm.Config.ScrollSpeed);
+                // In-memory value should be updated despite save failure
+                Assert.Equal(200, cm.Config.ScrollSpeed);
 
-            // Event should still fire despite save failure
-            Assert.NotNull(captured);
-            Assert.Equal(100, captured!.OldPercent);
-            Assert.Equal(200, captured.NewPercent);
+                // Event should still fire despite save failure
+                Assert.NotNull(captured);
+                Assert.Equal(100, captured!.OldPercent);
+                Assert.Equal(200, captured.NewPercent);
+            }
+            finally
+            {
+                if (File.Exists(blockerFile))
+                    File.Delete(blockerFile);
+            }
         }
     }
 }

--- a/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs
@@ -158,5 +158,35 @@ namespace DTXMania.Test.Config
             Assert.Equal(100, captured!.OldPercent);
             Assert.Equal(150, captured.NewPercent);
         }
+
+        [Fact]
+        [Trait("Category", "ConfigManager")]
+        public void SetScrollSpeed_SaveFailure_StillUpdatesInMemoryAndFiresEvent()
+        {
+            // Use an invalid path that cannot be written to (directory that doesn't exist
+            // on a path segment marked read-only isn't reliable cross-platform,
+            // so use a path with illegal characters on Windows / too-long on Unix).
+            // Instead: create a directory where the file should be, making it unwritable.
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 100;
+
+            ScrollSpeedChangedEventArgs? captured = null;
+            cm.ScrollSpeedChanged += (_, e) => captured = e;
+
+            // Use an impossible path — SaveConfig will throw, but in-memory should still update
+            var badPath = Path.Combine(Path.GetTempPath(),
+                "dtxmania-scrollspeed-nonexistent-" + Guid.NewGuid(), "sub", "config.ini");
+
+            // This should NOT throw — the failure is caught internally
+            cm.SetScrollSpeed(badPath, 200);
+
+            // In-memory value should be updated despite save failure
+            Assert.Equal(200, cm.Config.ScrollSpeed);
+
+            // Event should still fire despite save failure
+            Assert.NotNull(captured);
+            Assert.Equal(100, captured!.OldPercent);
+            Assert.Equal(200, captured.NewPercent);
+        }
     }
 }

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1541,4 +1541,31 @@ public class ConfigStageLogicTests
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
         }
     }
+
+    [Fact]
+    public void ApplyConfiguration_SaveFailure_ShouldRollbackScrollSpeed()
+    {
+        var configManager = new RecordingConfigManager(
+            new ConfigData { ScrollSpeed = 100 },
+            saveException: new IOException("disk full"));
+
+        var (stage, _, inputManager) = CreateStage(configManager);
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.SetPrivateField(stage, "_workingConfig", new ConfigData
+            {
+                ScreenWidth = 1280,
+                ScreenHeight = 720,
+                ScrollSpeed = 250
+            });
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+            var result = (bool)ReflectionHelpers.InvokePrivateMethod(stage, "ApplyConfiguration")!;
+
+            Assert.False(result);
+            // ScrollSpeed should be rolled back to the original value
+            Assert.Equal(100, configManager.Config.ScrollSpeed);
+        }
+    }
 }

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -68,13 +68,14 @@ public class ConfigStageLogicTests
 
             var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
             Assert.NotNull(configItems);
-            Assert.Equal(7, configItems!.Count);
+            Assert.Equal(8, configItems!.Count);
             Assert.Collection(configItems,
                 item => Assert.Equal("Screen Resolution", item.Name),
                 item => Assert.Equal("Fullscreen", item.Name),
                 item => Assert.Equal("VSync Wait", item.Name),
                 item => Assert.Equal("No Fail", item.Name),
                 item => Assert.Equal("Auto Play", item.Name),
+                item => Assert.Equal("Scroll Speed", item.Name),
                 item => Assert.Equal("Drum Key Mapping", item.Name),
                 item => Assert.Equal("System Key Mapping", item.Name));
             Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
@@ -186,7 +187,7 @@ public class ConfigStageLogicTests
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: true);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 5);
+            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 6);
             SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -600,7 +601,7 @@ public class ConfigStageLogicTests
             Assert.NotNull(ReflectionHelpers.GetPrivateField<SpriteBatch>(stage, "_spriteBatch"));
             Assert.NotNull(ReflectionHelpers.GetPrivateField<Texture2D>(stage, "_whitePixel"));
             Assert.NotNull(configItems);
-            Assert.Equal(7, configItems!.Count);
+            Assert.Equal(8, configItems!.Count);
             Assert.NotNull(ReflectionHelpers.GetPrivateField<DrumKeyAssignPanel>(stage, "_drumPanel"));
             Assert.NotNull(ReflectionHelpers.GetPrivateField<SystemKeyAssignPanel>(stage, "_systemPanel"));
         }
@@ -962,7 +963,7 @@ public class ConfigStageLogicTests
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 5);
+            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 6);
             SetKeyboardStates(stage, new KeyboardState(Keys.Left), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -978,7 +979,7 @@ public class ConfigStageLogicTests
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 6);
+            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 7);
             SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1381,12 +1381,14 @@ public class ConfigStageLogicTests
                 [Keys.F3] = InputCommandType.MoveLeft,
                 [Keys.F4] = InputCommandType.MoveRight,
                 [Keys.F5] = InputCommandType.Activate,
-                [Keys.F6] = InputCommandType.Back
+                [Keys.F6] = InputCommandType.Back,
+                [Keys.F7] = InputCommandType.IncreaseScrollSpeed,
+                [Keys.F8] = InputCommandType.DecreaseScrollSpeed
             };
 
             ReflectionHelpers.InvokePrivateMethod(stage, "OpenPanel", systemPanel!);
             ReflectionHelpers.SetPrivateField(systemPanel!, "_workingMapping", newWorkingMapping);
-            ReflectionHelpers.SetPrivateField(systemPanel!, "_selectedIndex", 6);
+            ReflectionHelpers.SetPrivateField(systemPanel!, "_selectedIndex", 8);
 
             systemPanel.Update(0.016, new KeyboardState(Keys.Enter), new KeyboardState());
 

--- a/DTXMania.Test/Config/ConfigStageTests.cs
+++ b/DTXMania.Test/Config/ConfigStageTests.cs
@@ -296,7 +296,7 @@ public class ConfigStageTests
         panel.Closed += (_, _) => closedFired = true;
         panel.Activate();
 
-        for (int i = 0; i < 6; i++)
+        for (int i = 0; i < 8; i++)
         {
             DispatchInjectedPanelCommand(stage, inputManager, panel, "Key.Down");
         }

--- a/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
+++ b/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
@@ -344,8 +344,6 @@ public class KeyAssignPanelWorkingCopyTests
     [InlineData(2, Keys.Left, InputCommandType.MoveLeft)]
     [InlineData(3, Keys.Right, InputCommandType.MoveRight)]
     [InlineData(5, Keys.Escape, InputCommandType.Back)]
-    [InlineData(6, Keys.PageUp, InputCommandType.IncreaseScrollSpeed)]
-    [InlineData(7, Keys.PageDown, InputCommandType.DecreaseScrollSpeed)]
     public void SystemPanel_DeleteOnRequiredAction_ShouldKeepBinding(int selectedIndex, Keys expectedKey, InputCommandType command)
     {
         using var inputManager = new InputManager();
@@ -361,6 +359,154 @@ public class KeyAssignPanelWorkingCopyTests
         var snapshot = panel.GetWorkingMappingSnapshot();
         Assert.True(snapshot.ContainsKey(expectedKey));
         Assert.Equal(command, snapshot[expectedKey]);
+    }
+
+    [Trait("Category", "Unit")]
+    [Theory]
+    [InlineData(6, Keys.PageUp, InputCommandType.IncreaseScrollSpeed)]
+    [InlineData(7, Keys.PageDown, InputCommandType.DecreaseScrollSpeed)]
+    public void SystemPanel_DeleteOnOptionalAction_ShouldClearBinding(int selectedIndex, Keys expectedKey, InputCommandType command)
+    {
+        using var inputManager = new InputManager();
+        var panel = new SystemKeyAssignPanel(inputManager);
+        panel._liveDrumBindingsProvider = () => new System.Collections.Generic.Dictionary<string, int>();
+        panel.Activate();
+
+        for (int i = 0; i < selectedIndex; i++)
+            PressKey(panel, Keys.Down);
+
+        var before = panel.GetWorkingMappingSnapshot();
+        Assert.True(before.ContainsKey(expectedKey));
+
+        PressKey(panel, Keys.Delete);
+
+        var after = panel.GetWorkingMappingSnapshot();
+        Assert.False(after.ContainsKey(expectedKey),
+            $"{command} is non-required and should be clearable via Delete");
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void DrumPanel_EvictSystemBinding_ShouldBeDeferredUntilSave()
+    {
+        var liveBindings = new KeyBindings();
+        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
+
+        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
+        {
+            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
+        };
+        panel._liveSystemMappingProvider = () => systemMap;
+
+        var evictedKeys = new System.Collections.Generic.List<Keys>();
+        panel.EvictSystemBinding = key => evictedKeys.Add(key);
+
+        panel.Activate();
+
+        // Enter key capture for lane 0 and assign PageUp
+        PressKey(panel, Keys.Enter);
+        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+
+        // Eviction should NOT have happened yet (deferred)
+        Assert.Empty(evictedKeys);
+
+        // Drum binding should be recorded in working copy
+        var snapshot = panel.GetWorkingBindingsSnapshot();
+        Assert.Equal(0, snapshot.GetLane(KeyBindings.CreateKeyButtonId(Keys.PageUp)));
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void DrumPanel_EvictSystemBinding_ShouldApplyOnSave()
+    {
+        var liveBindings = new KeyBindings();
+        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
+
+        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
+        {
+            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
+        };
+        panel._liveSystemMappingProvider = () => systemMap;
+
+        var evictedKeys = new System.Collections.Generic.List<Keys>();
+        panel.EvictSystemBinding = key => evictedKeys.Add(key);
+
+        panel.Activate();
+
+        // Assign PageUp to lane 0
+        PressKey(panel, Keys.Enter);
+        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+
+        // Navigate to SAVE and commit
+        for (int i = 0; i < 10; i++)
+            PressKey(panel, Keys.Down);
+        PressKey(panel, Keys.Enter);
+
+        // Now eviction should have been applied
+        Assert.Single(evictedKeys);
+        Assert.Equal(Keys.PageUp, evictedKeys[0]);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void DrumPanel_EvictSystemBinding_ShouldNotApplyOnCancel()
+    {
+        var liveBindings = new KeyBindings();
+        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
+
+        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
+        {
+            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
+        };
+        panel._liveSystemMappingProvider = () => systemMap;
+
+        var evictedKeys = new System.Collections.Generic.List<Keys>();
+        panel.EvictSystemBinding = key => evictedKeys.Add(key);
+
+        panel.Activate();
+
+        // Assign PageUp to lane 0
+        PressKey(panel, Keys.Enter);
+        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+
+        // Cancel the panel
+        PressKey(panel, Keys.Escape);
+
+        // Eviction should NOT have been applied
+        Assert.Empty(evictedKeys);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void DrumPanel_EvictSystemBinding_ShouldNotEvictClearedLane()
+    {
+        var liveBindings = new KeyBindings();
+        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
+
+        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
+        {
+            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
+        };
+        panel._liveSystemMappingProvider = () => systemMap;
+
+        var evictedKeys = new System.Collections.Generic.List<Keys>();
+        panel.EvictSystemBinding = key => evictedKeys.Add(key);
+
+        panel.Activate();
+
+        // Assign PageUp to lane 0
+        PressKey(panel, Keys.Enter);
+        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+
+        // Clear lane 0
+        PressKey(panel, Keys.Delete);
+
+        // Save — eviction should NOT apply because PageUp is no longer bound to any lane
+        for (int i = 0; i < 10; i++)
+            PressKey(panel, Keys.Down);
+        PressKey(panel, Keys.Enter);
+
+        Assert.Empty(evictedKeys);
     }
 
     [Trait("Category", "Unit")]

--- a/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
+++ b/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
@@ -377,6 +377,7 @@ public class KeyAssignPanelWorkingCopyTests
 
         var before = panel.GetWorkingMappingSnapshot();
         Assert.True(before.ContainsKey(expectedKey));
+        Assert.Equal(command, before[expectedKey]);
 
         PressKey(panel, Keys.Delete);
 

--- a/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
+++ b/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
@@ -113,8 +113,8 @@ public class KeyAssignPanelWorkingCopyTests
         panel.Saved += (_, _) => savedFired = true;
         panel.Closed += (_, _) => { closedFired = true; savedBeforeClosed = savedFired; };
 
-        // Navigate to FooterSave (index 6 = ActionCount)
-        for (int i = 0; i < 6; i++)
+        // Navigate to FooterSave (index = ActionCount)
+        for (int i = 0; i < 8; i++)
             PressKey(panel, Keys.Down);
         PressKey(panel, Keys.Enter);
 
@@ -344,6 +344,8 @@ public class KeyAssignPanelWorkingCopyTests
     [InlineData(2, Keys.Left, InputCommandType.MoveLeft)]
     [InlineData(3, Keys.Right, InputCommandType.MoveRight)]
     [InlineData(5, Keys.Escape, InputCommandType.Back)]
+    [InlineData(6, Keys.PageUp, InputCommandType.IncreaseScrollSpeed)]
+    [InlineData(7, Keys.PageDown, InputCommandType.DecreaseScrollSpeed)]
     public void SystemPanel_DeleteOnRequiredAction_ShouldKeepBinding(int selectedIndex, Keys expectedKey, InputCommandType command)
     {
         using var inputManager = new InputManager();
@@ -374,7 +376,7 @@ public class KeyAssignPanelWorkingCopyTests
         };
         panel.Activate();
 
-        for (int i = 0; i < 6; i++)
+        for (int i = 0; i < 8; i++)
             PressKey(panel, Keys.Down);
 
         PressKey(panel, Keys.Enter);
@@ -431,7 +433,7 @@ public class KeyAssignPanelWorkingCopyTests
 
         panel.Update(2.1, new KeyboardState(), new KeyboardState());
 
-        for (int i = 0; i < 4; i++)
+        for (int i = 0; i < 6; i++)
             PressKey(panel, Keys.S);
 
         PressKey(panel, Keys.F);
@@ -541,7 +543,7 @@ public class KeyAssignPanelWorkingCopyTests
 
         panel.Activate();
 
-        for (int i = 0; i < 6; i++)
+        for (int i = 0; i < 8; i++)
         {
             pressedCommand = InputCommandType.MoveDown;
             panel.Update(0.0, new KeyboardState(), new KeyboardState());

--- a/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
+++ b/DTXMania.Test/Config/KeyAssignPanelWorkingCopyTests.cs
@@ -386,9 +386,12 @@ public class KeyAssignPanelWorkingCopyTests
             $"{command} is non-required and should be clearable via Delete");
     }
 
-    [Trait("Category", "Unit")]
-    [Fact]
-    public void DrumPanel_EvictSystemBinding_ShouldBeDeferredUntilSave()
+    /// <summary>
+    /// Shared setup helper for the four EvictSystemBinding tests:
+    /// creates a DrumKeyAssignPanel with PageUp mapped to IncreaseScrollSpeed,
+    /// wires up the eviction callback, activates the panel, and assigns PageUp to lane 0.
+    /// </summary>
+    private static (DrumKeyAssignPanel panel, List<Keys> evictedKeys) SetupDrumPanelWithPageUpAssigned()
     {
         var liveBindings = new KeyBindings();
         var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
@@ -408,6 +411,15 @@ public class KeyAssignPanelWorkingCopyTests
         PressKey(panel, Keys.Enter);
         panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
 
+        return (panel, evictedKeys);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void DrumPanel_EvictSystemBinding_ShouldBeDeferredUntilSave()
+    {
+        var (panel, evictedKeys) = SetupDrumPanelWithPageUpAssigned();
+
         // Eviction should NOT have happened yet (deferred)
         Assert.Empty(evictedKeys);
 
@@ -420,23 +432,7 @@ public class KeyAssignPanelWorkingCopyTests
     [Fact]
     public void DrumPanel_EvictSystemBinding_ShouldApplyOnSave()
     {
-        var liveBindings = new KeyBindings();
-        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
-
-        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
-        {
-            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
-        };
-        panel._liveSystemMappingProvider = () => systemMap;
-
-        var evictedKeys = new System.Collections.Generic.List<Keys>();
-        panel.EvictSystemBinding = key => evictedKeys.Add(key);
-
-        panel.Activate();
-
-        // Assign PageUp to lane 0
-        PressKey(panel, Keys.Enter);
-        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+        var (panel, evictedKeys) = SetupDrumPanelWithPageUpAssigned();
 
         // Navigate to SAVE and commit
         for (int i = 0; i < 10; i++)
@@ -452,23 +448,7 @@ public class KeyAssignPanelWorkingCopyTests
     [Fact]
     public void DrumPanel_EvictSystemBinding_ShouldNotApplyOnCancel()
     {
-        var liveBindings = new KeyBindings();
-        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
-
-        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
-        {
-            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
-        };
-        panel._liveSystemMappingProvider = () => systemMap;
-
-        var evictedKeys = new System.Collections.Generic.List<Keys>();
-        panel.EvictSystemBinding = key => evictedKeys.Add(key);
-
-        panel.Activate();
-
-        // Assign PageUp to lane 0
-        PressKey(panel, Keys.Enter);
-        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+        var (panel, evictedKeys) = SetupDrumPanelWithPageUpAssigned();
 
         // Cancel the panel
         PressKey(panel, Keys.Escape);
@@ -481,23 +461,7 @@ public class KeyAssignPanelWorkingCopyTests
     [Fact]
     public void DrumPanel_EvictSystemBinding_ShouldNotEvictClearedLane()
     {
-        var liveBindings = new KeyBindings();
-        var panel = new DrumKeyAssignPanel(CreateUnusedModularInputManager(liveBindings));
-
-        var systemMap = new System.Collections.Generic.Dictionary<Keys, InputCommandType>
-        {
-            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed,
-        };
-        panel._liveSystemMappingProvider = () => systemMap;
-
-        var evictedKeys = new System.Collections.Generic.List<Keys>();
-        panel.EvictSystemBinding = key => evictedKeys.Add(key);
-
-        panel.Activate();
-
-        // Assign PageUp to lane 0
-        PressKey(panel, Keys.Enter);
-        panel.Update(0.0, new KeyboardState(Keys.PageUp), new KeyboardState());
+        var (panel, evictedKeys) = SetupDrumPanelWithPageUpAssigned();
 
         // Clear lane 0
         PressKey(panel, Keys.Delete);

--- a/DTXMania.Test/Config/ScrollSpeedRangeTests.cs
+++ b/DTXMania.Test/Config/ScrollSpeedRangeTests.cs
@@ -17,7 +17,8 @@ namespace DTXMania.Test.Config
         [InlineData(0, 50)]
         [InlineData(-50, 50)]
         [InlineData(9999, 400)]
-        public void SnapAndClamp_ReturnsExpected(int input, int expected)
+        [Trait("Category", "Unit")]
+        public void SnapAndClamp_GivenInput_ReturnsExpected(int input, int expected)
         {
             Assert.Equal(expected, ScrollSpeedRange.SnapAndClamp(input));
         }
@@ -27,13 +28,15 @@ namespace DTXMania.Test.Config
         [InlineData(100, "x1.0")]
         [InlineData(150, "x1.5")]
         [InlineData(400, "x4.0")]
-        public void Format_ReturnsXMultiplier(int percent, string expected)
+        [Trait("Category", "Unit")]
+        public void Format_GivenPercent_ReturnsXMultiplier(int percent, string expected)
         {
             Assert.Equal(expected, ScrollSpeedRange.Format(percent));
         }
 
         [Fact]
-        public void Constants_HaveExpectedValues()
+        [Trait("Category", "Unit")]
+        public void Constants_WhenChecked_HaveExpectedValues()
         {
             Assert.Equal(50, ScrollSpeedRange.Min);
             Assert.Equal(400, ScrollSpeedRange.Max);

--- a/DTXMania.Test/Config/ScrollSpeedRangeTests.cs
+++ b/DTXMania.Test/Config/ScrollSpeedRangeTests.cs
@@ -1,0 +1,44 @@
+using DTXMania.Game.Lib.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config
+{
+    public class ScrollSpeedRangeTests
+    {
+        [Theory]
+        [InlineData(50, 50)]
+        [InlineData(100, 100)]
+        [InlineData(400, 400)]
+        [InlineData(117, 100)]
+        [InlineData(130, 150)]
+        [InlineData(124, 100)]
+        [InlineData(125, 150)]
+        [InlineData(425, 400)]
+        [InlineData(0, 50)]
+        [InlineData(-50, 50)]
+        [InlineData(9999, 400)]
+        public void SnapAndClamp_ReturnsExpected(int input, int expected)
+        {
+            Assert.Equal(expected, ScrollSpeedRange.SnapAndClamp(input));
+        }
+
+        [Theory]
+        [InlineData(50, "x0.5")]
+        [InlineData(100, "x1.0")]
+        [InlineData(150, "x1.5")]
+        [InlineData(400, "x4.0")]
+        public void Format_ReturnsXMultiplier(int percent, string expected)
+        {
+            Assert.Equal(expected, ScrollSpeedRange.Format(percent));
+        }
+
+        [Fact]
+        public void Constants_HaveExpectedValues()
+        {
+            Assert.Equal(50, ScrollSpeedRange.Min);
+            Assert.Equal(400, ScrollSpeedRange.Max);
+            Assert.Equal(50, ScrollSpeedRange.Step);
+            Assert.Equal(100, ScrollSpeedRange.Default);
+        }
+    }
+}

--- a/DTXMania.Test/Config/ScrollSpeedRangeTests.cs
+++ b/DTXMania.Test/Config/ScrollSpeedRangeTests.cs
@@ -34,6 +34,15 @@ namespace DTXMania.Test.Config
             Assert.Equal(expected, ScrollSpeedRange.Format(percent));
         }
 
+        [Theory]
+        [InlineData(int.MaxValue, 400)]
+        [InlineData(int.MinValue, 50)]
+        [Trait("Category", "Unit")]
+        public void SnapAndClamp_ExtremeValues_ClampToRange(int input, int expected)
+        {
+            Assert.Equal(expected, ScrollSpeedRange.SnapAndClamp(input));
+        }
+
         [Fact]
         [Trait("Category", "Unit")]
         public void Constants_WhenChecked_HaveExpectedValues()

--- a/DTXMania.Test/Config/SystemKeyBindingsPersistenceTests.cs
+++ b/DTXMania.Test/Config/SystemKeyBindingsPersistenceTests.cs
@@ -411,4 +411,26 @@ public class SystemKeyBindingsPersistenceTests
         Assert.Equal(InputCommandType.IncreaseScrollSpeed, snapshot[Keys.PageUp]);
         Assert.Equal(InputCommandType.DecreaseScrollSpeed, snapshot[Keys.PageDown]);
     }
+
+    [Fact]
+    public void LoadSystemKeyBindings_SavedScrollKeyFilteredByDrumKey_ShouldRemoveConstructorDefault()
+    {
+        // Scenario: user configured IncreaseScrollSpeed=F1, but F1 is also a drum key.
+        // All configured keys are filtered out, so the command should be fully unbound —
+        // the constructor default PageUp -> IncreaseScrollSpeed must NOT survive.
+        var manager = new ConfigManager();
+        manager.Config.SystemKeyBindings["SystemKey.IncreaseScrollSpeed"] = "F1";
+        manager.Config.KeyBindings["Key.F1"] = 4; // F1 mapped to Snare Drum lane
+
+        var inputMgr = new InputManager();
+        manager.LoadSystemKeyBindings(inputMgr);
+
+        var snapshot = inputMgr.GetKeyMappingSnapshot();
+        // F1 should not be mapped (drum key conflict)
+        Assert.False(snapshot.TryGetValue(Keys.F1, out var f1Cmd)
+            && f1Cmd == InputCommandType.IncreaseScrollSpeed);
+        // PageUp default should also be removed since the saved binding was fully filtered
+        Assert.False(snapshot.TryGetValue(Keys.PageUp, out var pageUpCmd)
+            && pageUpCmd == InputCommandType.IncreaseScrollSpeed);
+    }
 }

--- a/DTXMania.Test/Config/SystemKeyBindingsPersistenceTests.cs
+++ b/DTXMania.Test/Config/SystemKeyBindingsPersistenceTests.cs
@@ -348,4 +348,67 @@ public class SystemKeyBindingsPersistenceTests
         Assert.False(snap1.ContainsKey(Keys.F1));
         Assert.True(snap2.ContainsKey(Keys.F1));
     }
+
+    // ─── EvictDrumKeyConflicts ─────────────────────────────────────────────
+
+    [Fact]
+    public void LoadSystemKeyBindings_DrumKeyOverlapsDefaultScrollSpeed_ShouldEvictDefaultScrollSpeedBinding()
+    {
+        // Scenario: player bound PageUp to a drum lane. The default PageUp -> IncreaseScrollSpeed
+        // should be removed so pressing PageUp during performance doesn't change scroll speed.
+        var manager = new ConfigManager();
+        manager.Config.KeyBindings["Key.PageUp"] = 4; // bind PageUp to Snare Drum lane
+
+        var inputMgr = new InputManager();
+        manager.LoadSystemKeyBindings(inputMgr);
+
+        var snapshot = inputMgr.GetKeyMappingSnapshot();
+        // PageUp should NOT be mapped to IncreaseScrollSpeed
+        Assert.False(snapshot.TryGetValue(Keys.PageUp, out var pageUpCmd)
+            && pageUpCmd == InputCommandType.IncreaseScrollSpeed);
+    }
+
+    [Fact]
+    public void LoadSystemKeyBindings_DrumKeyOverlapsDefaultScrollSpeed_ShouldKeepNonConflictingDefault()
+    {
+        // PageDown is NOT a drum key, so its default mapping should remain
+        var manager = new ConfigManager();
+        manager.Config.KeyBindings["Key.PageUp"] = 4; // only PageUp is a drum key
+
+        var inputMgr = new InputManager();
+        manager.LoadSystemKeyBindings(inputMgr);
+
+        var snapshot = inputMgr.GetKeyMappingSnapshot();
+        Assert.Equal(InputCommandType.DecreaseScrollSpeed, snapshot[Keys.PageDown]);
+    }
+
+    [Fact]
+    public void LoadSystemKeyBindings_DrumKeyOverlapsRequiredCommand_ShouldKeepRequiredBinding()
+    {
+        // A required system command (e.g., Back) should NOT be evicted even if it overlaps a drum key
+        var manager = new ConfigManager();
+        manager.Config.KeyBindings["Key.Escape"] = 0; // bind Escape to a drum lane
+
+        var inputMgr = new InputManager();
+        manager.LoadSystemKeyBindings(inputMgr);
+
+        var snapshot = inputMgr.GetKeyMappingSnapshot();
+        // Escape -> Back is required and should still be present
+        Assert.Equal(InputCommandType.Back, snapshot[Keys.Escape]);
+    }
+
+    [Fact]
+    public void LoadSystemKeyBindings_NoDrumOverlap_ShouldKeepDefaultScrollSpeedBindings()
+    {
+        // When no drum keys overlap, defaults should remain
+        var manager = new ConfigManager();
+        // No custom drum bindings — only defaults (A, S, D, F, G, J, K, L, Space, ;)
+
+        var inputMgr = new InputManager();
+        manager.LoadSystemKeyBindings(inputMgr);
+
+        var snapshot = inputMgr.GetKeyMappingSnapshot();
+        Assert.Equal(InputCommandType.IncreaseScrollSpeed, snapshot[Keys.PageUp]);
+        Assert.Equal(InputCommandType.DecreaseScrollSpeed, snapshot[Keys.PageDown]);
+    }
 }

--- a/DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs
+++ b/DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs
@@ -17,19 +17,5 @@ namespace DTXMania.Test.Input
             Assert.True(snapshot.TryGetValue(key, out var cmd));
             Assert.Equal(expected, cmd);
         }
-
-        [Fact]
-        [Trait("Category", "Unit")]
-        public void Enum_HasIncreaseScrollSpeed()
-        {
-            Assert.Contains(InputCommandType.IncreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
-        }
-
-        [Fact]
-        [Trait("Category", "Unit")]
-        public void Enum_HasDecreaseScrollSpeed()
-        {
-            Assert.Contains(InputCommandType.DecreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
-        }
     }
 }

--- a/DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs
+++ b/DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs
@@ -6,31 +6,27 @@ namespace DTXMania.Test.Input
 {
     public class InputManagerScrollSpeedKeysTests
     {
-        [Fact]
-        public void DefaultMapping_PageUp_MapsToIncreaseScrollSpeed()
+        [Theory]
+        [InlineData(Keys.PageUp, InputCommandType.IncreaseScrollSpeed)]
+        [InlineData(Keys.PageDown, InputCommandType.DecreaseScrollSpeed)]
+        [Trait("Category", "Unit")]
+        public void DefaultMapping_Key_WhenQueried_ShouldMapToExpectedScrollCommand(Keys key, InputCommandType expected)
         {
             var im = new InputManager();
             var snapshot = im.GetKeyMappingSnapshot();
-            Assert.True(snapshot.TryGetValue(Keys.PageUp, out var cmd));
-            Assert.Equal(InputCommandType.IncreaseScrollSpeed, cmd);
+            Assert.True(snapshot.TryGetValue(key, out var cmd));
+            Assert.Equal(expected, cmd);
         }
 
         [Fact]
-        public void DefaultMapping_PageDown_MapsToDecreaseScrollSpeed()
-        {
-            var im = new InputManager();
-            var snapshot = im.GetKeyMappingSnapshot();
-            Assert.True(snapshot.TryGetValue(Keys.PageDown, out var cmd));
-            Assert.Equal(InputCommandType.DecreaseScrollSpeed, cmd);
-        }
-
-        [Fact]
+        [Trait("Category", "Unit")]
         public void Enum_HasIncreaseScrollSpeed()
         {
             Assert.Contains(InputCommandType.IncreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
         }
 
         [Fact]
+        [Trait("Category", "Unit")]
         public void Enum_HasDecreaseScrollSpeed()
         {
             Assert.Contains(InputCommandType.DecreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());

--- a/DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs
+++ b/DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs
@@ -1,0 +1,39 @@
+using DTXMania.Game.Lib.Input;
+using Microsoft.Xna.Framework.Input;
+using Xunit;
+
+namespace DTXMania.Test.Input
+{
+    public class InputManagerScrollSpeedKeysTests
+    {
+        [Fact]
+        public void DefaultMapping_PageUp_MapsToIncreaseScrollSpeed()
+        {
+            var im = new InputManager();
+            var snapshot = im.GetKeyMappingSnapshot();
+            Assert.True(snapshot.TryGetValue(Keys.PageUp, out var cmd));
+            Assert.Equal(InputCommandType.IncreaseScrollSpeed, cmd);
+        }
+
+        [Fact]
+        public void DefaultMapping_PageDown_MapsToDecreaseScrollSpeed()
+        {
+            var im = new InputManager();
+            var snapshot = im.GetKeyMappingSnapshot();
+            Assert.True(snapshot.TryGetValue(Keys.PageDown, out var cmd));
+            Assert.Equal(InputCommandType.DecreaseScrollSpeed, cmd);
+        }
+
+        [Fact]
+        public void Enum_HasIncreaseScrollSpeed()
+        {
+            Assert.Contains(InputCommandType.IncreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
+        }
+
+        [Fact]
+        public void Enum_HasDecreaseScrollSpeed()
+        {
+            Assert.Contains(InputCommandType.DecreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
+        }
+    }
+}

--- a/DTXMania.Test/Stage/ConfigStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageCoverageTests.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.KeyAssign;
+using DTXMania.Game.Lib.Utilities;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using Moq;
+
+namespace DTXMania.Test.Stage;
+
+[Trait("Category", "Unit")]
+public class ConfigStageCoverageTests
+{
+    private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
+    {
+        configManager ??= new ConfigManager();
+        var inputManager = new InputManagerCompat(configManager);
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+        return (new ConfigStage(game), configManager, inputManager);
+    }
+
+    private static void InitializeStageMenu(ConfigStage stage, bool includePanels)
+    {
+        ReflectionHelpers.InvokePrivateMethod(stage, "LoadConfiguration");
+        ReflectionHelpers.InvokePrivateMethod(stage, "LoadWorkingInputBindings");
+        ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+        if (includePanels)
+        {
+            ReflectionHelpers.InvokePrivateMethod(stage, "InitializePanels");
+        }
+    }
+
+    private static void SetKeyboardStates(ConfigStage stage, KeyboardState current, KeyboardState previous)
+    {
+        ReflectionHelpers.SetPrivateField(stage, "_currentKeyboardState", current);
+        ReflectionHelpers.SetPrivateField(stage, "_previousKeyboardState", previous);
+    }
+
+    private static string CreateConfigSavePath()
+    {
+        var directory = Path.Combine(
+            AppContext.BaseDirectory,
+            "TestResults",
+            "config-stage-coverage",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        return Path.Combine(directory, "Config.ini");
+    }
+
+    private static void DeleteConfigSavePath(string path)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static KeyBindings CreateWorkingDrumBindings()
+    {
+        var bindings = new KeyBindings();
+        bindings.UnbindLane(0);
+        bindings.UnbindLane(4);
+        bindings.BindButton("Key.Z", 4);
+        return bindings;
+    }
+
+    private sealed class RecordingConfigManager : ConfigManager, IConfigManager
+    {
+        private readonly Exception? _saveException;
+        private readonly string? _redirectedSavePath;
+
+        public RecordingConfigManager(ConfigData originalConfig, Exception? saveException = null, string? redirectedSavePath = null)
+        {
+            _saveException = saveException;
+            _redirectedSavePath = redirectedSavePath;
+            CopyConfigData(Config, originalConfig);
+        }
+
+        public string? LastSavePath { get; private set; }
+
+        public new void SaveConfig(string filePath)
+            => ((IConfigManager)this).SaveConfig(filePath);
+
+        void IConfigManager.SaveConfig(string filePath)
+        {
+            LastSavePath = filePath;
+            if (_saveException != null)
+                throw _saveException;
+            base.SaveConfig(_redirectedSavePath ?? filePath);
+        }
+
+        private static void CopyConfigData(ConfigData target, ConfigData source)
+        {
+            target.ScreenWidth = source.ScreenWidth;
+            target.ScreenHeight = source.ScreenHeight;
+            target.FullScreen = source.FullScreen;
+            target.VSyncWait = source.VSyncWait;
+            target.NoFail = source.NoFail;
+            target.AutoPlay = source.AutoPlay;
+            target.ScrollSpeed = source.ScrollSpeed;
+            target.DTXManiaVersion = source.DTXManiaVersion;
+            target.SkinPath = source.SkinPath;
+            target.DTXPath = source.DTXPath;
+            target.UseBoxDefSkin = source.UseBoxDefSkin;
+            target.SystemSkinRoot = source.SystemSkinRoot;
+            target.LastUsedSkin = source.LastUsedSkin;
+            target.MasterVolume = source.MasterVolume;
+            target.BGMVolume = source.BGMVolume;
+            target.SEVolume = source.SEVolume;
+            target.BufferSizeMs = source.BufferSizeMs;
+            target.KeyBindings = new Dictionary<string, int>(source.KeyBindings);
+            target.UnboundDrumLanes = new HashSet<int>(source.UnboundDrumLanes);
+            target.UnboundDrumButtons = new HashSet<string>(source.UnboundDrumButtons);
+            target.SystemKeyBindings = new Dictionary<string, string>(source.SystemKeyBindings);
+        }
+    }
+
+    [Fact]
+    public void ApplyConfiguration_WhenSaveSucceedsAndInputManagerAvailable_ShouldReloadBindingsAndApplySystemBindings()
+    {
+        var redirectedSavePath = CreateConfigSavePath();
+        var configManager = new RecordingConfigManager(new ConfigData(), redirectedSavePath: redirectedSavePath);
+        try
+        {
+            var (stage, _, inputManager) = CreateStage(configManager);
+            using (inputManager)
+            {
+                InitializeStageMenu(stage, includePanels: false);
+                var workingSystemBindings = new Dictionary<Keys, InputCommandType>
+                {
+                    [Keys.W] = InputCommandType.MoveUp,
+                    [Keys.S] = InputCommandType.MoveDown,
+                    [Keys.A] = InputCommandType.MoveLeft,
+                    [Keys.D] = InputCommandType.MoveRight,
+                    [Keys.Enter] = InputCommandType.Activate,
+                    [Keys.Escape] = InputCommandType.Back
+                };
+                ReflectionHelpers.SetPrivateField(stage, "_workingConfig", new ConfigData
+                {
+                    ScreenWidth = 1920,
+                    ScreenHeight = 1080,
+                    FullScreen = true,
+                    VSyncWait = false
+                });
+                ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", CreateWorkingDrumBindings());
+                ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", workingSystemBindings);
+                ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+                var result = (bool)ReflectionHelpers.InvokePrivateMethod(stage, "ApplyConfiguration")!;
+
+                Assert.True(result);
+                Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+                Assert.Equal(4, inputManager.ModularInputManager.KeyBindings.GetLane("Key.Z"));
+                var snapshot = inputManager.GetKeyMappingSnapshot();
+                Assert.Equal(InputCommandType.MoveUp, snapshot[Keys.W]);
+                Assert.Equal(InputCommandType.Back, snapshot[Keys.Escape]);
+            }
+        }
+        finally
+        {
+            DeleteConfigSavePath(redirectedSavePath);
+        }
+    }
+
+    [Fact]
+    public void ApplyConfiguration_WhenSaveThrows_ShouldRollbackAndReturnFalse()
+    {
+        var configManager = new RecordingConfigManager(new ConfigData
+        {
+            ScreenWidth = 1280,
+            ScreenHeight = 720,
+            FullScreen = false,
+            VSyncWait = true,
+            NoFail = false,
+            AutoPlay = false,
+            KeyBindings = new Dictionary<string, int> { ["Key.A"] = 0 },
+            UnboundDrumLanes = new HashSet<int> { 3 },
+            UnboundDrumButtons = new HashSet<string> { "Key.B" },
+            SystemKeyBindings = new Dictionary<string, string> { ["SystemKey.MoveUp"] = "Up" }
+        }, saveException: new IOException("disk full"));
+        var (stage, _, inputManager) = CreateStage(configManager);
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.SetPrivateField(stage, "_workingConfig", new ConfigData
+            {
+                ScreenWidth = 2560,
+                ScreenHeight = 1440,
+                FullScreen = true,
+                VSyncWait = false,
+                NoFail = true,
+                AutoPlay = true
+            });
+            ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", CreateWorkingDrumBindings());
+            ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", new Dictionary<Keys, InputCommandType>
+            {
+                [Keys.W] = InputCommandType.MoveUp
+            });
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+            var result = (bool)ReflectionHelpers.InvokePrivateMethod(stage, "ApplyConfiguration")!;
+
+            Assert.False(result);
+            Assert.Equal(1280, configManager.Config.ScreenWidth);
+            Assert.Equal(720, configManager.Config.ScreenHeight);
+            Assert.False(configManager.Config.FullScreen);
+            Assert.True(configManager.Config.VSyncWait);
+            Assert.False(configManager.Config.NoFail);
+            Assert.False(configManager.Config.AutoPlay);
+            Assert.Equal(0, configManager.Config.KeyBindings["Key.A"]);
+            Assert.Contains(3, configManager.Config.UnboundDrumLanes);
+            Assert.Contains("Key.B", configManager.Config.UnboundDrumButtons);
+            Assert.Equal("Up", configManager.Config.SystemKeyBindings["SystemKey.MoveUp"]);
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_hasUnsavedChanges"));
+        }
+    }
+
+    [Fact]
+    public void OnSaveButtonClicked_WhenApplySucceeds_ShouldChangeStage()
+    {
+        var redirectedSavePath = CreateConfigSavePath();
+        var configManager = new RecordingConfigManager(new ConfigData(), redirectedSavePath: redirectedSavePath);
+        try
+        {
+            var (stage, _, inputManager) = CreateStage(configManager);
+            using (inputManager)
+            {
+                InitializeStageMenu(stage, includePanels: false);
+                var stageManager = new Mock<IStageManager>();
+                stage.StageManager = stageManager.Object;
+                ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+                ReflectionHelpers.InvokePrivateMethod(stage, "OnSaveButtonClicked", null, EventArgs.Empty);
+
+                stageManager.Verify(
+                    m => m.ChangeStage(
+                        StageType.Title,
+                        It.Is<IStageTransition>(t => t is CrossfadeTransition)),
+                    Times.Once);
+            }
+        }
+        finally
+        {
+            DeleteConfigSavePath(redirectedSavePath);
+        }
+    }
+
+    [Fact]
+    public void OnSaveButtonClicked_WhenApplyFails_ShouldStayOnConfigStage()
+    {
+        var configManager = new RecordingConfigManager(
+            new ConfigData(),
+            saveException: new IOException("disk full"));
+        var (stage, _, inputManager) = CreateStage(configManager);
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnSaveButtonClicked", null, EventArgs.Empty);
+
+            stageManager.Verify(
+                m => m.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>()),
+                Times.Never);
+        }
+    }
+
+    [Fact]
+    public void OnBackButtonClicked_ShouldChangeStageToTitle()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnBackButtonClicked", null, EventArgs.Empty);
+
+            stageManager.Verify(
+                m => m.ChangeStage(
+                    StageType.Title,
+                    It.Is<IStageTransition>(t => t is CrossfadeTransition)),
+                Times.Once);
+        }
+    }
+
+    [Fact]
+    public void ApplyConfiguration_WithConcreteConfigManager_ShouldSaveKeyBindings()
+    {
+        var redirectedSavePath = CreateConfigSavePath();
+        var configManager = new RecordingConfigManager(new ConfigData(), redirectedSavePath: redirectedSavePath);
+        try
+        {
+            var (stage, _, inputManager) = CreateStage(configManager);
+            using (inputManager)
+            {
+                InitializeStageMenu(stage, includePanels: false);
+                var workingDrumBindings = CreateWorkingDrumBindings();
+                var workingSystemBindings = new Dictionary<Keys, InputCommandType>
+                {
+                    [Keys.W] = InputCommandType.MoveUp,
+                    [Keys.Escape] = InputCommandType.Back
+                };
+                ReflectionHelpers.SetPrivateField(stage, "_workingConfig", new ConfigData
+                {
+                    ScreenWidth = 1920,
+                    ScreenHeight = 1080
+                });
+                ReflectionHelpers.SetPrivateField(stage, "_workingDrumBindings", workingDrumBindings);
+                ReflectionHelpers.SetPrivateField(stage, "_workingSystemBindings", workingSystemBindings);
+                ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", true);
+
+                var result = (bool)ReflectionHelpers.InvokePrivateMethod(stage, "ApplyConfiguration")!;
+
+                Assert.True(result);
+                Assert.Equal(4, configManager.Config.KeyBindings["Key.Z"]);
+                Assert.Contains(0, configManager.Config.UnboundDrumLanes);
+                Assert.Equal("W", configManager.Config.SystemKeyBindings["SystemKey.MoveUp"]);
+                Assert.Equal("Escape", configManager.Config.SystemKeyBindings["SystemKey.Back"]);
+            }
+        }
+        finally
+        {
+            DeleteConfigSavePath(redirectedSavePath);
+        }
+    }
+
+    [Fact]
+    public void HandleInput_WhenBackCommandPressed_ShouldChangeStage()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_hasUnsavedChanges", false);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Escape), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            stageManager.Verify(
+                m => m.ChangeStage(
+                    StageType.Title,
+                    It.Is<IStageTransition>(t => t is CrossfadeTransition)),
+                Times.Once);
+        }
+    }
+}

--- a/DTXMania.Test/Stage/KeyAssign/DrumKeyAssignPanelCoverageTests.cs
+++ b/DTXMania.Test/Stage/KeyAssign/DrumKeyAssignPanelCoverageTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Stage.KeyAssign;
+using Microsoft.Xna.Framework.Input;
+
+namespace DTXMania.Test.Stage.KeyAssign;
+
+[Trait("Category", "Unit")]
+public class DrumKeyAssignPanelCoverageTests
+{
+    private static ModularInputManager CreateModularInputManager()
+    {
+        var configManager = new ConfigManager();
+        return new ModularInputManager(configManager);
+    }
+
+    [Fact]
+    public void GetFooterCancelLabel_WithDefaultNavigation_ShouldReturnCancelWithEscape()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._navigationMappingProvider = null;
+        panel._workingBindingsProvider = null;
+        panel.Activate();
+
+        var label = panel.GetFooterCancelLabel();
+
+        Assert.Equal("CANCEL (ESCAPE)", label);
+    }
+
+    [Fact]
+    public void GetFooterCancelLabel_WithNoBackBinding_ShouldReturnCancel()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._navigationMappingProvider = () => new Dictionary<Keys, InputCommandType>
+        {
+            [Keys.Up] = InputCommandType.MoveUp,
+            [Keys.Down] = InputCommandType.MoveDown
+        };
+        panel._workingBindingsProvider = null;
+        panel.Activate();
+
+        var label = panel.GetFooterCancelLabel();
+
+        Assert.Equal("CANCEL", label);
+    }
+
+    [Fact]
+    public void GetInstructionText_WithDefaultNavigation_ShouldIncludeAllControls()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._navigationMappingProvider = null;
+        panel._workingBindingsProvider = null;
+        panel.Activate();
+
+        var text = panel.GetInstructionText();
+
+        Assert.Contains("UP/DOWN", text);
+        Assert.Contains("Navigate", text);
+        Assert.Contains("ENTER", text);
+        Assert.Contains("Assign", text);
+        Assert.Contains("DELETE", text);
+        Assert.Contains("ESCAPE", text);
+        Assert.Contains("Cancel", text);
+    }
+
+    [Fact]
+    public void GetInstructionText_WithEmptyNavigationMapping_ShouldUseDefaults()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._navigationMappingProvider = () => new Dictionary<Keys, InputCommandType>();
+        panel._workingBindingsProvider = null;
+        panel.Activate();
+
+        var text = panel.GetInstructionText();
+
+        Assert.Contains("UP/DOWN", text);
+        Assert.Contains("ENTER", text);
+        Assert.Contains("BACK", text);
+    }
+
+    [Fact]
+    public void Activate_WithWorkingBindingsProvider_ShouldUseProvidedBindings()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        var customBindings = new KeyBindings();
+        customBindings.BindButton("Key.Q", 0);
+        panel._workingBindingsProvider = () => customBindings.Clone();
+        panel._navigationMappingProvider = null;
+        panel._liveSystemMappingProvider = () => new Dictionary<Keys, InputCommandType>();
+
+        panel.Activate();
+
+        var snapshot = panel.GetWorkingBindingsSnapshot();
+        Assert.Equal(0, snapshot.GetLane("Key.Q"));
+    }
+
+    [Fact]
+    public void Update_WhenAwaitingKeyAndBackPressed_ShouldReturnToBrowsing()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._workingBindingsProvider = null;
+        panel._navigationMappingProvider = null;
+        panel._liveSystemMappingProvider = () => new Dictionary<Keys, InputCommandType>();
+        panel._commandPressedProvider = null;
+        panel.Activate();
+
+        panel.Update(0.016, new KeyboardState(Keys.Enter), new KeyboardState());
+        Assert.True(panel.IsActive);
+
+        panel.Update(0.016, new KeyboardState(Keys.Escape), new KeyboardState());
+
+        var snapshot = panel.GetWorkingBindingsSnapshot();
+        Assert.Equal(-1, snapshot.GetLane("Key.Escape"));
+    }
+
+    [Fact]
+    public void CommitAndClose_ShouldFireSavedAndClosed()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._workingBindingsProvider = null;
+        panel._navigationMappingProvider = null;
+        panel._liveSystemMappingProvider = () => new Dictionary<Keys, InputCommandType>();
+        panel.EvictSystemBinding = _ => { };
+        panel.Activate();
+        for (int i = 0; i < 10; i++)
+            panel.Update(0.016, new KeyboardState(Keys.Down), new KeyboardState());
+
+        var savedFired = false;
+        var closedFired = false;
+        panel.Saved += (_, _) => savedFired = true;
+        panel.Closed += (_, _) => closedFired = true;
+
+        panel.Update(0.016, new KeyboardState(Keys.Enter), new KeyboardState());
+
+        Assert.True(savedFired);
+        Assert.True(closedFired);
+        Assert.False(panel.IsActive);
+    }
+
+    [Fact]
+    public void CancelAndClose_ShouldFireClosedOnly()
+    {
+        var modularInputManager = CreateModularInputManager();
+        var panel = new DrumKeyAssignPanel(modularInputManager);
+        panel._workingBindingsProvider = null;
+        panel._navigationMappingProvider = null;
+        panel._liveSystemMappingProvider = () => new Dictionary<Keys, InputCommandType>();
+        panel._commandPressedProvider = null;
+        panel.Activate();
+
+        var savedFired = false;
+        var closedFired = false;
+        panel.Saved += (_, _) => savedFired = true;
+        panel.Closed += (_, _) => closedFired = true;
+
+        panel.Update(0.016, new KeyboardState(Keys.Escape), new KeyboardState());
+
+        Assert.False(savedFired);
+        Assert.True(closedFired);
+        Assert.False(panel.IsActive);
+    }
+}

--- a/DTXMania.Test/Stage/KeyAssign/DrumKeyAssignPanelCoverageTests.cs
+++ b/DTXMania.Test/Stage/KeyAssign/DrumKeyAssignPanelCoverageTests.cs
@@ -10,6 +10,12 @@ namespace DTXMania.Test.Stage.KeyAssign;
 [Trait("Category", "Unit")]
 public class DrumKeyAssignPanelCoverageTests
 {
+    /// <summary>
+    /// Number of Down presses needed to navigate past all drum lanes
+    /// to reach the Save footer row (LaneCount = 10 in DrumKeyAssignPanel).
+    /// </summary>
+    private const int PressesToReachSaveRow = 10;
+
     private static ModularInputManager CreateModularInputManager()
     {
         var configManager = new ConfigManager();
@@ -122,7 +128,7 @@ public class DrumKeyAssignPanelCoverageTests
     }
 
     [Fact]
-    public void CommitAndClose_ShouldFireSavedAndClosed()
+    public void CommitWithPendingChanges_ShouldFireSavedAndClosed()
     {
         var modularInputManager = CreateModularInputManager();
         var panel = new DrumKeyAssignPanel(modularInputManager);
@@ -131,7 +137,7 @@ public class DrumKeyAssignPanelCoverageTests
         panel._liveSystemMappingProvider = () => new Dictionary<Keys, InputCommandType>();
         panel.EvictSystemBinding = _ => { };
         panel.Activate();
-        for (int i = 0; i < 10; i++)
+        for (int i = 0; i < PressesToReachSaveRow; i++)
             panel.Update(0.016, new KeyboardState(Keys.Down), new KeyboardState());
 
         var savedFired = false;
@@ -147,7 +153,7 @@ public class DrumKeyAssignPanelCoverageTests
     }
 
     [Fact]
-    public void CancelAndClose_ShouldFireClosedOnly()
+    public void CancelWithoutSaving_ShouldFireClosedOnly()
     {
         var modularInputManager = CreateModularInputManager();
         var panel = new DrumKeyAssignPanel(modularInputManager);

--- a/DTXMania.Test/Stage/KeyAssign/KeyConflictCheckerTests.cs
+++ b/DTXMania.Test/Stage/KeyAssign/KeyConflictCheckerTests.cs
@@ -144,4 +144,78 @@ public class KeyConflictCheckerTests
         Assert.NotNull(result);
         Assert.Contains("MoveUp", result);
     }
+
+    // ─── IsRequiredCommand ──────────────────────────────────────────────────
+
+    [Fact]
+    public void IsRequiredCommand_RequiredCommand_ShouldReturnTrue()
+    {
+        Assert.True(KeyConflictChecker.IsRequiredCommand(InputCommandType.MoveUp));
+        Assert.True(KeyConflictChecker.IsRequiredCommand(InputCommandType.MoveDown));
+        Assert.True(KeyConflictChecker.IsRequiredCommand(InputCommandType.MoveLeft));
+        Assert.True(KeyConflictChecker.IsRequiredCommand(InputCommandType.MoveRight));
+        Assert.True(KeyConflictChecker.IsRequiredCommand(InputCommandType.Activate));
+        Assert.True(KeyConflictChecker.IsRequiredCommand(InputCommandType.Back));
+    }
+
+    [Fact]
+    public void IsRequiredCommand_NonRequiredCommand_ShouldReturnFalse()
+    {
+        Assert.False(KeyConflictChecker.IsRequiredCommand(InputCommandType.IncreaseScrollSpeed));
+        Assert.False(KeyConflictChecker.IsRequiredCommand(InputCommandType.DecreaseScrollSpeed));
+    }
+
+    // ─── GetRequiredSystemConflict ────────────────────────────────────────────
+
+    [Fact]
+    public void GetRequiredSystemConflict_RequiredCommand_ShouldReturnCommand()
+    {
+        var systemBindings = new Dictionary<Keys, InputCommandType>
+        {
+            [Keys.Up] = InputCommandType.MoveUp
+        };
+
+        var result = KeyConflictChecker.GetRequiredSystemConflict(systemBindings, Keys.Up);
+
+        Assert.Equal(InputCommandType.MoveUp, result);
+    }
+
+    [Fact]
+    public void GetRequiredSystemConflict_NonRequiredCommand_ShouldReturnNull()
+    {
+        var systemBindings = new Dictionary<Keys, InputCommandType>
+        {
+            [Keys.PageUp] = InputCommandType.IncreaseScrollSpeed
+        };
+
+        var result = KeyConflictChecker.GetRequiredSystemConflict(systemBindings, Keys.PageUp);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetRequiredSystemConflict_KeyNotInSystemBindings_ShouldReturnNull()
+    {
+        var systemBindings = new Dictionary<Keys, InputCommandType>
+        {
+            [Keys.Up] = InputCommandType.MoveUp
+        };
+
+        var result = KeyConflictChecker.GetRequiredSystemConflict(systemBindings, Keys.PageUp);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetRequiredSystemConflict_PageDownScrollSpeed_ShouldReturnNull()
+    {
+        var systemBindings = new Dictionary<Keys, InputCommandType>
+        {
+            [Keys.PageDown] = InputCommandType.DecreaseScrollSpeed
+        };
+
+        var result = KeyConflictChecker.GetRequiredSystemConflict(systemBindings, Keys.PageDown);
+
+        Assert.Null(result);
+    }
 }

--- a/DTXMania.Test/Stage/Performance/PerformanceStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageCoverageTests.cs
@@ -1,0 +1,708 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.Helpers;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+
+namespace DTXMania.Test.Stage.Performance;
+
+[Trait("Category", "Unit")]
+public class PerformanceStageCoverageTests
+{
+    [Fact]
+    public void OnActivate_WhenConfigManagerNotNull_ShouldSubscribeToScrollSpeedChanged()
+    {
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(x => x.Config).Returns(new ConfigData { AutoPlay = true });
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        var stage = CreateStage(game);
+        ReflectionHelpers.SetPrivateField(stage, "_sharedData", null);
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ExtractSharedData");
+        ReflectionHelpers.InvokePrivateMethod(stage, "InitializeAutoPlay");
+
+        var configManagerField = game.ConfigManager;
+        Assert.NotNull(configManagerField);
+
+        ReflectionHelpers.SetPrivateField(stage, "_subscribedConfigManager", configManagerField);
+        configManagerField.ScrollSpeedChanged += OnScrollSpeedChangedHandler;
+
+        Assert.Same(configManagerField, ReflectionHelpers.GetPrivateField<IConfigManager>(stage, "_subscribedConfigManager"));
+    }
+
+    [Fact]
+    public void OnActivate_WhenConfigManagerIsNull_ShouldNotSubscribe()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), null);
+        var stage = CreateStage(game);
+        ReflectionHelpers.SetPrivateField(stage, "_sharedData", null);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ExtractSharedData");
+        ReflectionHelpers.InvokePrivateMethod(stage, "InitializeAutoPlay");
+
+        Assert.Null(ReflectionHelpers.GetPrivateField<IConfigManager>(stage, "_subscribedConfigManager"));
+    }
+
+    private static void OnScrollSpeedChangedHandler(object? sender, ScrollSpeedChangedEventArgs e) { }
+
+    [Fact]
+    public void OnDeactivate_WhenSubscribedConfigManager_ShouldUnsubscribeFlushAndCleanup()
+    {
+        var configManager = new Mock<IConfigManager>();
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_subscribedConfigManager", configManager.Object);
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", true);
+        ReflectionHelpers.SetPrivateField(stage, "_inputPaused", true);
+        ReflectionHelpers.SetPrivateField(stage, "_totalTime", 12.0);
+        ReflectionHelpers.SetPrivateField(stage, "_stageElapsedTime", 15.0);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.25);
+        ReflectionHelpers.SetPrivateField(stage, "_autoPlayNoteIndex", 8);
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("deactivate-test.dtx"));
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnDeactivate");
+
+        configManager.Verify(x => x.FlushPendingSave(), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<IConfigManager>(stage, "_subscribedConfigManager"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_isLoading"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_totalTime"));
+        Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_stageElapsedTime"));
+        Assert.Equal(1.0, ReflectionHelpers.GetPrivateField<double>(stage, "_readyCountdown"));
+        Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_autoPlayNoteIndex"));
+    }
+
+    [Fact]
+    public void OnDeactivate_WhenNoSubscribedConfigManager_ShouldStillCleanupComponents()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_subscribedConfigManager", null);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", true);
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound>());
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+
+        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "OnDeactivate"));
+
+        Assert.Null(exception);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_isLoading"));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+    }
+
+    [Fact]
+    public void HandleInput_WhenIncreaseScrollSpeedPressed_ShouldCallAdjustScrollSpeed()
+    {
+        var configManager = new Mock<IConfigManager>();
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        var stage = CreateStage(game);
+        var inputManager = new ScrollSpeedInputManagerCompat(InputCommandType.IncreaseScrollSpeed);
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", inputManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        configManager.Verify(x => x.AdjustScrollSpeed(It.IsAny<string>(), 1), Times.Once);
+    }
+
+    [Fact]
+    public void HandleInput_WhenDecreaseScrollSpeedPressed_ShouldCallAdjustScrollSpeedNegative()
+    {
+        var configManager = new Mock<IConfigManager>();
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        var stage = CreateStage(game);
+        var inputManager = new ScrollSpeedInputManagerCompat(InputCommandType.DecreaseScrollSpeed);
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", inputManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        configManager.Verify(x => x.AdjustScrollSpeed(It.IsAny<string>(), -1), Times.Once);
+    }
+
+    [Fact]
+    public void HandleInput_WhenNoConfigManager_ShouldNotThrowOnScrollSpeed()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), null);
+        var stage = CreateStage(game);
+        var inputManager = new ScrollSpeedInputManagerCompat(InputCommandType.IncreaseScrollSpeed);
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", inputManager);
+
+        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void OnScrollSpeedChanged_ShouldSetScrollSpeedOnNoteRendererAndShowIndicator()
+    {
+        var stage = CreateStage();
+        var noteRenderer = CreateNoteRenderer();
+        ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", noteRenderer);
+        var indicator = new ScrollSpeedIndicator(null);
+        ReflectionHelpers.SetPrivateField(stage, "_scrollSpeedIndicator", indicator);
+
+        var args = new ScrollSpeedChangedEventArgs(50, 75);
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnScrollSpeedChanged", null, args);
+
+        Assert.Equal("Scroll Speed " + ScrollSpeedRange.Format(75), indicator.Text);
+    }
+
+    [Fact]
+    public void OnScrollSpeedChanged_WhenNoteRendererNull_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", null);
+        ReflectionHelpers.SetPrivateField(stage, "_scrollSpeedIndicator", new ScrollSpeedIndicator(null));
+
+        var exception = Record.Exception(() =>
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnScrollSpeedChanged", null, new ScrollSpeedChangedEventArgs(50, 75)));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void OnScrollSpeedChanged_WhenIndicatorNull_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", null);
+        ReflectionHelpers.SetPrivateField(stage, "_scrollSpeedIndicator", null);
+
+        var exception = Record.Exception(() =>
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnScrollSpeedChanged", null, new ScrollSpeedChangedEventArgs(50, 75)));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ReturnToSongSelect_ShouldStopTimerDeactivateJudgementPauseInputAndChangeStage()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote())
+        {
+            IsActive = true
+        };
+        var songTimer = CreateStoppedSongTimer();
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "ReturnToSongSelect");
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        Assert.False(judgementManager.IsActive);
+        stageManager.Verify(
+            x => x.ChangeStage(
+                StageType.SongSelect,
+                It.Is<IStageTransition>(t => t is DTXManiaFadeTransition),
+                null),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ReturnToSongSelect_WhenSongTimerNull_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", null);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", null);
+
+        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "ReturnToSongSelect"));
+
+        Assert.Null(exception);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+    }
+
+    [Fact]
+    public void UpdateGameplay_WhenLoading_ShouldReturnEarlyWithoutMutatingState()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", true);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.75);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplay", 0.25);
+
+        Assert.Equal(0.75, ReflectionHelpers.GetPrivateField<double>(stage, "_readyCountdown"));
+    }
+
+    [Fact]
+    public void UpdateGameplay_WhenReadyCountdownActive_ShouldDecreaseCountdown()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.75);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplay", 0.25);
+
+        Assert.Equal(0.5, ReflectionHelpers.GetPrivateField<double>(stage, "_readyCountdown"), 3);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+    }
+
+    [Fact]
+    public void UpdateGameplay_WhenReadyCountdownExpires_ShouldStartSongAndActivateJudgement()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.1);
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreateStoppedSongTimer());
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplay", 0.25);
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.True(judgementManager.IsActive);
+    }
+
+    [Fact]
+    public void UpdateGameplay_WhenSongPlaying_ShouldAdvanceManagersAndProgress()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", false);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromMilliseconds(1301.0), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreatePlayingSongTimer());
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("progress-coverage.dtx") { DurationMs = 2000.0 });
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "UpdateGameplay", 0.016);
+
+        Assert.Equal(1, judgementManager.GetJudgementCount(JudgementType.Miss));
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+    }
+
+    [Fact]
+    public void StartSong_WhenNoBgmEvents_ShouldSetVolumeToOne()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        var songTimer = CreateStoppedSongTimer();
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "StartSong");
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.True(judgementManager.IsActive);
+    }
+
+    [Fact]
+    public void StartSong_WhenBgmEventsExist_ShouldMuteBackgroundAudio()
+    {
+        var stage = CreateStage();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote());
+        var songTimer = CreateStoppedSongTimer();
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent> { new() { WavId = "01", TimeMs = 100.0 } });
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "StartSong");
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+        Assert.True(judgementManager.IsActive);
+    }
+
+    [Fact]
+    public void StartSong_WhenSongTimerIsNull_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", null);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "StartSong"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void FinalizePerformance_ShouldMarkCompletedPauseInputStopTimerCreateSummary()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        Dictionary<string, object>? capturedSharedData = null;
+        stageManager
+            .Setup(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, sharedData) => capturedSharedData = sharedData);
+        stage.StageManager = stageManager.Object;
+
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var scoreManager = new ScoreManager(chartManager.TotalNotes);
+        var comboManager = new ComboManager();
+        var gaugeManager = new GaugeManager();
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", scoreManager);
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", gaugeManager);
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreateStoppedSongTimer());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.SongComplete);
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+        Assert.False(judgementManager.IsActive);
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.Equal(CompletionReason.SongComplete, summary.CompletionReason);
+        Assert.True(summary.ClearFlag);
+        Assert.Equal(chartManager.TotalNotes, summary.TotalNotes);
+        stageManager.Verify(x => x.ChangeStage(StageType.Result, It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void FinalizePerformance_WhenPlayerFailed_ShouldSetClearFlagFalse()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.PlayerFailed);
+
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.Equal(CompletionReason.PlayerFailed, summary.CompletionReason);
+        Assert.False(summary.ClearFlag);
+    }
+
+    [Fact]
+    public void CheckStageCompletion_WhenSongEndBufferPassed_ShouldFinalizeAsSongComplete()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        Dictionary<string, object>? capturedSharedData = null;
+        stageManager
+            .Setup(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, sharedData) => capturedSharedData = sharedData);
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("check-complete.dtx") { DurationMs = 1000.0 });
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CheckStageCompletion", 5000.0);
+
+        var summary = Assert.IsType<PerformanceSummary>(capturedSharedData!["performanceSummary"]);
+        Assert.Equal(CompletionReason.SongComplete, summary.CompletionReason);
+        Assert.True(summary.ClearFlag);
+        stageManager.Verify(x => x.ChangeStage(StageType.Result, It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Once);
+    }
+
+    [Fact]
+    public void CheckStageCompletion_WhenPlayerFailedAndNoFailDisabled_ShouldFinalizeAsPlayerFailed()
+    {
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), CreateConfigManager(new ConfigData { NoFail = false }));
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        Dictionary<string, object>? capturedSharedData = null;
+        stageManager
+            .Setup(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, sharedData) => capturedSharedData = sharedData);
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("check-failed.dtx") { DurationMs = 5000.0 });
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        var gaugeManager = new GaugeManager();
+        ReflectionHelpers.SetPrivateField(gaugeManager, "_hasFailed", true);
+        ReflectionHelpers.SetPrivateField(gaugeManager, "_currentLife", 0.0f);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", gaugeManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CheckStageCompletion", 1000.0);
+
+        var summary = Assert.IsType<PerformanceSummary>(capturedSharedData!["performanceSummary"]);
+        Assert.Equal(CompletionReason.PlayerFailed, summary.CompletionReason);
+        Assert.False(summary.ClearFlag);
+    }
+
+    [Fact]
+    public void CheckStageCompletion_WhenStageAlreadyCompleted_ShouldNotTransitionAgain()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", true);
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", new ParsedChart("already-done.dtx") { DurationMs = 1000.0 });
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CheckStageCompletion", 5000.0);
+
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void CheckStageCompletion_WhenParsedChartNull_ShouldNotTransition()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", null);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CheckStageCompletion", 5000.0);
+
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void DrawGameplayState_WhenLoading_ShouldDrawLoadingText()
+    {
+        var stage = CreateStage();
+        Rectangle? actualRectangle = null;
+        Color? actualColor = null;
+        float? actualDepth = null;
+
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", true);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", false);
+        ReflectionHelpers.SetPrivateField(stage, "_readyFont", null);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_fallbackRectangleDrawer",
+            (Action<Rectangle, Color, float>)((rectangle, color, depth) =>
+            {
+                actualRectangle = rectangle;
+                actualColor = color;
+                actualDepth = depth;
+            }));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "DrawGameplayState");
+
+        Assert.NotNull(actualRectangle);
+        Assert.Equal(Color.White, actualColor);
+        Assert.Equal(0.1f, actualDepth);
+    }
+
+    [Fact]
+    public void DrawGameplayState_WhenReadyWithCountdown_ShouldDrawPulsingReadyText()
+    {
+        var stage = CreateStage();
+        Rectangle? actualRectangle = null;
+        Color? actualColor = null;
+        float? actualDepth = null;
+
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+        ReflectionHelpers.SetPrivateField(stage, "_readyCountdown", 0.5);
+        ReflectionHelpers.SetPrivateField(stage, "_totalTime", 0.125);
+        ReflectionHelpers.SetPrivateField(stage, "_readyFont", null);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_fallbackRectangleDrawer",
+            (Action<Rectangle, Color, float>)((rectangle, color, depth) =>
+            {
+                actualRectangle = rectangle;
+                actualColor = color;
+                actualDepth = depth;
+            }));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "DrawGameplayState");
+
+        Assert.NotNull(actualRectangle);
+        Assert.Equal(0.1f, actualDepth);
+    }
+
+    [Fact]
+    public void DrawGameplayState_WhenNotLoadingAndNotReady_ShouldNotDraw()
+    {
+        var stage = CreateStage();
+        var fallbackInvoked = false;
+
+        ReflectionHelpers.SetPrivateField(stage, "_isLoading", false);
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", false);
+        ReflectionHelpers.SetPrivateField(stage, "_readyFont", null);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_fallbackRectangleDrawer",
+            (Action<Rectangle, Color, float>)((_, _, _) => fallbackInvoked = true));
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "DrawGameplayState");
+
+        Assert.False(fallbackInvoked);
+    }
+
+    [Fact]
+    public void FinalizePerformance_WhenAllManagersNull_ShouldBuildZeroedSummary()
+    {
+        var stage = CreateStage();
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.SongComplete);
+
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.Equal(0, summary.Score);
+        Assert.Equal(0, summary.MaxCombo);
+        Assert.Equal(0, summary.JustCount);
+        Assert.Equal(0, summary.GreatCount);
+        Assert.Equal(0, summary.GoodCount);
+        Assert.Equal(0, summary.PoorCount);
+        Assert.Equal(0, summary.MissCount);
+        Assert.Equal(0, summary.TotalNotes);
+        Assert.Equal(0.0f, summary.FinalLife);
+        Assert.True(summary.ClearFlag);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+    }
+
+    [Fact]
+    public void FinalizePerformance_ShouldStopSongTimerAndDeactivateJudgementManager()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote())
+        {
+            IsActive = true
+        };
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreateStoppedSongTimer());
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", CreateChartManagerWithSingleNote());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.SongComplete);
+
+        Assert.False(judgementManager.IsActive);
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_inputPaused"));
+    }
+
+    private static PerformanceStage CreateStage(BaseGame? game = null)
+    {
+#pragma warning disable SYSLIB0050
+        var stage = (PerformanceStage)FormatterServices.GetUninitializedObject(typeof(PerformanceStage));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(stage, "_game", game ?? ReflectionHelpers.CreateGame());
+        return stage;
+    }
+
+    private static IConfigManager CreateConfigManager(ConfigData configData)
+    {
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(x => x.Config).Returns(configData);
+        return configManager.Object;
+    }
+
+    private static ChartManager CreateChartManagerWithSingleNote()
+    {
+        var parsedChart = new ParsedChart("coverage-test.dtx")
+        {
+            Bpm = 120.0
+        };
+        parsedChart.AddNote(new Note(0, 0, 96, 0x11, "01"));
+        parsedChart.FinalizeChart();
+        return new ChartManager(parsedChart);
+    }
+
+    private static SongTimer CreateStoppedSongTimer()
+    {
+#pragma warning disable SYSLIB0050
+        var timer = (SongTimer)FormatterServices.GetUninitializedObject(typeof(SongTimer));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(timer, "_disposed", true);
+        return timer;
+    }
+
+    private static SongTimer CreatePlayingSongTimer()
+    {
+#pragma warning disable SYSLIB0050
+        var timer = (SongTimer)FormatterServices.GetUninitializedObject(typeof(SongTimer));
+#pragma warning restore SYSLIB0050
+        ReflectionHelpers.SetPrivateField(timer, "_disposed", false);
+        ReflectionHelpers.SetPrivateField(timer, "_isPlaying", true);
+        ReflectionHelpers.SetPrivateField(timer, "_startTime", TimeSpan.Zero);
+        return timer;
+    }
+
+    private static NoteRenderer CreateNoteRenderer()
+    {
+#pragma warning disable SYSLIB0050
+        var renderer = (NoteRenderer)FormatterServices.GetUninitializedObject(typeof(NoteRenderer));
+        var whiteTexture = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+#pragma warning restore SYSLIB0050
+        var lanePositions = new Vector2[PerformanceUILayout.LaneCount];
+        for (var i = 0; i < lanePositions.Length; i++)
+        {
+            lanePositions[i] = new Vector2(PerformanceUILayout.GetLaneX(i) - 16f, 0f);
+        }
+
+        ReflectionHelpers.SetPrivateField(renderer, "_whiteTexture", whiteTexture);
+        ReflectionHelpers.SetPrivateField(renderer, "_lanePositions", lanePositions);
+        ReflectionHelpers.SetPrivateField(renderer, "_laneColors", Enumerable.Repeat(Color.White, PerformanceUILayout.LaneCount).ToArray());
+        ReflectionHelpers.SetPrivateField(renderer, "_laneFlashAlpha", new float[10]);
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 0.5);
+        ReflectionHelpers.SetPrivateField(renderer, "<EffectiveLookAheadMs>k__BackingField", 1200.0);
+        ReflectionHelpers.SetPrivateField(renderer, "_disposed", false);
+        return renderer;
+    }
+
+    private sealed class ScrollSpeedInputManagerCompat : MockInputManagerCompat
+    {
+        private readonly InputCommandType _activeCommand;
+
+        public ScrollSpeedInputManagerCompat(InputCommandType activeCommand)
+        {
+            _activeCommand = activeCommand;
+        }
+
+        public override bool IsCommandPressed(InputCommandType command)
+        {
+            return command == _activeCommand;
+        }
+
+        public override bool IsBackActionTriggered()
+        {
+            return false;
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
@@ -25,7 +25,7 @@ namespace DTXMania.Test.Stage.Performance
         #region Show
 
         [Fact]
-        public void Show_SetsTextFromScrollSpeedPercent()
+        public void Show_ShouldSetTextFromScrollSpeedPercent()
         {
             var indicator = CreateIndicator();
             indicator.Show(200);
@@ -34,23 +34,19 @@ namespace DTXMania.Test.Stage.Performance
             Assert.True(indicator.IsVisible);
         }
 
-        [Fact]
-        public void Show_WithDifferentSpeeds_SetsDifferentText()
+        [Theory]
+        [InlineData(50, "Scroll Speed x0.5")]
+        [InlineData(100, "Scroll Speed x1.0")]
+        [InlineData(400, "Scroll Speed x4.0")]
+        public void Show_WithDifferentSpeeds_ShouldSetExpectedText(int speed, string expectedText)
         {
             var indicator = CreateIndicator();
-
-            indicator.Show(50);
-            Assert.Equal("Scroll Speed x0.5", indicator.Text);
-
-            indicator.Show(100);
-            Assert.Equal("Scroll Speed x1.0", indicator.Text);
-
-            indicator.Show(400);
-            Assert.Equal("Scroll Speed x4.0", indicator.Text);
+            indicator.Show(speed);
+            Assert.Equal(expectedText, indicator.Text);
         }
 
         [Fact]
-        public void Show_CalledMultipleTimes_ResetsTimer()
+        public void Show_CalledMultipleTimes_ShouldResetTimer()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -72,7 +68,7 @@ namespace DTXMania.Test.Stage.Performance
         #region Update
 
         [Fact]
-        public void Update_CountsDownRemainingTime()
+        public void Update_ShouldCountDownRemainingTime()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -86,7 +82,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_ClampsRemainingToZero()
+        public void Update_ShouldClampRemainingToZero()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -100,7 +96,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_WhenNotShown_IsNoOp()
+        public void Update_WhenNotShown_ShouldBeNoOp()
         {
             var indicator = CreateIndicator();
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(100));
@@ -111,7 +107,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_AfterExpired_ContinuesAsNoOp()
+        public void Update_AfterExpired_ShouldContinueAsNoOp()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -131,7 +127,7 @@ namespace DTXMania.Test.Stage.Performance
         #region Alpha
 
         [Fact]
-        public void Alpha_IsFullWhenRecentlyShown()
+        public void Alpha_ShouldBeFullWhenRecentlyShown()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -143,7 +139,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Alpha_FadesNearEndOfDuration()
+        public void Alpha_ShouldFadeNearEndOfDuration()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -160,7 +156,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Alpha_IsZeroWhenExpired()
+        public void Alpha_ShouldBeZeroWhenExpired()
         {
             var indicator = CreateIndicator();
             indicator.Show(100);
@@ -172,7 +168,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Alpha_IsZeroBeforeFirstShow()
+        public void Alpha_ShouldBeZeroBeforeFirstShow()
         {
             var indicator = CreateIndicator();
             Assert.Equal(0f, indicator.Alpha);

--- a/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
@@ -1,0 +1,193 @@
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Stage.Performance;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    [Trait("Category", "Unit")]
+    public class ScrollSpeedIndicatorTests
+    {
+        /// <summary>
+        /// ScrollSpeedIndicator is created with null font (font init can fail at runtime).
+        /// All logic tests work without a real BitmapFont because Show/Update/ComputeAlpha
+        /// do not touch the font — only Draw does, and Draw is excluded from unit tests.
+        /// </summary>
+        private static ScrollSpeedIndicator CreateIndicator()
+        {
+            return new ScrollSpeedIndicator(null);
+        }
+
+        #region Show
+
+        [Fact]
+        public void Show_SetsTextFromScrollSpeedPercent()
+        {
+            // We can't read _text directly, but we can verify indirectly through
+            // the visible state: after Show, Update should count down from > 0.
+            var indicator = CreateIndicator();
+            indicator.Show(200);
+
+            // After Show with no Update, the indicator should be in a visible state.
+            // We verify by updating and checking it doesn't crash and accepts frames.
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(100));
+            indicator.Update(gameTime);
+            // If Show didn't set _remainingSeconds, Update would be a no-op.
+            // After 100ms of a 1500ms timer, it should still have time remaining.
+        }
+
+        [Fact]
+        public void Show_WithDifferentSpeeds_SetsDifferentText()
+        {
+            var indicator = CreateIndicator();
+            // Show sets _text = "Scroll Speed " + Format(percent)
+            // Format is tested in ScrollSpeedRangeTests, so we just verify Show doesn't throw
+            indicator.Show(50);
+            indicator.Show(100);
+            indicator.Show(400);
+            // No exception = success
+        }
+
+        [Fact]
+        public void Show_CalledMultipleTimes_ResetsTimer()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            // Advance most of the duration
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1400));
+            indicator.Update(gameTime);
+
+            // Show again — should reset the timer
+            indicator.Show(200);
+
+            // After another 200ms, it should still be visible (timer was reset to 1500ms)
+            var gameTime2 = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(200));
+            indicator.Update(gameTime2);
+            // If timer wasn't reset, total time would be 1600ms > 1500ms and indicator would be hidden
+        }
+
+        #endregion
+
+        #region Update
+
+        [Fact]
+        public void Update_CountsDownRemainingTime()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            // Duration is 1.5 seconds (1500ms)
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(500));
+            indicator.Update(gameTime);
+            // Remaining should be ~1000ms — indicator still visible
+        }
+
+        [Fact]
+        public void Update_ClampsRemainingToZero()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            // Advance past the full duration
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            indicator.Update(gameTime);
+            // Remaining should be clamped to 0, not negative
+        }
+
+        [Fact]
+        public void Update_WhenNotShown_IsNoOp()
+        {
+            var indicator = CreateIndicator();
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(100));
+            indicator.Update(gameTime);
+            // No exception — Update is a no-op when not shown
+        }
+
+        [Fact]
+        public void Update_AfterExpired_ContinuesAsNoOp()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            // Expire the timer
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            indicator.Update(gameTime);
+
+            // Update again — should be no-op, not crash
+            indicator.Update(gameTime);
+        }
+
+        #endregion
+
+        #region ComputeAlpha (indirect)
+
+        [Fact]
+        public void Alpha_IsFullWhenRecentlyShown()
+        {
+            // ComputeAlpha is private, but we can verify the behavior indirectly.
+            // When recently shown, the indicator should be fully visible (alpha = 1).
+            // We test this by showing, updating a tiny amount, and verifying no exception.
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
+            indicator.Update(gameTime);
+            // Alpha should be 1.0 at this point (1.5s - 0.001s >> 0.3s fade)
+        }
+
+        [Fact]
+        public void Alpha_FadesNearEndOfDuration()
+        {
+            // Fade starts at _remainingSeconds < ScrollSpeedIndicatorFadeSeconds (0.3s).
+            // Show sets _remainingSeconds = 1.5s. After 1.3s, remaining = 0.2s < 0.3s = fade.
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1300));
+            indicator.Update(gameTime);
+            // _remainingSeconds ≈ 0.2s, which is in the fade zone.
+            // Alpha ≈ 0.2 / 0.3 ≈ 0.667
+        }
+
+        [Fact]
+        public void Alpha_IsZeroWhenExpired()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            indicator.Update(gameTime);
+            // _remainingSeconds = 0, so Draw would return early.
+        }
+
+        #endregion
+
+        #region Integration
+
+        [Fact]
+        public void FullLifecycle_ShowUpdateExpire_ShouldNotThrow()
+        {
+            var indicator = CreateIndicator();
+
+            // Show
+            indicator.Show(150);
+
+            // Update through visible period
+            var frameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(16));
+            for (var i = 0; i < 100; i++) // ~1.6 seconds
+            {
+                indicator.Update(frameTime);
+            }
+
+            // After all updates, timer should be expired
+            // Show again
+            indicator.Show(300);
+
+            // Partial update
+            indicator.Update(frameTime);
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
@@ -1,5 +1,6 @@
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI.Layout;
 using Microsoft.Xna.Framework;
 using Xunit;
 
@@ -8,6 +9,9 @@ namespace DTXMania.Test.Stage.Performance
     [Trait("Category", "Unit")]
     public class ScrollSpeedIndicatorTests
     {
+        private const float Duration = PerformanceUILayout.ScrollSpeedIndicatorDurationSeconds;
+        private const float Fade = PerformanceUILayout.ScrollSpeedIndicatorFadeSeconds;
+
         /// <summary>
         /// ScrollSpeedIndicator is created with null font (font init can fail at runtime).
         /// All logic tests work without a real BitmapFont because Show/Update/ComputeAlpha
@@ -23,29 +27,26 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void Show_SetsTextFromScrollSpeedPercent()
         {
-            // We can't read _text directly, but we can verify indirectly through
-            // the visible state: after Show, Update should count down from > 0.
             var indicator = CreateIndicator();
             indicator.Show(200);
 
-            // After Show with no Update, the indicator should be in a visible state.
-            // We verify by updating and checking it doesn't crash and accepts frames.
-            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(100));
-            indicator.Update(gameTime);
-            // If Show didn't set _remainingSeconds, Update would be a no-op.
-            // After 100ms of a 1500ms timer, it should still have time remaining.
+            Assert.Equal("Scroll Speed x2.0", indicator.Text);
+            Assert.True(indicator.IsVisible);
         }
 
         [Fact]
         public void Show_WithDifferentSpeeds_SetsDifferentText()
         {
             var indicator = CreateIndicator();
-            // Show sets _text = "Scroll Speed " + Format(percent)
-            // Format is tested in ScrollSpeedRangeTests, so we just verify Show doesn't throw
+
             indicator.Show(50);
+            Assert.Equal("Scroll Speed x0.5", indicator.Text);
+
             indicator.Show(100);
+            Assert.Equal("Scroll Speed x1.0", indicator.Text);
+
             indicator.Show(400);
-            // No exception = success
+            Assert.Equal("Scroll Speed x4.0", indicator.Text);
         }
 
         [Fact]
@@ -57,14 +58,13 @@ namespace DTXMania.Test.Stage.Performance
             // Advance most of the duration
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1400));
             indicator.Update(gameTime);
+            Assert.True(indicator.RemainingSeconds < Duration - 1.0f);
 
             // Show again — should reset the timer
             indicator.Show(200);
 
-            // After another 200ms, it should still be visible (timer was reset to 1500ms)
-            var gameTime2 = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(200));
-            indicator.Update(gameTime2);
-            // If timer wasn't reset, total time would be 1600ms > 1500ms and indicator would be hidden
+            Assert.Equal(Duration, indicator.RemainingSeconds);
+            Assert.True(indicator.IsVisible);
         }
 
         #endregion
@@ -77,10 +77,12 @@ namespace DTXMania.Test.Stage.Performance
             var indicator = CreateIndicator();
             indicator.Show(100);
 
-            // Duration is 1.5 seconds (1500ms)
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(500));
             indicator.Update(gameTime);
-            // Remaining should be ~1000ms — indicator still visible
+
+            var expected = Duration - 0.5f;
+            Assert.InRange(indicator.RemainingSeconds, expected - 0.01f, expected + 0.01f);
+            Assert.True(indicator.IsVisible);
         }
 
         [Fact]
@@ -92,7 +94,9 @@ namespace DTXMania.Test.Stage.Performance
             // Advance past the full duration
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
             indicator.Update(gameTime);
-            // Remaining should be clamped to 0, not negative
+
+            Assert.Equal(0f, indicator.RemainingSeconds);
+            Assert.False(indicator.IsVisible);
         }
 
         [Fact]
@@ -101,7 +105,9 @@ namespace DTXMania.Test.Stage.Performance
             var indicator = CreateIndicator();
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(100));
             indicator.Update(gameTime);
-            // No exception — Update is a no-op when not shown
+
+            Assert.Equal(0f, indicator.RemainingSeconds);
+            Assert.False(indicator.IsVisible);
         }
 
         [Fact]
@@ -113,41 +119,44 @@ namespace DTXMania.Test.Stage.Performance
             // Expire the timer
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
             indicator.Update(gameTime);
+            Assert.Equal(0f, indicator.RemainingSeconds);
 
-            // Update again — should be no-op, not crash
+            // Update again — remaining should stay at 0
             indicator.Update(gameTime);
+            Assert.Equal(0f, indicator.RemainingSeconds);
         }
 
         #endregion
 
-        #region ComputeAlpha (indirect)
+        #region Alpha
 
         [Fact]
         public void Alpha_IsFullWhenRecentlyShown()
         {
-            // ComputeAlpha is private, but we can verify the behavior indirectly.
-            // When recently shown, the indicator should be fully visible (alpha = 1).
-            // We test this by showing, updating a tiny amount, and verifying no exception.
             var indicator = CreateIndicator();
             indicator.Show(100);
 
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1));
             indicator.Update(gameTime);
-            // Alpha should be 1.0 at this point (1.5s - 0.001s >> 0.3s fade)
+
+            Assert.Equal(1.0f, indicator.Alpha);
         }
 
         [Fact]
         public void Alpha_FadesNearEndOfDuration()
         {
-            // Fade starts at _remainingSeconds < ScrollSpeedIndicatorFadeSeconds (0.3s).
-            // Show sets _remainingSeconds = 1.5s. After 1.3s, remaining = 0.2s < 0.3s = fade.
             var indicator = CreateIndicator();
             indicator.Show(100);
 
+            // Advance to 1300ms: remaining = 200ms, which is in the fade zone (200ms < 300ms fade)
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1300));
             indicator.Update(gameTime);
-            // _remainingSeconds ≈ 0.2s, which is in the fade zone.
+
             // Alpha ≈ 0.2 / 0.3 ≈ 0.667
+            var expected = (Duration - 1.3f) / Fade;
+            Assert.InRange(indicator.Alpha, expected - 0.05f, expected + 0.05f);
+            Assert.True(indicator.Alpha < 1.0f);
+            Assert.True(indicator.Alpha > 0f);
         }
 
         [Fact]
@@ -158,7 +167,15 @@ namespace DTXMania.Test.Stage.Performance
 
             var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
             indicator.Update(gameTime);
-            // _remainingSeconds = 0, so Draw would return early.
+
+            Assert.Equal(0f, indicator.Alpha);
+        }
+
+        [Fact]
+        public void Alpha_IsZeroBeforeFirstShow()
+        {
+            var indicator = CreateIndicator();
+            Assert.Equal(0f, indicator.Alpha);
         }
 
         #endregion
@@ -166,26 +183,39 @@ namespace DTXMania.Test.Stage.Performance
         #region Integration
 
         [Fact]
-        public void FullLifecycle_ShowUpdateExpire_ShouldNotThrow()
+        public void FullLifecycle_ShowUpdateExpire_ShouldTransitionThroughStates()
         {
             var indicator = CreateIndicator();
 
+            // Initially not visible
+            Assert.False(indicator.IsVisible);
+            Assert.Equal(string.Empty, indicator.Text);
+
             // Show
             indicator.Show(150);
+            Assert.Equal("Scroll Speed x1.5", indicator.Text);
+            Assert.True(indicator.IsVisible);
+            Assert.Equal(1.0f, indicator.Alpha);
 
-            // Update through visible period
+            // Update through visible period (100 frames × 16ms ≈ 1.6s > 1.5s duration)
             var frameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(16));
-            for (var i = 0; i < 100; i++) // ~1.6 seconds
+            for (var i = 0; i < 100; i++)
             {
                 indicator.Update(frameTime);
             }
 
-            // After all updates, timer should be expired
+            // Timer should be expired
+            Assert.False(indicator.IsVisible);
+            Assert.Equal(0f, indicator.RemainingSeconds);
+
             // Show again
             indicator.Show(300);
+            Assert.Equal("Scroll Speed x3.0", indicator.Text);
+            Assert.True(indicator.IsVisible);
 
-            // Partial update
+            // Partial update — still visible
             indicator.Update(frameTime);
+            Assert.True(indicator.IsVisible);
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
@@ -1,7 +1,11 @@
 using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
 using Xunit;
 
 namespace DTXMania.Test.Stage.Performance
@@ -212,6 +216,123 @@ namespace DTXMania.Test.Stage.Performance
             // Partial update — still visible
             indicator.Update(frameTime);
             Assert.True(indicator.IsVisible);
+        }
+
+        #endregion
+
+        #region Draw
+
+        [Fact]
+        public void Draw_WhenNotShown_ShouldNotThrow()
+        {
+            var indicator = CreateIndicator();
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+
+            Assert.False(indicator.IsVisible);
+        }
+
+        [Fact]
+        public void Draw_WhenExpired_ShouldNotThrow()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromSeconds(5));
+            indicator.Update(gameTime);
+            Assert.Equal(0f, indicator.RemainingSeconds);
+
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+        }
+
+        [Fact]
+        public void Draw_WithVisibleStateAndNullFont_ShouldReturnEarly()
+        {
+            var indicator = CreateIndicator();
+            indicator.Show(100);
+            Assert.True(indicator.IsVisible);
+
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+        }
+
+        [Fact]
+        public void Draw_WithFontAndVisible_ShouldExecuteDrawPath()
+        {
+            var font = CreateTestBitmapFont();
+            var indicator = new ScrollSpeedIndicator(font);
+            indicator.Show(100);
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+
+            Assert.True(indicator.IsVisible);
+            Assert.Equal(1.0f, indicator.Alpha);
+        }
+
+        [Fact]
+        public void Draw_WithFontDuringFade_ShouldExecuteDrawPathWithFadedAlpha()
+        {
+            var font = CreateTestBitmapFont();
+            var indicator = new ScrollSpeedIndicator(font);
+            indicator.Show(100);
+
+            var gameTime = new GameTime(TimeSpan.Zero, TimeSpan.FromMilliseconds(1300));
+            indicator.Update(gameTime);
+            Assert.True(indicator.Alpha < 1.0f);
+            Assert.True(indicator.Alpha > 0f);
+
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+        }
+
+        [Fact]
+        public void Draw_WithFontAtFullAlpha_ShouldPassWhiteColorToDrawText()
+        {
+            var font = CreateTestBitmapFont();
+            var indicator = new ScrollSpeedIndicator(font);
+            indicator.Show(200);
+
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+        }
+
+        [Fact]
+        public void Draw_AfterReShow_ShouldUseNewText()
+        {
+            var font = CreateTestBitmapFont();
+            var indicator = new ScrollSpeedIndicator(font);
+            indicator.Show(100);
+
+            var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
+
+            indicator.Draw(spriteBatch);
+
+            indicator.Show(400);
+            Assert.Equal("Scroll Speed x4.0", indicator.Text);
+
+            indicator.Draw(spriteBatch);
+        }
+
+        private static BitmapFont CreateTestBitmapFont()
+        {
+            var font = ReflectionHelpers.CreateUninitialized<BitmapFont>();
+
+            var config = BitmapFont.CreateConsoleFontConfig();
+            ReflectionHelpers.SetPrivateField(font, "_config", config);
+
+            var mockTexture = new Mock<ITexture>().Object;
+            ReflectionHelpers.SetPrivateField(font, "_fontTextures", new ITexture[] { mockTexture });
+
+            ReflectionHelpers.SetPrivateField(font, "_characterRectangles",
+                new Rectangle[config.DisplayableCharacters.Length]);
+
+            return font;
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScrollSpeedIndicatorTests.cs
@@ -19,7 +19,8 @@ namespace DTXMania.Test.Stage.Performance
         /// <summary>
         /// ScrollSpeedIndicator is created with null font (font init can fail at runtime).
         /// All logic tests work without a real BitmapFont because Show/Update/ComputeAlpha
-        /// do not touch the font — only Draw does, and Draw is excluded from unit tests.
+        /// do not touch the font — only Draw does. Draw tests use CreateTestBitmapFont
+        /// for full coverage, while logic tests rely on the null-font fast path.
         /// </summary>
         private static ScrollSpeedIndicator CreateIndicator()
         {
@@ -291,7 +292,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Draw_WithFontAtFullAlpha_ShouldPassWhiteColorToDrawText()
+        public void Draw_WithFontAtFullAlpha_DoesNotThrow()
         {
             var font = CreateTestBitmapFont();
             var indicator = new ScrollSpeedIndicator(font);

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -785,6 +785,29 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void Deactivate_ShouldFlushPendingSave()
+        {
+            var configManager = new Mock<IConfigManager>();
+            var stage = CreateStage();
+            SetPrivateField(stage, "_configManager", configManager.Object);
+
+            stage.Deactivate();
+
+            configManager.Verify(x => x.FlushPendingSave(), Times.Once);
+        }
+
+        [Fact]
+        public void Deactivate_WhenConfigManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_configManager", null);
+
+            var exception = Record.Exception(() => stage.Deactivate());
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void NavigateIntoBox_ShouldPushStateAndPopulateChildren()
         {
             var stage = CreateStage();

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1,0 +1,1051 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Utilities;
+using DTXMania.Game.Lib.UI.Components;
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionStageCoverageTests
+    {
+        [Fact]
+        public void HandleInput_WithNonNullInputManager_ShouldDelegateToProcessInputCommands()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+            var inputManager = new QueuedInputManager();
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_inputManager", inputManager);
+            inputManager.Enqueue(new InputCommand(InputCommandType.MoveDown, 0.0));
+
+            InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.Equal("B", display.SelectedSong!.Title);
+        }
+
+        [Fact]
+        public void HandleInput_WhenInputManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_inputManager", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "HandleInput"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ProcessInputCommands_WithQueuedCommands_ShouldExecuteAll()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B"), CreateScoreNode("C")]
+            };
+            var inputManager = new QueuedInputManager();
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_inputManager", inputManager);
+            inputManager.Enqueue(new InputCommand(InputCommandType.MoveDown, 0.0));
+            inputManager.Enqueue(new InputCommand(InputCommandType.MoveDown, 0.0));
+
+            InvokePrivateMethod(stage, "ProcessInputCommands");
+
+            Assert.Equal("C", display.SelectedSong!.Title);
+            Assert.False(inputManager.HasPendingCommands);
+        }
+
+        [Fact]
+        public void ProcessInputCommands_WhenInputManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_inputManager", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "ProcessInputCommands"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveUp_ShouldNavigatePrevious()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+            var cursorSound = new Mock<ISound>();
+
+            AttachCoreUi(stage, display: display);
+            display.MoveNext();
+            SetPrivateField(stage, "_elapsedTime", 5.0);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveUp, 0.0));
+
+            Assert.Equal("A", display.SelectedSong!.Title);
+            Assert.Equal(5.0, GetPrivateField<double>(stage, "_lastNavigationTime"));
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveDown_ShouldNavigateNext()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+            var cursorSound = new Mock<ISound>();
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_elapsedTime", 3.0);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveDown, 0.0));
+
+            Assert.Equal("B", display.SelectedSong!.Title);
+            Assert.Equal(3.0, GetPrivateField<double>(stage, "_lastNavigationTime"));
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveUpInStatusPanel_ShouldNavigatePrevious()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+
+            AttachCoreUi(stage, display: display);
+            display.MoveNext();
+            SetPrivateField(stage, "_isInStatusPanel", true);
+            SetPrivateField(stage, "_elapsedTime", 7.0);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveUp, 0.0));
+
+            Assert.Equal("A", display.SelectedSong!.Title);
+            Assert.Equal(7.0, GetPrivateField<double>(stage, "_lastNavigationTime"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveDownInStatusPanel_ShouldNavigateNext()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+            SetPrivateField(stage, "_elapsedTime", 4.0);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveDown, 0.0));
+
+            Assert.Equal("B", display.SelectedSong!.Title);
+            Assert.Equal(4.0, GetPrivateField<double>(stage, "_lastNavigationTime"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveLeftInStatusPanel_ShouldCycleDifficultyBackward()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("Song", CreateScores(0, 2, 4));
+            var display = new SongListDisplay { CurrentList = [song] };
+            var statusPanel = new SongStatusPanel();
+            var cursorSound = new Mock<ISound>();
+
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 4);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            display.CurrentDifficulty = 4;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveLeft, 0.0));
+
+            Assert.Equal(2, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal(2, display.CurrentDifficulty);
+            Assert.Equal(2, GetPrivateField<int>(statusPanel, "_currentDifficulty"));
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveRightInStatusPanel_ShouldCycleDifficultyForward()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("Song", CreateScores(0, 2));
+            var display = new SongListDisplay { CurrentList = [song] };
+            var statusPanel = new SongStatusPanel();
+            var cursorSound = new Mock<ISound>();
+
+            display.DifficultyChanged += (sender, e) => InvokePrivateMethod(stage, "OnDifficultyChanged", sender!, e);
+
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 0);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            display.CurrentDifficulty = 0;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveRight, 0.0));
+
+            Assert.Equal(2, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal(2, display.CurrentDifficulty);
+            Assert.Equal(2, GetPrivateField<int>(statusPanel, "_currentDifficulty"));
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveLeftOutsideStatusPanel_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = [CreateScoreNode("A")] };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_currentDifficulty", 3);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveLeft, 0.0));
+
+            Assert.Equal(3, GetPrivateField<int>(stage, "_currentDifficulty"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_MoveRightOutsideStatusPanel_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = [CreateScoreNode("A")] };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_currentDifficulty", 1);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.MoveRight, 0.0));
+
+            Assert.Equal(1, GetPrivateField<int>(stage, "_currentDifficulty"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_Activate_ShouldDelegateToHandleActivateInput()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel { Visible = false };
+            var selectedSong = CreateScoreNode("Song");
+
+            AttachCoreUi(stage, statusPanel: statusPanel);
+            SetPrivateField(stage, "_selectedSong", selectedSong);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
+
+            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            Assert.True(statusPanel.Visible);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackInStatusPanel_ShouldExitStatusPanelMode()
+        {
+            var stage = CreateStage();
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            Assert.False(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            stageManager.Verify(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>()), Times.Never);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackWithNavigationStack_ShouldNavigateBack()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root Song") };
+            var stack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("Child Song") });
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Child");
+            stack.Push(new SongListNode { Children = rootSongs, Title = "Root" });
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            Assert.Same(rootSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Empty(stack);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackAtRoot_WhenTransitionAllowed_ShouldReturnToTitle()
+        {
+            var game = CreateGame(totalGameTime: 1.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.Title,
+                    It.Is<IStageTransition>(t => t is DTXManiaFadeTransition)),
+                Times.Once);
+            Assert.Equal(1.0, GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackAtRoot_WhenTransitionDebounced_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            stageManager.Verify(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>()), Times.Never);
+            Assert.Equal(0.0, GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_IncreaseScrollSpeed_ShouldCallConfigManager()
+        {
+            var stage = CreateStage();
+            var configManager = new Mock<IConfigManager>();
+
+            SetPrivateField(stage, "_configManager", configManager.Object);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.IncreaseScrollSpeed, 0.0));
+
+            configManager.Verify(x => x.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), 1), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_DecreaseScrollSpeed_ShouldCallConfigManager()
+        {
+            var stage = CreateStage();
+            var configManager = new Mock<IConfigManager>();
+
+            SetPrivateField(stage, "_configManager", configManager.Object);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.DecreaseScrollSpeed, 0.0));
+
+            configManager.Verify(x => x.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1), Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_IncreaseScrollSpeed_WhenConfigManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_configManager", null);
+
+            var exception = Record.Exception(() =>
+                InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.IncreaseScrollSpeed, 0.0)));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_DecreaseScrollSpeed_WhenConfigManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_configManager", null);
+
+            var exception = Record.Exception(() =>
+                InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.DecreaseScrollSpeed, 0.0)));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void HandleActivateInput_InStatusPanelWithScore_ShouldSelectSong()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var selectedSong = CreateScoreNode("Song", songId: 99);
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_selectedSong", selectedSong);
+            SetPrivateField(stage, "_currentDifficulty", 1);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.Is<IStageTransition>(t => t is InstantTransition),
+                    It.Is<Dictionary<string, object>>(d =>
+                        ReferenceEquals(d["selectedSong"], selectedSong) &&
+                        (int)d["selectedDifficulty"] == 1 &&
+                        (int)d["songId"] == 99)),
+                Times.Once);
+        }
+
+        [Fact]
+        public void HandleActivateInput_InStatusPanelWithNonScoreNode_ShouldIgnore()
+        {
+            var stage = CreateStage();
+            var stageManager = new Mock<IStageManager>();
+            var folder = CreateBoxNode("Folder");
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_selectedSong", folder);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void HandleActivateInput_InStatusPanelWithNullSelection_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_selectedSong", null);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void HandleActivateInput_NotInStatusPanelWithScore_ShouldEnterStatusPanel()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel { Visible = false };
+            var selectedSong = CreateScoreNode("Song");
+
+            AttachCoreUi(stage, statusPanel: statusPanel);
+            SetPrivateField(stage, "_selectedSong", selectedSong);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            Assert.True(statusPanel.Visible);
+        }
+
+        [Fact]
+        public void HandleActivateInput_NotInStatusPanelWithBox_ShouldNavigateIntoBox()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var childSong = CreateScoreNode("Child");
+            var box = CreateBoxNode("Folder", childSong);
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", box);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { box });
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.Same(box.Children, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal(NodeType.BackBox, display.CurrentList[0].Type);
+            Assert.Same(childSong, display.CurrentList[1]);
+        }
+
+        [Fact]
+        public void HandleActivateInput_NotInStatusPanelWithBackBox_ShouldNavigateBack()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root Song") };
+            var backBox = new SongListNode { Type = NodeType.BackBox, Title = ".. (Back)" };
+            var stack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", backBox);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("Child Song") });
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Child");
+            stack.Push(new SongListNode { Children = rootSongs, Title = "Root" });
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.Same(rootSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+        }
+
+        [Fact]
+        public void HandleActivateInput_WhenSelectedSongIsNullAndNotInStatusPanel_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_selectedSong", null);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "HandleActivateInput"));
+
+            Assert.Null(exception);
+            Assert.False(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+        }
+
+        [Fact]
+        public void CycleDifficulty_Forward_ShouldCallSongListDisplay()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("Song", CreateScores(0, 2));
+            var display = new SongListDisplay { CurrentList = [song] };
+            var cursorSound = new Mock<ISound>();
+
+            display.DifficultyChanged += (sender, e) => InvokePrivateMethod(stage, "OnDifficultyChanged", sender!, e);
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 0);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            display.CurrentDifficulty = 0;
+
+            InvokePrivateMethod(stage, "CycleDifficulty", 1);
+
+            Assert.Equal(2, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal(2, display.CurrentDifficulty);
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void CycleDifficulty_Backward_ShouldCycleToPreviousDifficulty()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("Song", CreateScores(0, 2, 4));
+            var display = new SongListDisplay { CurrentList = [song] };
+            var statusPanel = new SongStatusPanel();
+            var cursorSound = new Mock<ISound>();
+
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 4);
+            SetPrivateField(stage, "_cursorMoveSound", cursorSound.Object);
+            display.CurrentDifficulty = 4;
+
+            InvokePrivateMethod(stage, "CycleDifficulty", -1);
+
+            Assert.Equal(2, GetPrivateField<int>(stage, "_currentDifficulty"));
+            Assert.Equal(2, display.CurrentDifficulty);
+            Assert.Equal(2, GetPrivateField<int>(statusPanel, "_currentDifficulty"));
+            cursorSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void CycleDifficulty_BackwardWithSingleDifficulty_ShouldNotChange()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("Song", CreateScores(2));
+            var display = new SongListDisplay { CurrentList = [song] };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 2);
+            display.CurrentDifficulty = 2;
+
+            InvokePrivateMethod(stage, "CycleDifficulty", -1);
+
+            Assert.Equal(2, GetPrivateField<int>(stage, "_currentDifficulty"));
+        }
+
+        [Fact]
+        public void CycleDifficulty_BackwardWithNullSelectedSong_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = [CreateScoreNode("A")] };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", null);
+            SetPrivateField(stage, "_currentDifficulty", 0);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "CycleDifficulty", -1));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void CycleDifficulty_BackwardWhenCurrentDifficultyNotInAvailable_ShouldNotChange()
+        {
+            var stage = CreateStage();
+            var scores = new SongScore[5];
+            scores[0] = new SongScore { DifficultyLevel = 0, DifficultyLabel = "Basic" };
+            scores[2] = new SongScore { DifficultyLevel = 2, DifficultyLabel = "Advanced" };
+            var song = CreateScoreNode("Song", scores);
+            var display = new SongListDisplay { CurrentList = [song] };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_currentDifficulty", 1);
+            display.CurrentDifficulty = 1;
+
+            InvokePrivateMethod(stage, "CycleDifficulty", -1);
+
+            Assert.Equal(1, GetPrivateField<int>(stage, "_currentDifficulty"));
+        }
+
+        [Fact]
+        public void SelectSong_WhenTransitionAllowed_ShouldTransitionToSongTransition()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var song = CreateScoreNode("Song", CreateScores(0, 2), songId: 17);
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentDifficulty", 2);
+
+            InvokePrivateMethod(stage, "SelectSong", song);
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.Is<IStageTransition>(t => t is InstantTransition),
+                    It.Is<Dictionary<string, object>>(d =>
+                        ReferenceEquals(d["selectedSong"], song) &&
+                        (int)d["selectedDifficulty"] == 2 &&
+                        (int)d["songId"] == 17)),
+                Times.Once);
+            Assert.Equal(2.0, GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void SelectSong_WhenNodeIsNull_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "SelectSong", new object?[] { null });
+
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void SelectSong_WhenNodeIsNotScoreType_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var box = CreateBoxNode("Folder");
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "SelectSong", box);
+
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void SelectSong_WhenDebounceBlocksTransition_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "SelectSong", CreateScoreNode("Song", songId: 12));
+
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void SelectRandomSong_WhenSinglePlayableSongExists_ShouldSelectIt()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var song = CreateScoreNode("Only Song", songId: 45);
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode>
+            {
+                CreateBoxNode("Folder"),
+                song
+            });
+
+            InvokePrivateMethod(stage, "SelectRandomSong");
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.IsAny<IStageTransition>(),
+                    It.Is<Dictionary<string, object>>(d => ReferenceEquals(d["selectedSong"], song))),
+                Times.Once);
+        }
+
+        [Fact]
+        public void SelectRandomSong_WhenNoPlayableSongsExist_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode>
+            {
+                CreateBoxNode("Folder"),
+                new SongListNode { Type = NodeType.Random, Title = "Random" },
+                new SongListNode { Type = NodeType.BackBox, Title = ".." }
+            });
+
+            InvokePrivateMethod(stage, "SelectRandomSong");
+
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void SelectRandomSong_WhenCurrentSongListIsEmpty_ShouldNotTransition()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode>());
+
+            InvokePrivateMethod(stage, "SelectRandomSong");
+
+            stageManager.Verify(
+                x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public void SelectRandomSong_WhenCurrentSongListIsNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_currentSongList", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "SelectRandomSong"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void OnScrollSpeedChanged_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var args = new ScrollSpeedChangedEventArgs(50, 75);
+
+            var exception = Record.Exception(() =>
+                InvokePrivateMethod(stage, "OnScrollSpeedChanged", stage, args));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void NavigateIntoBox_ShouldPushStateAndPopulateChildren()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var childSong = CreateScoreNode("Child Song");
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root Song") };
+            var box = CreateBoxNode("Folder", childSong);
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", rootSongs);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root");
+
+            InvokePrivateMethod(stage, "NavigateIntoBox", box);
+
+            Assert.Equal(1, GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!.Count);
+            var currentList = GetPrivateField<List<SongListNode>>(stage, "_currentSongList");
+            Assert.NotNull(currentList);
+            Assert.Single(currentList!);
+            Assert.Equal("Root > Folder", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Equal(NodeType.BackBox, display.CurrentList[0].Type);
+            Assert.Same(childSong, display.CurrentList[1]);
+        }
+
+        [Fact]
+        public void NavigateIntoBox_WhenBreadcrumbIsEmpty_ShouldUseTitleWithoutSeparator()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var childSong = CreateScoreNode("Child");
+            var box = CreateBoxNode("Folder", childSong);
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("Root") });
+            SetPrivateField(stage, "_currentBreadcrumb", "");
+
+            InvokePrivateMethod(stage, "NavigateIntoBox", box);
+
+            Assert.Equal("Folder", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+        }
+
+        [Fact]
+        public void NavigateIntoBox_WhenChildrenAreEmpty_ShouldNotNavigate()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var box = CreateBoxNode("Empty");
+
+            AttachCoreUi(stage, display: display);
+            var originalList = new List<SongListNode> { CreateScoreNode("Root") };
+            SetPrivateField(stage, "_currentSongList", originalList);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root");
+
+            InvokePrivateMethod(stage, "NavigateIntoBox", box);
+
+            Assert.Same(originalList, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+        }
+
+        [Fact]
+        public void NavigateBack_ShouldRestorePreviousState()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root Song") };
+            var stack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("Child") });
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Child");
+            stack.Push(new SongListNode { Children = rootSongs, Title = "Root" });
+
+            InvokePrivateMethod(stage, "NavigateBack");
+
+            Assert.Same(rootSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Empty(stack);
+        }
+
+        [Fact]
+        public void NavigateBack_WhenStackEmpty_ShouldLeaveStateUnchanged()
+        {
+            var stage = CreateStage();
+            var songs = new List<SongListNode> { CreateScoreNode("Root") };
+
+            SetPrivateField(stage, "_currentSongList", songs);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root");
+
+            InvokePrivateMethod(stage, "NavigateBack");
+
+            Assert.Same(songs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Equal("Root", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+        }
+
+        [Fact]
+        public void HandleSongActivation_BackBox_ShouldNavigateBack()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var rootSongs = new List<SongListNode> { CreateScoreNode("Root") };
+            var stack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("Child") });
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Child");
+            stack.Push(new SongListNode { Children = rootSongs, Title = "Root" });
+
+            InvokePrivateMethod(stage, "HandleSongActivation", new SongListNode { Type = NodeType.BackBox, Title = ".." });
+
+            Assert.Same(rootSongs, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+        }
+
+        [Fact]
+        public void HandleSongActivation_Box_ShouldNavigateIntoBox()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var child = CreateScoreNode("Child");
+            var box = CreateBoxNode("Folder", child);
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { box });
+
+            InvokePrivateMethod(stage, "HandleSongActivation", box);
+
+            Assert.Same(box.Children, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+        }
+
+        [Fact]
+        public void HandleSongActivation_Score_ShouldSelectSong()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var song = CreateScoreNode("Song", songId: 21);
+
+            stage.StageManager = stageManager.Object;
+
+            InvokePrivateMethod(stage, "HandleSongActivation", song);
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.IsAny<IStageTransition>(),
+                    It.Is<Dictionary<string, object>>(d => ReferenceEquals(d["selectedSong"], song))),
+                Times.Once);
+        }
+
+        [Fact]
+        public void HandleSongActivation_Random_ShouldSelectRandomSong()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = CreateStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var song = CreateScoreNode("Song", songId: 22);
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { song });
+
+            InvokePrivateMethod(stage, "HandleSongActivation", new SongListNode { Type = NodeType.Random, Title = "Random" });
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.IsAny<IStageTransition>(),
+                    It.Is<Dictionary<string, object>>(d => ReferenceEquals(d["selectedSong"], song))),
+                Times.Once);
+        }
+
+        private static void AttachCoreUi(
+            SongSelectionStage stage,
+            SongListDisplay? display = null,
+            SongStatusPanel? statusPanel = null,
+            PreviewImagePanel? previewPanel = null,
+            UILabel? breadcrumb = null)
+        {
+            SetPrivateField(stage, "_songListDisplay", display ?? new SongListDisplay());
+            SetPrivateField(stage, "_statusPanel", statusPanel ?? new SongStatusPanel());
+            SetPrivateField(stage, "_previewImagePanel", previewPanel ?? new PreviewImagePanel());
+            SetPrivateField(stage, "_breadcrumbLabel", breadcrumb ?? new UILabel());
+        }
+
+        private static SongSelectionStage CreateStage(BaseGame? game = null)
+        {
+            return new SongSelectionStage(game ?? CreateGame());
+        }
+
+        private static SongListNode CreateScoreNode(
+            string title,
+            SongScore[]? scores = null,
+            int? songId = null,
+            SongChart? chart = null)
+        {
+            chart ??= new SongChart
+            {
+                FilePath = CreateWorkspacePath("charts", $"{Guid.NewGuid():N}.dtx"),
+                HasDrumChart = true,
+                DrumLevel = 35
+            };
+
+            var song = new SongEntity
+            {
+                Title = title,
+                Artist = "Test Artist",
+                Charts = [chart]
+            };
+            chart.Song = song;
+
+            return new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = title,
+                Scores = scores ?? CreateScores(0),
+                DatabaseSong = song,
+                DatabaseChart = chart,
+                DatabaseSongId = songId
+            };
+        }
+
+        private static SongListNode CreateBoxNode(string title, params SongListNode[] children)
+        {
+            return new SongListNode
+            {
+                Type = NodeType.Box,
+                Title = title,
+                Children = new List<SongListNode>(children)
+            };
+        }
+
+        private static SongScore[] CreateScores(params int[] difficulties)
+        {
+            var scores = new SongScore[5];
+            foreach (var difficulty in difficulties)
+            {
+                scores[difficulty] = new SongScore
+                {
+                    DifficultyLevel = difficulty,
+                    DifficultyLabel = $"Level {difficulty}"
+                };
+            }
+
+            return scores;
+        }
+
+        private static string CreateWorkspacePath(params string[] parts)
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "TestResults", "song-selection-stage-coverage");
+            Directory.CreateDirectory(path);
+            foreach (var part in parts)
+            {
+                path = Path.Combine(path, part);
+            }
+
+            return path;
+        }
+
+        private sealed class QueuedInputManager : InputManager
+        {
+            public void Enqueue(InputCommand command)
+            {
+                EnqueueCommand(command);
+            }
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-05-04-scroll-speed-control.md
+++ b/docs/superpowers/plans/2026-05-04-scroll-speed-control.md
@@ -1,0 +1,1178 @@
+# Scroll Speed Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add user-facing controls to adjust visual scroll speed (x0.5–x4.0, step x0.5) from the Config menu, song-select screen, and during play, with write-through persistence to `Config.ini`.
+
+**Architecture:** Centralize the mutation in `ConfigManager` (new `SetScrollSpeed` / `AdjustScrollSpeed` + `ScrollSpeedChanged` event). Add two new `InputCommandType` values bound to PageUp/PageDown. Stages subscribe to the event and forward hotkey input to the ConfigManager. A small `ScrollSpeedIndicator` shows a fade-out toast in-game.
+
+**Tech Stack:** .NET 8, C#, MonoGame 3.8, xUnit, Moq.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-scroll-speed-control-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `DTXMania.Game/Lib/Config/ScrollSpeedRange.cs` — constants + snap/clamp/format helpers.
+- `DTXMania.Game/Lib/Config/ScrollSpeedChangedEventArgs.cs` — event args.
+- `DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs` — fade toast.
+- `DTXMania.Test/Config/ScrollSpeedRangeTests.cs`
+- `DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs`
+- `DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs`
+
+**Modified:**
+- `DTXMania.Game/Lib/Config/IConfigManager.cs` — add event + methods.
+- `DTXMania.Game/Lib/Config/ConfigManager.cs` — implement event + methods.
+- `DTXMania.Game/Lib/Config/ConfigItems.cs` — extend `IntegerConfigItem` with optional formatter.
+- `DTXMania.Game/Lib/Input/InputManager.cs` — add enum values + PageUp/PageDown bindings.
+- `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs` — indicator constants.
+- `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs` — scroll-speed label position constants.
+- `DTXMania.Game/Lib/Stage/PerformanceStage.cs` — read config, subscribe, poll input, own indicator.
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs` — subscribe, poll input, render label.
+- `DTXMania.Game/Lib/Stage/ConfigStage.cs` — add scroll-speed config item; commit `ScrollSpeed` on save.
+- `DTXMania.Test/DTXMania.Test.Mac.csproj` — add new test files to explicit `Compile Include`.
+
+---
+
+## Task 1: `ScrollSpeedRange` helper + tests
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Config/ScrollSpeedRange.cs`
+- Test: `DTXMania.Test/Config/ScrollSpeedRangeTests.cs`
+- Modify: `DTXMania.Test/DTXMania.Test.Mac.csproj`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `DTXMania.Test/Config/ScrollSpeedRangeTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config
+{
+    public class ScrollSpeedRangeTests
+    {
+        [Theory]
+        [InlineData(50, 50)]
+        [InlineData(100, 100)]
+        [InlineData(400, 400)]
+        [InlineData(117, 100)]
+        [InlineData(130, 150)]
+        [InlineData(124, 100)]
+        [InlineData(125, 150)]
+        [InlineData(425, 400)]
+        [InlineData(0, 50)]
+        [InlineData(-50, 50)]
+        [InlineData(9999, 400)]
+        public void SnapAndClamp_ReturnsExpected(int input, int expected)
+        {
+            Assert.Equal(expected, ScrollSpeedRange.SnapAndClamp(input));
+        }
+
+        [Theory]
+        [InlineData(50, "x0.5")]
+        [InlineData(100, "x1.0")]
+        [InlineData(150, "x1.5")]
+        [InlineData(400, "x4.0")]
+        public void Format_ReturnsXMultiplier(int percent, string expected)
+        {
+            Assert.Equal(expected, ScrollSpeedRange.Format(percent));
+        }
+
+        [Fact]
+        public void Constants_HaveExpectedValues()
+        {
+            Assert.Equal(50, ScrollSpeedRange.Min);
+            Assert.Equal(400, ScrollSpeedRange.Max);
+            Assert.Equal(50, ScrollSpeedRange.Step);
+            Assert.Equal(100, ScrollSpeedRange.Default);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the new test file to the Mac test project**
+
+Open `DTXMania.Test/DTXMania.Test.Mac.csproj` and add `<Compile Include="Config\ScrollSpeedRangeTests.cs" />` next to the other `Config\*.cs` includes.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ScrollSpeedRangeTests"`
+Expected: FAIL — `ScrollSpeedRange` does not exist (compile error).
+
+- [ ] **Step 4: Create `ScrollSpeedRange.cs`**
+
+```csharp
+using System;
+using System.Globalization;
+
+namespace DTXMania.Game.Lib.Config
+{
+    /// <summary>
+    /// Range, step, and formatting for the visual scroll-speed setting.
+    /// Single source of truth used by ConfigManager, ConfigStage, SongSelectionStage,
+    /// and the in-game ScrollSpeedIndicator.
+    /// </summary>
+    public static class ScrollSpeedRange
+    {
+        public const int Min = 50;
+        public const int Max = 400;
+        public const int Step = 50;
+        public const int Default = 100;
+
+        /// <summary>
+        /// Snaps an arbitrary integer percent to the nearest multiple of Step,
+        /// then clamps to [Min, Max].
+        /// </summary>
+        public static int SnapAndClamp(int percent)
+        {
+            var snapped = (int)Math.Round(percent / (double)Step) * Step;
+            if (snapped < Min) return Min;
+            if (snapped > Max) return Max;
+            return snapped;
+        }
+
+        /// <summary>
+        /// Formats a percent as "x1.0", "x1.5", etc. (one decimal).
+        /// </summary>
+        public static string Format(int percent)
+        {
+            var multiplier = percent / 100.0;
+            return "x" + multiplier.ToString("0.0", CultureInfo.InvariantCulture);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ScrollSpeedRangeTests"`
+Expected: PASS (all 16 cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Config/ScrollSpeedRange.cs DTXMania.Test/Config/ScrollSpeedRangeTests.cs DTXMania.Test/DTXMania.Test.Mac.csproj
+git commit -m "feat: add ScrollSpeedRange helper with snap/clamp/format"
+```
+
+---
+
+## Task 2: `ScrollSpeedChangedEventArgs`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Config/ScrollSpeedChangedEventArgs.cs`
+
+- [ ] **Step 1: Create the event args type**
+
+```csharp
+using System;
+
+namespace DTXMania.Game.Lib.Config
+{
+    public sealed class ScrollSpeedChangedEventArgs : EventArgs
+    {
+        public int OldPercent { get; }
+        public int NewPercent { get; }
+
+        public ScrollSpeedChangedEventArgs(int oldPercent, int newPercent)
+        {
+            OldPercent = oldPercent;
+            NewPercent = newPercent;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: SUCCESS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Config/ScrollSpeedChangedEventArgs.cs
+git commit -m "feat: add ScrollSpeedChangedEventArgs"
+```
+
+---
+
+## Task 3: `ConfigManager.SetScrollSpeed` / `AdjustScrollSpeed` + event
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Config/IConfigManager.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- Test: `DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs`
+- Modify: `DTXMania.Test/DTXMania.Test.Mac.csproj`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs`:
+
+```csharp
+using System;
+using System.IO;
+using DTXMania.Game.Lib.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config
+{
+    public class ConfigManagerScrollSpeedTests : IDisposable
+    {
+        private readonly string _tempPath;
+
+        public ConfigManagerScrollSpeedTests()
+        {
+            _tempPath = Path.Combine(Path.GetTempPath(),
+                "dtxmania-scrollspeed-" + Guid.NewGuid().ToString("N") + ".ini");
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(_tempPath))
+                File.Delete(_tempPath);
+        }
+
+        [Theory]
+        [InlineData(117, 100)]
+        [InlineData(130, 150)]
+        [InlineData(425, 400)]
+        [InlineData(30, 50)]
+        public void SetScrollSpeed_SnapsToNearestStep(int input, int expected)
+        {
+            var cm = new ConfigManager();
+            cm.SetScrollSpeed(_tempPath, input);
+            Assert.Equal(expected, cm.Config.ScrollSpeed);
+        }
+
+        [Theory]
+        [InlineData(0, 50)]
+        [InlineData(-100, 50)]
+        [InlineData(9999, 400)]
+        public void SetScrollSpeed_ClampsToRange(int input, int expected)
+        {
+            var cm = new ConfigManager();
+            cm.SetScrollSpeed(_tempPath, input);
+            Assert.Equal(expected, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void SetScrollSpeed_RaisesChangedEventWithOldAndNew()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 100;
+
+            ScrollSpeedChangedEventArgs? captured = null;
+            cm.ScrollSpeedChanged += (_, e) => captured = e;
+
+            cm.SetScrollSpeed(_tempPath, 200);
+
+            Assert.NotNull(captured);
+            Assert.Equal(100, captured!.OldPercent);
+            Assert.Equal(200, captured.NewPercent);
+        }
+
+        [Fact]
+        public void SetScrollSpeed_NoOpWhenUnchanged_DoesNotRaiseEvent()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 150;
+            var raised = false;
+            cm.ScrollSpeedChanged += (_, _) => raised = true;
+
+            cm.SetScrollSpeed(_tempPath, 150);
+
+            Assert.False(raised);
+            Assert.False(File.Exists(_tempPath));
+        }
+
+        [Fact]
+        public void SetScrollSpeed_PersistsToConfigIni()
+        {
+            var cm = new ConfigManager();
+            cm.SetScrollSpeed(_tempPath, 250);
+
+            var roundTrip = new ConfigManager();
+            roundTrip.LoadConfig(_tempPath);
+            Assert.Equal(250, roundTrip.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_StepsUp()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 100;
+            cm.AdjustScrollSpeed(_tempPath, +1);
+            Assert.Equal(150, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_StepsDown()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 200;
+            cm.AdjustScrollSpeed(_tempPath, -1);
+            Assert.Equal(150, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_FloorsAtMin()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 50;
+            cm.AdjustScrollSpeed(_tempPath, -1);
+            Assert.Equal(50, cm.Config.ScrollSpeed);
+        }
+
+        [Fact]
+        public void AdjustScrollSpeed_CeilingsAtMax()
+        {
+            var cm = new ConfigManager();
+            cm.Config.ScrollSpeed = 400;
+            cm.AdjustScrollSpeed(_tempPath, +1);
+            Assert.Equal(400, cm.Config.ScrollSpeed);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add to Mac test project**
+
+Edit `DTXMania.Test/DTXMania.Test.Mac.csproj`: add `<Compile Include="Config\ConfigManagerScrollSpeedTests.cs" />` next to the other `Config\*.cs` includes.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigManagerScrollSpeedTests"`
+Expected: FAIL — `SetScrollSpeed`, `AdjustScrollSpeed`, `ScrollSpeedChanged` do not exist.
+
+- [ ] **Step 4: Update `IConfigManager`**
+
+Replace contents of `DTXMania.Game/Lib/Config/IConfigManager.cs`:
+
+```csharp
+using System;
+
+namespace DTXMania.Game.Lib.Config
+{
+    public interface IConfigManager
+    {
+        ConfigData Config { get; }
+        void LoadConfig(string filePath);
+        void SaveConfig(string filePath);
+        void ResetToDefaults();
+
+        /// <summary>
+        /// Raised when the scroll-speed setting changes via SetScrollSpeed or AdjustScrollSpeed.
+        /// Not raised by direct mutation of Config.ScrollSpeed or by LoadConfig.
+        /// </summary>
+        event EventHandler<ScrollSpeedChangedEventArgs>? ScrollSpeedChanged;
+
+        /// <summary>
+        /// Sets the scroll speed (percent), snapping to the nearest allowed step and
+        /// clamping to the allowed range. Persists to the given file path and raises
+        /// ScrollSpeedChanged when the value actually changes.
+        /// No-op (and no save) if the new value equals the current value.
+        /// </summary>
+        void SetScrollSpeed(string configFilePath, int percent);
+
+        /// <summary>
+        /// Adjusts scroll speed by stepDelta * Step. Equivalent to
+        /// SetScrollSpeed(path, current + stepDelta * Step).
+        /// </summary>
+        void AdjustScrollSpeed(string configFilePath, int stepDelta);
+    }
+}
+```
+
+- [ ] **Step 5: Implement on `ConfigManager`**
+
+In `DTXMania.Game/Lib/Config/ConfigManager.cs`, after the existing `ResetToDefaults` method (or near the end of the class), add:
+
+```csharp
+public event EventHandler<ScrollSpeedChangedEventArgs>? ScrollSpeedChanged;
+
+public void SetScrollSpeed(string configFilePath, int percent)
+{
+    var snapped = ScrollSpeedRange.SnapAndClamp(percent);
+    var old = Config.ScrollSpeed;
+    if (snapped == old)
+        return;
+
+    Config.ScrollSpeed = snapped;
+
+    try
+    {
+        SaveConfig(configFilePath);
+    }
+    catch (Exception ex)
+    {
+        _logger.LogWarning(ex, "Failed to persist ScrollSpeed change to {Path}; in-memory value still updated.", configFilePath);
+    }
+
+    ScrollSpeedChanged?.Invoke(this, new ScrollSpeedChangedEventArgs(old, snapped));
+}
+
+public void AdjustScrollSpeed(string configFilePath, int stepDelta)
+{
+    SetScrollSpeed(configFilePath, Config.ScrollSpeed + stepDelta * ScrollSpeedRange.Step);
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigManagerScrollSpeedTests"`
+Expected: PASS (all cases).
+
+- [ ] **Step 7: Run full test suite to confirm no regressions**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass (same baseline count + the new tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Config/IConfigManager.cs DTXMania.Game/Lib/Config/ConfigManager.cs DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs DTXMania.Test/DTXMania.Test.Mac.csproj
+git commit -m "feat: add SetScrollSpeed/AdjustScrollSpeed with change event on ConfigManager"
+```
+
+---
+
+## Task 4: Add `IncreaseScrollSpeed` / `DecreaseScrollSpeed` to input system
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Input/InputManager.cs`
+- Test: `DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs`
+- Modify: `DTXMania.Test/DTXMania.Test.Mac.csproj`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Input;
+using Microsoft.Xna.Framework.Input;
+using Xunit;
+
+namespace DTXMania.Test.Input
+{
+    public class InputManagerScrollSpeedKeysTests
+    {
+        [Fact]
+        public void DefaultMapping_PageUp_MapsToIncreaseScrollSpeed()
+        {
+            var im = new InputManager();
+            var snapshot = im.GetKeyMappingSnapshot();
+            Assert.True(snapshot.TryGetValue(Keys.PageUp, out var cmd));
+            Assert.Equal(InputCommandType.IncreaseScrollSpeed, cmd);
+        }
+
+        [Fact]
+        public void DefaultMapping_PageDown_MapsToDecreaseScrollSpeed()
+        {
+            var im = new InputManager();
+            var snapshot = im.GetKeyMappingSnapshot();
+            Assert.True(snapshot.TryGetValue(Keys.PageDown, out var cmd));
+            Assert.Equal(InputCommandType.DecreaseScrollSpeed, cmd);
+        }
+
+        [Fact]
+        public void Enum_HasIncreaseScrollSpeed()
+        {
+            Assert.Contains(InputCommandType.IncreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
+        }
+
+        [Fact]
+        public void Enum_HasDecreaseScrollSpeed()
+        {
+            Assert.Contains(InputCommandType.DecreaseScrollSpeed, System.Enum.GetValues<InputCommandType>());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add to Mac test project**
+
+Edit `DTXMania.Test/DTXMania.Test.Mac.csproj`: add `<Compile Include="Input\InputManagerScrollSpeedKeysTests.cs" />` (create the `Input` group entry if not present, or place beside other input includes).
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~InputManagerScrollSpeedKeysTests"`
+Expected: FAIL — enum values missing.
+
+- [ ] **Step 4: Add enum values**
+
+In `DTXMania.Game/Lib/Input/InputManager.cs`, replace the `InputCommandType` enum block:
+
+```csharp
+public enum InputCommandType
+{
+    MoveUp,
+    MoveDown,
+    MoveLeft,
+    MoveRight,
+    Activate,
+    Back,
+    IncreaseScrollSpeed,
+    DecreaseScrollSpeed
+}
+```
+
+- [ ] **Step 5: Add default key bindings**
+
+In `DTXMania.Game/Lib/Input/InputManager.cs`, in `InitializeDefaultKeyMapping()`, append:
+
+```csharp
+_keyMapping[Keys.PageUp] = InputCommandType.IncreaseScrollSpeed;
+_keyMapping[Keys.PageDown] = InputCommandType.DecreaseScrollSpeed;
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~InputManagerScrollSpeedKeysTests"`
+Expected: PASS.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All previously passing tests still pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Input/InputManager.cs DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs DTXMania.Test/DTXMania.Test.Mac.csproj
+git commit -m "feat: add IncreaseScrollSpeed/DecreaseScrollSpeed input commands on PageUp/PageDown"
+```
+
+---
+
+## Task 5: Wire `PerformanceStage` to read config + react to event + poll hotkeys
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+- Modify: `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs` (constants)
+
+This task does NOT yet add the visible toast indicator (that's Task 6). It wires the data flow first.
+
+- [ ] **Step 1: Add layout constants for indicator**
+
+In `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs`, near the existing `NoteDefaultScrollSpeed` constant, add:
+
+```csharp
+// Scroll-speed indicator (in-game toast shown when player adjusts scroll speed)
+public const float ScrollSpeedIndicatorDurationSeconds = 1.5f;
+public const float ScrollSpeedIndicatorFadeSeconds = 0.3f;
+public const int ScrollSpeedIndicatorX = 640; // top-center of 1280-wide screen
+public const int ScrollSpeedIndicatorY = 40;
+```
+
+- [ ] **Step 2: Replace the hardcoded scroll-speed read in PerformanceStage**
+
+In `DTXMania.Game/Lib/Stage/PerformanceStage.cs`, find the block at lines 538-541:
+
+```csharp
+// Set scroll speed based on user preference
+// TODO: Get scroll speed from user config
+var scrollSpeedSetting = 100; // Default scroll speed
+_noteRenderer?.SetScrollSpeed(scrollSpeedSetting);
+```
+
+Replace with:
+
+```csharp
+// Set scroll speed based on user preference (read from config, applied at chart load).
+// In-game adjustments are handled via ConfigManager.ScrollSpeedChanged subscription.
+var scrollSpeedSetting = _configManager?.Config?.ScrollSpeed ?? ScrollSpeedRange.Default;
+_noteRenderer?.SetScrollSpeed(scrollSpeedSetting);
+```
+
+Add `using DTXMania.Game.Lib.Config;` to the file if not already present.
+
+- [ ] **Step 3: Subscribe / unsubscribe to ScrollSpeedChanged**
+
+In `PerformanceStage`, find `OnActivate` (lifecycle entry — locate via `protected override void OnActivate`). Append a subscription line:
+
+```csharp
+if (_configManager != null)
+{
+    _configManager.ScrollSpeedChanged += OnScrollSpeedChanged;
+}
+```
+
+In `OnDeactivate` (matching lifecycle exit), append:
+
+```csharp
+if (_configManager != null)
+{
+    _configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+}
+```
+
+Add the handler method to `PerformanceStage`:
+
+```csharp
+private void OnScrollSpeedChanged(object? sender, ScrollSpeedChangedEventArgs e)
+{
+    _noteRenderer?.SetScrollSpeed(e.NewPercent);
+    // Indicator hookup added in Task 6.
+}
+```
+
+If `OnActivate` / `OnDeactivate` do not yet exist as overrides in `PerformanceStage`, locate the equivalent lifecycle hooks (`Activate` / `Deactivate` from `BaseStage`) and add the same subscribe/unsubscribe code. Verify by `grep -n "OnActivate\|OnDeactivate\|Activate(\|Deactivate(" DTXMania.Game/Lib/Stage/PerformanceStage.cs`.
+
+- [ ] **Step 4: Poll hotkeys each frame**
+
+Locate the per-frame update method in `PerformanceStage` (likely `OnUpdate` or `Update`). Find where input is already polled (e.g., escape key). Add:
+
+```csharp
+var input = (_game as BaseGame)?.InputManager?.ModularInputManager;
+if (input != null)
+{
+    if (input.IsCommandPressed(InputCommandType.IncreaseScrollSpeed))
+    {
+        _configManager.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), +1);
+    }
+    else if (input.IsCommandPressed(InputCommandType.DecreaseScrollSpeed))
+    {
+        _configManager.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
+    }
+}
+```
+
+If the existing input access pattern differs (e.g., `_inputManager.IsCommandPressed`), match the surrounding style. Add `using DTXMania.Game.Lib.Input;` and `using DTXMania.Game.Lib.Utilities;` if not already present.
+
+- [ ] **Step 5: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: SUCCESS.
+
+- [ ] **Step 6: Run full Mac test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/PerformanceStage.cs DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+git commit -m "feat: PerformanceStage reads ScrollSpeed from config and reacts to PageUp/PageDown"
+```
+
+---
+
+## Task 6: `ScrollSpeedIndicator` component + integrate into PerformanceStage
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs`
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+
+The indicator depends on `BitmapFont` which is graphics-dependent and excluded from Mac tests; therefore no automated unit tests for the indicator itself. We rely on manual verification.
+
+- [ ] **Step 1: Create the indicator class**
+
+Create `DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs`:
+
+```csharp
+#nullable enable
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Brief on-screen toast that displays the current scroll-speed value
+    /// for a short duration after the player adjusts it.
+    /// </summary>
+    public class ScrollSpeedIndicator
+    {
+        private readonly BitmapFont? _font;
+        private string _text = string.Empty;
+        private float _remainingSeconds;
+        private bool _hasShown;
+
+        public ScrollSpeedIndicator(BitmapFont? font)
+        {
+            _font = font;
+        }
+
+        public void Show(int scrollSpeedPercent)
+        {
+            _text = "Scroll Speed " + ScrollSpeedRange.Format(scrollSpeedPercent);
+            _remainingSeconds = PerformanceUILayout.ScrollSpeedIndicatorDurationSeconds;
+            _hasShown = true;
+        }
+
+        public void Update(GameTime gameTime)
+        {
+            if (_remainingSeconds <= 0f)
+                return;
+            _remainingSeconds -= (float)gameTime.ElapsedGameTime.TotalSeconds;
+            if (_remainingSeconds < 0f)
+                _remainingSeconds = 0f;
+        }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (!_hasShown || _remainingSeconds <= 0f || _font == null)
+                return;
+
+            var alpha = ComputeAlpha();
+            var color = Color.White * alpha;
+            _font.DrawText(spriteBatch, _text,
+                PerformanceUILayout.ScrollSpeedIndicatorX,
+                PerformanceUILayout.ScrollSpeedIndicatorY,
+                color);
+        }
+
+        private float ComputeAlpha()
+        {
+            var fade = PerformanceUILayout.ScrollSpeedIndicatorFadeSeconds;
+            if (_remainingSeconds >= fade)
+                return 1f;
+            return _remainingSeconds / fade;
+        }
+    }
+}
+```
+
+If `BitmapFont.DrawText` has a different signature, adjust the call in `Draw` accordingly. Verify by `grep -n "public.*DrawText" DTXMania.Game/Lib/Resources/BitmapFont.cs`.
+
+- [ ] **Step 2: Add the indicator field + lifecycle to PerformanceStage**
+
+In `DTXMania.Game/Lib/Stage/PerformanceStage.cs`:
+
+(a) Add a private field near the other component fields:
+
+```csharp
+private ScrollSpeedIndicator? _scrollSpeedIndicator;
+```
+
+(b) In the same place where other Performance components are constructed (search `new NoteRenderer(` to find the construction block), construct the indicator using the existing bitmap font reference (look for a `_bitmapFont` or equivalent field used by other components like `ComboDisplay`):
+
+```csharp
+_scrollSpeedIndicator = new ScrollSpeedIndicator(_bitmapFont);
+```
+
+If the font field has a different name (e.g., `_font`, `_consoleFont`), use that name. Verify with `grep -n "BitmapFont\|_bitmapFont\|_font\b" DTXMania.Game/Lib/Stage/PerformanceStage.cs`.
+
+(c) In the `OnScrollSpeedChanged` handler from Task 5, add the `Show` call:
+
+```csharp
+private void OnScrollSpeedChanged(object? sender, ScrollSpeedChangedEventArgs e)
+{
+    _noteRenderer?.SetScrollSpeed(e.NewPercent);
+    _scrollSpeedIndicator?.Show(e.NewPercent);
+}
+```
+
+(d) In the per-frame `Update`, after other component updates, add:
+
+```csharp
+_scrollSpeedIndicator?.Update(gameTime);
+```
+
+(e) In the per-frame `Draw` (find where `_comboDisplay?.Draw(...)` or similar is called — the indicator should draw on top of lane content, after notes), add:
+
+```csharp
+_scrollSpeedIndicator?.Draw(_spriteBatch);
+```
+
+Use the actual `SpriteBatch` variable name from surrounding code.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: SUCCESS.
+
+- [ ] **Step 4: Run full Mac test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs DTXMania.Game/Lib/Stage/PerformanceStage.cs
+git commit -m "feat: add ScrollSpeedIndicator toast shown when scroll speed changes mid-song"
+```
+
+---
+
+## Task 7: Wire `SongSelectionStage` to poll hotkeys + render label
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Modify: `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs`
+
+- [ ] **Step 1: Add label position constants**
+
+In `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs`, add (placement: near other status-area constants; if uncertain, place at bottom of class):
+
+```csharp
+// Scroll-speed display (e.g., "Scroll: x1.5") on song-select panel
+public const int ScrollSpeedLabelX = 20;
+public const int ScrollSpeedLabelY = 680; // bottom-left, above standard status bar
+```
+
+If the file already groups label constants, place these next to them and match the naming style.
+
+- [ ] **Step 2: Subscribe / unsubscribe to ScrollSpeedChanged**
+
+In `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`, find lifecycle hooks (search `protected override void OnActivate\|protected override void OnDeactivate\|Activate(\|Deactivate(`).
+
+Add to the activation method:
+
+```csharp
+var configManager = (_game as BaseGame)?.ConfigManager;
+if (configManager != null)
+{
+    configManager.ScrollSpeedChanged += OnScrollSpeedChanged;
+}
+```
+
+Add to the deactivation method:
+
+```csharp
+var configManager = (_game as BaseGame)?.ConfigManager;
+if (configManager != null)
+{
+    configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
+}
+```
+
+Add the handler:
+
+```csharp
+private void OnScrollSpeedChanged(object? sender, DTXMania.Game.Lib.Config.ScrollSpeedChangedEventArgs e)
+{
+    // Label re-renders each frame from current config; nothing to do here today.
+    // Hook kept for symmetry and future caching.
+}
+```
+
+- [ ] **Step 3: Poll hotkeys in OnUpdate**
+
+Locate `OnUpdate` (line ~794) in `SongSelectionStage`. After existing input processing, add:
+
+```csharp
+var configManager = (_game as BaseGame)?.ConfigManager;
+if (_inputManager != null && configManager != null)
+{
+    if (_inputManager.IsCommandPressed(InputCommandType.IncreaseScrollSpeed))
+    {
+        configManager.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), +1);
+    }
+    else if (_inputManager.IsCommandPressed(InputCommandType.DecreaseScrollSpeed))
+    {
+        configManager.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
+    }
+}
+```
+
+Add `using DTXMania.Game.Lib.Input;`, `using DTXMania.Game.Lib.Config;`, `using DTXMania.Game.Lib.Utilities;` if not present.
+
+- [ ] **Step 4: Render the label**
+
+Locate the `Draw` (or `OnDraw`) method in `SongSelectionStage`. After existing UI draw calls, add:
+
+```csharp
+var bf = _bitmapFont; // or the actual field; verify with grep -n "BitmapFont" DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+var cm = (_game as BaseGame)?.ConfigManager;
+if (bf != null && cm != null)
+{
+    var label = "Scroll " + DTXMania.Game.Lib.Config.ScrollSpeedRange.Format(cm.Config.ScrollSpeed);
+    bf.DrawText(_spriteBatch, label,
+        SongSelectionUILayout.ScrollSpeedLabelX,
+        SongSelectionUILayout.ScrollSpeedLabelY,
+        Microsoft.Xna.Framework.Color.White);
+}
+```
+
+If `SongSelectionStage` does not use a `BitmapFont` directly today, follow whatever text-rendering pattern other status labels in the stage use (search for existing label rendering, e.g., `grep -n "DrawText\|DrawString" DTXMania.Game/Lib/Stage/SongSelectionStage.cs`). If no font exists at all in this stage, instantiate one the same way `PerformanceStage` does (look at how the font is constructed there) — this is a hard prerequisite for displaying the label.
+
+- [ ] **Step 5: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: SUCCESS.
+
+- [ ] **Step 6: Run full Mac test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+git commit -m "feat: SongSelectionStage shows scroll-speed label and adjusts via PageUp/PageDown"
+```
+
+---
+
+## Task 8: Extend `IntegerConfigItem` with optional value formatter
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Config/ConfigItems.cs`
+
+The Config menu needs to display "Scroll Speed: x1.5" rather than "Scroll Speed: 150". Smallest change: add an optional `Func<int, string>?` formatter to `IntegerConfigItem`.
+
+- [ ] **Step 1: Modify the constructor and `GetDisplayText`**
+
+In `DTXMania.Game/Lib/Config/ConfigItems.cs`, replace the `IntegerConfigItem` class with:
+
+```csharp
+/// <summary>
+/// Configuration item for integer values with min/max bounds.
+/// Optional valueFormatter customizes the displayed value (default: stringified integer).
+/// </summary>
+public class IntegerConfigItem : BaseConfigItem
+{
+    private readonly Func<int> _getCurrentValue;
+    private readonly Action<int> _setValue;
+    private readonly int _minValue;
+    private readonly int _maxValue;
+    private readonly int _step;
+    private readonly Func<int, string>? _valueFormatter;
+
+    public IntegerConfigItem(string name, Func<int> getCurrentValue, Action<int> setValue,
+        int minValue, int maxValue, int step = 1, Func<int, string>? valueFormatter = null)
+        : base(name)
+    {
+        _getCurrentValue = getCurrentValue ?? throw new ArgumentNullException(nameof(getCurrentValue));
+        _setValue = setValue ?? throw new ArgumentNullException(nameof(setValue));
+        _minValue = minValue;
+        _maxValue = maxValue;
+        _step = step;
+        _valueFormatter = valueFormatter;
+
+        if (_minValue >= _maxValue)
+            throw new ArgumentException("Min value must be less than max value");
+        if (_step <= 0)
+            throw new ArgumentException("Step must be positive");
+    }
+
+    public override string GetDisplayText()
+    {
+        var currentValue = _getCurrentValue();
+        var formatted = _valueFormatter != null ? _valueFormatter(currentValue) : currentValue.ToString();
+        return $"{Name}: {formatted}";
+    }
+
+    public override void PreviousValue()
+    {
+        var currentValue = _getCurrentValue();
+        var newValue = Math.Max(_minValue, currentValue - _step);
+        _setValue(newValue);
+        OnValueChanged();
+    }
+
+    public override void NextValue()
+    {
+        var currentValue = _getCurrentValue();
+        var newValue = Math.Min(_maxValue, currentValue + _step);
+        _setValue(newValue);
+        OnValueChanged();
+    }
+
+    public override void ToggleValue()
+    {
+        // For integer, toggle acts like next value
+        NextValue();
+    }
+}
+```
+
+- [ ] **Step 2: Build and run all tests**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass — formatter parameter is optional and defaults to existing behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Config/ConfigItems.cs
+git commit -m "feat: IntegerConfigItem accepts optional value formatter"
+```
+
+---
+
+## Task 9: Add Scroll Speed item to `ConfigStage` + commit on save
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+
+`ConfigStage` uses a working-copy + commit-on-save model. The existing `LoadConfiguration` (line ~194) already copies `ScrollSpeed` into `_workingConfig`. The save path (line ~501) does NOT currently write `ScrollSpeed` back — we add that.
+
+- [ ] **Step 1: Add the Scroll Speed config item**
+
+In `DTXMania.Game/Lib/Stage/ConfigStage.cs`, find `SetupConfigItems` (line ~232). After the `autoPlayItem` definition (line ~289 area), and before the `_configItems.Add(new NavigationConfigItem(...))` calls, add:
+
+```csharp
+var scrollSpeedItem = new IntegerConfigItem(
+    "Scroll Speed",
+    () => _workingConfig.ScrollSpeed,
+    value =>
+    {
+        _workingConfig.ScrollSpeed = ScrollSpeedRange.SnapAndClamp(value);
+        _hasUnsavedChanges = true;
+    },
+    minValue: ScrollSpeedRange.Min,
+    maxValue: ScrollSpeedRange.Max,
+    step: ScrollSpeedRange.Step,
+    valueFormatter: ScrollSpeedRange.Format);
+```
+
+Then, where the other items are added to `_configItems` (search for `_configItems.Add(autoPlayItem);` or the surrounding `Add` block), add:
+
+```csharp
+_configItems.Add(scrollSpeedItem);
+```
+
+Add `using DTXMania.Game.Lib.Config;` if not already imported.
+
+- [ ] **Step 2: Persist ScrollSpeed on save**
+
+In the same file, find the save block at line ~500 (the "Stage 1: prepare in-memory config data from working copies" section). After the line `config.AutoPlay = _workingConfig.AutoPlay;`, add:
+
+```csharp
+config.ScrollSpeed = _workingConfig.ScrollSpeed;
+```
+
+Find the rollback block at ~line 524 and add a corresponding rollback:
+
+(a) Before the assignment block, capture the previous value alongside the others — find `bool prevAutoPlay = config.AutoPlay;` (~line 494) and add directly after:
+
+```csharp
+int prevScrollSpeed = config.ScrollSpeed;
+```
+
+(b) In the catch block, after `config.AutoPlay = prevAutoPlay;` (~line 529), add:
+
+```csharp
+config.ScrollSpeed = prevScrollSpeed;
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: SUCCESS.
+
+- [ ] **Step 4: Run full Mac test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ConfigStage.cs
+git commit -m "feat: ConfigStage exposes Scroll Speed item and persists on save"
+```
+
+---
+
+## Task 10: Manual verification
+
+**Files:** none (gameplay testing).
+
+This task has no code. It validates the user-facing behavior the spec promises but cannot cover with automated tests on Mac.
+
+- [ ] **Step 1: Run the game**
+
+Run: `dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj`
+
+- [ ] **Step 2: Config menu persistence**
+
+1. Enter Config menu.
+2. Navigate to "Scroll Speed". Default reads as `x1.0`.
+3. Press right arrow several times to reach `x2.5`. Confirm display updates step-by-step.
+4. Save and exit.
+5. Open `~/Library/Application Support/DTXMania/Config.ini` (or wherever `AppPaths.GetConfigFilePath()` resolves on your machine) and confirm `ScrollSpeed=250`.
+6. Restart the app, re-enter Config menu, confirm "Scroll Speed: x2.5" still shown.
+
+- [ ] **Step 3: Song-select adjust**
+
+1. From the title screen, enter Song Selection.
+2. Confirm "Scroll x2.5" label visible at the configured position.
+3. Press `PageUp` → label changes to `x3.0`. Press repeatedly → caps at `x4.0`.
+4. Press `PageDown` repeatedly → drops to `x0.5` and stops.
+5. Open `Config.ini` after each change to verify write-through.
+
+- [ ] **Step 4: In-game adjust**
+
+1. Set scroll speed to `x1.0` (via song-select PageDown).
+2. Start a song.
+3. Press `PageUp` mid-song → toast appears top-center reading "Scroll Speed x1.5"; notes visibly fall faster.
+4. Press `PageUp` again → toast updates to `x2.0`. Wait for toast to fade out (~1.5s).
+5. Press `PageDown` → toast shows `x1.5`, notes slow down.
+6. Confirm: judgement timing still feels correct (hits register against the audio, not the visuals).
+7. Confirm: hold `PageUp` does NOT continuously scroll through values — it must be pressed each time (edge-triggered).
+
+- [ ] **Step 5: Boundary behavior**
+
+1. Press `PageUp` until toast shows `x4.0`. Press `PageUp` again — no visible change, no new toast.
+2. Press `PageDown` until `x0.5`. Press `PageDown` again — same.
+
+- [ ] **Step 6: Cross-stage consistency**
+
+1. After in-game adjust to `x3.0`, exit to song select. Confirm label reads `x3.0`.
+2. Exit to Config menu. Confirm "Scroll Speed: x3.0".
+3. Confirm `Config.ini` reads `ScrollSpeed=300`.
+
+- [ ] **Step 7: Document any deviations**
+
+If any step fails, add a TODO comment in this plan describing the failure (do NOT mark it complete) and report back before proceeding to merge.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Implemented in |
+| --- | --- |
+| §2 Range/step/storage/format | Task 1 (`ScrollSpeedRange`), Task 3 (snap on set) |
+| §2 Adjustable from Config menu | Tasks 8 + 9 |
+| §2 Adjustable from song-select | Task 7 |
+| §2 Adjustable in-game | Tasks 4, 5 |
+| §2 Persistence (write-through) | Task 3 (`SetScrollSpeed` calls `SaveConfig`) |
+| §2 No audio/judgement effect | Inherited from existing NoteRenderer behavior; verified manually in Task 10 step 4 |
+| §2 Boundaries (no wrap) | Task 1 (`SnapAndClamp`); Task 10 step 5 verifies |
+| §3.1 `IConfigManager` event + methods | Task 3 |
+| §3.2 `ScrollSpeedRange` helper | Task 1 |
+| §3.3 Input enum + bindings | Task 4 |
+| §3.4 PerformanceStage subscribe + poll | Task 5 |
+| §3.4 SongSelectStage subscribe + poll + label | Task 7 |
+| §3.4 ConfigStage item | Tasks 8, 9 |
+| §3.5 ScrollSpeedIndicator | Task 6 |
+| §4 Data flow | Tasks 3, 5, 6, 7 collectively |
+| §5 Mid-song correctness | No code — relies on existing `NoteRenderer` per-frame behavior (verified in spec) |
+| §6 Error handling (Save failure) | Task 3 step 5 (try/catch around `SaveConfig`) |
+| §6 Edge-triggered (no hold-repeat) | Task 5 step 4, Task 7 step 3 (uses `IsCommandPressed`); Task 10 step 4 verifies |
+| §6 Unsubscribe on deactivate | Task 5 step 3, Task 7 step 2 |
+| §7.1 Unit tests (ConfigManager) | Task 3 step 1 |
+| §7.1 Unit tests (ScrollSpeedRange) | Task 1 step 1 |
+| §7.2 Input tests | Task 4 step 1 |
+| §7.4 Manual checklist | Task 10 |
+
+All spec items mapped to a task.
+
+**Placeholder scan:** No "TBD"/"TODO"/"add appropriate" inside code blocks. The plan does say "if the field has a different name" in a couple of places — those are explicit verification instructions for the engineer with the exact `grep` command to run, not vague handwaving. Acceptable.
+
+**Type consistency check:**
+- `SetScrollSpeed(string configFilePath, int percent)` — same signature in IConfigManager, ConfigManager impl, and all callers (Tasks 5, 7).
+- `AdjustScrollSpeed(string configFilePath, int stepDelta)` — same.
+- `ScrollSpeedChanged` event — `EventHandler<ScrollSpeedChangedEventArgs>?` consistently.
+- `ScrollSpeedRange` members `Min/Max/Step/Default/SnapAndClamp/Format` — same names everywhere referenced.
+- `InputCommandType.IncreaseScrollSpeed` / `DecreaseScrollSpeed` — same in enum, bindings, polling.
+- `ScrollSpeedIndicator.Show(int)` / `.Update(GameTime)` / `.Draw(SpriteBatch)` — consistent in Task 6.
+- `PerformanceUILayout.ScrollSpeedIndicator{X,Y,DurationSeconds,FadeSeconds}` — consistent in Task 5 (defs) and Task 6 (uses).
+- `SongSelectionUILayout.ScrollSpeedLabel{X,Y}` — consistent in Task 7.
+
+No type drift detected.

--- a/docs/superpowers/specs/2026-05-04-scroll-speed-control-design.md
+++ b/docs/superpowers/specs/2026-05-04-scroll-speed-control-design.md
@@ -1,0 +1,224 @@
+# Scroll Speed Control — Design
+
+**Date:** 2026-05-04
+**Status:** Draft for review
+**Scope:** Visual scroll-speed control for the Performance stage. Audio playback rate (true PlaySpeed) is **out of scope** and explicitly deferred.
+
+## 1. Summary
+
+Let the player control how fast notes visually fall down the lane. Adjustable from the Config menu, song-select screen, and during play, with `PageUp` / `PageDown` hotkeys. Range x0.5 to x4.0, step x0.5. Every change writes through to `Config.ini` immediately and updates listeners via an event on `IConfigManager`.
+
+The underlying field (`ConfigData.ScrollSpeed`, integer percentage, default 100) and the renderer hook (`NoteRenderer.SetScrollSpeed(int)`) already exist. This design adds the user-facing controls, the in-game indicator, and the central mutation path that ties them together.
+
+## 2. User-facing behavior
+
+| Property | Value |
+| --- | --- |
+| Range | x0.5 – x4.0 |
+| Step | x0.5 (8 discrete values) |
+| Storage | integer percentage (`50, 100, 150, …, 400`), step 50 |
+| Display format | `x1.0`, `x1.5`, etc. (one decimal) |
+| Persistence | write-through to `Config.ini` on every change |
+| Affects audio? | No |
+| Affects judgement timing? | No |
+
+**Adjustable from:**
+- **Config menu** — scroll-speed item, left/right adjusts.
+- **Song-select** — `PageUp` / `PageDown` adjusts; current value visible on the panel.
+- **In-game (Performance)** — `PageUp` / `PageDown` adjusts mid-song; brief toast indicator shows the new value.
+
+**Boundary behavior:** at `x4.0`, `PageUp` is a no-op; at `x0.5`, `PageDown` is a no-op. No wrap-around.
+
+## 3. Architecture
+
+### 3.1 Single mutation point on `IConfigManager`
+
+Add to `IConfigManager` (and implement on `ConfigManager`):
+
+```csharp
+event EventHandler<ScrollSpeedChangedEventArgs>? ScrollSpeedChanged;
+
+void SetScrollSpeed(int percent);       // snaps & clamps, persists, raises event
+void AdjustScrollSpeed(int stepDelta);  // +1 / -1 step; calls SetScrollSpeed
+```
+
+`ScrollSpeedChangedEventArgs` carries `OldPercent` and `NewPercent`.
+
+`SetScrollSpeed(int percent)` semantics:
+1. Snap `percent` to nearest allowed value (multiple of 50).
+2. Clamp to `[ScrollSpeedRange.Min, ScrollSpeedRange.Max]`.
+3. If equal to current `Config.ScrollSpeed` → no-op (no event, no save).
+4. Otherwise: assign, call `SaveConfig()`, raise `ScrollSpeedChanged`.
+
+`AdjustScrollSpeed(int stepDelta)` computes `newPercent = current + stepDelta * Step` and delegates to `SetScrollSpeed`.
+
+### 3.2 `ScrollSpeedRange` helper
+
+New file `DTXMania.Game/Lib/Config/ScrollSpeedRange.cs`:
+
+```csharp
+public static class ScrollSpeedRange
+{
+    public const int Min = 50;
+    public const int Max = 400;
+    public const int Step = 50;
+    public const int Default = 100;
+
+    public static int SnapAndClamp(int percent);     // nearest multiple of Step, clamped
+    public static string Format(int percent);        // 50 -> "x0.5", 100 -> "x1.0"
+}
+```
+
+Single source of truth for range and formatting. Used by ConfigManager, ConfigStage, SongSelectStage, and the in-game indicator.
+
+### 3.3 Input layer
+
+Extend `InputCommandType` (in `DTXMania.Game/Lib/Input/InputManager.cs`):
+
+```csharp
+public enum InputCommandType
+{
+    MoveUp, MoveDown, MoveLeft, MoveRight, Activate, Back,
+    IncreaseScrollSpeed,
+    DecreaseScrollSpeed
+}
+```
+
+Add to `InputManager.InitializeDefaultMappings()`:
+```csharp
+_keyMapping[Keys.PageUp]   = InputCommandType.IncreaseScrollSpeed;
+_keyMapping[Keys.PageDown] = InputCommandType.DecreaseScrollSpeed;
+```
+
+Hotkeys are edge-triggered via `IsCommandPressed`, so holding the key does **not** repeat. Hold-to-repeat is a deliberate non-goal here; revisit if requested.
+
+### 3.4 Consumers
+
+All three stages subscribe to `ConfigManager.ScrollSpeedChanged` on activation, unsubscribe on deactivation.
+
+**`PerformanceStage`:**
+- On `ScrollSpeedChanged` → `_noteRenderer.SetScrollSpeed(e.NewPercent)` and `_scrollSpeedIndicator.Show(e.NewPercent)`.
+- Each frame in `OnUpdate`: if `IsCommandPressed(IncreaseScrollSpeed)` → `ConfigManager.AdjustScrollSpeed(+1)`; same for decrease.
+- Owns the `ScrollSpeedIndicator` (see 3.5).
+
+**`SongSelectStage`:**
+- Same input polling and `AdjustScrollSpeed` calls.
+- Renders current value (formatted via `ScrollSpeedRange.Format`) on the song-select status panel area, beside other session-mode displays. Exact pixel position is a layout-class constant added to `SongSelectionUILayout`; choose a free slot near existing indicators rather than introducing a new region.
+- On `ScrollSpeedChanged` → mark UI dirty / refresh label text.
+
+**`ConfigStage`:**
+- Adds a config item "Scroll Speed: x1.5" using the existing item-adjust mechanism. Left/right calls `ConfigManager.AdjustScrollSpeed(-1)` / `(+1)`. Already copies `originalConfig.ScrollSpeed` (line 214); this stays.
+- On `ScrollSpeedChanged` → refresh the displayed value.
+
+### 3.5 `ScrollSpeedIndicator` (new)
+
+`DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs`. Small fade-in/fade-out label drawn over the lane area.
+
+```csharp
+public class ScrollSpeedIndicator
+{
+    public void Show(int scrollSpeedPercent);   // resets timer, sets label text
+    public void Update(GameTime gameTime);
+    public void Draw(SpriteBatch spriteBatch);
+}
+```
+
+- Visible duration: 1500 ms (constant in `PerformanceUILayout`).
+- Position: top-center of the lane area (constant in `PerformanceUILayout`).
+- Renders nothing until first `Show` call.
+
+## 4. Data flow
+
+**In-game `PageUp` press:**
+```
+Keys.PageUp
+  -> InputManager           : edge-detected -> InputCommandType.IncreaseScrollSpeed
+  -> PerformanceStage.OnUpdate: IsCommandPressed -> ConfigManager.AdjustScrollSpeed(+1)
+  -> ConfigManager           : snap+clamp, assign, SaveConfig(), raise ScrollSpeedChanged
+  -> PerformanceStage handler: NoteRenderer.SetScrollSpeed, Indicator.Show
+```
+
+**Song-select adjust:** identical path; consumer is `SongSelectStage` (panel label refresh) instead.
+
+**Config menu adjust:** identical path; consumer is `ConfigStage` (item label refresh).
+
+**Game launch:** `ConfigManager.LoadConfig()` populates `Config.ScrollSpeed` (existing behavior). `PerformanceStage` calls `_noteRenderer.SetScrollSpeed(scrollSpeedSetting)` at startup (existing line 541). No change.
+
+## 5. Mid-song correctness
+
+`NoteRenderer` recomputes `_scrollPixelsPerMs` and `EffectiveLookAheadMs` inside `SetScrollSpeed`. Note positions are computed each frame as `JudgementY - _scrollPixelsPerMs * (note.TimeMs - currentSongTimeMs)`, and the active-note window in `PerformanceStage` (lines 694, 716) reads `_noteRenderer.EffectiveLookAheadMs` per frame. Therefore a mid-song speed change:
+- Repositions all visible notes instantly (they snap to the new pixels-per-ms).
+- Adjusts which notes are "active" (the look-ahead window grows/shrinks) on the next frame.
+- Does **not** affect `currentSongTimeMs`, audio, or judgement (those use real time).
+
+The visual snap is a known and acceptable artifact — it's the expected behavior for scroll-speed changes in DTXMania.
+
+## 6. Error handling
+
+- `SetScrollSpeed` clamps and snaps silently. No exceptions for out-of-range input.
+- `SaveConfig()` failures are logged via the existing logger; the in-memory value still updates and the event still fires. Config saving is best-effort elsewhere in the codebase — match that.
+- `NoteRenderer.SetScrollSpeed` already throws on `<= 0` input; clamp upstream means it never sees an invalid value.
+- Stage handlers must unsubscribe from `ScrollSpeedChanged` on deactivation to prevent leaks.
+
+## 7. Testing
+
+### 7.1 Unit tests (Mac-safe)
+
+In `DTXMania.Test/Config/`:
+- `ConfigManager_SetScrollSpeed_SnapsToNearestStep` — 117→100, 130→150, 425→400, 30→50.
+- `ConfigManager_SetScrollSpeed_ClampsToRange` — 0, -50, 9999 all land inside [50, 400].
+- `ConfigManager_SetScrollSpeed_RaisesChangedEventWithOldAndNew`.
+- `ConfigManager_SetScrollSpeed_NoOpWhenUnchanged` — no event, no save.
+- `ConfigManager_SetScrollSpeed_PersistsToConfigIni` — round-trip via `SaveConfig` / `LoadConfig`.
+- `ConfigManager_AdjustScrollSpeed_StepsUpAndDown` — +1 from 100→150; -1 from 50→50 (floor); +1 from 400→400 (ceiling).
+- `ScrollSpeedRange_Format_FormatsAsXMultiplier` — 50→"x0.5", 100→"x1.0", 400→"x4.0".
+- `ScrollSpeedRange_SnapAndClamp` — boundary and snap cases.
+
+### 7.2 Input tests (Mac-safe)
+
+In `DTXMania.Test/Input/`:
+- `InputManager_PageUp_MapsToIncreaseScrollSpeed`.
+- `InputManager_PageDown_MapsToDecreaseScrollSpeed`.
+
+### 7.3 Out of automated coverage
+
+The Mac test project excludes graphics/UI tests, so the on-screen indicator, ConfigStage rendering, and SongSelectStage panel rendering rely on manual verification. Existing `NoteRenderer` tests already cover `SetScrollSpeed` math.
+
+### 7.4 Manual verification checklist
+
+1. Launch, open Config menu, change scroll speed to x2.5, exit, restart app → Config.ini and Config menu both show x2.5.
+2. In song-select, press `PageUp` / `PageDown` → panel label updates; values clamp at x0.5 and x4.0.
+3. Start a song, press `PageUp` mid-song → toast appears, notes visibly fall faster, judgement still feels correct (note that hits register at the same time as before relative to the audio).
+4. Press `PageDown` repeatedly to floor → indicator stops updating once at x0.5.
+5. Open Config.ini after each change → `ScrollSpeed=...` reflects the latest value.
+
+## 8. Files touched
+
+**New files:**
+- `DTXMania.Game/Lib/Config/ScrollSpeedRange.cs`
+- `DTXMania.Game/Lib/Config/ScrollSpeedChangedEventArgs.cs`
+- `DTXMania.Game/Lib/Stage/Performance/ScrollSpeedIndicator.cs`
+
+**Modified:**
+- `DTXMania.Game/Lib/Config/IConfigManager.cs` — add event and methods.
+- `DTXMania.Game/Lib/Config/ConfigManager.cs` — implement event and methods.
+- `DTXMania.Game/Lib/Input/InputManager.cs` — add enum values and PageUp/PageDown bindings.
+- `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs` — add indicator position + duration constants.
+- `DTXMania.Game/Lib/Stage/PerformanceStage.cs` — subscribe, poll input, own indicator.
+- `DTXMania.Game/Lib/Stage/SongSelectStage.cs` (or its panel component) — subscribe, poll input, render label.
+- `DTXMania.Game/Lib/Stage/ConfigStage.cs` — add scroll-speed config item.
+
+**New tests:**
+- `DTXMania.Test/Config/ConfigManagerScrollSpeedTests.cs`
+- `DTXMania.Test/Config/ScrollSpeedRangeTests.cs`
+- `DTXMania.Test/Input/InputManagerScrollSpeedKeysTests.cs`
+
+(All new test files are Mac-safe — no `GraphicsDevice` dependency — so they go in both `DTXMania.Test.csproj` and `DTXMania.Test.Mac.csproj` via the explicit include list.)
+
+## 9. Out of scope (deferred)
+
+- True PlaySpeed (audio + chart playback rate).
+- Hold-to-repeat for `PageUp` / `PageDown`.
+- Per-song scroll-speed memory.
+- Time-stretch vs pitch-shift toggle.
+- Score-saving policy for non-default scroll speed (DTXManiaNX legacy `bSaveScoreIfModifiedPlaySpeed` — only meaningful for true PlaySpeed).


### PR DESCRIPTION
## Summary
- Adds configurable scroll speed that can be adjusted via PageUp/PageDown keys in song selection and performance
- Scroll speed can be set in Config stage with persistent storage
- Shows toast indicator when scroll speed changes mid-song
- Implements scroll speed range validation and formatting

## Changes
- Added ScrollSpeedRange, ScrollSpeedChangedEventArgs to Config
- Extended ConfigItems, ConfigManager, IConfigManager for scroll speed
- Added ScrollSpeedIndicator toast component to Performance stage
- Added tests for ScrollSpeedRange, ConfigManager scroll speed, and input handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PageUp/PageDown adjust scroll speed; setting exposed in Settings and Song Select.
  * On-screen toast displays current scroll multiplier during gameplay.
  * Public APIs/events notify scroll-speed changes.

* **Improvements**
  * Scroll speed now snaps, clamps, uses a sensible default, and persists atomically with deferred saves.
  * Safer key-binding flow with deferred eviction and protection for required system commands.

* **Tests**
  * Extensive unit tests for scroll speed, formatting, input mappings, UI indicator, and key-binding eviction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->