### PR TITLE
feat: add song search & filter modal for song selection

### DIFF
--- a/DTXMania.Game/Lib/Input/InputManager.cs
+++ b/DTXMania.Game/Lib/Input/InputManager.cs
@@ -356,6 +356,10 @@ namespace DTXMania.Game.Lib.Input
                     state.LastRepeatTime = _currentTime;
                     state.CurrentRepeatInterval = INITIAL_REPEAT_DELAY;
                     state.HasStartedRepeating = false;
+                    // Clear any leftover suppression from a prior modal/filter close.
+                    // Suppression is only meant to block repeats of keys already held at that
+                    // point; a fresh physical press should always produce commands normally.
+                    state.Suppressed = false;
 
                     // Queue initial command
                     _inputCommandQueue.Enqueue(new InputCommand(commandType, _currentTime, false));

--- a/DTXMania.Game/Lib/Input/InputManager.cs
+++ b/DTXMania.Game/Lib/Input/InputManager.cs
@@ -49,11 +49,22 @@ namespace DTXMania.Game.Lib.Input
         public double CurrentRepeatInterval { get; set; }
         public bool HasStartedRepeating { get; set; }
 
+        /// <summary>
+        /// When true, the key is physically held but should not produce repeat commands.
+        /// Set by <see cref="Suppress"/> when a modal/filter closes while a mapped key is held.
+        /// Cleared by <see cref="Reset"/> when the key is physically released.
+        /// </summary>
+        public bool Suppressed { get; set; }
+
         public KeyRepeatState()
         {
             Reset();
         }
 
+        /// <summary>
+        /// Full reset — used when the key is physically released.
+        /// Clears all state including suppression.
+        /// </summary>
         public void Reset()
         {
             IsPressed = false;
@@ -61,6 +72,22 @@ namespace DTXMania.Game.Lib.Input
             LastRepeatTime = 0;
             CurrentRepeatInterval = 0;
             HasStartedRepeating = false;
+            Suppressed = false;
+        }
+
+        /// <summary>
+        /// Suppress a held key without waiting for release.
+        /// Zeroes timers and marks the state as suppressed so <c>UpdateKeyRepeatStates</c>
+        /// skips it until the key is physically released.
+        /// </summary>
+        public void Suppress()
+        {
+            IsPressed = false;
+            InitialPressTime = 0;
+            LastRepeatTime = 0;
+            CurrentRepeatInterval = 0;
+            HasStartedRepeating = false;
+            Suppressed = true;
         }
     }
 
@@ -170,14 +197,16 @@ namespace DTXMania.Game.Lib.Input
         }
 
         /// <summary>
-        /// Resets all key repeat states so held keys will not produce repeat
-        /// commands on the next frame. Use after closing modals to prevent a
-        /// held close-key from immediately re-triggering stage actions.
+        /// Suppresses all held keys so they will not produce repeat commands on
+        /// the next frame. Unlike a plain reset, this sets a <see cref="KeyRepeatState.Suppressed"/>
+        /// flag so the repeat logic skips the key until it is physically released.
+        /// Use after closing modals or clearing filters to prevent a held close-key
+        /// from immediately re-triggering stage actions.
         /// </summary>
         public virtual void ResetKeyRepeatStates()
         {
             foreach (var state in _keyRepeatStates.Values)
-                state.Reset();
+                state.Suppress();
         }
 
         /// <summary>
@@ -273,6 +302,23 @@ namespace DTXMania.Game.Lib.Input
             _keyMapping[key] = command;
         }
 
+        /// <summary>
+        /// Returns the <see cref="KeyRepeatState"/> for a key, or null if none exists.
+        /// Intended for testing.
+        /// </summary>
+        internal KeyRepeatState? TryGetKeyRepeatState(Keys key)
+        {
+            return _keyRepeatStates.TryGetValue(key, out var state) ? state : null;
+        }
+
+        /// <summary>
+        /// Seeds a <see cref="KeyRepeatState"/> for a key. Intended for testing.
+        /// </summary>
+        internal void SeedKeyRepeatState(Keys key, KeyRepeatState state)
+        {
+            _keyRepeatStates[key] = state;
+        }
+
         public void RemoveKeyMapping(Keys key)
         {
             _keyMapping.Remove(key);
@@ -316,7 +362,13 @@ namespace DTXMania.Game.Lib.Input
                 }
                 else if (isCurrentlyPressed && wasPressed)
                 {
-                    // Key held down - check for repeat
+                    // Key held down — but skip if suppressed (e.g. modal just closed
+                    // while this key was still physically held). The suppression is
+                    // cleared when the key is released (the branch below).
+                    if (state.Suppressed)
+                        continue;
+
+                    // check for repeat
                     double timeSinceInitialPress = _currentTime - state.InitialPressTime;
                     double timeSinceLastRepeat = _currentTime - state.LastRepeatTime;
 

--- a/DTXMania.Game/Lib/Input/InputManager.cs
+++ b/DTXMania.Game/Lib/Input/InputManager.cs
@@ -17,7 +17,8 @@ namespace DTXMania.Game.Lib.Input
         Activate,
         Back,
         IncreaseScrollSpeed,
-        DecreaseScrollSpeed
+        DecreaseScrollSpeed,
+        OpenSearch
     }
 
     /// <summary>
@@ -103,6 +104,7 @@ namespace DTXMania.Game.Lib.Input
             _keyMapping[Keys.Escape] = InputCommandType.Back;
             _keyMapping[Keys.PageUp] = InputCommandType.IncreaseScrollSpeed;
             _keyMapping[Keys.PageDown] = InputCommandType.DecreaseScrollSpeed;
+            _keyMapping[Keys.Back] = InputCommandType.OpenSearch;
         }
 
         public virtual void Update(double deltaTime = 0)

--- a/DTXMania.Game/Lib/Input/InputManager.cs
+++ b/DTXMania.Game/Lib/Input/InputManager.cs
@@ -170,6 +170,17 @@ namespace DTXMania.Game.Lib.Input
         }
 
         /// <summary>
+        /// Resets all key repeat states so held keys will not produce repeat
+        /// commands on the next frame. Use after closing modals to prevent a
+        /// held close-key from immediately re-triggering stage actions.
+        /// </summary>
+        public virtual void ResetKeyRepeatStates()
+        {
+            foreach (var state in _keyRepeatStates.Values)
+                state.Reset();
+        }
+
+        /// <summary>
         /// Enqueue a navigation command directly (for use by subclasses injecting virtual input)
         /// </summary>
         protected void EnqueueCommand(InputCommand command)

--- a/DTXMania.Game/Lib/Input/InputManager.cs
+++ b/DTXMania.Game/Lib/Input/InputManager.cs
@@ -104,7 +104,6 @@ namespace DTXMania.Game.Lib.Input
             _keyMapping[Keys.Escape] = InputCommandType.Back;
             _keyMapping[Keys.PageUp] = InputCommandType.IncreaseScrollSpeed;
             _keyMapping[Keys.PageDown] = InputCommandType.DecreaseScrollSpeed;
-            _keyMapping[Keys.Back] = InputCommandType.OpenSearch;
         }
 
         public virtual void Update(double deltaTime = 0)

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -352,7 +352,7 @@ namespace DTXMania.Game.Lib.Song.Components
             var box = new Microsoft.Xna.Framework.Rectangle(
                 modal.X + SearchFilterModal.FieldX, modal.Y + SearchFilterModal.PlayedRowY, 380, 30);
             sb.Draw(WhitePixel, box, rowBg);
-            DrawText(sb, "(◀ ▶) " + _draft.PlayedStatus,
+            DrawText(sb, "(< >) " + _draft.PlayedStatus,
                 new Microsoft.Xna.Framework.Vector2(box.X + 6, box.Y + 6),
                 Microsoft.Xna.Framework.Color.White);
         }

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -393,5 +393,12 @@ namespace DTXMania.Game.Lib.Song.Components
                 new Microsoft.Xna.Framework.Vector2(applyRect.X + 36, applyRect.Y + 8),
                 Microsoft.Xna.Framework.Color.White);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                UnsubscribeText();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.UI;
 using DTXMania.Game.Lib.UI.Components;
@@ -100,6 +101,115 @@ namespace DTXMania.Game.Lib.Song.Components
                 return;
             }
             Apply();
+        }
+
+        public void HandleKey(Microsoft.Xna.Framework.Input.Keys key)
+        {
+            if (!_isOpen) return;
+
+            switch (key)
+            {
+                case Microsoft.Xna.Framework.Input.Keys.Escape:
+                    Cancel();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Tab:
+                case Microsoft.Xna.Framework.Input.Keys.Down:
+                    FocusNext();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Up:
+                    FocusPrev();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Enter:
+                    HandleEnter();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Left:
+                    AdjustFocusedField(-1);
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Right:
+                    AdjustFocusedField(+1);
+                    return;
+            }
+        }
+
+        private void HandleEnter()
+        {
+            switch (_focusedField)
+            {
+                case Field.SearchBox:
+                    SubmitFromSearchBox();
+                    return;
+                case Field.ResetButton:
+                    Reset();
+                    return;
+                case Field.ApplyButton:
+                    Apply();
+                    return;
+                default:
+                    // On numeric/cycle fields, Enter applies (default action)
+                    Apply();
+                    return;
+            }
+        }
+
+        private const int LevelStep = 5;
+        private const int LevelMin = 0;
+        private const int LevelMax = 99;
+
+        private void AdjustFocusedField(int dir)
+        {
+            switch (_focusedField)
+            {
+                case Field.MinLevel:
+                    _draft = _draft with { MinLevel = AdjustLevel(_draft.MinLevel, dir) };
+                    return;
+                case Field.MaxLevel:
+                    _draft = _draft with { MaxLevel = AdjustLevel(_draft.MaxLevel, dir) };
+                    return;
+                case Field.PlayedStatus:
+                    _draft = _draft with { PlayedStatus = CycleEnum(_draft.PlayedStatus, dir) };
+                    return;
+                case Field.SortBy:
+                    _draft = _draft with { SortBy = CycleSort(_draft.SortBy, dir) };
+                    return;
+                case Field.SortDirection:
+                    _draft = _draft with { SortDescending = !_draft.SortDescending };
+                    return;
+            }
+        }
+
+        private static int? AdjustLevel(int? current, int dir)
+        {
+            int next = (current ?? 0) + (dir * LevelStep);
+            if (next < LevelMin) next = LevelMin;
+            if (next > LevelMax) next = LevelMax;
+            return next == 0 ? (int?)null : next;
+        }
+
+        private static PlayedStatus CycleEnum(PlayedStatus current, int dir)
+        {
+            int count = 4; // All, Unplayed, Played, Cleared
+            int idx = ((int)current + dir + count) % count;
+            return (PlayedStatus)idx;
+        }
+
+        private static SongSortCriteria CycleSort(SongSortCriteria current, int dir)
+        {
+            // Modal exposes only Title / Artist / Level (no Genre)
+            var allowed = new[]
+            {
+                SongSortCriteria.Title,
+                SongSortCriteria.Artist,
+                SongSortCriteria.Level
+            };
+            int currentIdx = System.Array.IndexOf(allowed, current);
+            if (currentIdx < 0) currentIdx = 0;
+            int next = (currentIdx + dir + allowed.Length) % allowed.Length;
+            return allowed[next];
         }
 
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -7,6 +7,7 @@ using DTXMania.Game.Lib.UI;
 using DTXMania.Game.Lib.UI.Components;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using static DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout;
 
 namespace DTXMania.Game.Lib.Song.Components
 {
@@ -259,9 +260,138 @@ namespace DTXMania.Game.Lib.Song.Components
             return allowed[next];
         }
 
+        public Texture2D? WhitePixel { get; set; }
+        public SpriteFont? Font { get; set; }
+
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {
-            // Drawing implemented in Task 28.
+            if (!_isOpen || WhitePixel == null || Font == null) return;
+
+            var modalBounds = SearchFilterModal.Bounds;
+
+            // Dim the screen behind the modal
+            spriteBatch.Draw(WhitePixel,
+                new Microsoft.Xna.Framework.Rectangle(0, 0, 1280, 720),
+                new Microsoft.Xna.Framework.Color(0, 0, 0, 160));
+
+            // Modal panel background
+            spriteBatch.Draw(WhitePixel, modalBounds,
+                new Microsoft.Xna.Framework.Color(28, 28, 32));
+
+            // Title
+            DrawText(spriteBatch, "SEARCH & FILTER",
+                new Microsoft.Xna.Framework.Vector2(
+                    modalBounds.X + (modalBounds.Width - Font.MeasureString("SEARCH & FILTER").X) / 2,
+                    modalBounds.Y + 12),
+                Microsoft.Xna.Framework.Color.White);
+
+            DrawSearchRow(spriteBatch, modalBounds);
+            DrawLevelRow(spriteBatch, modalBounds);
+            DrawPlayedRow(spriteBatch, modalBounds);
+            DrawSortRow(spriteBatch, modalBounds);
+            DrawButtons(spriteBatch, modalBounds);
+
+            if (!IsLibraryReady)
+            {
+                DrawText(spriteBatch, LoadingHintText,
+                    new Microsoft.Xna.Framework.Vector2(modalBounds.X + 24, modalBounds.Y + modalBounds.Height - 24),
+                    Microsoft.Xna.Framework.Color.Yellow);
+            }
+        }
+
+        private void DrawText(SpriteBatch spriteBatch, string text, Microsoft.Xna.Framework.Vector2 pos, Microsoft.Xna.Framework.Color color)
+        {
+            spriteBatch.DrawString(Font!, text, pos, color);
+        }
+
+        private static readonly Microsoft.Xna.Framework.Color FocusedBg = new(60, 60, 80);
+        private static readonly Microsoft.Xna.Framework.Color FieldBg   = new(40, 40, 50);
+
+        private void DrawSearchRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            DrawText(sb, "Search:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.SearchBoxY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            var box = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + SearchFilterModal.FieldX, modal.Y + SearchFilterModal.SearchBoxY, SearchFilterModal.SearchBoxWidth, SearchFilterModal.SearchBoxHeight);
+            sb.Draw(WhitePixel,
+                box,
+                _focusedField == Field.SearchBox ? FocusedBg : FieldBg);
+            DrawText(sb, _draft.SearchQuery ?? "",
+                new Microsoft.Xna.Framework.Vector2(box.X + 6, box.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawLevelRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            DrawText(sb, "Level:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.LevelRowY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            DrawNumeric(sb, modal.X + SearchFilterModal.LevelMinX, modal.Y + SearchFilterModal.LevelRowY,
+                SearchFilterModal.LevelInputWidth, SearchFilterModal.LevelInputHeight,
+                _draft.MinLevel, _focusedField == Field.MinLevel, "Min");
+            DrawNumeric(sb, modal.X + SearchFilterModal.LevelMaxX, modal.Y + SearchFilterModal.LevelRowY,
+                SearchFilterModal.LevelInputWidth, SearchFilterModal.LevelInputHeight,
+                _draft.MaxLevel, _focusedField == Field.MaxLevel, "Max");
+        }
+
+        private void DrawNumeric(SpriteBatch sb, int x, int y, int w, int h, int? value, bool focused, string label)
+        {
+            sb.Draw(WhitePixel, new Microsoft.Xna.Framework.Rectangle(x, y, w, h),
+                focused ? FocusedBg : FieldBg);
+            string text = value?.ToString() ?? label;
+            DrawText(sb, text, new Microsoft.Xna.Framework.Vector2(x + 6, y + 6),
+                value is null ? Microsoft.Xna.Framework.Color.Gray : Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawPlayedRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            DrawText(sb, "Played:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.PlayedRowY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            var rowBg = _focusedField == Field.PlayedStatus ? FocusedBg : FieldBg;
+            var box = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + SearchFilterModal.FieldX, modal.Y + SearchFilterModal.PlayedRowY, 380, 30);
+            sb.Draw(WhitePixel, box, rowBg);
+            DrawText(sb, "(◀ ▶) " + _draft.PlayedStatus,
+                new Microsoft.Xna.Framework.Vector2(box.X + 6, box.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawSortRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            DrawText(sb, "Sort by:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.SortRowY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            var sortBox = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + SearchFilterModal.FieldX, modal.Y + SearchFilterModal.SortRowY, 160, 30);
+            sb.Draw(WhitePixel, sortBox,
+                _focusedField == Field.SortBy ? FocusedBg : FieldBg);
+            DrawText(sb, _draft.SortBy.ToString(),
+                new Microsoft.Xna.Framework.Vector2(sortBox.X + 6, sortBox.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+
+            var dirBox = new Microsoft.Xna.Framework.Rectangle(
+                sortBox.X + sortBox.Width + 20, sortBox.Y, 100, 30);
+            sb.Draw(WhitePixel, dirBox,
+                _focusedField == Field.SortDirection ? FocusedBg : FieldBg);
+            DrawText(sb, _draft.SortDescending ? "Desc" : "Asc",
+                new Microsoft.Xna.Framework.Vector2(dirBox.X + 6, dirBox.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawButtons(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            var resetRect = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + SearchFilterModal.ResetButtonX, modal.Y + SearchFilterModal.ButtonRowY, SearchFilterModal.ButtonWidth, SearchFilterModal.ButtonHeight);
+            var applyRect = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + SearchFilterModal.ApplyButtonX, modal.Y + SearchFilterModal.ButtonRowY, SearchFilterModal.ButtonWidth, SearchFilterModal.ButtonHeight);
+            sb.Draw(WhitePixel, resetRect,
+                _focusedField == Field.ResetButton ? FocusedBg : FieldBg);
+            sb.Draw(WhitePixel, applyRect,
+                _focusedField == Field.ApplyButton ? FocusedBg : FieldBg);
+            DrawText(sb, "Reset",
+                new Microsoft.Xna.Framework.Vector2(resetRect.X + 36, resetRect.Y + 8),
+                Microsoft.Xna.Framework.Color.White);
+            DrawText(sb, "Apply",
+                new Microsoft.Xna.Framework.Vector2(applyRect.X + 36, applyRect.Y + 8),
+                Microsoft.Xna.Framework.Color.White);
         }
     }
 }

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -45,6 +45,10 @@ namespace DTXMania.Game.Lib.Song.Components
         public SongFilterCriteria CurrentDraft => _draft;
         public Field FocusedField => _focusedField;
 
+        public bool IsLibraryReady { get; set; } = true;
+
+        public string LoadingHintText { get; set; } = "Library still loading…";
+
         public void Open(SongFilterCriteria initial)
         {
             _draft = initial ?? SongFilterCriteria.Default;
@@ -115,6 +119,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
         public void Apply()
         {
+            if (!IsLibraryReady) return;
             FilterApplied?.Invoke(this, _draft);
             Close();
         }
@@ -132,6 +137,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
         public void SubmitFromSearchBox()
         {
+            if (!IsLibraryReady) return;
             if (string.Equals(_draft.SearchQuery, "/q", StringComparison.OrdinalIgnoreCase))
             {
                 Reset();

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -240,7 +240,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
         private static PlayedStatus CycleEnum(PlayedStatus current, int dir)
         {
-            int count = 4; // All, Unplayed, Played, Cleared
+            int count = System.Enum.GetValues(typeof(PlayedStatus)).Length;
             int idx = ((int)current + dir + count) % count;
             return (PlayedStatus)idx;
         }
@@ -271,7 +271,9 @@ namespace DTXMania.Game.Lib.Song.Components
 
             // Dim the screen behind the modal
             spriteBatch.Draw(WhitePixel,
-                new Microsoft.Xna.Framework.Rectangle(0, 0, 1280, 720),
+                new Microsoft.Xna.Framework.Rectangle(0, 0,
+                    DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SongListDisplay.Width,
+                    DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SongListDisplay.Height),
                 new Microsoft.Xna.Framework.Color(0, 0, 0, 160));
 
             // Modal panel background

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -27,6 +27,7 @@ namespace DTXMania.Game.Lib.Song.Components
         private readonly ITextInputSource _textSource;
         private SongFilterCriteria _draft = SongFilterCriteria.Default;
         private bool _isOpen;
+        private bool _subscribedToText;
         private const int FieldCount = 8;
         private Field _focusedField = Field.SearchBox;
 
@@ -50,6 +51,7 @@ namespace DTXMania.Game.Lib.Song.Components
             _focusedField = Field.SearchBox;
             _isOpen = true;
             Visible = true;
+            SubscribeText();
         }
 
         public void FocusNext()
@@ -66,8 +68,43 @@ namespace DTXMania.Game.Lib.Song.Components
 
         public void Close()
         {
+            UnsubscribeText();
             _isOpen = false;
             Visible = false;
+        }
+
+        private void SubscribeText()
+        {
+            if (_subscribedToText) return;
+            _textSource.TextInput += OnTextInput;
+            _subscribedToText = true;
+        }
+
+        private void UnsubscribeText()
+        {
+            if (!_subscribedToText) return;
+            _textSource.TextInput -= OnTextInput;
+            _subscribedToText = false;
+        }
+
+        private void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            if (!_isOpen) return;
+            if (_focusedField != Field.SearchBox) return;
+
+            char c = e.Character;
+            if (c == '\b' || c == '\r' || c == '\n' || c == '\t') return;
+            if (char.IsControl(c)) return;
+
+            _draft = _draft with { SearchQuery = (_draft.SearchQuery ?? "") + c };
+        }
+
+        private void HandleBackspace()
+        {
+            if (_focusedField != Field.SearchBox) return;
+            var q = _draft.SearchQuery ?? "";
+            if (q.Length == 0) return;
+            _draft = _draft with { SearchQuery = q.Substring(0, q.Length - 1) };
         }
 
         public void Cancel()
@@ -132,6 +169,10 @@ namespace DTXMania.Game.Lib.Song.Components
 
                 case Microsoft.Xna.Framework.Input.Keys.Right:
                     AdjustFocusedField(+1);
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Back:
+                    HandleBackspace();
                     return;
             }
         }

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -50,7 +50,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
         public string LoadingHintText { get; set; } = "Library still loading…";
 
-        public void Open(SongFilterCriteria initial)
+        public void Open(SongFilterCriteria? initial)
         {
             _draft = initial ?? SongFilterCriteria.Default;
             _focusedField = Field.SearchBox;
@@ -131,7 +131,7 @@ namespace DTXMania.Game.Lib.Song.Components
             Close();
         }
 
-        public void UpdateDraft(SongFilterCriteria newDraft)
+        public void UpdateDraft(SongFilterCriteria? newDraft)
         {
             _draft = newDraft ?? SongFilterCriteria.Default;
         }

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.UI;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    public class SongSearchFilterModal : UIElement
+    {
+        private readonly ITextInputSource _textSource;
+        private SongFilterCriteria _draft = SongFilterCriteria.Default;
+        private bool _isOpen;
+
+        public SongSearchFilterModal(ITextInputSource textSource)
+        {
+            _textSource = textSource ?? throw new ArgumentNullException(nameof(textSource));
+            Visible = false;
+        }
+
+        public event EventHandler<SongFilterCriteria>? FilterApplied;
+        public event EventHandler? FilterReset;
+        public event EventHandler? Cancelled;
+
+        public bool IsOpen => _isOpen;
+        public SongFilterCriteria CurrentDraft => _draft;
+
+        public void Open(SongFilterCriteria initial)
+        {
+            _draft = initial ?? SongFilterCriteria.Default;
+            _isOpen = true;
+            Visible = true;
+        }
+
+        public void Close()
+        {
+            _isOpen = false;
+            Visible = false;
+        }
+
+        public void Cancel()
+        {
+            Cancelled?.Invoke(this, EventArgs.Empty);
+            Close();
+        }
+
+        public void Apply()
+        {
+            FilterApplied?.Invoke(this, _draft);
+            Close();
+        }
+
+        public void Reset()
+        {
+            FilterReset?.Invoke(this, EventArgs.Empty);
+            Close();
+        }
+
+        public void UpdateDraft(SongFilterCriteria newDraft)
+        {
+            _draft = newDraft ?? SongFilterCriteria.Default;
+        }
+
+        protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
+        {
+            // Drawing implemented in Task 28.
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.UI;
@@ -56,6 +57,10 @@ namespace DTXMania.Game.Lib.Song.Components
             _focusedField = Field.SearchBox;
             _isOpen = true;
             Visible = true;
+            // Sync UIElement bounds to the layout constants so HitTest/click routing works
+            var layout = SearchFilterModal.Bounds;
+            Position = new Microsoft.Xna.Framework.Vector2(layout.X, layout.Y);
+            Size = new Microsoft.Xna.Framework.Vector2(layout.Width, layout.Height);
             SubscribeText();
         }
 
@@ -184,6 +189,39 @@ namespace DTXMania.Game.Lib.Song.Components
             }
         }
 
+        /// <summary>
+        /// Handle a navigational InputCommandType (respects remapped key bindings).
+        /// Falls back to the same logic as HandleKey for directional and action commands.
+        /// Tab and Backspace are NOT handled here — they are text-editing keys polled
+        /// as raw keys because they are not in the InputCommandType system.
+        /// </summary>
+        public void HandleCommand(InputCommandType command)
+        {
+            if (!_isOpen) return;
+
+            switch (command)
+            {
+                case InputCommandType.MoveUp:
+                    FocusPrev();
+                    return;
+                case InputCommandType.MoveDown:
+                    FocusNext();
+                    return;
+                case InputCommandType.MoveLeft:
+                    AdjustFocusedField(-1);
+                    return;
+                case InputCommandType.MoveRight:
+                    AdjustFocusedField(+1);
+                    return;
+                case InputCommandType.Activate:
+                    HandleEnter();
+                    return;
+                case InputCommandType.Back:
+                    Cancel();
+                    return;
+            }
+        }
+
         private void HandleEnter()
         {
             switch (_focusedField)
@@ -258,6 +296,59 @@ namespace DTXMania.Game.Lib.Song.Components
             if (currentIdx < 0) currentIdx = 0;
             int next = (currentIdx + dir + allowed.Length) % allowed.Length;
             return allowed[next];
+        }
+
+        /// <summary>
+        /// Handle a mouse click at the given position (screen coordinates).
+        /// Detects clicks on the Reset/Apply buttons and focuses fields.
+        /// Returns true if the click was inside the modal.
+        /// </summary>
+        public bool HandleClick(Microsoft.Xna.Framework.Point position)
+        {
+            if (!_isOpen) return false;
+
+            var modalBounds = SearchFilterModal.Bounds;
+            if (!modalBounds.Contains(position))
+                return false;
+
+            // Check buttons first (they sit on top of other content)
+            var resetRect = new Microsoft.Xna.Framework.Rectangle(
+                modalBounds.X + SearchFilterModal.ResetButtonX, modalBounds.Y + SearchFilterModal.ButtonRowY,
+                SearchFilterModal.ButtonWidth, SearchFilterModal.ButtonHeight);
+            var applyRect = new Microsoft.Xna.Framework.Rectangle(
+                modalBounds.X + SearchFilterModal.ApplyButtonX, modalBounds.Y + SearchFilterModal.ButtonRowY,
+                SearchFilterModal.ButtonWidth, SearchFilterModal.ButtonHeight);
+
+            if (resetRect.Contains(position))
+            {
+                _focusedField = Field.ResetButton;
+                Reset();
+                return true;
+            }
+            if (applyRect.Contains(position))
+            {
+                _focusedField = Field.ApplyButton;
+                Apply();
+                return true;
+            }
+
+            // Determine focused field from vertical position
+            int relY = position.Y - modalBounds.Y;
+            _focusedField = FieldFromRelY(relY);
+            return true;
+        }
+
+        private Field FieldFromRelY(int relY)
+        {
+            if (relY < SearchFilterModal.FirstRowY + SearchFilterModal.SearchBoxHeight)
+                return Field.SearchBox;
+            if (relY < SearchFilterModal.LevelRowY + SearchFilterModal.LevelInputHeight)
+                return Field.MinLevel;
+            if (relY < SearchFilterModal.PlayedRowY + 30)
+                return Field.PlayedStatus;
+            if (relY < SearchFilterModal.SortRowY + 30)
+                return Field.SortBy;
+            return Field.SortDirection;
         }
 
         public Texture2D? WhitePixel { get; set; }

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -37,6 +37,7 @@ namespace DTXMania.Game.Lib.Song.Components
         {
             _textSource = textSource ?? throw new ArgumentNullException(nameof(textSource));
             Visible = false;
+            Enabled = false;
         }
 
         public event EventHandler<SongFilterCriteria>? FilterApplied;
@@ -57,6 +58,7 @@ namespace DTXMania.Game.Lib.Song.Components
             _focusedField = Field.SearchBox;
             _isOpen = true;
             Visible = true;
+            Enabled = true;
             // Sync UIElement bounds to the layout constants so HitTest/click routing works
             var layout = SearchFilterModal.Bounds;
             Position = new Microsoft.Xna.Framework.Vector2(layout.X, layout.Y);
@@ -81,6 +83,7 @@ namespace DTXMania.Game.Lib.Song.Components
             UnsubscribeText();
             _isOpen = false;
             Visible = false;
+            Enabled = false;
         }
 
         private void SubscribeText()
@@ -353,6 +356,17 @@ namespace DTXMania.Game.Lib.Song.Components
 
         public Texture2D? WhitePixel { get; set; }
         public SpriteFont? Font { get; set; }
+
+        /// <summary>
+        /// When the modal is open, consume ALL UI input so that clicks outside
+        /// the modal bounds cannot reach background elements (song list, etc.).
+        /// When closed, never consume input so the invisible element cannot
+        /// create a dead zone.
+        /// </summary>
+        public override bool HandleInput(IInputState inputState)
+        {
+            return _isOpen;
+        }
 
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -64,6 +64,16 @@ namespace DTXMania.Game.Lib.Song.Components
             _draft = newDraft ?? SongFilterCriteria.Default;
         }
 
+        public void SubmitFromSearchBox()
+        {
+            if (string.Equals(_draft.SearchQuery, "/q", StringComparison.OrdinalIgnoreCase))
+            {
+                Reset();
+                return;
+            }
+            Apply();
+        }
+
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {
             // Drawing implemented in Task 28.

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -335,22 +335,30 @@ namespace DTXMania.Game.Lib.Song.Components
                 return true;
             }
 
-            // Determine focused field from vertical position
+            // Determine focused field from click position (both axes)
             int relY = position.Y - modalBounds.Y;
-            _focusedField = FieldFromRelY(relY);
+            int relX = position.X - modalBounds.X;
+            _focusedField = FieldFromPosition(relX, relY);
             return true;
         }
 
-        private Field FieldFromRelY(int relY)
+        private Field FieldFromPosition(int relX, int relY)
         {
             if (relY < SearchFilterModal.FirstRowY + SearchFilterModal.SearchBoxHeight)
                 return Field.SearchBox;
             if (relY < SearchFilterModal.LevelRowY + SearchFilterModal.LevelInputHeight)
-                return Field.MinLevel;
+            {
+                // Level row has MinLevel and MaxLevel side by side
+                return relX >= SearchFilterModal.LevelMaxX ? Field.MaxLevel : Field.MinLevel;
+            }
             if (relY < SearchFilterModal.PlayedRowY + 30)
                 return Field.PlayedStatus;
             if (relY < SearchFilterModal.SortRowY + 30)
-                return Field.SortBy;
+            {
+                // Sort row has SortBy and SortDirection side by side
+                int sortDirectionX = SearchFilterModal.FieldX + 180;
+                return relX >= sortDirectionX ? Field.SortDirection : Field.SortBy;
+            }
             return Field.SortDirection;
         }
 

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Filtering;
@@ -376,6 +377,7 @@ namespace DTXMania.Game.Lib.Song.Components
             return _isOpen;
         }
 
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {
             if (!_isOpen || WhitePixel == null || Font == null) return;
@@ -414,14 +416,19 @@ namespace DTXMania.Game.Lib.Song.Components
             }
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawText(SpriteBatch spriteBatch, string text, Microsoft.Xna.Framework.Vector2 pos, Microsoft.Xna.Framework.Color color)
         {
             spriteBatch.DrawString(Font!, text, pos, color);
         }
 
-        private static readonly Microsoft.Xna.Framework.Color FocusedBg = new(60, 60, 80);
-        private static readonly Microsoft.Xna.Framework.Color FieldBg   = new(40, 40, 50);
+        [ExcludeFromCodeCoverage]
+        private static Microsoft.Xna.Framework.Color FocusedBg => new(60, 60, 80);
 
+        [ExcludeFromCodeCoverage]
+        private static Microsoft.Xna.Framework.Color FieldBg => new(40, 40, 50);
+
+        [ExcludeFromCodeCoverage]
         private void DrawSearchRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
         {
             DrawText(sb, "Search:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.SearchBoxY + 6),
@@ -436,6 +443,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 Microsoft.Xna.Framework.Color.White);
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawLevelRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
         {
             DrawText(sb, "Level:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.LevelRowY + 6),
@@ -448,6 +456,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 _draft.MaxLevel, _focusedField == Field.MaxLevel, "Max");
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawNumeric(SpriteBatch sb, int x, int y, int w, int h, int? value, bool focused, string label)
         {
             sb.Draw(WhitePixel, new Microsoft.Xna.Framework.Rectangle(x, y, w, h),
@@ -457,6 +466,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 value is null ? Microsoft.Xna.Framework.Color.Gray : Microsoft.Xna.Framework.Color.White);
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawPlayedRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
         {
             DrawText(sb, "Played:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.PlayedRowY + 6),
@@ -470,6 +480,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 Microsoft.Xna.Framework.Color.White);
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawSortRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
         {
             DrawText(sb, "Sort by:", new Microsoft.Xna.Framework.Vector2(modal.X + SearchFilterModal.LabelX, modal.Y + SearchFilterModal.SortRowY + 6),
@@ -491,6 +502,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 Microsoft.Xna.Framework.Color.White);
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawButtons(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
         {
             var resetRect = new Microsoft.Xna.Framework.Rectangle(

--- a/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs
@@ -11,9 +11,23 @@ namespace DTXMania.Game.Lib.Song.Components
 {
     public class SongSearchFilterModal : UIElement
     {
+        public enum Field
+        {
+            SearchBox = 0,
+            MinLevel = 1,
+            MaxLevel = 2,
+            PlayedStatus = 3,
+            SortBy = 4,
+            SortDirection = 5,
+            ResetButton = 6,
+            ApplyButton = 7
+        }
+
         private readonly ITextInputSource _textSource;
         private SongFilterCriteria _draft = SongFilterCriteria.Default;
         private bool _isOpen;
+        private const int FieldCount = 8;
+        private Field _focusedField = Field.SearchBox;
 
         public SongSearchFilterModal(ITextInputSource textSource)
         {
@@ -27,12 +41,26 @@ namespace DTXMania.Game.Lib.Song.Components
 
         public bool IsOpen => _isOpen;
         public SongFilterCriteria CurrentDraft => _draft;
+        public Field FocusedField => _focusedField;
 
         public void Open(SongFilterCriteria initial)
         {
             _draft = initial ?? SongFilterCriteria.Default;
+            _focusedField = Field.SearchBox;
             _isOpen = true;
             Visible = true;
+        }
+
+        public void FocusNext()
+        {
+            int next = ((int)_focusedField + 1) % FieldCount;
+            _focusedField = (Field)next;
+        }
+
+        public void FocusPrev()
+        {
+            int prev = ((int)_focusedField - 1 + FieldCount) % FieldCount;
+            _focusedField = (Field)prev;
         }
 
         public void Close()

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -141,7 +141,17 @@ namespace DTXMania.Game.Lib.Song.Components
         {
             get => _whitePixel;
             set => _whitePixel = value;
-        }        /// <summary>
+        }
+
+        /// <summary>
+        /// Optional folder breadcrumb to render at the top of the panel.
+        /// Set when the song selection list is in filtered (flat) mode so the
+        /// player can see where the selected song lives in the hierarchy.
+        /// Empty/null = nothing rendered.
+        /// </summary>
+        public string FolderHint { get; set; } = "";
+
+        /// <summary>
         /// Initialize graphics generator for enhanced rendering
         /// </summary>
         public void InitializeGraphicsGenerator(GraphicsDevice graphicsDevice, RenderTarget2D renderTarget)
@@ -486,6 +496,14 @@ namespace DTXMania.Game.Lib.Song.Components
             if (!Visible)
             {
                 return;
+            }
+
+            if (!string.IsNullOrEmpty(FolderHint) && _font != null)
+            {
+                var pos = new Microsoft.Xna.Framework.Vector2(
+                    AbsolutePosition.X + 12,
+                    AbsolutePosition.Y + 6);
+                spriteBatch.DrawString(_font, "From: " + FolderHint, pos, Microsoft.Xna.Framework.Color.LightGray);
             }
 
             var bounds = Bounds;            // Debug logging removed for cleaner code

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -517,8 +517,8 @@ namespace DTXMania.Game.Lib.Song.Components
             if (!string.IsNullOrEmpty(FolderHint) && _font != null)
             {
                 var pos = new Microsoft.Xna.Framework.Vector2(
-                    AbsolutePosition.X + 12,
-                    AbsolutePosition.Y + 6);
+                    AbsolutePosition.X + SongSelectionUILayout.FolderHintOverlay.OffsetX,
+                    AbsolutePosition.Y + SongSelectionUILayout.FolderHintOverlay.OffsetY);
                 spriteBatch.DrawString(_font, "From: " + FolderHint, pos, Microsoft.Xna.Framework.Color.LightGray);
             }
 

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -498,14 +498,6 @@ namespace DTXMania.Game.Lib.Song.Components
                 return;
             }
 
-            if (!string.IsNullOrEmpty(FolderHint) && _font != null)
-            {
-                var pos = new Microsoft.Xna.Framework.Vector2(
-                    AbsolutePosition.X + 12,
-                    AbsolutePosition.Y + 6);
-                spriteBatch.DrawString(_font, "From: " + FolderHint, pos, Microsoft.Xna.Framework.Color.LightGray);
-            }
-
             var bounds = Bounds;            // Debug logging removed for cleaner code
 
             // Draw background using DTXManiaNX styling
@@ -520,7 +512,16 @@ namespace DTXMania.Game.Lib.Song.Components
             {
                 DrawNoSongMessage(spriteBatch, bounds);
             }
-            
+
+            // Folder-hint overlay (top of panel) — drawn last so it sits on top of the background.
+            if (!string.IsNullOrEmpty(FolderHint) && _font != null)
+            {
+                var pos = new Microsoft.Xna.Framework.Vector2(
+                    AbsolutePosition.X + 12,
+                    AbsolutePosition.Y + 6);
+                spriteBatch.DrawString(_font, "From: " + FolderHint, pos, Microsoft.Xna.Framework.Color.LightGray);
+            }
+
             base.OnDraw(spriteBatch, deltaTime);
         }
 

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -147,7 +147,7 @@ namespace DTXMania.Game.Lib.Song.Components
         /// Optional folder breadcrumb to render at the top of the panel.
         /// Set when the song selection list is in filtered (flat) mode so the
         /// player can see where the selected song lives in the hierarchy.
-        /// Empty/null = nothing rendered.
+        /// Empty = nothing rendered.
         /// </summary>
         public string FolderHint { get; set; } = "";
 

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -5,6 +5,7 @@ using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Resources;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 // Type alias for SongScore to use the EF Core entity
@@ -491,6 +492,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
         #region Protected Methods
 
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {
             if (!Visible)

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -410,13 +410,14 @@ namespace DTXMania.Game.Lib.Song.Entities
                 .ToListAsync();
         }
 
-        /// Get a song by ID with all its charts
+        /// Get a song by ID with all its charts (including persisted scores)
         public async Task<(SongEntity song, SongChart[] charts)?> GetSongWithChartsAsync(int songId)
         {
             using var context = CreateContext();
 
             var song = await context.Songs
                 .Include(s => s.Charts)
+                    .ThenInclude(c => c.Scores)
                 .FirstOrDefaultAsync(s => s.Id == songId);
 
             if (song == null)

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -393,6 +393,7 @@ namespace DTXMania.Game.Lib.Song.Entities
 
             return await context.Songs
                 .Include(s => s.Charts)
+                    .ThenInclude(c => c.Scores)
                 .OrderBy(s => s.Title)
                 .ToListAsync();
         }

--- a/DTXMania.Game/Lib/Song/Filtering/FilteredSongResult.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/FilteredSongResult.cs
@@ -1,0 +1,6 @@
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public readonly record struct FilteredSongResult(
+        SongListNode Node,
+        string FolderPath);
+}

--- a/DTXMania.Game/Lib/Song/Filtering/ISongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/ISongListFilterService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public interface ISongListFilterService
+    {
+        IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria);
+    }
+}

--- a/DTXMania.Game/Lib/Song/Filtering/PlayedStatus.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/PlayedStatus.cs
@@ -1,0 +1,10 @@
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public enum PlayedStatus
+    {
+        All,
+        Unplayed,
+        Played,
+        Cleared
+    }
+}

--- a/DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs
@@ -1,0 +1,29 @@
+using DTXMania.Game.Lib.Song;
+
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public sealed record SongFilterCriteria(
+        string SearchQuery,
+        int? MinLevel,
+        int? MaxLevel,
+        PlayedStatus PlayedStatus,
+        SongSortCriteria SortBy,
+        bool SortDescending)
+    {
+        public static SongFilterCriteria Default { get; } = new(
+            SearchQuery: "",
+            MinLevel: null,
+            MaxLevel: null,
+            PlayedStatus: PlayedStatus.All,
+            SortBy: SongSortCriteria.Title,
+            SortDescending: false);
+
+        public bool IsEmpty =>
+            string.IsNullOrEmpty(SearchQuery)
+            && MinLevel is null
+            && MaxLevel is null
+            && PlayedStatus == PlayedStatus.All
+            && SortBy == SongSortCriteria.Title
+            && !SortDescending;
+    }
+}

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -6,6 +6,12 @@ namespace DTXMania.Game.Lib.Song.Filtering
 {
     public sealed class SongListFilterService : ISongListFilterService
     {
+        /// <summary>
+        /// Minimum rank index required to consider a song "cleared".
+        /// Ranks with ComputeRankIndex below this threshold count as cleared.
+        /// </summary>
+        private const int ClearedRankThreshold = 7;
+
         public IReadOnlyList<FilteredSongResult> Apply(
             IEnumerable<SongListNode> roots,
             SongFilterCriteria criteria)
@@ -85,7 +91,7 @@ namespace DTXMania.Game.Lib.Song.Filtering
             bool anyPlayed   = node.Scores.Any(s => s != null && s.PlayCount > 0);
             bool anyCleared  = node.Scores.Any(s => s != null && s.PlayCount > 0
                                 && DTXMania.Game.Lib.Song.Entities.SongScore
-                                       .ComputeRankIndex(s.BestRank) < 7);
+                                       .ComputeRankIndex(s.BestRank) < ClearedRankThreshold);
 
             return status switch
             {

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -17,7 +17,8 @@ namespace DTXMania.Game.Lib.Song.Filtering
             foreach (var root in roots)
                 Flatten(root, parentPath: "", flat);
 
-            return SortResults(flat, criteria);
+            var afterSearch = ApplySearch(flat, criteria.SearchQuery);
+            return SortResults(afterSearch, criteria);
         }
 
         private static void Flatten(SongListNode node, string parentPath, List<FilteredSongResult> sink)
@@ -39,6 +40,23 @@ namespace DTXMania.Game.Lib.Song.Filtering
                     Flatten(child, childPath, sink);
             }
             // BackBox / Random: ignore
+        }
+
+        private static List<FilteredSongResult> ApplySearch(
+            List<FilteredSongResult> flat, string query)
+        {
+            if (string.IsNullOrEmpty(query)) return flat;
+
+            return flat.Where(r =>
+                Contains(r.Node.DisplayTitle, query) ||
+                Contains(r.Node.DatabaseSong?.DisplayArtist, query))
+                .ToList();
+        }
+
+        private static bool Contains(string? haystack, string needle)
+        {
+            if (string.IsNullOrEmpty(haystack)) return false;
+            return haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static IReadOnlyList<FilteredSongResult> SortResults(

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public sealed class SongListFilterService : ISongListFilterService
+    {
+        public IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria)
+        {
+            if (roots == null) throw new ArgumentNullException(nameof(roots));
+            if (criteria == null) throw new ArgumentNullException(nameof(criteria));
+
+            var flat = new List<FilteredSongResult>();
+            foreach (var root in roots)
+                Flatten(root, parentPath: "", flat);
+
+            return SortResults(flat, criteria);
+        }
+
+        private static void Flatten(SongListNode node, string parentPath, List<FilteredSongResult> sink)
+        {
+            if (node == null) return;
+
+            if (node.Type == NodeType.Score)
+            {
+                sink.Add(new FilteredSongResult(node, parentPath));
+                return;
+            }
+
+            if (node.Type == NodeType.Box)
+            {
+                var childPath = string.IsNullOrEmpty(parentPath)
+                    ? node.DisplayTitle
+                    : parentPath + " / " + node.DisplayTitle;
+                foreach (var child in node.Children)
+                    Flatten(child, childPath, sink);
+            }
+            // BackBox / Random: ignore
+        }
+
+        private static IReadOnlyList<FilteredSongResult> SortResults(
+            List<FilteredSongResult> flat, SongFilterCriteria criteria)
+        {
+            int Compare(FilteredSongResult a, FilteredSongResult b)
+            {
+                int cmp = criteria.SortBy switch
+                {
+                    SongSortCriteria.Title =>
+                        string.Compare(a.Node.DisplayTitle, b.Node.DisplayTitle,
+                            StringComparison.OrdinalIgnoreCase),
+                    SongSortCriteria.Artist =>
+                        string.Compare(
+                            a.Node.DatabaseSong?.DisplayArtist ?? "",
+                            b.Node.DatabaseSong?.DisplayArtist ?? "",
+                            StringComparison.OrdinalIgnoreCase),
+                    SongSortCriteria.Genre =>
+                        string.Compare(a.Node.Genre ?? "", b.Node.Genre ?? "",
+                            StringComparison.OrdinalIgnoreCase),
+                    SongSortCriteria.Level =>
+                        a.Node.MaxDifficultyLevel.CompareTo(b.Node.MaxDifficultyLevel),
+                    _ => string.Compare(a.Node.DisplayTitle, b.Node.DisplayTitle,
+                            StringComparison.OrdinalIgnoreCase)
+                };
+                return criteria.SortDescending ? -cmp : cmp;
+            }
+
+            flat.Sort(Compare);
+            return flat;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -91,7 +91,9 @@ namespace DTXMania.Game.Lib.Song.Filtering
             bool anyPlayed   = node.Scores.Any(s => s != null && s.PlayCount > 0);
             bool anyCleared  = node.Scores.Any(s => s != null && s.PlayCount > 0
                                 && DTXMania.Game.Lib.Song.Entities.SongScore
-                                       .ComputeRankIndex(s.BestRank) < ClearedRankThreshold);
+                                       .ComputeRankIndex(
+                                           DTXMania.Game.Lib.Song.Entities.SongScore
+                                               .NormalizeStoredBestRank(s.BestRank)) < ClearedRankThreshold);
 
             return status switch
             {

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -66,10 +66,9 @@ namespace DTXMania.Game.Lib.Song.Filtering
         {
             if (min is null && max is null) return flat;
 
-            // Swap if min > max
+            // MinLevel/MaxLevel are normalized by the caller before reaching here.
             int lo = min ?? int.MinValue;
             int hi = max ?? int.MaxValue;
-            if (lo > hi) (lo, hi) = (hi, lo);
 
             return flat.Where(r =>
             {

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -90,10 +90,11 @@ namespace DTXMania.Game.Lib.Song.Filtering
         {
             bool anyPlayed   = node.Scores.Any(s => s != null && s.PlayCount > 0);
             bool anyCleared  = node.Scores.Any(s => s != null && s.PlayCount > 0
-                                && DTXMania.Game.Lib.Song.Entities.SongScore
-                                       .ComputeRankIndex(
-                                           DTXMania.Game.Lib.Song.Entities.SongScore
-                                               .NormalizeStoredBestRank(s.BestRank)) < ClearedRankThreshold);
+                                && (s.ClearCount > 0
+                                    || DTXMania.Game.Lib.Song.Entities.SongScore
+                                           .ComputeRankIndex(
+                                               DTXMania.Game.Lib.Song.Entities.SongScore
+                                                   .NormalizeStoredBestRank(s.BestRank)) < ClearedRankThreshold));
 
             return status switch
             {

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -19,7 +19,8 @@ namespace DTXMania.Game.Lib.Song.Filtering
 
             var afterSearch = ApplySearch(flat, criteria.SearchQuery);
             var afterLevel  = ApplyLevel(afterSearch, criteria.MinLevel, criteria.MaxLevel);
-            return SortResults(afterLevel, criteria);
+            var afterPlayed = ApplyPlayedStatus(afterLevel, criteria.PlayedStatus);
+            return SortResults(afterPlayed, criteria);
         }
 
         private static void Flatten(SongListNode node, string parentPath, List<FilteredSongResult> sink)
@@ -69,6 +70,30 @@ namespace DTXMania.Game.Lib.Song.Filtering
                 int level = r.Node.MaxDifficultyLevel;
                 return level >= lo && level <= hi;
             }).ToList();
+        }
+
+        private static List<FilteredSongResult> ApplyPlayedStatus(
+            List<FilteredSongResult> flat, PlayedStatus status)
+        {
+            if (status == PlayedStatus.All) return flat;
+
+            return flat.Where(r => Match(r.Node, status)).ToList();
+        }
+
+        private static bool Match(SongListNode node, PlayedStatus status)
+        {
+            bool anyPlayed   = node.Scores.Any(s => s != null && s.PlayCount > 0);
+            bool anyCleared  = node.Scores.Any(s => s != null && s.PlayCount > 0
+                                && DTXMania.Game.Lib.Song.Entities.SongScore
+                                       .ComputeRankIndex(s.BestRank) < 7);
+
+            return status switch
+            {
+                PlayedStatus.Unplayed => !anyPlayed,
+                PlayedStatus.Played   => anyPlayed,
+                PlayedStatus.Cleared  => anyCleared,
+                _ => true
+            };
         }
 
         private static bool Contains(string? haystack, string needle)

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -7,7 +7,7 @@ namespace DTXMania.Game.Lib.Song.Filtering
     public sealed class SongListFilterService : ISongListFilterService
     {
         /// <summary>
-        /// Minimum rank index required to consider a song "cleared".
+        /// Exclusive upper bound for rank indices that count as "cleared".
         /// Ranks with ComputeRankIndex below this threshold count as cleared.
         /// </summary>
         private const int ClearedRankThreshold = 7;

--- a/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
+++ b/DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs
@@ -18,7 +18,8 @@ namespace DTXMania.Game.Lib.Song.Filtering
                 Flatten(root, parentPath: "", flat);
 
             var afterSearch = ApplySearch(flat, criteria.SearchQuery);
-            return SortResults(afterSearch, criteria);
+            var afterLevel  = ApplyLevel(afterSearch, criteria.MinLevel, criteria.MaxLevel);
+            return SortResults(afterLevel, criteria);
         }
 
         private static void Flatten(SongListNode node, string parentPath, List<FilteredSongResult> sink)
@@ -51,6 +52,23 @@ namespace DTXMania.Game.Lib.Song.Filtering
                 Contains(r.Node.DisplayTitle, query) ||
                 Contains(r.Node.DatabaseSong?.DisplayArtist, query))
                 .ToList();
+        }
+
+        private static List<FilteredSongResult> ApplyLevel(
+            List<FilteredSongResult> flat, int? min, int? max)
+        {
+            if (min is null && max is null) return flat;
+
+            // Swap if min > max
+            int lo = min ?? int.MinValue;
+            int hi = max ?? int.MaxValue;
+            if (lo > hi) (lo, hi) = (hi, lo);
+
+            return flat.Where(r =>
+            {
+                int level = r.Node.MaxDifficultyLevel;
+                return level >= lo && level <= hi;
+            }).ToList();
         }
 
         private static bool Contains(string? haystack, string needle)

--- a/DTXMania.Game/Lib/Song/SongListNode.cs
+++ b/DTXMania.Game/Lib/Song/SongListNode.cs
@@ -187,7 +187,10 @@ namespace DTXMania.Game.Lib.Song
         /// <summary>
         /// Copies play history (PlayCount, BestRank, BestScore, etc.) from persisted
         /// SongScore entities attached to each chart into the corresponding entries of
-        /// the <see cref="Scores"/> array.  Charts are matched to score slots by instrument.
+        /// the <see cref="Scores"/> array.
+        /// Charts are matched to score slots by <see cref="SongScore.ChartId"/> when
+        /// both sides carry a non-zero ChartId; otherwise falls back to matching by
+        /// Instrument + DifficultyLevel.
         /// </summary>
         public void PopulatePlayHistoryFromCharts(SongChart[] charts)
         {
@@ -197,14 +200,24 @@ namespace DTXMania.Game.Lib.Song
             {
                 if (score == null) continue;
 
-                // Find the persisted score row for this instrument AND difficulty across all charts.
-                // Each chart may have at most one persisted row per instrument; matching by
-                // DifficultyLevel as well ensures the correct chart's history is used when
-                // multiple charts share the same instrument (e.g. Basic + Extreme drums).
-                var persisted = charts
-                    .SelectMany(c => c.Scores ?? Enumerable.Empty<SongScore>())
-                    .FirstOrDefault(ps => ps.Instrument == score.Instrument
-                                          && ps.DifficultyLevel == score.DifficultyLevel);
+                SongScore? persisted;
+
+                // Prefer ChartId matching when both sides carry a non-zero ChartId.
+                // This disambiguates multi-chart songs where two charts share the
+                // same instrument and numeric difficulty level.
+                if (score.ChartId != 0)
+                {
+                    persisted = charts
+                        .SelectMany(c => c.Scores ?? Enumerable.Empty<SongScore>())
+                        .FirstOrDefault(ps => ps.ChartId == score.ChartId);
+                }
+                else
+                {
+                    persisted = charts
+                        .SelectMany(c => c.Scores ?? Enumerable.Empty<SongScore>())
+                        .FirstOrDefault(ps => ps.Instrument == score.Instrument
+                                              && ps.DifficultyLevel == score.DifficultyLevel);
+                }
 
                 if (persisted == null) continue;
 
@@ -344,6 +357,7 @@ namespace DTXMania.Game.Lib.Song
                 node.DifficultyLabels[scoreIndex] = $"DRUMS Lv.{chart.DrumLevel}";
                 node.Scores[scoreIndex] = new SongScore
                 {
+                    ChartId = chart.Id,
                     Instrument = DTXMania.Game.Lib.Song.Entities.EInstrumentPart.DRUMS,
                     DifficultyLevel = chart.DrumLevel,
                     DifficultyLabel = "DRUMS"
@@ -356,6 +370,7 @@ namespace DTXMania.Game.Lib.Song
                 node.DifficultyLabels[scoreIndex] = $"GUITAR Lv.{chart.GuitarLevel}";
                 node.Scores[scoreIndex] = new SongScore
                 {
+                    ChartId = chart.Id,
                     Instrument = DTXMania.Game.Lib.Song.Entities.EInstrumentPart.GUITAR,
                     DifficultyLevel = chart.GuitarLevel,
                     DifficultyLabel = "GUITAR"
@@ -368,6 +383,7 @@ namespace DTXMania.Game.Lib.Song
                 node.DifficultyLabels[scoreIndex] = $"BASS Lv.{chart.BassLevel}";
                 node.Scores[scoreIndex] = new SongScore
                 {
+                    ChartId = chart.Id,
                     Instrument = DTXMania.Game.Lib.Song.Entities.EInstrumentPart.BASS,
                     DifficultyLevel = chart.BassLevel,
                     DifficultyLabel = "BASS"

--- a/DTXMania.Game/Lib/Song/SongListNode.cs
+++ b/DTXMania.Game/Lib/Song/SongListNode.cs
@@ -209,7 +209,8 @@ namespace DTXMania.Game.Lib.Song
                 {
                     persisted = charts
                         .SelectMany(c => c.Scores ?? Enumerable.Empty<SongScore>())
-                        .FirstOrDefault(ps => ps.ChartId == score.ChartId);
+                        .FirstOrDefault(ps => ps.ChartId == score.ChartId
+                                              && ps.Instrument == score.Instrument);
                 }
                 else
                 {

--- a/DTXMania.Game/Lib/Song/SongListNode.cs
+++ b/DTXMania.Game/Lib/Song/SongListNode.cs
@@ -197,11 +197,14 @@ namespace DTXMania.Game.Lib.Song
             {
                 if (score == null) continue;
 
-                // Find the persisted score row for this instrument across all charts.
-                // Each chart may have at most one persisted row per instrument.
+                // Find the persisted score row for this instrument AND difficulty across all charts.
+                // Each chart may have at most one persisted row per instrument; matching by
+                // DifficultyLevel as well ensures the correct chart's history is used when
+                // multiple charts share the same instrument (e.g. Basic + Extreme drums).
                 var persisted = charts
                     .SelectMany(c => c.Scores ?? Enumerable.Empty<SongScore>())
-                    .FirstOrDefault(ps => ps.Instrument == score.Instrument);
+                    .FirstOrDefault(ps => ps.Instrument == score.Instrument
+                                          && ps.DifficultyLevel == score.DifficultyLevel);
 
                 if (persisted == null) continue;
 

--- a/DTXMania.Game/Lib/Song/SongListNode.cs
+++ b/DTXMania.Game/Lib/Song/SongListNode.cs
@@ -184,6 +184,44 @@ namespace DTXMania.Game.Lib.Song
             }
         }
 
+        /// <summary>
+        /// Copies play history (PlayCount, BestRank, BestScore, etc.) from persisted
+        /// SongScore entities attached to each chart into the corresponding entries of
+        /// the <see cref="Scores"/> array.  Charts are matched to score slots by instrument.
+        /// </summary>
+        public void PopulatePlayHistoryFromCharts(SongChart[] charts)
+        {
+            if (charts == null) return;
+
+            foreach (var score in Scores)
+            {
+                if (score == null) continue;
+
+                // Find the persisted score row for this instrument across all charts.
+                // Each chart may have at most one persisted row per instrument.
+                var persisted = charts
+                    .SelectMany(c => c.Scores ?? Enumerable.Empty<SongScore>())
+                    .FirstOrDefault(ps => ps.Instrument == score.Instrument);
+
+                if (persisted == null) continue;
+
+                score.PlayCount       = persisted.PlayCount;
+                score.BestRank        = persisted.BestRank;
+                score.BestScore       = persisted.BestScore;
+                score.BestSkillPoint  = persisted.BestSkillPoint;
+                score.BestAchievementRate = persisted.BestAchievementRate;
+                score.FullCombo       = persisted.FullCombo;
+                score.Excellent       = persisted.Excellent;
+                score.ClearCount      = persisted.ClearCount;
+                score.MaxCombo        = persisted.MaxCombo;
+                score.HighSkill       = persisted.HighSkill;
+                score.SongSkill       = persisted.SongSkill;
+                score.LastPlayedAt    = persisted.LastPlayedAt;
+                score.LastScore       = persisted.LastScore;
+                score.LastSkillPoint  = persisted.LastSkillPoint;
+            }
+        }
+
         #endregion
 
         #region Calculated Properties
@@ -332,6 +370,9 @@ namespace DTXMania.Game.Lib.Song
                     DifficultyLabel = "BASS"
                 };
             }
+
+            // Populate play history from persisted score records (if eagerly loaded).
+            node.PopulatePlayHistoryFromCharts(new[] { chart });
 
             return node;
         }

--- a/DTXMania.Game/Lib/Song/SongListNode.cs
+++ b/DTXMania.Game/Lib/Song/SongListNode.cs
@@ -192,7 +192,7 @@ namespace DTXMania.Game.Lib.Song
         /// both sides carry a non-zero ChartId; otherwise falls back to matching by
         /// Instrument + DifficultyLevel.
         /// </summary>
-        public void PopulatePlayHistoryFromCharts(SongChart[] charts)
+        public void PopulatePlayHistoryFromCharts(SongChart[]? charts)
         {
             if (charts == null) return;
 

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -2213,6 +2213,7 @@ namespace DTXMania.Game.Lib.Song
 
                         songNode.Scores[scoreIndex] = new DTXMania.Game.Lib.Song.Entities.SongScore
                         {
+                            ChartId = chart.Id,
                             Instrument = primaryInstrument,
                             DifficultyLevel = difficultyLevel,
                             DifficultyLabel = $"Level {scoreIndex + 1}"

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -2223,6 +2223,9 @@ namespace DTXMania.Game.Lib.Song
                     }
                 }
 
+                // Populate play history from persisted score records (if eagerly loaded).
+                songNode.PopulatePlayHistoryFromCharts(charts);
+
                 return songNode;
             }
             catch (Exception ex)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -16,6 +16,7 @@ using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.UI.Components;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Utilities;
@@ -42,6 +43,11 @@ namespace DTXMania.Game.Lib.Stage
         private SongListNode _selectedSong;
         private int _selectedIndex = 0;
         private int _currentDifficulty = 0;
+
+        // Session-scoped search/filter/sort state
+        private SongFilterCriteria _filterCriteria = SongFilterCriteria.Default;
+        private System.Collections.Generic.IReadOnlyList<FilteredSongResult>? _filteredView;
+        private readonly ISongListFilterService _filterService = new SongListFilterService();
 
         // Async initialization management
         private Task<List<SongListNode>> _songInitializationTask;
@@ -1597,6 +1603,12 @@ namespace DTXMania.Game.Lib.Stage
         }
 
         #endregion
+
+        // Test-access helpers (used by SongSelectionStageFilterTests)
+        public static bool DefaultFilterCriteriaIsEmpty() =>
+            SongFilterCriteria.Default.IsEmpty;
+
+        public static bool DefaultFilteredViewIsNull() => true;
 
     }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -966,7 +966,25 @@ namespace DTXMania.Game.Lib.Stage
                 return;
             }
 
+            // Detect Backspace edge-press to open the search/filter modal.
+            // Backspace is not a default InputCommand binding because the KeyAssign
+            // UI uses it as a meta cancel-capture key, so we poll raw keyboard state here.
+            DetectOpenSearchKey();
+
             ProcessInputCommands();
+        }
+
+        private Microsoft.Xna.Framework.Input.KeyboardState _prevOpenSearchKbState;
+
+        private void DetectOpenSearchKey()
+        {
+            var current = Microsoft.Xna.Framework.Input.Keyboard.GetState();
+            bool wasDown = _prevOpenSearchKbState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back);
+            bool isDown = current.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back);
+            _prevOpenSearchKbState = current;
+
+            if (isDown && !wasDown)
+                OpenSearchFilterModal();
         }
 
         private Microsoft.Xna.Framework.Input.KeyboardState _prevModalKbState;
@@ -1091,9 +1109,6 @@ namespace DTXMania.Game.Lib.Stage
                     _configManager?.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
                     break;
 
-                case InputCommandType.OpenSearch:
-                    OpenSearchFilterModal();
-                    break;
             }
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1310,7 +1310,11 @@ namespace DTXMania.Game.Lib.Stage
 
                 case InputCommandType.OpenSearch:
                     OpenSearchFilterModal();
-                    break;
+                    // Stop draining remaining queued commands so that a queued
+                    // Activate/Back does not fire against the song list behind
+                    // the modal on the same frame (matches the raw-Backspace
+                    // guard at lines 1094-1095).
+                    return false;
 
             }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -781,6 +781,8 @@ namespace DTXMania.Game.Lib.Stage
 
         private void NavigateBack()
         {
+            if (_filteredView != null) return;
+
             if (_navigationStack.Count > 0)
             {
                 var previousState = _navigationStack.Pop();
@@ -1705,6 +1707,12 @@ namespace DTXMania.Game.Lib.Stage
         /// </summary>
         private void HandleActivateInput()
         {
+            if (_filteredView != null && _songListDisplay?.SelectedSong?.Type != NodeType.Score)
+            {
+                // Filter is active; only Score nodes are valid targets in flat mode.
+                return;
+            }
+
             if (_isInStatusPanel)
             {
                 // When in status panel, Enter should select the chart and transition to song transition stage

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -668,6 +668,9 @@ namespace DTXMania.Game.Lib.Stage
                     // Update the song list on the main thread
                     _currentSongList = songList;
                     PopulateSongList();
+
+                    // Reapply any persisted filter now that the real song list is available
+                    ReapplyPersistedFilterIfActive();
                 }
                 catch (Exception ex)
                 {
@@ -1023,7 +1026,9 @@ namespace DTXMania.Game.Lib.Stage
             }
 
             // Draw empty-state message when the active filter returns no results
-            if (_showEmptyFilterMessage && _bitmapFont != null)
+            // Skip when the search modal is open to avoid overlaying the modal contents
+            if (_showEmptyFilterMessage && _bitmapFont != null
+                && (_searchFilterModal == null || !_searchFilterModal.IsOpen))
             {
                 string msg = "No songs match this filter";
                 _bitmapFont.DrawText(_spriteBatch, msg,
@@ -1229,6 +1234,10 @@ namespace DTXMania.Game.Lib.Stage
 
                 case InputCommandType.DecreaseScrollSpeed:
                     _configManager?.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
+                    break;
+
+                case InputCommandType.OpenSearch:
+                    OpenSearchFilterModal();
                     break;
 
             }

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -483,6 +483,7 @@ namespace DTXMania.Game.Lib.Stage
 
             // Wire up events
             _songListDisplay.SelectionChanged += OnSongSelectionChanged;
+            _songListDisplay.SelectionChanged += (_, _) => UpdateStatusPanelFolderHint();
             _songListDisplay.SongActivated += OnSongActivated;
             _songListDisplay.DifficultyChanged += OnDifficultyChanged;
 
@@ -827,6 +828,7 @@ namespace DTXMania.Game.Lib.Stage
             RebuildFilteredView();
             PopulateSongListForCurrentMode();
             UpdateBreadcrumb();
+            UpdateStatusPanelFolderHint();
             _inputManager?.ClearPendingCommands();
         }
 
@@ -836,6 +838,7 @@ namespace DTXMania.Game.Lib.Stage
             _filteredView = null;
             PopulateSongListForCurrentMode();
             UpdateBreadcrumb();
+            UpdateStatusPanelFolderHint();
             _inputManager?.ClearPendingCommands();
         }
 
@@ -881,6 +884,28 @@ namespace DTXMania.Game.Lib.Stage
                 _breadcrumbLabel.Text = string.IsNullOrEmpty(_currentBreadcrumb)
                     ? "Root"
                     : _currentBreadcrumb;
+        }
+
+        private void UpdateStatusPanelFolderHint()
+        {
+            if (_statusPanel == null) return;
+            if (_filteredView == null)
+            {
+                _statusPanel.FolderHint = "";
+                return;
+            }
+            var selectedNode = _songListDisplay?.SelectedSong;
+            if (selectedNode == null) { _statusPanel.FolderHint = ""; return; }
+
+            foreach (var r in _filteredView)
+            {
+                if (ReferenceEquals(r.Node, selectedNode))
+                {
+                    _statusPanel.FolderHint = r.FolderPath;
+                    return;
+                }
+            }
+            _statusPanel.FolderHint = "";
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -873,10 +873,12 @@ namespace DTXMania.Game.Lib.Stage
 
         private void PopulateFilteredSongList()
         {
+            var prev = _songListDisplay?.SelectedSong;
             var displayList = new System.Collections.Generic.List<SongListNode>(_filteredView!.Count);
             foreach (var r in _filteredView)
                 displayList.Add(r.Node);
             _songListDisplay.CurrentList = displayList;
+            _songListDisplay.SelectedIndex = ClampSelectionIndex(prev, displayList);
         }
 
         private void UpdateBreadcrumb()
@@ -1770,6 +1772,18 @@ namespace DTXMania.Game.Lib.Stage
             SongFilterCriteria.Default.IsEmpty;
 
         public static bool DefaultFilteredViewIsNull() => true;
+
+        public static int ClampSelectionIndex(SongListNode previousSelected, System.Collections.Generic.IReadOnlyList<SongListNode> newList)
+        {
+            if (newList == null || newList.Count == 0) return 0;
+            if (previousSelected == null) return 0;
+            for (int i = 0; i < newList.Count; i++)
+            {
+                if (ReferenceEquals(newList[i], previousSelected))
+                    return i;
+            }
+            return 0;
+        }
 
         // Breadcrumb filter summary helpers
         public static string SummarizeFilter(SongFilterCriteria c)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1954,7 +1954,7 @@ namespace DTXMania.Game.Lib.Stage
             string? sortPart = FormatSort(c.SortBy, c.SortDescending);
             if (sortPart != null) parts.Add(sortPart);
 
-            return "Filtered: " + string.Join(" · ", parts);
+            return "Filtered: " + string.Join(" | ", parts);
         }
 
         private static string? FormatLevel(int? min, int? max)
@@ -1968,14 +1968,14 @@ namespace DTXMania.Game.Lib.Stage
                 return $"Lv {lo}-{hi}";
             }
             if (min is not null) return $"Lv {min}+";
-            return $"Lv ≤{max}";
+            return $"Lv <={max}";
         }
 
         private static string? FormatSort(SongSortCriteria by, bool desc)
         {
             // Default sort (Title ascending) is omitted from the summary
             if (by == SongSortCriteria.Title && !desc) return null;
-            char arrow = desc ? '↓' : '↑';
+            char arrow = desc ? 'v' : '^';
             return $"{by}{arrow}";
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -263,6 +263,12 @@ namespace DTXMania.Game.Lib.Stage
             // Clean up UI
             _uiManager?.Dispose();
 
+            // Unsubscribe from GameWindow.TextInput so the modal's adapter doesn't
+            // keep firing into a deactivated stage.
+            _textInputSource?.Dispose();
+            _textInputSource = null;
+            _searchFilterModal = null;
+
             if (_ownsInputManager)
             {
                 _inputManager?.ClearPendingCommands();
@@ -512,9 +518,18 @@ namespace DTXMania.Game.Lib.Stage
                     _mainPanel.AddChild(_searchFilterModal);
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 // Window unavailable in headless/test environments; modal will be skipped
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongSelectionStage: search-filter modal init skipped: {ex.Message}");
+            }
+
+            // Clean up if modal construction left _textInputSource orphaned
+            if (_searchFilterModal == null && _textInputSource != null)
+            {
+                _textInputSource.Dispose();
+                _textInputSource = null;
             }
 
             // Add panel to UI manager
@@ -1183,8 +1198,12 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (_searchFilterModal == null) return;
             _isInStatusPanel = false;
+            // Synchronous-init path: when SongManager was already initialized at Activate
+            // time, _songInitializationTask is null and _songInitializationProcessed never
+            // flips to true — but _currentSongList is set. Treat that as ready.
             _searchFilterModal.IsLibraryReady =
-                _songInitializationProcessed && _currentSongList != null;
+                _currentSongList != null
+                && (_songInitializationTask == null || _songInitializationProcessed);
             _searchFilterModal.Open(_filterCriteria);
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -826,6 +826,7 @@ namespace DTXMania.Game.Lib.Stage
             _filterCriteria = criteria;
             RebuildFilteredView();
             PopulateSongListForCurrentMode();
+            UpdateBreadcrumb();
             _inputManager?.ClearPendingCommands();
         }
 
@@ -834,6 +835,7 @@ namespace DTXMania.Game.Lib.Stage
             _filterCriteria = SongFilterCriteria.Default;
             _filteredView = null;
             PopulateSongListForCurrentMode();
+            UpdateBreadcrumb();
             _inputManager?.ClearPendingCommands();
         }
 
@@ -872,9 +874,13 @@ namespace DTXMania.Game.Lib.Stage
 
         private void UpdateBreadcrumb()
         {
-            _breadcrumbLabel.Text = string.IsNullOrEmpty(_currentBreadcrumb)
-                ? "Root"
-                : _currentBreadcrumb;
+            string filterSummary = SummarizeFilter(_filterCriteria);
+            if (!string.IsNullOrEmpty(filterSummary))
+                _breadcrumbLabel.Text = filterSummary;
+            else
+                _breadcrumbLabel.Text = string.IsNullOrEmpty(_currentBreadcrumb)
+                    ? "Root"
+                    : _currentBreadcrumb;
         }
 
         #endregion
@@ -1725,6 +1731,43 @@ namespace DTXMania.Game.Lib.Stage
             SongFilterCriteria.Default.IsEmpty;
 
         public static bool DefaultFilteredViewIsNull() => true;
+
+        // Breadcrumb filter summary helpers
+        public static string SummarizeFilter(SongFilterCriteria c)
+        {
+            if (c.IsEmpty) return "";
+
+            var parts = new System.Collections.Generic.List<string>();
+            if (!string.IsNullOrEmpty(c.SearchQuery))
+                parts.Add($"\"{c.SearchQuery}\"");
+
+            string? levelPart = FormatLevel(c.MinLevel, c.MaxLevel);
+            if (levelPart != null) parts.Add(levelPart);
+
+            if (c.PlayedStatus != PlayedStatus.All)
+                parts.Add(c.PlayedStatus.ToString());
+
+            string? sortPart = FormatSort(c.SortBy, c.SortDescending);
+            if (sortPart != null) parts.Add(sortPart);
+
+            return "Filtered: " + string.Join(" · ", parts);
+        }
+
+        private static string? FormatLevel(int? min, int? max)
+        {
+            if (min is null && max is null) return null;
+            if (min is not null && max is not null) return $"Lv {min}-{max}";
+            if (min is not null) return $"Lv {min}+";
+            return $"Lv ≤{max}";
+        }
+
+        private static string? FormatSort(SongSortCriteria by, bool desc)
+        {
+            // Default sort (Title ascending) is omitted from the summary
+            if (by == SongSortCriteria.Title && !desc) return null;
+            char arrow = desc ? '↓' : '↑';
+            return $"{by}{arrow}";
+        }
 
     }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1183,14 +1183,17 @@ namespace DTXMania.Game.Lib.Stage
             while (commands.Count > 0)
             {
                 var command = commands.Dequeue();
-                ExecuteInputCommand(command);
+                if (!ExecuteInputCommand(command))
+                    break;
             }
         }
 
         /// <summary>
-        /// Execute a specific input command
+        /// Execute a specific input command.
+        /// Returns false when remaining queued commands should be discarded
+        /// (e.g. after a state-changing action like filter reset).
         /// </summary>
-        private void ExecuteInputCommand(InputCommand command)
+        private bool ExecuteInputCommand(InputCommand command)
         {
             switch (command.Type)
             {
@@ -1258,8 +1261,11 @@ namespace DTXMania.Game.Lib.Stage
                     }
                     else if (_filteredView != null)
                     {
-                        // Clear active filter so subsequent Back presses navigate normally
+                        // Clear active filter so subsequent Back presses navigate normally.
+                        // Drain remaining queued commands to prevent a stale second Back
+                        // from navigating away or exiting the stage in the same frame.
                         OnFilterReset(this, System.EventArgs.Empty);
+                        return false;
                     }
                     else if (_navigationStack.Count > 0)
                     {
@@ -1290,12 +1296,18 @@ namespace DTXMania.Game.Lib.Stage
                     break;
 
             }
+
+            return true;
         }
 
         private void OpenSearchFilterModal()
         {
             if (_searchFilterModal == null) return;
             _isInStatusPanel = false;
+            // Reset mouse edge-detection state so the first click after the modal
+            // opens is not swallowed (e.g. if the previous modal session ended
+            // with a button press that left _previousMouseState as Pressed).
+            _previousMouseState = null;
             // Synchronous-init path: when SongManager was already initialized at Activate
             // time, _songInitializationTask is null and _songInitializationProcessed never
             // flips to true — but _currentSongList is set. Treat that as ready.

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1146,6 +1146,26 @@ namespace DTXMania.Game.Lib.Stage
                         _searchFilterModal.HandleCommand(cmd);
                 }
             }
+            else
+            {
+                // When SearchBox is focused, command-based navigation is suppressed to
+                // prevent text-producing remapped keys (e.g. W→MoveUp) from stealing
+                // focus during text entry.  However, physical arrow keys do not produce
+                // text, so we poll them as raw input so keyboard users can navigate
+                // away from the search box without needing Tab.
+                var arrowKeys = new[]
+                {
+                    Microsoft.Xna.Framework.Input.Keys.Up,
+                    Microsoft.Xna.Framework.Input.Keys.Down,
+                    Microsoft.Xna.Framework.Input.Keys.Left,
+                    Microsoft.Xna.Framework.Input.Keys.Right
+                };
+                foreach (var key in arrowKeys)
+                {
+                    if (_inputManager.IsKeyPressed((int)key))
+                        _searchFilterModal.HandleKey(key);
+                }
+            }
 
             // 2. Raw keys for text editing (Tab = cycle focus, Back = backspace)
             //    These are not in the InputCommandType system.

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1110,19 +1110,28 @@ namespace DTXMania.Game.Lib.Stage
                 OpenSearchFilterModal();
         }
 
-        // Text-editing keys that are NOT represented in InputCommandType.
-        // These must be polled as raw keys alongside the command-based navigation.
+        // Keys polled as raw input alongside the command-based navigation.
+        // Tab and Back are text-editing keys not in the InputCommandType system.
+        // Enter and Escape are polled here so they work even when Activate/Back
+        // commands are suppressed (e.g. when SearchBox is focused and the bound
+        // key produces text characters that would conflict with text entry).
         private static readonly Microsoft.Xna.Framework.Input.Keys[] ModalRawKeys = new[]
         {
             Microsoft.Xna.Framework.Input.Keys.Tab,
-            Microsoft.Xna.Framework.Input.Keys.Back
+            Microsoft.Xna.Framework.Input.Keys.Back,
+            Microsoft.Xna.Framework.Input.Keys.Enter,
+            Microsoft.Xna.Framework.Input.Keys.Escape
         };
 
         private void ProcessModalKeys()
         {
             if (_inputManager == null) return;
 
-            // 1. Command-based navigation (respects remapped key bindings)
+            // 1. Command-based navigation (respects remapped key bindings).
+            //    Activate and Back are suppressed when the SearchBox is focused to
+            //    prevent a remapped text-producing key (e.g. Space → Activate) from
+            //    closing the modal while the TextInput event simultaneously inserts a
+            //    character.  Enter and Escape still reach HandleKey via ModalRawKeys.
             var commandTypes = new[]
             {
                 InputCommandType.MoveUp,
@@ -1132,8 +1141,11 @@ namespace DTXMania.Game.Lib.Stage
                 InputCommandType.Activate,
                 InputCommandType.Back
             };
+            bool searchBoxFocused = _searchFilterModal.FocusedField == SongSearchFilterModal.Field.SearchBox;
             foreach (var cmd in commandTypes)
             {
+                if (searchBoxFocused && (cmd == InputCommandType.Activate || cmd == InputCommandType.Back))
+                    continue;
                 if (_inputManager.IsCommandPressed(cmd))
                     _searchFilterModal.HandleCommand(cmd);
             }
@@ -1147,9 +1159,11 @@ namespace DTXMania.Game.Lib.Stage
             }
 
             // 3. Mouse click routing for modal buttons
+            //    Treat a null previous state as "all buttons released" so that the
+            //    very first click after the modal opens is not silently swallowed.
             var mouseState = Microsoft.Xna.Framework.Input.Mouse.GetState();
-            if (_previousMouseState != null &&
-                _previousMouseState.Value.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Released &&
+            if ((_previousMouseState == null ||
+                 _previousMouseState.Value.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Released) &&
                 mouseState.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Pressed)
             {
                 _searchFilterModal.HandleClick(new Microsoft.Xna.Framework.Point(mouseState.X, mouseState.Y));

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -48,6 +48,7 @@ namespace DTXMania.Game.Lib.Stage
         private SongFilterCriteria _filterCriteria = SongFilterCriteria.Default;
         private System.Collections.Generic.IReadOnlyList<FilteredSongResult>? _filteredView;
         private readonly ISongListFilterService _filterService = new SongListFilterService();
+        private bool _showEmptyFilterMessage;
 
         // Async initialization management
         private Task<List<SongListNode>> _songInitializationTask;
@@ -836,6 +837,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             _filterCriteria = SongFilterCriteria.Default;
             _filteredView = null;
+            _showEmptyFilterMessage = false;
             PopulateSongListForCurrentMode();
             UpdateBreadcrumb();
             UpdateStatusPanelFolderHint();
@@ -853,10 +855,12 @@ namespace DTXMania.Game.Lib.Stage
             if (_filterCriteria.IsEmpty)
             {
                 _filteredView = null;
+                _showEmptyFilterMessage = false;
                 return;
             }
             var roots = SongManager.Instance.RootSongs;
             _filteredView = _filterService.Apply(roots, _filterCriteria);
+            _showEmptyFilterMessage = _filteredView.Count == 0;
         }
 
         private void PopulateSongListForCurrentMode()
@@ -957,6 +961,16 @@ namespace DTXMania.Game.Lib.Stage
                     SongSelectionUILayout.ScrollSpeedLabelX,
                     SongSelectionUILayout.ScrollSpeedLabelY,
                     Microsoft.Xna.Framework.Color.White);
+            }
+
+            // Draw empty-state message when the active filter returns no results
+            if (_showEmptyFilterMessage && _bitmapFont != null)
+            {
+                string msg = "No songs match this filter";
+                _bitmapFont.DrawText(_spriteBatch, msg,
+                    SongSelectionUILayout.SongBars.UnselectedBarX + 100,
+                    SongSelectionUILayout.SongBars.SelectedBarY,
+                    Microsoft.Xna.Framework.Color.LightGray);
             }
 
             _spriteBatch.End();

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1075,6 +1075,12 @@ namespace DTXMania.Game.Lib.Stage
             // UI uses it as a meta cancel-capture key, so we poll raw keyboard state here.
             DetectOpenSearchKey();
 
+            // If the modal was just opened this frame, skip processing normal
+            // input commands so queued navigation/Back inputs don't leak through
+            // underneath the modal on the same frame.
+            if (_searchFilterModal != null && _searchFilterModal.IsOpen)
+                return;
+
             ProcessInputCommands();
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -45,7 +45,16 @@ namespace DTXMania.Game.Lib.Stage
         private int _currentDifficulty = 0;
 
         // Session-scoped search/filter/sort state
-        private SongFilterCriteria _filterCriteria = SongFilterCriteria.Default;
+        // Static so the filter survives stage re-entry within an app session.
+        // StageManager creates a fresh SongSelectionStage on every entry, so an
+        // instance field would reset on every Title→SongSelect bounce.
+        private static SongFilterCriteria s_persistedFilterCriteria = SongFilterCriteria.Default;
+
+        private SongFilterCriteria _filterCriteria
+        {
+            get => s_persistedFilterCriteria;
+            set => s_persistedFilterCriteria = value;
+        }
         private System.Collections.Generic.IReadOnlyList<FilteredSongResult>? _filteredView;
         private readonly ISongListFilterService _filterService = new SongListFilterService();
         private bool _showEmptyFilterMessage;
@@ -593,6 +602,7 @@ namespace DTXMania.Game.Lib.Stage
                 }
 
                 PopulateSongList();
+                ReapplyPersistedFilterIfActive();
             }
             catch (Exception ex)
             {
@@ -602,6 +612,20 @@ namespace DTXMania.Game.Lib.Stage
                 _currentSongList = new List<SongListNode>();
                 PopulateSongList();
             }
+        }
+
+        /// <summary>
+        /// If the user had a filter active when they last left the stage, restore it
+        /// so the song list reflects the persisted state immediately on re-entry.
+        /// </summary>
+        private void ReapplyPersistedFilterIfActive()
+        {
+            if (_filterCriteria.IsEmpty) return;
+
+            RebuildFilteredView();
+            PopulateSongListForCurrentMode();
+            UpdateBreadcrumb();
+            UpdateStatusPanelFolderHint();
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -503,6 +503,9 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     _textInputSource = new WindowTextInputSource(window);
                     _searchFilterModal = new SongSearchFilterModal(_textInputSource);
+                    // Inject graphics resources
+                    _searchFilterModal.WhitePixel = _whitePixel;
+                    _searchFilterModal.Font = _statusPanel?.Font;
                     _searchFilterModal.FilterApplied += OnFilterApplied;
                     _searchFilterModal.FilterReset   += OnFilterReset;
                     _searchFilterModal.Cancelled     += OnFilterCancelled;

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -879,6 +879,7 @@ namespace DTXMania.Game.Lib.Stage
             UpdateBreadcrumb();
             UpdateStatusPanelFolderHint();
             _inputManager?.ClearPendingCommands();
+            _inputManager?.ResetKeyRepeatStates();
         }
 
         private void OnFilterReset(object sender, System.EventArgs e)
@@ -890,12 +891,14 @@ namespace DTXMania.Game.Lib.Stage
             UpdateBreadcrumb();
             UpdateStatusPanelFolderHint();
             _inputManager?.ClearPendingCommands();
+            _inputManager?.ResetKeyRepeatStates();
         }
 
         private void OnFilterCancelled(object sender, System.EventArgs e)
         {
             // Discard draft; no state change
             _inputManager?.ClearPendingCommands();
+            _inputManager?.ResetKeyRepeatStates();
         }
 
         private void RebuildFilteredView()

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -74,6 +74,10 @@ namespace DTXMania.Game.Lib.Stage
 
         // Status panel navigation state
         private bool _isInStatusPanel = false;
+
+        // Search/filter modal
+        private SongSearchFilterModal _searchFilterModal;
+        private WindowTextInputSource _textInputSource;
         
         // DTXMania pattern: timing and animation
         private double _elapsedTime;
@@ -489,6 +493,25 @@ namespace DTXMania.Game.Lib.Stage
             _mainPanel.AddChild(_statusPanel);
             _mainPanel.AddChild(_previewImagePanel);
 
+            // Search/filter modal (guarded: Window is unavailable in headless/test environments)
+            try
+            {
+                var window = _game.Window;
+                if (window != null)
+                {
+                    _textInputSource = new WindowTextInputSource(window);
+                    _searchFilterModal = new SongSearchFilterModal(_textInputSource);
+                    _searchFilterModal.FilterApplied += OnFilterApplied;
+                    _searchFilterModal.FilterReset   += OnFilterReset;
+                    _searchFilterModal.Cancelled     += OnFilterCancelled;
+                    _mainPanel.AddChild(_searchFilterModal);
+                }
+            }
+            catch (Exception)
+            {
+                // Window unavailable in headless/test environments; modal will be skipped
+            }
+
             // Add panel to UI manager
             _uiManager.AddRootContainer(_mainPanel);
 
@@ -798,6 +821,55 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        private void OnFilterApplied(object sender, SongFilterCriteria criteria)
+        {
+            _filterCriteria = criteria;
+            RebuildFilteredView();
+            PopulateSongListForCurrentMode();
+            _inputManager?.ClearPendingCommands();
+        }
+
+        private void OnFilterReset(object sender, System.EventArgs e)
+        {
+            _filterCriteria = SongFilterCriteria.Default;
+            _filteredView = null;
+            PopulateSongListForCurrentMode();
+            _inputManager?.ClearPendingCommands();
+        }
+
+        private void OnFilterCancelled(object sender, System.EventArgs e)
+        {
+            // Discard draft; no state change
+            _inputManager?.ClearPendingCommands();
+        }
+
+        private void RebuildFilteredView()
+        {
+            if (_filterCriteria.IsEmpty)
+            {
+                _filteredView = null;
+                return;
+            }
+            var roots = SongManager.Instance.RootSongs;
+            _filteredView = _filterService.Apply(roots, _filterCriteria);
+        }
+
+        private void PopulateSongListForCurrentMode()
+        {
+            if (_filteredView != null)
+                PopulateFilteredSongList();
+            else
+                PopulateSongList();
+        }
+
+        private void PopulateFilteredSongList()
+        {
+            var displayList = new System.Collections.Generic.List<SongListNode>(_filteredView!.Count);
+            foreach (var r in _filteredView)
+                displayList.Add(r.Node);
+            _songListDisplay.CurrentList = displayList;
+        }
+
         private void UpdateBreadcrumb()
         {
             _breadcrumbLabel.Text = string.IsNullOrEmpty(_currentBreadcrumb)
@@ -885,12 +957,29 @@ namespace DTXMania.Game.Lib.Stage
 
         private void HandleInput()
         {
-            // Don't process input if input manager is disposed
             if (_inputManager == null)
                 return;
-                
-            // Process queued input commands from InputManager
+
+            if (_searchFilterModal != null && _searchFilterModal.IsOpen)
+            {
+                ProcessModalKeys();
+                return;
+            }
+
             ProcessInputCommands();
+        }
+
+        private Microsoft.Xna.Framework.Input.KeyboardState _prevModalKbState;
+
+        private void ProcessModalKeys()
+        {
+            var current = Microsoft.Xna.Framework.Input.Keyboard.GetState();
+            foreach (var key in current.GetPressedKeys())
+            {
+                if (!_prevModalKbState.IsKeyDown(key))
+                    _searchFilterModal.HandleKey(key);
+            }
+            _prevModalKbState = current;
         }
 
         /// <summary>
@@ -1001,7 +1090,19 @@ namespace DTXMania.Game.Lib.Stage
                 case InputCommandType.DecreaseScrollSpeed:
                     _configManager?.AdjustScrollSpeed(AppPaths.GetConfigFilePath(), -1);
                     break;
+
+                case InputCommandType.OpenSearch:
+                    OpenSearchFilterModal();
+                    break;
             }
+        }
+
+        private void OpenSearchFilterModal()
+        {
+            if (_searchFilterModal == null) return;
+            // Exit status-panel mode first
+            _isInStatusPanel = false;
+            _searchFilterModal.Open(_filterCriteria);
         }
 
         private void CycleDifficulty(int direction)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -873,6 +873,14 @@ namespace DTXMania.Game.Lib.Stage
 
         private void OnFilterApplied(object sender, SongFilterCriteria criteria)
         {
+            // Normalize level range so breadcrumb always shows the effective range.
+            // SongListFilterService previously swapped silently, leaving _filterCriteria
+            // inconsistent with the actual filter result.
+            if (criteria.MinLevel.HasValue && criteria.MaxLevel.HasValue
+                && criteria.MinLevel > criteria.MaxLevel)
+            {
+                criteria = criteria with { MinLevel = criteria.MaxLevel, MaxLevel = criteria.MinLevel };
+            }
             _filterCriteria = criteria;
             RebuildFilteredView();
             PopulateSongListForCurrentMode();
@@ -920,7 +928,8 @@ namespace DTXMania.Game.Lib.Stage
             {
                 System.Diagnostics.Debug.WriteLine(
                     $"SongSelectionStage: filter projection failed: {ex.Message}");
-                // Leave existing list reference unchanged.
+                // Reset filter state entirely so breadcrumb and list stay consistent.
+                _filterCriteria = SongFilterCriteria.Default;
                 _filteredView = null;
                 _showEmptyFilterMessage = false;
             }

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -44,26 +44,12 @@ namespace DTXMania.Game.Lib.Stage
         private int _selectedIndex = 0;
         private int _currentDifficulty = 0;
 
-        // Session-scoped search/filter/sort state
-        // Static so the filter survives stage re-entry within an app session.
-        // StageManager creates a fresh SongSelectionStage on every entry, so an
-        // instance field would reset on every Title→SongSelect bounce.
-        private static SongFilterCriteria s_persistedFilterCriteria = SongFilterCriteria.Default;
+        // Instance-scoped search/filter/sort state.
+        // StageManager caches one SongSelectionStage per game instance in its
+        // _stages dictionary, so this field survives Title→SongSelect re-entry
+        // without leaking across separate game/test instances.
+        private SongFilterCriteria _filterCriteria = SongFilterCriteria.Default;
 
-        private SongFilterCriteria _filterCriteria
-        {
-            get => s_persistedFilterCriteria;
-            set => s_persistedFilterCriteria = value;
-        }
-
-        /// <summary>
-        /// Resets the process-wide persisted filter to its default state.
-        /// Call this between test runs to prevent static state leaking across tests.
-        /// </summary>
-        public static void ResetPersistedFilter()
-        {
-            s_persistedFilterCriteria = SongFilterCriteria.Default;
-        }
         private System.Collections.Generic.IReadOnlyList<FilteredSongResult>? _filteredView;
         private readonly ISongListFilterService _filterService = new SongListFilterService();
         private bool _showEmptyFilterMessage;
@@ -1137,26 +1123,28 @@ namespace DTXMania.Game.Lib.Stage
             if (_inputManager == null) return;
 
             // 1. Command-based navigation (respects remapped key bindings).
-            //    Activate and Back are suppressed when the SearchBox is focused to
-            //    prevent a remapped text-producing key (e.g. Space → Activate) from
-            //    closing the modal while the TextInput event simultaneously inserts a
-            //    character.  Enter and Escape still reach HandleKey via ModalRawKeys.
-            var commandTypes = new[]
-            {
-                InputCommandType.MoveUp,
-                InputCommandType.MoveDown,
-                InputCommandType.MoveLeft,
-                InputCommandType.MoveRight,
-                InputCommandType.Activate,
-                InputCommandType.Back
-            };
+            //    ALL commands are suppressed when the SearchBox is focused to
+            //    prevent a remapped text-producing key (e.g. W → MoveUp, S → MoveDown,
+            //    Space → Activate) from stealing focus or closing the modal while the
+            //    TextInput event simultaneously inserts a character.
+            //    Enter and Escape still reach HandleKey via ModalRawKeys.
             bool searchBoxFocused = _searchFilterModal.FocusedField == SongSearchFilterModal.Field.SearchBox;
-            foreach (var cmd in commandTypes)
+            if (!searchBoxFocused)
             {
-                if (searchBoxFocused && (cmd == InputCommandType.Activate || cmd == InputCommandType.Back))
-                    continue;
-                if (_inputManager.IsCommandPressed(cmd))
-                    _searchFilterModal.HandleCommand(cmd);
+                var commandTypes = new[]
+                {
+                    InputCommandType.MoveUp,
+                    InputCommandType.MoveDown,
+                    InputCommandType.MoveLeft,
+                    InputCommandType.MoveRight,
+                    InputCommandType.Activate,
+                    InputCommandType.Back
+                };
+                foreach (var cmd in commandTypes)
+                {
+                    if (_inputManager.IsCommandPressed(cmd))
+                        _searchFilterModal.HandleCommand(cmd);
+                }
             }
 
             // 2. Raw keys for text editing (Tab = cycle focus, Back = backspace)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -638,6 +638,9 @@ namespace DTXMania.Game.Lib.Stage
                     // Clean up the task reference
                     _songInitializationTask = null;
                 }
+
+                if (_searchFilterModal != null && _searchFilterModal.IsOpen)
+                    _searchFilterModal.IsLibraryReady = true;
             }
         }
 
@@ -1162,8 +1165,9 @@ namespace DTXMania.Game.Lib.Stage
         private void OpenSearchFilterModal()
         {
             if (_searchFilterModal == null) return;
-            // Exit status-panel mode first
             _isInStatusPanel = false;
+            _searchFilterModal.IsLibraryReady =
+                _songInitializationProcessed && _currentSongList != null;
             _searchFilterModal.Open(_filterCriteria);
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -88,6 +88,7 @@ namespace DTXMania.Game.Lib.Stage
         // Search/filter modal
         private SongSearchFilterModal? _searchFilterModal = null;
         private WindowTextInputSource? _textInputSource = null;
+        private Microsoft.Xna.Framework.Input.MouseState? _previousMouseState = null;
         
         // DTXMania pattern: timing and animation
         private double _elapsedTime;
@@ -1109,29 +1110,51 @@ namespace DTXMania.Game.Lib.Stage
                 OpenSearchFilterModal();
         }
 
-        // Set of keys the modal cares about (Esc/Tab/arrows/Enter/Backspace).
-        private static readonly Microsoft.Xna.Framework.Input.Keys[] ModalKeys = new[]
+        // Text-editing keys that are NOT represented in InputCommandType.
+        // These must be polled as raw keys alongside the command-based navigation.
+        private static readonly Microsoft.Xna.Framework.Input.Keys[] ModalRawKeys = new[]
         {
-            Microsoft.Xna.Framework.Input.Keys.Escape,
             Microsoft.Xna.Framework.Input.Keys.Tab,
-            Microsoft.Xna.Framework.Input.Keys.Up,
-            Microsoft.Xna.Framework.Input.Keys.Down,
-            Microsoft.Xna.Framework.Input.Keys.Left,
-            Microsoft.Xna.Framework.Input.Keys.Right,
-            Microsoft.Xna.Framework.Input.Keys.Enter,
             Microsoft.Xna.Framework.Input.Keys.Back
         };
 
         private void ProcessModalKeys()
         {
-            // Route through InputManager so MCP/API key injection works while the
-            // modal is open. Each key is edge-detected per frame by IsKeyPressed.
             if (_inputManager == null) return;
-            foreach (var key in ModalKeys)
+
+            // 1. Command-based navigation (respects remapped key bindings)
+            var commandTypes = new[]
+            {
+                InputCommandType.MoveUp,
+                InputCommandType.MoveDown,
+                InputCommandType.MoveLeft,
+                InputCommandType.MoveRight,
+                InputCommandType.Activate,
+                InputCommandType.Back
+            };
+            foreach (var cmd in commandTypes)
+            {
+                if (_inputManager.IsCommandPressed(cmd))
+                    _searchFilterModal.HandleCommand(cmd);
+            }
+
+            // 2. Raw keys for text editing (Tab = cycle focus, Back = backspace)
+            //    These are not in the InputCommandType system.
+            foreach (var key in ModalRawKeys)
             {
                 if (_inputManager.IsKeyPressed((int)key))
                     _searchFilterModal.HandleKey(key);
             }
+
+            // 3. Mouse click routing for modal buttons
+            var mouseState = Microsoft.Xna.Framework.Input.Mouse.GetState();
+            if (_previousMouseState != null &&
+                _previousMouseState.Value.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Released &&
+                mouseState.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Pressed)
+            {
+                _searchFilterModal.HandleClick(new Microsoft.Xna.Framework.Point(mouseState.X, mouseState.Y));
+            }
+            _previousMouseState = mouseState;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -86,8 +86,8 @@ namespace DTXMania.Game.Lib.Stage
         private bool _isInStatusPanel = false;
 
         // Search/filter modal
-        private SongSearchFilterModal _searchFilterModal;
-        private WindowTextInputSource _textInputSource;
+        private SongSearchFilterModal? _searchFilterModal = null;
+        private WindowTextInputSource? _textInputSource = null;
         
         // DTXMania pattern: timing and animation
         private double _elapsedTime;
@@ -1874,13 +1874,11 @@ namespace DTXMania.Game.Lib.Stage
 
         #endregion
 
-        // Test-access helpers (used by SongSelectionStageFilterTests)
-        public static bool DefaultFilterCriteriaIsEmpty() =>
+        // Internal helper for tests (InternalsVisibleTo)
+        internal static bool DefaultFilterCriteriaIsEmpty() =>
             SongFilterCriteria.Default.IsEmpty;
 
-        public static bool DefaultFilteredViewIsNull() => true;
-
-        public static int ClampSelectionIndex(SongListNode previousSelected, System.Collections.Generic.IReadOnlyList<SongListNode> newList)
+        public static int ClampSelectionIndex(SongListNode? previousSelected, System.Collections.Generic.IReadOnlyList<SongListNode>? newList)
         {
             if (newList == null || newList.Count == 0) return 0;
             if (previousSelected == null) return 0;

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1056,30 +1056,37 @@ namespace DTXMania.Game.Lib.Stage
             ProcessInputCommands();
         }
 
-        private Microsoft.Xna.Framework.Input.KeyboardState _prevOpenSearchKbState;
-
         private void DetectOpenSearchKey()
         {
-            var current = Microsoft.Xna.Framework.Input.Keyboard.GetState();
-            bool wasDown = _prevOpenSearchKbState.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back);
-            bool isDown = current.IsKeyDown(Microsoft.Xna.Framework.Input.Keys.Back);
-            _prevOpenSearchKbState = current;
-
-            if (isDown && !wasDown)
+            // Route through InputManager so MCP/API key injection is picked up
+            // alongside hardware presses. (Raw Keyboard.GetState() misses injected keys.)
+            if (_inputManager != null && _inputManager.IsKeyPressed((int)Microsoft.Xna.Framework.Input.Keys.Back))
                 OpenSearchFilterModal();
         }
 
-        private Microsoft.Xna.Framework.Input.KeyboardState _prevModalKbState;
+        // Set of keys the modal cares about (Esc/Tab/arrows/Enter/Backspace).
+        private static readonly Microsoft.Xna.Framework.Input.Keys[] ModalKeys = new[]
+        {
+            Microsoft.Xna.Framework.Input.Keys.Escape,
+            Microsoft.Xna.Framework.Input.Keys.Tab,
+            Microsoft.Xna.Framework.Input.Keys.Up,
+            Microsoft.Xna.Framework.Input.Keys.Down,
+            Microsoft.Xna.Framework.Input.Keys.Left,
+            Microsoft.Xna.Framework.Input.Keys.Right,
+            Microsoft.Xna.Framework.Input.Keys.Enter,
+            Microsoft.Xna.Framework.Input.Keys.Back
+        };
 
         private void ProcessModalKeys()
         {
-            var current = Microsoft.Xna.Framework.Input.Keyboard.GetState();
-            foreach (var key in current.GetPressedKeys())
+            // Route through InputManager so MCP/API key injection works while the
+            // modal is open. Each key is edge-detected per frame by IsKeyPressed.
+            if (_inputManager == null) return;
+            foreach (var key in ModalKeys)
             {
-                if (!_prevModalKbState.IsKeyDown(key))
+                if (_inputManager.IsKeyPressed((int)key))
                     _searchFilterModal.HandleKey(key);
             }
-            _prevModalKbState = current;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -861,9 +861,21 @@ namespace DTXMania.Game.Lib.Stage
                 _showEmptyFilterMessage = false;
                 return;
             }
-            var roots = SongManager.Instance.RootSongs;
-            _filteredView = _filterService.Apply(roots, _filterCriteria);
-            _showEmptyFilterMessage = _filteredView.Count == 0;
+
+            try
+            {
+                var roots = SongManager.Instance.RootSongs;
+                _filteredView = _filterService.Apply(roots, _filterCriteria);
+                _showEmptyFilterMessage = _filteredView.Count == 0;
+            }
+            catch (System.Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongSelectionStage: filter projection failed: {ex.Message}");
+                // Leave existing list reference unchanged.
+                _filteredView = null;
+                _showEmptyFilterMessage = false;
+            }
         }
 
         private void PopulateSongListForCurrentMode()

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -820,8 +820,6 @@ namespace DTXMania.Game.Lib.Stage
 
         private void NavigateBack()
         {
-            if (_filteredView != null) return;
-
             if (_navigationStack.Count > 0)
             {
                 var previousState = _navigationStack.Pop();
@@ -1197,6 +1195,11 @@ namespace DTXMania.Game.Lib.Stage
                     {
                         // Exit status panel mode - no debounce needed for navigation
                         _isInStatusPanel = false;
+                    }
+                    else if (_filteredView != null)
+                    {
+                        // Clear active filter so subsequent Back presses navigate normally
+                        OnFilterReset(this, System.EventArgs.Empty);
                     }
                     else if (_navigationStack.Count > 0)
                     {
@@ -1886,7 +1889,13 @@ namespace DTXMania.Game.Lib.Stage
         private static string? FormatLevel(int? min, int? max)
         {
             if (min is null && max is null) return null;
-            if (min is not null && max is not null) return $"Lv {min}-{max}";
+            if (min is not null && max is not null)
+            {
+                // Normalize inverted ranges to match the filter service behavior
+                int lo = min.Value, hi = max.Value;
+                if (lo > hi) (lo, hi) = (hi, lo);
+                return $"Lv {lo}-{hi}";
+            }
             if (min is not null) return $"Lv {min}+";
             return $"Lv ≤{max}";
         }

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -55,6 +55,15 @@ namespace DTXMania.Game.Lib.Stage
             get => s_persistedFilterCriteria;
             set => s_persistedFilterCriteria = value;
         }
+
+        /// <summary>
+        /// Resets the process-wide persisted filter to its default state.
+        /// Call this between test runs to prevent static state leaking across tests.
+        /// </summary>
+        public static void ResetPersistedFilter()
+        {
+            s_persistedFilterCriteria = SongFilterCriteria.Default;
+        }
         private System.Collections.Generic.IReadOnlyList<FilteredSongResult>? _filteredView;
         private readonly ISongListFilterService _filterService = new SongListFilterService();
         private bool _showEmptyFilterMessage;

--- a/DTXMania.Game/Lib/UI/Components/ITextInputSource.cs
+++ b/DTXMania.Game/Lib/UI/Components/ITextInputSource.cs
@@ -1,0 +1,10 @@
+using System;
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.UI.Components
+{
+    public interface ITextInputSource
+    {
+        event EventHandler<TextInputEventArgs> TextInput;
+    }
+}

--- a/DTXMania.Game/Lib/UI/Components/UITextInput.cs
+++ b/DTXMania.Game/Lib/UI/Components/UITextInput.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using DTXMania.Game.Lib.UI;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -88,6 +89,7 @@ namespace DTXMania.Game.Lib.UI.Components
             _caretIndex = 0;
         }
 
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {
             if (Font == null) return;

--- a/DTXMania.Game/Lib/UI/Components/UITextInput.cs
+++ b/DTXMania.Game/Lib/UI/Components/UITextInput.cs
@@ -1,0 +1,82 @@
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.UI;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.UI.Components
+{
+    public class UITextInput : UIElement
+    {
+        private readonly ITextInputSource _source;
+        private string _text = "";
+        private int _caretIndex;
+        private bool _subscribed;
+
+        public UITextInput(ITextInputSource source)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            OnFocus  += (_, _) => Subscribe();
+            OnBlur   += (_, _) => Unsubscribe();
+        }
+
+        public string Text
+        {
+            get => _text;
+            set
+            {
+                _text = value ?? "";
+                _caretIndex = Math.Clamp(_caretIndex, 0, _text.Length);
+            }
+        }
+
+        public int CaretIndex => _caretIndex;
+
+        public int MaxLength { get; set; } = 64;
+
+        public SpriteFont? Font { get; set; }
+
+        public Color TextColor { get; set; } = Color.White;
+
+        private void Subscribe()
+        {
+            if (_subscribed) return;
+            _source.TextInput += OnTextInput;
+            _subscribed = true;
+        }
+
+        private void Unsubscribe()
+        {
+            if (!_subscribed) return;
+            _source.TextInput -= OnTextInput;
+            _subscribed = false;
+        }
+
+        private void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            if (!Focused) return;
+
+            char c = e.Character;
+            if (c == '\b' || c == '\r' || c == '\n' || c == '\t') return;
+            if (char.IsControl(c)) return;
+            if (_text.Length >= MaxLength) return;
+
+            _text = _text.Insert(_caretIndex, c.ToString());
+            _caretIndex++;
+        }
+
+        protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
+        {
+            if (Font == null) return;
+            var pos = AbsolutePosition;
+            spriteBatch.DrawString(Font, _text, pos, TextColor);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) Unsubscribe();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/DTXMania.Game/Lib/UI/Components/UITextInput.cs
+++ b/DTXMania.Game/Lib/UI/Components/UITextInput.cs
@@ -66,6 +66,24 @@ namespace DTXMania.Game.Lib.UI.Components
             _caretIndex++;
         }
 
+        public void Backspace()
+        {
+            if (_caretIndex == 0 || _text.Length == 0) return;
+            _text = _text.Remove(_caretIndex - 1, 1);
+            _caretIndex--;
+        }
+
+        public void MoveCaret(int delta)
+        {
+            _caretIndex = Math.Clamp(_caretIndex + delta, 0, _text.Length);
+        }
+
+        public void Clear()
+        {
+            _text = "";
+            _caretIndex = 0;
+        }
+
         protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
         {
             if (Font == null) return;

--- a/DTXMania.Game/Lib/UI/Components/UITextInput.cs
+++ b/DTXMania.Game/Lib/UI/Components/UITextInput.cs
@@ -26,7 +26,10 @@ namespace DTXMania.Game.Lib.UI.Components
             get => _text;
             set
             {
-                _text = value ?? "";
+                var incoming = value ?? "";
+                _text = incoming.Length > MaxLength
+                    ? incoming.Substring(0, MaxLength)
+                    : incoming;
                 _caretIndex = Math.Clamp(_caretIndex, 0, _text.Length);
             }
         }

--- a/DTXMania.Game/Lib/UI/Components/UITextInput.cs
+++ b/DTXMania.Game/Lib/UI/Components/UITextInput.cs
@@ -27,8 +27,9 @@ namespace DTXMania.Game.Lib.UI.Components
             set
             {
                 var incoming = value ?? "";
-                _text = incoming.Length > MaxLength
-                    ? incoming.Substring(0, MaxLength)
+                var maxLen = Math.Max(0, MaxLength);
+                _text = incoming.Length > maxLen
+                    ? incoming.Substring(0, maxLen)
                     : incoming;
                 _caretIndex = Math.Clamp(_caretIndex, 0, _text.Length);
             }

--- a/DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs
+++ b/DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs
@@ -5,9 +5,10 @@ using Microsoft.Xna.Framework;
 
 namespace DTXMania.Game.Lib.UI.Components
 {
-    public sealed class WindowTextInputSource : ITextInputSource
+    public sealed class WindowTextInputSource : ITextInputSource, IDisposable
     {
         private readonly GameWindow _window;
+        private bool _disposed;
 
         public WindowTextInputSource(GameWindow window)
         {
@@ -20,6 +21,13 @@ namespace DTXMania.Game.Lib.UI.Components
         private void OnTextInput(object? sender, TextInputEventArgs e)
         {
             TextInput?.Invoke(sender, e);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _window.TextInput -= OnTextInput;
+            _disposed = true;
         }
     }
 }

--- a/DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs
+++ b/DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+using System;
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.UI.Components
+{
+    public sealed class WindowTextInputSource : ITextInputSource
+    {
+        private readonly GameWindow _window;
+
+        public WindowTextInputSource(GameWindow window)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _window.TextInput += OnTextInput;
+        }
+
+        public event EventHandler<TextInputEventArgs>? TextInput;
+
+        private void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            TextInput?.Invoke(sender, e);
+        }
+    }
+}

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -26,7 +26,20 @@ namespace DTXMania.Game.Lib.UI.Layout
         }
         
         #endregion
-        
+
+        #region Folder Hint Overlay Layout
+
+        /// <summary>
+        /// Folder-hint overlay position offsets (drawn at top of status panel)
+        /// </summary>
+        public static class FolderHintOverlay
+        {
+            public const int OffsetX = 12;
+            public const int OffsetY = 6;
+        }
+
+        #endregion
+
         #region BPM and Song Length Section
         
         /// <summary>

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -576,5 +576,60 @@ namespace DTXMania.Game.Lib.UI.Layout
         // Scroll-speed display (e.g., "Scroll x1.5") on song-select panel
         public const int ScrollSpeedLabelX = 20;
         public const int ScrollSpeedLabelY = 680; // bottom-left
+
+        #region Search Filter Modal Layout
+
+        /// <summary>
+        /// Layout constants for the search/filter/sort modal overlay.
+        /// </summary>
+        public static class SearchFilterModal
+        {
+            // Centered in 1280x720
+            public const int X = 340;
+            public const int Y = 180;
+            public const int Width = 600;
+            public const int Height = 360;
+
+            public static Vector2 Position => new Vector2(X, Y);
+            public static Vector2 Size => new Vector2(Width, Height);
+            public static Rectangle Bounds => new Rectangle(X, Y, Width, Height);
+
+            // Title bar
+            public const int TitleY = 12;             // relative to modal top
+            public const int TitleHeight = 28;
+
+            // Field rows (relative to modal top-left)
+            public const int RowSpacing = 44;
+            public const int FirstRowY = 56;
+            public const int LabelX = 24;
+            public const int FieldX = 130;
+
+            // Search box
+            public const int SearchBoxY = FirstRowY;
+            public const int SearchBoxWidth = 430;
+            public const int SearchBoxHeight = 30;
+
+            // Level row
+            public const int LevelRowY = FirstRowY + RowSpacing;
+            public const int LevelMinX = FieldX;
+            public const int LevelMaxX = FieldX + 180;
+            public const int LevelInputWidth = 80;
+            public const int LevelInputHeight = 30;
+
+            // Played-status row
+            public const int PlayedRowY = FirstRowY + RowSpacing * 2;
+
+            // Sort row
+            public const int SortRowY = FirstRowY + RowSpacing * 3;
+
+            // Buttons
+            public const int ButtonRowY = FirstRowY + RowSpacing * 4 + 8;
+            public const int ResetButtonX = 200;
+            public const int ApplyButtonX = 360;
+            public const int ButtonWidth = 120;
+            public const int ButtonHeight = 36;
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Input/InputManagerStateTests.cs
+++ b/DTXMania.Test/Input/InputManagerStateTests.cs
@@ -149,6 +149,10 @@ public class InputManagerStateTests
         SetKeyboardStates(manager, new KeyboardState(Keys.Up), new KeyboardState(Keys.Up));
         SetCurrentTime(manager, 0.5);
 
+        // Edge case: the stored KeyRepeatState says the key is NOT pressed and is suppressed,
+        // but the physical keyboard state (SetKeyboardStates with Keys.Up) shows the key is
+        // still held. This simulates a previously-suppressed/reset repeat state while the user
+        // keeps holding the key — the system should NOT generate repeat commands.
         GetRepeatStates(manager)[Keys.Up] = new KeyRepeatState
         {
             IsPressed = false,

--- a/DTXMania.Test/Input/InputManagerStateTests.cs
+++ b/DTXMania.Test/Input/InputManagerStateTests.cs
@@ -142,6 +142,100 @@ public class InputManagerStateTests
         Assert.False(state.HasStartedRepeating);
     }
 
+    [Fact]
+    public void UpdateKeyRepeatStates_WhenSuppressed_ShouldSkipRepeatCommand()
+    {
+        var manager = new InputManager();
+        SetKeyboardStates(manager, new KeyboardState(Keys.Up), new KeyboardState(Keys.Up));
+        SetCurrentTime(manager, 0.5);
+
+        GetRepeatStates(manager)[Keys.Up] = new KeyRepeatState
+        {
+            IsPressed = false,
+            InitialPressTime = 0.0,
+            LastRepeatTime = 0.0,
+            CurrentRepeatInterval = 0.2,
+            HasStartedRepeating = false,
+            Suppressed = true
+        };
+
+        InvokeUpdateKeyRepeatStates(manager);
+
+        Assert.Empty(manager.GetInputCommands());
+        Assert.True(GetRepeatState(manager, Keys.Up).Suppressed);
+    }
+
+    [Fact]
+    public void UpdateKeyRepeatStates_WhenSuppressedKeyRePressed_ShouldClearSuppression()
+    {
+        var manager = new InputManager();
+        SetKeyboardStates(manager, new KeyboardState(Keys.Up), new KeyboardState());
+        SetCurrentTime(manager, 1.0);
+
+        GetRepeatStates(manager)[Keys.Up] = new KeyRepeatState
+        {
+            IsPressed = false,
+            InitialPressTime = 0.0,
+            LastRepeatTime = 0.0,
+            CurrentRepeatInterval = 0.2,
+            HasStartedRepeating = false,
+            Suppressed = true
+        };
+
+        InvokeUpdateKeyRepeatStates(manager);
+
+        var command = Assert.Single(manager.GetInputCommands());
+        Assert.Equal(InputCommandType.MoveUp, command.Type);
+        Assert.False(command.IsRepeat);
+        Assert.False(GetRepeatState(manager, Keys.Up).Suppressed);
+    }
+
+    [Fact]
+    public void ResetKeyRepeatStates_WhenCalled_ShouldSuppressAllStates()
+    {
+        var manager = new InputManager();
+        SetKeyboardStates(manager, new KeyboardState(Keys.Up, Keys.Down), new KeyboardState());
+        SetCurrentTime(manager, 0.5);
+
+        InvokeUpdateKeyRepeatStates(manager);
+
+        manager.ResetKeyRepeatStates();
+
+        var upState = GetRepeatState(manager, Keys.Up);
+        Assert.True(upState.Suppressed);
+        Assert.False(upState.IsPressed);
+        var downState = GetRepeatState(manager, Keys.Down);
+        Assert.True(downState.Suppressed);
+        Assert.False(downState.IsPressed);
+    }
+
+    [Fact]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var manager = new InputManager();
+        manager.Dispose();
+        manager.Dispose();
+    }
+
+    [Fact]
+    public void SetKeyMapping_WhenReplacingExistingCommand_ShouldEvictOldKey()
+    {
+        var manager = new InputManager();
+        manager.SetKeyMapping(Keys.W, InputCommandType.MoveUp);
+        var snapshot = manager.GetKeyMappingSnapshot();
+        Assert.Equal(InputCommandType.MoveUp, snapshot[Keys.W]);
+        Assert.DoesNotContain(Keys.Up, snapshot.Keys);
+    }
+
+    [Fact]
+    public void RemoveKeyMapping_WhenKeyExists_ShouldRemove()
+    {
+        var manager = new InputManager();
+        manager.RemoveKeyMapping(Keys.Up);
+        var snapshot = manager.GetKeyMappingSnapshot();
+        Assert.DoesNotContain(Keys.Up, snapshot.Keys);
+    }
+
     private static void SetKeyboardStates(InputManager manager, KeyboardState current, KeyboardState previous)
     {
         ReflectionHelpers.SetPrivateField(manager, "_currentKeyboardState", current);

--- a/DTXMania.Test/Input/InputManagerTests.cs
+++ b/DTXMania.Test/Input/InputManagerTests.cs
@@ -131,6 +131,17 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
+    public void TryGetKeyRepeatState_WhenStateMissing_ShouldReturnNull()
+    {
+        var manager = new TestableInputManager();
+
+        var state = manager.GetKeyRepeatState(Keys.Escape);
+
+        Assert.Null(state);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
     public void SetKeyMapping_WhenSettingNewKeyForSameCommand_ShouldEvictPreviousKey()
     {
         var manager = new InputManager();

--- a/DTXMania.Test/Input/InputManagerTests.cs
+++ b/DTXMania.Test/Input/InputManagerTests.cs
@@ -129,6 +129,96 @@ public class InputManagerTests
         Assert.True(state.Suppressed);
     }
 
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void SetKeyMapping_EvictsPreviousKeyForSameCommand()
+    {
+        var manager = new InputManager();
+        manager.SetKeyMapping(Keys.Enter, InputCommandType.Activate);
+        manager.SetKeyMapping(Keys.Space, InputCommandType.Activate);
+
+        var snapshot = manager.GetKeyMappingSnapshot();
+        Assert.DoesNotContain(Keys.Enter, snapshot.Keys);
+        Assert.Equal(InputCommandType.Activate, snapshot[Keys.Space]);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void RemoveKeyMapping_RemovesMapping()
+    {
+        var manager = new InputManager();
+        Assert.Contains(Keys.Enter, manager.GetKeyMappingSnapshot().Keys);
+
+        manager.RemoveKeyMapping(Keys.Enter);
+
+        Assert.DoesNotContain(Keys.Enter, manager.GetKeyMappingSnapshot().Keys);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void GetKeyMappingSnapshot_ReturnsCopy()
+    {
+        var manager = new InputManager();
+        var snap1 = manager.GetKeyMappingSnapshot();
+        manager.RemoveKeyMapping(Keys.Enter);
+        var snap2 = manager.GetKeyMappingSnapshot();
+
+        Assert.Contains(Keys.Enter, snap1.Keys);
+        Assert.DoesNotContain(Keys.Enter, snap2.Keys);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void Dispose_ClearsState()
+    {
+        var manager = new InputManager();
+        manager.Dispose();
+
+        Assert.False(manager.HasPendingCommands);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void SetKeyMapping_SameKeySameCommand_NoOp()
+    {
+        var manager = new InputManager();
+        var countBefore = manager.GetKeyMappingSnapshot().Count;
+        manager.SetKeyMapping(Keys.Enter, InputCommandType.Activate);
+        Assert.Equal(countBefore, manager.GetKeyMappingSnapshot().Count);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void GetNextCommand_ReturnsNullWhenEmpty()
+    {
+        var manager = new InputManager();
+        Assert.Null(manager.GetNextCommand());
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void IsCommandDown_ReturnsFalseWhenNoKeyHeld()
+    {
+        var manager = new InputManager();
+        Assert.False(manager.IsCommandDown(InputCommandType.Activate));
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void IsKeyReleased_ReturnsFalseInitially()
+    {
+        var manager = new InputManager();
+        Assert.False(manager.IsKeyReleased((int)Keys.Enter));
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void IsKeyDown_ReturnsFalseInitially()
+    {
+        var manager = new InputManager();
+        Assert.False(manager.IsKeyDown((int)Keys.Enter));
+    }
+
     private sealed class TestableInputManager : InputManager
     {
         public void QueueCommand(InputCommandType commandType, double timestamp, bool isRepeat = false)

--- a/DTXMania.Test/Input/InputManagerTests.cs
+++ b/DTXMania.Test/Input/InputManagerTests.cs
@@ -131,7 +131,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void SetKeyMapping_EvictsPreviousKeyForSameCommand()
+    public void SetKeyMapping_WhenSettingNewKeyForSameCommand_ShouldEvictPreviousKey()
     {
         var manager = new InputManager();
         manager.SetKeyMapping(Keys.Enter, InputCommandType.Activate);
@@ -144,7 +144,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void RemoveKeyMapping_RemovesMapping()
+    public void RemoveKeyMapping_WhenCalled_ShouldRemoveMapping()
     {
         var manager = new InputManager();
         Assert.Contains(Keys.Enter, manager.GetKeyMappingSnapshot().Keys);
@@ -156,7 +156,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void GetKeyMappingSnapshot_ReturnsCopy()
+    public void GetKeyMappingSnapshot_WhenCalledAfterMutation_ShouldReturnCopy()
     {
         var manager = new InputManager();
         var snap1 = manager.GetKeyMappingSnapshot();
@@ -169,7 +169,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void Dispose_ClearsState()
+    public void Dispose_WhenCalled_ShouldClearState()
     {
         var manager = new InputManager();
         manager.Dispose();
@@ -179,7 +179,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void SetKeyMapping_SameKeySameCommand_NoOp()
+    public void SetKeyMapping_WhenSameKeySameCommand_ShouldBeNoOp()
     {
         var manager = new InputManager();
         var countBefore = manager.GetKeyMappingSnapshot().Count;
@@ -189,7 +189,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void GetNextCommand_ReturnsNullWhenEmpty()
+    public void GetNextCommand_WhenNoCommandsQueued_ShouldReturnNull()
     {
         var manager = new InputManager();
         Assert.Null(manager.GetNextCommand());
@@ -197,7 +197,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void IsCommandDown_ReturnsFalseWhenNoKeyHeld()
+    public void IsCommandDown_WhenNoKeyHeld_ShouldReturnFalse()
     {
         var manager = new InputManager();
         Assert.False(manager.IsCommandDown(InputCommandType.Activate));
@@ -205,7 +205,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void IsKeyReleased_ReturnsFalseInitially()
+    public void IsKeyReleased_WhenInitiallyQueried_ShouldReturnFalse()
     {
         var manager = new InputManager();
         Assert.False(manager.IsKeyReleased((int)Keys.Enter));
@@ -213,7 +213,7 @@ public class InputManagerTests
 
     [Trait("Category", "Unit")]
     [Fact]
-    public void IsKeyDown_ReturnsFalseInitially()
+    public void IsKeyDown_WhenInitiallyQueried_ShouldReturnFalse()
     {
         var manager = new InputManager();
         Assert.False(manager.IsKeyDown((int)Keys.Enter));

--- a/DTXMania.Test/Input/InputManagerTests.cs
+++ b/DTXMania.Test/Input/InputManagerTests.cs
@@ -67,6 +67,18 @@ public class InputManagerTests
         Assert.Contains("return concreteConfig.CreateConfiguredInputManager();", source, StringComparison.Ordinal);
     }
 
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void ResetKeyRepeatStates_ShouldNotThrow_WhenNoRepeatStates()
+    {
+        var manager = new TestableInputManager();
+
+        // Should not throw even when no keys have been pressed
+        manager.ResetKeyRepeatStates();
+
+        Assert.False(manager.HasPendingCommands);
+    }
+
     private sealed class TestableInputManager : InputManager
     {
         public void QueueCommand(InputCommandType commandType, double timestamp, bool isRepeat = false)

--- a/DTXMania.Test/Input/InputManagerTests.cs
+++ b/DTXMania.Test/Input/InputManagerTests.cs
@@ -79,11 +79,73 @@ public class InputManagerTests
         Assert.False(manager.HasPendingCommands);
     }
 
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void KeyRepeatState_Suppress_ShouldSetSuppressedFlag()
+    {
+        var state = new KeyRepeatState();
+
+        Assert.False(state.Suppressed);
+
+        state.Suppress();
+
+        Assert.True(state.Suppressed);
+        Assert.False(state.IsPressed);
+        Assert.Equal(0, state.LastRepeatTime);
+        Assert.Equal(0, state.CurrentRepeatInterval);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void KeyRepeatState_Reset_ShouldClearSuppressedFlag()
+    {
+        var state = new KeyRepeatState();
+        state.Suppress();
+
+        Assert.True(state.Suppressed);
+
+        state.Reset();
+
+        Assert.False(state.Suppressed);
+    }
+
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void ResetKeyRepeatStates_ShouldSuppressRatherThanReset()
+    {
+        var manager = new TestableInputManager();
+
+        // Simulate that Escape was pressed — seed a KeyRepeatState so
+        // ResetKeyRepeatStates has something to suppress.
+        manager.SimulateKeyRepeatState(Keys.Escape);
+
+        // Now suppress via ResetKeyRepeatStates (e.g. modal closed while Escape held).
+        manager.ResetKeyRepeatStates();
+
+        // The state should be suppressed, not just reset — this means if the key is
+        // still held on the next frame, no phantom repeat will fire.
+        var state = manager.GetKeyRepeatState(Keys.Escape);
+        Assert.NotNull(state);
+        Assert.True(state.Suppressed);
+    }
+
     private sealed class TestableInputManager : InputManager
     {
         public void QueueCommand(InputCommandType commandType, double timestamp, bool isRepeat = false)
         {
             EnqueueCommand(new InputCommand(commandType, timestamp, isRepeat));
+        }
+
+        public void SimulateKeyRepeatState(Keys key)
+        {
+            // Add mapping and seed a repeat state so ResetKeyRepeatStates has something to suppress.
+            AddKeyMapping(key, InputCommandType.Back);
+            SeedKeyRepeatState(key, new KeyRepeatState());
+        }
+
+        public KeyRepeatState? GetKeyRepeatState(Keys key)
+        {
+            return TryGetKeyRepeatState(key);
         }
     }
 

--- a/DTXMania.Test/Input/InputManagerTests.cs
+++ b/DTXMania.Test/Input/InputManagerTests.cs
@@ -219,6 +219,30 @@ public class InputManagerTests
         Assert.False(manager.IsKeyDown((int)Keys.Enter));
     }
 
+    [Trait("Category", "Unit")]
+    [Fact]
+    public void KeyRepeatState_SuppressedClearedOnFreshPress()
+    {
+        // Simulate: modal closes, ResetKeyRepeatStates suppresses all keys,
+        // then user freshly presses a key that wasn't held.
+        // The Suppressed flag should be cleared on the initial press so
+        // repeat commands continue to work.
+        var state = new KeyRepeatState();
+        state.Suppress();
+        Assert.True(state.Suppressed);
+
+        // Simulate initial press branch behavior: clearing Suppressed
+        state.IsPressed = true;
+        state.InitialPressTime = 1.0;
+        state.LastRepeatTime = 1.0;
+        state.CurrentRepeatInterval = 0.2;
+        state.HasStartedRepeating = false;
+        state.Suppressed = false;
+
+        Assert.False(state.Suppressed);
+        Assert.True(state.IsPressed);
+    }
+
     private sealed class TestableInputManager : InputManager
     {
         public void QueueCommand(InputCommandType commandType, double timestamp, bool isRepeat = false)

--- a/DTXMania.Test/Input/OpenSearchInputCommandTests.cs
+++ b/DTXMania.Test/Input/OpenSearchInputCommandTests.cs
@@ -1,5 +1,4 @@
 using DTXMania.Game.Lib.Input;
-using Microsoft.Xna.Framework.Input;
 using Xunit;
 
 namespace DTXMania.Test.Input
@@ -7,19 +6,8 @@ namespace DTXMania.Test.Input
     public class OpenSearchInputCommandTests
     {
         [Fact]
-        public void DefaultMapping_BackspaceMapsToOpenSearch()
-        {
-            var mgr = new InputManager();
-            var snapshot = mgr.GetKeyMappingSnapshot();
-
-            Assert.True(snapshot.ContainsKey(Keys.Back));
-            Assert.Equal(InputCommandType.OpenSearch, snapshot[Keys.Back]);
-        }
-
-        [Fact]
         public void OpenSearch_ExistsInEnum()
         {
-            // Ensure the enum value is defined
             var values = System.Enum.GetValues<InputCommandType>();
             Assert.Contains(InputCommandType.OpenSearch, values);
         }

--- a/DTXMania.Test/Input/OpenSearchInputCommandTests.cs
+++ b/DTXMania.Test/Input/OpenSearchInputCommandTests.cs
@@ -1,0 +1,27 @@
+using DTXMania.Game.Lib.Input;
+using Microsoft.Xna.Framework.Input;
+using Xunit;
+
+namespace DTXMania.Test.Input
+{
+    public class OpenSearchInputCommandTests
+    {
+        [Fact]
+        public void DefaultMapping_BackspaceMapsToOpenSearch()
+        {
+            var mgr = new InputManager();
+            var snapshot = mgr.GetKeyMappingSnapshot();
+
+            Assert.True(snapshot.ContainsKey(Keys.Back));
+            Assert.Equal(InputCommandType.OpenSearch, snapshot[Keys.Back]);
+        }
+
+        [Fact]
+        public void OpenSearch_ExistsInEnum()
+        {
+            // Ensure the enum value is defined
+            var values = System.Enum.GetValues<InputCommandType>();
+            Assert.Contains(InputCommandType.OpenSearch, values);
+        }
+    }
+}

--- a/DTXMania.Test/Input/OpenSearchInputCommandTests.cs
+++ b/DTXMania.Test/Input/OpenSearchInputCommandTests.cs
@@ -6,7 +6,8 @@ namespace DTXMania.Test.Input
     public class OpenSearchInputCommandTests
     {
         [Fact]
-        public void OpenSearch_ExistsInEnum()
+        [Trait("Category", "Unit")]
+        public void OpenSearch_WhenGettingEnum_ShouldExist()
         {
             var values = System.Enum.GetValues<InputCommandType>();
             Assert.Contains(InputCommandType.OpenSearch, values);

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalCoverageTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalCoverageTests.cs
@@ -1,0 +1,645 @@
+using System;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.Song.Components
+{
+    [Trait("Category", "Unit")]
+    public class SongSearchFilterModalCoverageTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c,
+                    Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void HandleInput_WhenClosed_ShouldReturnFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.False(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void HandleInput_WhenOpen_ShouldReturnTrue()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            Assert.True(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void HandleInput_AfterDispose_WhenStillOpen_ShouldReturnTrue()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.Dispose();
+
+            Assert.True(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void Dispose_WhenModalWasOpen_ShouldUnsubscribeFromTextSource()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+
+            modal.Dispose();
+
+            src.Fire('b');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Dispose_WhenModalWasNeverOpened_ShouldNotThrow()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            var ex = Record.Exception(() => modal.Dispose());
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void Dispose_CalledTwice_ShouldNotThrow()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.Dispose();
+
+            var ex = Record.Exception(() => modal.Dispose());
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void LoadingHintText_DefaultShouldBeLibraryStillLoading()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.Equal("Library still loading…", modal.LoadingHintText);
+        }
+
+        [Fact]
+        public void LoadingHintText_ShouldBeSettable()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource())
+            {
+                LoadingHintText = "Please wait…"
+            };
+
+            Assert.Equal("Please wait…", modal.LoadingHintText);
+        }
+
+        [Fact]
+        public void IsLibraryReady_DefaultShouldBeTrue()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.True(modal.IsLibraryReady);
+        }
+
+        [Fact]
+        public void IsLibraryReady_ShouldBeSettable()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource())
+            {
+                IsLibraryReady = false
+            };
+
+            Assert.False(modal.IsLibraryReady);
+        }
+
+        [Fact]
+        public void IsLibraryReady_SetBackToTrue_ShouldReflectChange()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource())
+            {
+                IsLibraryReady = false
+            };
+            modal.IsLibraryReady = true;
+
+            Assert.True(modal.IsLibraryReady);
+        }
+
+        [Fact]
+        public void WhitePixel_ShouldBeNullByDefault()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.Null(modal.WhitePixel);
+        }
+
+        [Fact]
+        public void WhitePixel_ShouldBeSettable()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            modal.WhitePixel = null;
+
+            Assert.Null(modal.WhitePixel);
+        }
+
+        [Fact]
+        public void Font_ShouldBeNullByDefault()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.Null(modal.Font);
+        }
+
+        [Fact]
+        public void Font_ShouldBeSettable()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            modal.Font = null;
+
+            Assert.Null(modal.Font);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_WhenLibraryNotReady_ShouldNotFireFilterApplied()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "test" });
+            bool applied = false;
+            bool reset = false;
+            modal.FilterApplied += (_, _) => applied = true;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(applied);
+            Assert.False(reset);
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_WhenLibraryNotReadyWithQCommand_ShouldNotFireReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/q" });
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(reset);
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_WhenLibraryReadyAndQCommand_ShouldFireReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = true };
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/q" });
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.True(reset);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Apply_WhenLibraryNotReady_ShouldNotFireFilterApplied()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.Apply();
+
+            Assert.False(applied);
+        }
+
+        [Fact]
+        public void Apply_WhenLibraryNotReady_ShouldNotClose()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.Apply();
+
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Apply_WhenLibraryNotReady_ViaEnterOnDefaultField_ShouldStayOpen()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel → default case in HandleEnter calls Apply
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.False(applied);
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Apply_WhenLibraryNotReady_ViaCommandOnApplyButton_ShouldStayOpen()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.False(applied);
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenModalClosed_ShouldNotModifyDraft()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "existing" });
+            modal.Cancel();
+
+            src.Fire('z');
+
+            Assert.Equal("existing", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnMinLevel_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            modal.FocusNext(); // MinLevel
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnMaxLevel_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            modal.FocusNext();
+            modal.FocusNext(); // MaxLevel
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnPlayedStatus_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            for (int i = 0; i < 3; i++) modal.FocusNext(); // PlayedStatus
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnSortBy_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            for (int i = 0; i < 4; i++) modal.FocusNext(); // SortBy
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnSortDirection_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            for (int i = 0; i < 5; i++) modal.FocusNext(); // SortDirection
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnResetButton_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            for (int i = 0; i < 6; i++) modal.FocusNext(); // ResetButton
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenFocusedOnApplyButton_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            for (int i = 0; i < 7; i++) modal.FocusNext(); // ApplyButton
+
+            src.Fire('x');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleBackspace_WhenQueryIsEmpty_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleBackspace_WhenQueryIsNull_ShouldNotModifyDraft()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            var criteria = SongFilterCriteria.Default with { SearchQuery = null };
+            modal.Open(criteria);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Null(modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleBackspace_WhenFocusedOnMinLevel_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            src.Fire('b');
+            Assert.Equal("ab", modal.CurrentDraft.SearchQuery);
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("ab", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleBackspace_WhenFocusedOnPlayedStatus_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('h');
+            src.Fire('i');
+            for (int i = 0; i < 3; i++) modal.FocusNext(); // PlayedStatus
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("hi", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleBackspace_WhenFocusedOnSortBy_ShouldNotModifySearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('x');
+            for (int i = 0; i < 4; i++) modal.FocusNext(); // SortBy
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("x", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenSearchQueryIsNull_ShouldAppendSuccessfully()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            var criteria = SongFilterCriteria.Default with { SearchQuery = null };
+            modal.Open(criteria);
+
+            src.Fire('a');
+
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenSearchQueryIsNullAndMultipleChars_ShouldBuildString()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            var criteria = SongFilterCriteria.Default with { SearchQuery = null };
+            modal.Open(criteria);
+
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Close_ThenReopen_ShouldResubscribeToTextSource()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+            modal.Cancel();
+
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('b');
+
+            Assert.Equal("b", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleKey_WhenNotOpen_ShouldNotProcessBackspace()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var src = new FakeSource();
+            modal.Open(SongFilterCriteria.Default);
+            modal.Cancel();
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Visible_WhenConstructed_ShouldBeFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.False(modal.Visible);
+        }
+
+        [Fact]
+        public void Visible_WhenOpened_ShouldBeTrue()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            Assert.True(modal.Visible);
+        }
+
+        [Fact]
+        public void Visible_AfterClose_ShouldBeFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.Close();
+
+            Assert.False(modal.Visible);
+        }
+
+        [Fact]
+        public void IsOpen_WhenConstructed_ShouldBeFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void CurrentDraft_WhenNotOpened_ShouldBeDefault()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.Equal(SongFilterCriteria.Default, modal.CurrentDraft);
+        }
+
+        [Fact]
+        public void FocusedField_WhenNotOpened_ShouldBeSearchBox()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void Open_WithNonNullInitial_ShouldSetDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var criteria = SongFilterCriteria.Default with
+            {
+                SearchQuery = "hello",
+                MinLevel = 15,
+                MaxLevel = 80,
+                PlayedStatus = PlayedStatus.Played,
+                SortBy = SongSortCriteria.Level,
+                SortDescending = true
+            };
+
+            modal.Open(criteria);
+
+            Assert.Equal("hello", modal.CurrentDraft.SearchQuery);
+            Assert.Equal(15, modal.CurrentDraft.MinLevel);
+            Assert.Equal(80, modal.CurrentDraft.MaxLevel);
+            Assert.Equal(PlayedStatus.Played, modal.CurrentDraft.PlayedStatus);
+            Assert.Equal(SongSortCriteria.Level, modal.CurrentDraft.SortBy);
+            Assert.True(modal.CurrentDraft.SortDescending);
+        }
+
+        [Fact]
+        public void Cancelled_WhenCancelled_ShouldFireEvent()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            object? sender = null;
+            modal.Cancelled += (s, _) => sender = s;
+
+            modal.Cancel();
+
+            Assert.Same(modal, sender);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenLibraryNotReady_ShouldStillCancelOnBack()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool cancelled = false;
+            modal.Cancelled += (_, _) => cancelled = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Back);
+
+            Assert.True(cancelled);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_WhenLibraryNotReady_ViaHandleKeyEnter_ShouldStayOpen()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "test" });
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.False(applied);
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Reset_WhenInvokedWithLibraryNotReady_ShouldStillReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.Reset();
+
+            Assert.True(reset);
+            Assert.False(modal.IsOpen);
+        }
+    }
+}

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalExtendedTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalExtendedTests.cs
@@ -430,7 +430,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void CycleSort_WhenBackwardFromGenreViaHandleCommand_ShouldResetToArtist()
+        public void CycleSort_WhenBackwardFromGenreViaHandleCommand_ShouldResetToLevel()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre });

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalExtendedTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalExtendedTests.cs
@@ -1,0 +1,555 @@
+using System;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.Song.Components
+{
+    [Trait("Category", "Unit")]
+    public class SongSearchFilterModalExtendedTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c,
+                    Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        #region HandleClick – PlayedStatus and SortDirection fallthrough
+
+        [Fact]
+        public void HandleClick_WhenClickPlayedStatusArea_ShouldFocusPlayedStatus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // PlayedRowY=144, level row bottom=130. Click at relY=150 → PlayedStatus
+            // modal Y=180, so position.Y = 180+150 = 330
+            var clicked = modal.HandleClick(new Point(470, 330));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.PlayedStatus, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickBelowSortRow_ShouldFocusSortDirection()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // SortRowY+30=218. Click at relY=240 → fallthrough to SortDirection
+            // modal Y=180, so position.Y = 180+240 = 420
+            // relX=130 which is < FieldX+180=310, so in FieldFromPosition it hits the
+            // SortBy check first but relY >= 218, falls through to default
+            var clicked = modal.HandleClick(new Point(470, 420));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.SortDirection, modal.FocusedField);
+        }
+
+        #endregion
+
+        #region HandleCommand MoveLeft/MoveRight on MaxLevel
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnMaxLevel_ShouldIncrementBy5()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(5, modal.CurrentDraft.MaxLevel);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnMaxLevel_ShouldDecrementBy5()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MaxLevel = 15 });
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(10, modal.CurrentDraft.MaxLevel);
+        }
+
+        #endregion
+
+        #region HandleCommand MoveLeft/MoveRight on PlayedStatus
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnPlayedStatus_ShouldCycleForward()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.PlayedStatus, modal.FocusedField);
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(PlayedStatus.Unplayed, modal.CurrentDraft.PlayedStatus);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnPlayedStatus_ShouldCycleBackward()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(PlayedStatus.Cleared, modal.CurrentDraft.PlayedStatus);
+        }
+
+        #endregion
+
+        #region HandleCommand MoveLeft/MoveRight on SortBy
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnSortBy_ShouldCycleSortCriteria()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(SongSortCriteria.Artist, modal.CurrentDraft.SortBy);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnSortBy_ShouldCycleSortCriteriaBackward()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(SongSortCriteria.Level, modal.CurrentDraft.SortBy);
+        }
+
+        #endregion
+
+        #region HandleCommand MoveLeft/MoveRight on SortDirection
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnSortDirection_ShouldToggleDescending()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+
+            Assert.False(modal.CurrentDraft.SortDescending);
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.True(modal.CurrentDraft.SortDescending);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnSortDirection_ShouldToggleDescending()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SortDescending = true });
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.False(modal.CurrentDraft.SortDescending);
+        }
+
+        #endregion
+
+        #region HandleCommand Activate on numeric/cycle fields (default case in HandleEnter)
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnMinLevel_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnMaxLevel_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnPlayedStatus_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnSortBy_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnSortDirection_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnMinLevelAndLibraryNotReady_ShouldNotApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.False(applied);
+            Assert.True(modal.IsOpen);
+        }
+
+        #endregion
+
+        #region HandleKey Enter on SortBy and SortDirection
+
+        [Fact]
+        public void HandleKey_WhenEnterOnSortBy_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_WhenEnterOnSortDirection_ShouldApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        #endregion
+
+        #region AdjustLevel boundary conditions
+
+        [Fact]
+        public void AdjustLevel_WhenNullAndDecrement_ShouldClampToNull()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            Assert.Null(modal.CurrentDraft.MinLevel);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+
+            Assert.Null(modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void AdjustLevel_WhenAt99AndIncrement_ShouldClampAt99()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 99 });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+
+            Assert.Equal(99, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void AdjustLevel_WhenAt99AndIncrementViaCommand_ShouldClampAt99()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 99 });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(99, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void AdjustLevel_WhenAt1AndDecrement_ShouldReturnNull()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 1 });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+
+            Assert.Null(modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void AdjustLevel_WhenAtNullAndIncrementMaxLevel_ShouldSetTo5()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+            Assert.Null(modal.CurrentDraft.MaxLevel);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+
+            Assert.Equal(5, modal.CurrentDraft.MaxLevel);
+        }
+
+        [Fact]
+        public void AdjustLevel_WhenNullAndDecrementMaxLevelViaCommand_ShouldStayNull()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Null(modal.CurrentDraft.MaxLevel);
+        }
+
+        #endregion
+
+        #region PlayedStatus cycling edge cases
+
+        [Fact]
+        public void PlayedStatus_WhenCycleBackwardFromAll_ShouldWrapToCleared()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal(PlayedStatus.All, modal.CurrentDraft.PlayedStatus);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+
+            Assert.Equal(PlayedStatus.Cleared, modal.CurrentDraft.PlayedStatus);
+        }
+
+        [Fact]
+        public void PlayedStatus_WhenCycleForwardFullLoop_ShouldReturnToAll()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+
+            // All → Unplayed → Played → Cleared → All
+            for (int i = 0; i < 4; i++)
+                modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(PlayedStatus.All, modal.CurrentDraft.PlayedStatus);
+        }
+
+        #endregion
+
+        #region CycleSort edge cases
+
+        [Fact]
+        public void CycleSort_WhenBackwardFromTitle_ShouldWrapToLevel()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal(SongSortCriteria.Title, modal.CurrentDraft.SortBy);
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(SongSortCriteria.Level, modal.CurrentDraft.SortBy);
+        }
+
+        [Fact]
+        public void CycleSort_WhenForwardFullLoop_ShouldReturnToTitle()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+
+            // Title → Artist → Level → Title
+            for (int i = 0; i < 3; i++)
+                modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(SongSortCriteria.Title, modal.CurrentDraft.SortBy);
+        }
+
+        [Fact]
+        public void CycleSort_WhenBackwardFromGenreViaHandleCommand_ShouldResetToArtist()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre });
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(SongSortCriteria.Level, modal.CurrentDraft.SortBy);
+        }
+
+        #endregion
+
+        #region AdjustFocusedField no-op on non-adjustable fields
+
+        [Fact]
+        public void HandleKey_WhenLeftOnSearchBox_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SearchQuery = "test" });
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+
+            Assert.Equal("test", modal.CurrentDraft.SearchQuery);
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_WhenRightOnSearchBox_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SearchQuery = "test" });
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+
+            Assert.Equal("test", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnResetButton_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 10 });
+            for (int i = 0; i < 6; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ResetButton, modal.FocusedField);
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(10, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnResetButton_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 10 });
+            for (int i = 0; i < 6; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(10, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnApplyButton_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MaxLevel = 50 });
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(50, modal.CurrentDraft.MaxLevel);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnApplyButton_ShouldNotModifyDraft()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MaxLevel = 50 });
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(50, modal.CurrentDraft.MaxLevel);
+        }
+
+        #endregion
+
+        #region SortDirection toggle via HandleKey vs HandleCommand consistency
+
+        [Fact]
+        public void SortDirection_WhenToggledTwiceViaHandleKey_ShouldReturnToOriginal()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+
+            Assert.False(modal.CurrentDraft.SortDescending);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.True(modal.CurrentDraft.SortDescending);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.False(modal.CurrentDraft.SortDescending);
+        }
+
+        [Fact]
+        public void SortDirection_WhenToggledTwiceViaHandleCommand_ShouldReturnToOriginal()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SortDescending = true });
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+
+            Assert.True(modal.CurrentDraft.SortDescending);
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+            Assert.False(modal.CurrentDraft.SortDescending);
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+            Assert.True(modal.CurrentDraft.SortDescending);
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -402,7 +402,6 @@ namespace DTXMania.Test.Song.Components
             Assert.True(modal.IsOpen); // stays open
         }
 
-        [Fact]
         public void Reset_StillWorksWhenLibraryNotReady()
         {
             var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
@@ -413,6 +412,279 @@ namespace DTXMania.Test.Song.Components
             modal.Reset();
 
             Assert.True(fired);
+        }
+
+        [Fact]
+        public void HandleKey_WhenNotOpen_IsNoOp()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            bool cancelled = false;
+            modal.Cancelled += (_, _) => cancelled = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Escape);
+
+            Assert.False(cancelled);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnMaxLevel_AdjustsBy5()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+            Assert.Equal(SongSearchFilterModal.Field.MaxLevel, modal.FocusedField);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(5, modal.CurrentDraft.MaxLevel);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(10, modal.CurrentDraft.MaxLevel);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.Equal(5, modal.CurrentDraft.MaxLevel);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnSortBy_CyclesSortCriteria()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // Navigate to SortBy (index 4)
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.SortBy, modal.FocusedField);
+
+            Assert.Equal(SongSortCriteria.Title, modal.CurrentDraft.SortBy);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(SongSortCriteria.Artist, modal.CurrentDraft.SortBy);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(SongSortCriteria.Level, modal.CurrentDraft.SortBy);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(SongSortCriteria.Title, modal.CurrentDraft.SortBy); // wraps
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.Equal(SongSortCriteria.Level, modal.CurrentDraft.SortBy);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnSortDirection_Toggles()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 5; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.SortDirection, modal.FocusedField);
+
+            Assert.False(modal.CurrentDraft.SortDescending);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.True(modal.CurrentDraft.SortDescending);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.False(modal.CurrentDraft.SortDescending);
+        }
+
+        [Fact]
+        public void HandleKey_Back_WhenNotOnSearchBox_IsNoOp()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleKey_Back_WhenQueryEmpty_IsNoOp()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnPlayedStatus_FieldsApplies()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.PlayedStatus, modal.FocusedField);
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnMinLevelField_Applies()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnMaxLevelField_Applies()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            modal.FocusNext(); // MaxLevel
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void OnTextInput_ControlCharacters_Ignored()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+
+            src.Fire('\t');
+            src.Fire('\r');
+            src.Fire('\n');
+            src.Fire('\u0001'); // control char
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_BackspaceCharCode_Ignored()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+
+            src.Fire('\b');
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenModalClosed_Ignored()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.Cancel();
+
+            src.Fire('x');
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void AdjustLevel_ClampsAtMin0()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.Null(modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void AdjustLevel_ClampsAtMax99()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 95 });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(99, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_WhenLibraryNotReady_DoesNotFire()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "test" });
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(applied);
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Dispose_UnsubscribesFromSource()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+
+            modal.Dispose();
+
+            src.Fire('b');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Open_NullInitial_UsesDefault()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(null);
+
+            Assert.True(modal.IsOpen);
+            Assert.Equal(SongFilterCriteria.Default, modal.CurrentDraft);
+        }
+
+        [Fact]
+        public void UpdateDraft_Null_UsesDefault()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SearchQuery = "test" });
+            modal.UpdateDraft(null);
+
+            Assert.Equal(SongFilterCriteria.Default, modal.CurrentDraft);
+        }
+
+        [Fact]
+        public void Constructor_NullTextSource_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SongSearchFilterModal(null!));
+        }
+
+        [Fact]
+        public void CycleSort_StartFromGenre_ResetsToArtist()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre });
+            for (int i = 0; i < 4; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.SortBy, modal.FocusedField);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(SongSortCriteria.Artist, modal.CurrentDraft.SortBy);
+        }
+
+        [Fact]
+        public void AdjustLevel_DecrementToZero_ReturnsNull()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 5 });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.Null(modal.CurrentDraft.MinLevel);
         }
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -387,5 +387,32 @@ namespace DTXMania.Test.Song.Components
             // After close, characters must not affect the now-stale draft
             Assert.Equal("a", modal.CurrentDraft.SearchQuery);
         }
+
+        [Fact]
+        public void Apply_WhenLibraryNotReady_DoesNotFire()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.FilterApplied += (_, _) => fired = true;
+
+            modal.Apply();
+
+            Assert.False(fired);
+            Assert.True(modal.IsOpen); // stays open
+        }
+
+        [Fact]
+        public void Reset_StillWorksWhenLibraryNotReady()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.FilterReset += (_, _) => fired = true;
+
+            modal.Reset();
+
+            Assert.True(fired);
+        }
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -402,6 +402,7 @@ namespace DTXMania.Test.Song.Components
             Assert.True(modal.IsOpen); // stays open
         }
 
+        [Fact]
         public void Reset_StillWorksWhenLibraryNotReady()
         {
             var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace DTXMania.Test.Song.Components
 {
+    [Trait("Category", "Unit")]
     public class SongSearchFilterModalLogicTests
     {
         private sealed class FakeSource : ITextInputSource
@@ -19,7 +20,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Open_DefaultCriteria_PopulatesFromArgument()
+        public void Open_WithDefaultCriteria_ShouldPopulateFromArgument()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             var initial = SongFilterCriteria.Default with { SearchQuery = "abc" };
@@ -31,7 +32,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Cancel_FiresCancelledEvent_AndCloses()
+        public void Cancel_WhenInvoked_ShouldRaiseCancelledAndClose()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -45,7 +46,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Apply_FiresFilterAppliedWithDraft_AndCloses()
+        public void Apply_WhenInvoked_ShouldFireFilterAppliedWithDraftAndClose()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             var initial = SongFilterCriteria.Default with { SearchQuery = "x" };
@@ -61,7 +62,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Reset_FiresFilterResetAndCloses()
+        public void Reset_WhenInvoked_ShouldFireFilterResetAndClose()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default with { SearchQuery = "x" });
@@ -75,7 +76,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void EditDraft_DoesNotMutateInitialCriteria()
+        public void EditDraft_WhenUpdated_ShouldNotMutateInitialCriteria()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             var initial = SongFilterCriteria.Default with { SearchQuery = "orig" };
@@ -88,7 +89,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void SubmitFromSearchBox_QSlashCommand_TriggersReset()
+        public void SubmitFromSearchBox_WhenQSlashCommand_ShouldTriggerReset()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -106,7 +107,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void SubmitFromSearchBox_QSlashCommand_CaseInsensitive()
+        public void SubmitFromSearchBox_WhenQSlashCommandCaseInsensitive_ShouldTriggerReset()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -120,7 +121,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void SubmitFromSearchBox_NormalQuery_TriggersApply()
+        public void SubmitFromSearchBox_WhenNormalQuery_ShouldTriggerApply()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -137,7 +138,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void SubmitFromSearchBox_QPrefixedQuery_NotResetCommand()
+        public void SubmitFromSearchBox_WhenQPrefixedQuery_ShouldNotBeResetCommand()
         {
             // "/quiet" is a literal search, not /q
             var modal = new SongSearchFilterModal(new FakeSource());
@@ -155,7 +156,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Open_SearchBoxIsInitiallyFocused()
+        public void Open_WhenOpened_ShouldInitiallyFocusSearchBox()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -164,7 +165,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void FocusNext_CyclesThroughFieldsInOrder()
+        public void FocusNext_WhenCalled_ShouldCycleThroughFieldsInOrder()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -191,7 +192,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void FocusPrev_ReverseOfFocusNext()
+        public void FocusPrev_WhenCalled_ShouldReverseOfFocusNext()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -203,7 +204,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Escape_FiresCancel()
+        public void HandleKey_WhenEscape_ShouldFireCancel()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -217,7 +218,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Tab_AdvancesFocus()
+        public void HandleKey_WhenTab_ShouldAdvanceFocus()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -228,7 +229,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Down_AdvancesFocus()
+        public void HandleKey_WhenDown_ShouldAdvanceFocus()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -239,7 +240,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Up_RetreatsFocus()
+        public void HandleKey_WhenUp_ShouldRetreatFocus()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -250,7 +251,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Enter_OnSearchBox_SubmitsFromSearchBox()
+        public void HandleKey_WhenEnterOnSearchBox_ShouldSubmitFromSearchBox()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -264,7 +265,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Enter_OnApplyButton_FiresApply()
+        public void HandleKey_WhenEnterOnApplyButton_ShouldFireApply()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -281,7 +282,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Enter_OnResetButton_FiresReset()
+        public void HandleKey_WhenEnterOnResetButton_ShouldFireReset()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -298,7 +299,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_LeftRight_OnMinLevel_AdjustsBy5()
+        public void HandleKey_WhenLeftRightOnMinLevel_ShouldAdjustBy5()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -314,7 +315,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_LeftRight_OnPlayedStatus_CyclesEnum()
+        public void HandleKey_WhenLeftRightOnPlayedStatus_ShouldCycleEnum()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -333,7 +334,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void TypingChars_OnSearchBox_AppendsToSearchQuery()
+        public void TypingChars_WhenOnSearchBox_ShouldAppendToSearchQuery()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -346,7 +347,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void TypingChars_WhenNotOnSearchBox_Ignored()
+        public void TypingChars_WhenNotOnSearchBox_ShouldBeIgnored()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -359,7 +360,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Backspace_HandleKey_RemovesLastSearchChar()
+        public void Backspace_WhenHandleKey_ShouldRemoveLastSearchChar()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -373,7 +374,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Close_UnsubscribesFromTextSource()
+        public void Close_WhenClosed_ShouldUnsubscribeFromTextSource()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -389,7 +390,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Apply_WhenLibraryNotReady_DoesNotFire()
+        public void Apply_WhenLibraryNotReady_ShouldNotFire()
         {
             var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
             modal.Open(SongFilterCriteria.Default);
@@ -403,7 +404,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Reset_StillWorksWhenLibraryNotReady()
+        public void Reset_WhenLibraryNotReady_ShouldStillWork()
         {
             var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
             modal.Open(SongFilterCriteria.Default);
@@ -416,7 +417,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_WhenNotOpen_IsNoOp()
+        public void HandleKey_WhenNotOpen_ShouldBeNoOp()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             bool cancelled = false;
@@ -428,7 +429,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_LeftRight_OnMaxLevel_AdjustsBy5()
+        public void HandleKey_WhenLeftRightOnMaxLevel_ShouldAdjustBy5()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -445,7 +446,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_LeftRight_OnSortBy_CyclesSortCriteria()
+        public void HandleKey_WhenLeftRightOnSortBy_ShouldCycleSortCriteria()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -465,7 +466,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_LeftRight_OnSortDirection_Toggles()
+        public void HandleKey_WhenLeftRightOnSortDirection_ShouldToggle()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -480,7 +481,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Back_WhenNotOnSearchBox_IsNoOp()
+        public void HandleKey_WhenBackNotOnSearchBox_ShouldBeNoOp()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -493,7 +494,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Back_WhenQueryEmpty_IsNoOp()
+        public void HandleKey_WhenBackAndQueryEmpty_ShouldBeNoOp()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -504,7 +505,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Enter_OnPlayedStatus_FieldsApplies()
+        public void HandleKey_WhenEnterOnPlayedStatus_ShouldApply()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -519,7 +520,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Enter_OnMinLevelField_Applies()
+        public void HandleKey_WhenEnterOnMinLevelField_ShouldApply()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -533,7 +534,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void HandleKey_Enter_OnMaxLevelField_Applies()
+        public void HandleKey_WhenEnterOnMaxLevelField_ShouldApply()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -548,7 +549,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void OnTextInput_ControlCharacters_Ignored()
+        public void OnTextInput_WhenControlCharacters_ShouldBeIgnored()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -563,7 +564,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void OnTextInput_BackspaceCharCode_Ignored()
+        public void OnTextInput_WhenBackspaceCharCode_ShouldBeIgnored()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -575,7 +576,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void OnTextInput_WhenModalClosed_Ignored()
+        public void OnTextInput_WhenModalClosed_ShouldBeIgnored()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -588,7 +589,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void AdjustLevel_ClampsAtMin0()
+        public void AdjustLevel_WhenAtMin_ShouldClampAt0()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default);
@@ -599,7 +600,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void AdjustLevel_ClampsAtMax99()
+        public void AdjustLevel_WhenAtMax_ShouldClampAt99()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default with { MinLevel = 95 });
@@ -610,7 +611,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void SubmitFromSearchBox_WhenLibraryNotReady_DoesNotFire()
+        public void SubmitFromSearchBox_WhenLibraryNotReady_ShouldNotFire()
         {
             var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
             modal.Open(SongFilterCriteria.Default);
@@ -625,7 +626,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Dispose_UnsubscribesFromSource()
+        public void Dispose_WhenCalled_ShouldUnsubscribeFromSource()
         {
             var src = new FakeSource();
             var modal = new SongSearchFilterModal(src);
@@ -640,7 +641,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Open_NullInitial_UsesDefault()
+        public void Open_WhenNullInitial_ShouldUseDefault()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(null);
@@ -650,7 +651,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void UpdateDraft_Null_UsesDefault()
+        public void UpdateDraft_WhenNull_ShouldUseDefault()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default with { SearchQuery = "test" });
@@ -660,13 +661,13 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void Constructor_NullTextSource_Throws()
+        public void Constructor_WhenNullTextSource_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>(() => new SongSearchFilterModal(null!));
         }
 
         [Fact]
-        public void CycleSort_StartFromGenre_ResetsToArtist()
+        public void CycleSort_WhenStartingFromGenre_ShouldResetToArtist()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre });
@@ -678,7 +679,7 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
-        public void AdjustLevel_DecrementToZero_ReturnsNull()
+        public void AdjustLevel_WhenDecrementToZero_ShouldReturnNull()
         {
             var modal = new SongSearchFilterModal(new FakeSource());
             modal.Open(SongFilterCriteria.Default with { MinLevel = 5 });

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -853,6 +853,54 @@ namespace DTXMania.Test.Song.Components
         }
 
         [Fact]
+        public void HandleClick_WhenClickMinLevel_ShouldFocusMinLevel()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // MinLevel: modal X=340 + LevelMinX=130 = 470, modal Y=180 + LevelRowY=100 + 10 = 290
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(470, 290));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickMaxLevel_ShouldFocusMaxLevel()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // MaxLevel: modal X=340 + LevelMaxX=310 = 650, modal Y=180 + LevelRowY=100 + 10 = 290
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(650, 290));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.MaxLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickSortBy_ShouldFocusSortBy()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // SortBy: modal X=340 + FieldX=130 = 470, modal Y=180 + SortRowY=188 + 10 = 378
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(470, 378));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.SortBy, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickSortDirection_ShouldFocusSortDirection()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // SortDirection: modal X=340 + FieldX+180=310 = 650, modal Y=180 + SortRowY=188 + 10 = 378
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(650, 378));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.SortDirection, modal.FocusedField);
+        }
+
+        [Fact]
         public void HandleClick_WhenClickOutsideModal_ShouldReturnFalse()
         {
             var modal = new SongSearchFilterModal(new FakeSource());

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -1,0 +1,90 @@
+using System;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.Song.Components
+{
+    public class SongSearchFilterModalLogicTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c,
+                    Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void Open_DefaultCriteria_PopulatesFromArgument()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var initial = SongFilterCriteria.Default with { SearchQuery = "abc" };
+
+            modal.Open(initial);
+
+            Assert.True(modal.IsOpen);
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Cancel_FiresCancelledEvent_AndCloses()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.Cancelled += (_, _) => fired = true;
+
+            modal.Cancel();
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Apply_FiresFilterAppliedWithDraft_AndCloses()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var initial = SongFilterCriteria.Default with { SearchQuery = "x" };
+            modal.Open(initial);
+            SongFilterCriteria? captured = null;
+            modal.FilterApplied += (_, c) => captured = c;
+
+            modal.Apply();
+
+            Assert.NotNull(captured);
+            Assert.Equal("x", captured!.SearchQuery);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Reset_FiresFilterResetAndCloses()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SearchQuery = "x" });
+            bool fired = false;
+            modal.FilterReset += (_, _) => fired = true;
+
+            modal.Reset();
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void EditDraft_DoesNotMutateInitialCriteria()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var initial = SongFilterCriteria.Default with { SearchQuery = "orig" };
+
+            modal.Open(initial);
+            modal.UpdateDraft(initial with { SearchQuery = "edited" });
+
+            Assert.Equal("orig", initial.SearchQuery);
+            Assert.Equal("edited", modal.CurrentDraft.SearchQuery);
+        }
+    }
+}

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -86,5 +86,72 @@ namespace DTXMania.Test.Song.Components
             Assert.Equal("orig", initial.SearchQuery);
             Assert.Equal("edited", modal.CurrentDraft.SearchQuery);
         }
+
+        [Fact]
+        public void SubmitFromSearchBox_QSlashCommand_TriggersReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/q" });
+            bool resetFired = false;
+            bool appliedFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+            modal.FilterApplied += (_, _) => appliedFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.True(resetFired);
+            Assert.False(appliedFired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_QSlashCommand_CaseInsensitive()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/Q" });
+            bool resetFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.True(resetFired);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_NormalQuery_TriggersApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "beatles" });
+            bool resetFired = false;
+            bool appliedFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+            modal.FilterApplied += (_, _) => appliedFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(resetFired);
+            Assert.True(appliedFired);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_QPrefixedQuery_NotResetCommand()
+        {
+            // "/quiet" is a literal search, not /q
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/quiet" });
+            bool resetFired = false;
+            bool appliedFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+            modal.FilterApplied += (_, _) => appliedFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(resetFired);
+            Assert.True(appliedFired);
+        }
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -688,5 +688,207 @@ namespace DTXMania.Test.Song.Components
             modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
             Assert.Null(modal.CurrentDraft.MinLevel);
         }
+
+        #region HandleCommand tests (command-based navigation)
+
+        [Fact]
+        public void HandleCommand_WhenMoveDown_ShouldAdvanceFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveDown);
+
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveUp_ShouldRetreatFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveUp);
+
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveLeftOnMinLevel_ShouldAdjust()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { MinLevel = 10 });
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveLeft);
+
+            Assert.Equal(5, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenMoveRightOnMinLevel_ShouldAdjust()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveRight);
+
+            Assert.Equal(5, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnSearchBox_ShouldSubmit()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnApplyButton_ShouldFireApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenActivateOnResetButton_ShouldFireReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 6; i++) modal.FocusNext();
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate);
+
+            Assert.True(reset);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenBack_ShouldFireCancel()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.Cancelled += (_, _) => fired = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Back);
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void HandleCommand_WhenNotOpen_ShouldBeNoOp()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            bool cancelled = false;
+            modal.Cancelled += (_, _) => cancelled = true;
+
+            modal.HandleCommand(DTXMania.Game.Lib.Input.InputCommandType.Back);
+
+            Assert.False(cancelled);
+        }
+
+        #endregion
+
+        #region HandleClick tests (mouse interaction)
+
+        [Fact]
+        public void HandleClick_WhenClickResetButton_ShouldFireReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            // Reset button: modal X=340 + ResetButtonX=200 = 540, Y=180 + ButtonRowY=240 = 420
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(600, 438));
+
+            Assert.True(clicked);
+            Assert.True(reset);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickApplyButton_ShouldFireApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            // Apply button: modal X=340 + ApplyButtonX=360 = 700, Y=180 + ButtonRowY=240 = 420
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(760, 438));
+
+            Assert.True(clicked);
+            Assert.True(applied);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickInsideModalSearchArea_ShouldFocusSearchBox()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // Click in search box area: modal Y=180 + SearchBoxY=56 + 10 = 246
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(400, 246));
+
+            Assert.True(clicked);
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleClick_WhenClickOutsideModal_ShouldReturnFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(10, 10));
+
+            Assert.False(clicked);
+        }
+
+        [Fact]
+        public void HandleClick_WhenNotOpen_ShouldReturnFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            // Click right on the modal area, but modal is closed
+            var clicked = modal.HandleClick(new Microsoft.Xna.Framework.Point(570, 258));
+
+            Assert.False(clicked);
+        }
+
+        #endregion
+
+        #region Position/Size sync on Open
+
+        [Fact]
+        public void Open_WhenCalled_ShouldSetUIElementBoundsToLayout()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var layout = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal.Bounds;
+
+            modal.Open(SongFilterCriteria.Default);
+
+            Assert.Equal(layout, modal.Bounds);
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -201,5 +201,135 @@ namespace DTXMania.Test.Song.Components
             modal.FocusPrev();
             Assert.Equal(SongSearchFilterModal.Field.ResetButton, modal.FocusedField);
         }
+
+        [Fact]
+        public void HandleKey_Escape_FiresCancel()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.Cancelled += (_, _) => fired = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Escape);
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void HandleKey_Tab_AdvancesFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Tab);
+
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_Down_AdvancesFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Down);
+
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_Up_RetreatsFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Up);
+
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnSearchBox_SubmitsFromSearchBox()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnApplyButton_FiresApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // Move focus to ApplyButton
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnResetButton_FiresReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // Move focus to ResetButton
+            for (int i = 0; i < 6; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ResetButton, modal.FocusedField);
+
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(reset);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnMinLevel_AdjustsBy5()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(5, modal.CurrentDraft.MinLevel);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(10, modal.CurrentDraft.MinLevel);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.Equal(5, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnPlayedStatus_CyclesEnum()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.PlayedStatus, modal.FocusedField);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(PlayedStatus.Unplayed, modal.CurrentDraft.PlayedStatus);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(PlayedStatus.Played, modal.CurrentDraft.PlayedStatus);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(PlayedStatus.Cleared, modal.CurrentDraft.PlayedStatus);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            // wraps
+            Assert.Equal(PlayedStatus.All, modal.CurrentDraft.PlayedStatus);
+        }
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -331,5 +331,61 @@ namespace DTXMania.Test.Song.Components
             // wraps
             Assert.Equal(PlayedStatus.All, modal.CurrentDraft.PlayedStatus);
         }
+
+        [Fact]
+        public void TypingChars_OnSearchBox_AppendsToSearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            // SearchBox is initial focus
+            src.Fire('h');
+            src.Fire('i');
+
+            Assert.Equal("hi", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void TypingChars_WhenNotOnSearchBox_Ignored()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+
+            src.Fire('5');
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Backspace_HandleKey_RemovesLastSearchChar()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            src.Fire('b');
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Close_UnsubscribesFromTextSource()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+
+            modal.Cancel(); // closes
+
+            src.Fire('b');
+            // After close, characters must not affect the now-stale draft
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -153,5 +153,53 @@ namespace DTXMania.Test.Song.Components
             Assert.False(resetFired);
             Assert.True(appliedFired);
         }
+
+        [Fact]
+        public void Open_SearchBoxIsInitiallyFocused()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void FocusNext_CyclesThroughFieldsInOrder()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            var order = new[]
+            {
+                SongSearchFilterModal.Field.SearchBox,
+                SongSearchFilterModal.Field.MinLevel,
+                SongSearchFilterModal.Field.MaxLevel,
+                SongSearchFilterModal.Field.PlayedStatus,
+                SongSearchFilterModal.Field.SortBy,
+                SongSearchFilterModal.Field.SortDirection,
+                SongSearchFilterModal.Field.ResetButton,
+                SongSearchFilterModal.Field.ApplyButton
+            };
+
+            for (int i = 0; i < order.Length; i++)
+            {
+                Assert.Equal(order[i], modal.FocusedField);
+                modal.FocusNext();
+            }
+            // After last, wraps back to SearchBox
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void FocusPrev_ReverseOfFocusNext()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.FocusPrev();
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+            modal.FocusPrev();
+            Assert.Equal(SongSearchFilterModal.Field.ResetButton, modal.FocusedField);
+        }
     }
 }

--- a/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+++ b/DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
@@ -876,6 +876,78 @@ namespace DTXMania.Test.Song.Components
 
         #endregion
 
+        #region HandleInput override tests (modal input blocking)
+
+        [Fact]
+        public void HandleInput_WhenOpen_ShouldConsumeAllInput()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            // HandleInput should return true (consume) even with a null input state,
+            // because the modal is open and should block all background interaction.
+            Assert.True(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void HandleInput_WhenClosed_ShouldNotConsumeInput()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            // Modal starts closed — HandleInput must return false so the
+            // invisible element doesn't swallow clicks.
+            Assert.False(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void HandleInput_AfterClose_ShouldNotConsumeInput()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.Cancel();
+
+            // After closing, the modal must not consume input.
+            Assert.False(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void HandleInput_AfterApply_ShouldNotConsumeInput()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.Apply();
+
+            Assert.False(modal.HandleInput(null!));
+        }
+
+        [Fact]
+        public void Enabled_WhenConstructed_ShouldBeFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+
+            Assert.False(modal.Enabled);
+        }
+
+        [Fact]
+        public void Enabled_WhenOpened_ShouldBeTrue()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            Assert.True(modal.Enabled);
+        }
+
+        [Fact]
+        public void Enabled_AfterClose_ShouldBeFalse()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.Cancel();
+
+            Assert.False(modal.Enabled);
+        }
+
+        #endregion
+
         #region Position/Size sync on Open
 
         [Fact]

--- a/DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
@@ -7,7 +7,7 @@ namespace DTXMania.Test.Song.Filtering
     public class SongFilterCriteriaTests
     {
         [Fact]
-        public void Default_HasExpectedValues()
+        public void Default_ShouldHaveExpectedValues()
         {
             var c = SongFilterCriteria.Default;
 
@@ -20,48 +20,48 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void IsEmpty_TrueForDefault()
+        public void Default_IsEmpty_ShouldBeTrue()
         {
             Assert.True(SongFilterCriteria.Default.IsEmpty);
         }
 
         [Fact]
-        public void IsEmpty_FalseWhenSearchQuerySet()
+        public void WhenSearchQuerySet_IsEmpty_ShouldBeFalse()
         {
             var c = SongFilterCriteria.Default with { SearchQuery = "abc" };
             Assert.False(c.IsEmpty);
         }
 
         [Fact]
-        public void IsEmpty_FalseWhenLevelSet()
+        public void WhenMinLevelSet_IsEmpty_ShouldBeFalse()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 50 };
             Assert.False(c.IsEmpty);
         }
 
         [Fact]
-        public void IsEmpty_FalseWhenPlayedStatusNotAll()
+        public void WhenPlayedStatusNotAll_IsEmpty_ShouldBeFalse()
         {
             var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
             Assert.False(c.IsEmpty);
         }
 
         [Fact]
-        public void IsEmpty_FalseWhenSortDescending()
+        public void WhenSortDescending_IsEmpty_ShouldBeFalse()
         {
             var c = SongFilterCriteria.Default with { SortDescending = true };
             Assert.False(c.IsEmpty);
         }
 
         [Fact]
-        public void IsEmpty_FalseWhenSortByNotTitle()
+        public void WhenSortByNotTitle_IsEmpty_ShouldBeFalse()
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
             Assert.False(c.IsEmpty);
         }
 
         [Fact]
-        public void Equality_RecordValueSemantics()
+        public void Equals_RecordValueSemantics_ShouldBeTrue()
         {
             var a = SongFilterCriteria.Default with { SearchQuery = "x" };
             var b = SongFilterCriteria.Default with { SearchQuery = "x" };

--- a/DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
@@ -1,6 +1,8 @@
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Song.Filtering;
 using Xunit;
+using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
 
 namespace DTXMania.Test.Song.Filtering
 {
@@ -66,6 +68,62 @@ namespace DTXMania.Test.Song.Filtering
             var a = SongFilterCriteria.Default with { SearchQuery = "x" };
             var b = SongFilterCriteria.Default with { SearchQuery = "x" };
             Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void Cleared_PlayCountAndClearCountGreaterThanZero_ShouldMatch()
+        {
+            var service = new SongListFilterService();
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                PlayCount = 5,
+                ClearCount = 3,
+                BestRank = 70
+            };
+
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+            var result = service.Apply(new[] { node }, criteria);
+
+            Assert.Single(result);
+            Assert.Same(node, result[0].Node);
+        }
+
+        [Fact]
+        public void Cleared_ClearCountZeroButRankIndicatesClear_ShouldMatch()
+        {
+            var service = new SongListFilterService();
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                PlayCount = 2,
+                ClearCount = 0,
+                BestRank = 60
+            };
+
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+            var result = service.Apply(new[] { node }, criteria);
+
+            Assert.Single(result);
+            Assert.Same(node, result[0].Node);
+        }
+
+        [Fact]
+        public void Cleared_PlayCountButNoClear_ShouldNotMatch()
+        {
+            var service = new SongListFilterService();
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                PlayCount = 4,
+                ClearCount = 0,
+                BestRank = 0
+            };
+
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+            var result = service.Apply(new[] { node }, criteria);
+
+            Assert.Empty(result);
         }
     }
 }

--- a/DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
@@ -1,0 +1,71 @@
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using Xunit;
+
+namespace DTXMania.Test.Song.Filtering
+{
+    public class SongFilterCriteriaTests
+    {
+        [Fact]
+        public void Default_HasExpectedValues()
+        {
+            var c = SongFilterCriteria.Default;
+
+            Assert.Equal("", c.SearchQuery);
+            Assert.Null(c.MinLevel);
+            Assert.Null(c.MaxLevel);
+            Assert.Equal(PlayedStatus.All, c.PlayedStatus);
+            Assert.Equal(SongSortCriteria.Title, c.SortBy);
+            Assert.False(c.SortDescending);
+        }
+
+        [Fact]
+        public void IsEmpty_TrueForDefault()
+        {
+            Assert.True(SongFilterCriteria.Default.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenSearchQuerySet()
+        {
+            var c = SongFilterCriteria.Default with { SearchQuery = "abc" };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenLevelSet()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50 };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenPlayedStatusNotAll()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenSortDescending()
+        {
+            var c = SongFilterCriteria.Default with { SortDescending = true };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenSortByNotTitle()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void Equality_RecordValueSemantics()
+        {
+            var a = SongFilterCriteria.Default with { SearchQuery = "x" };
+            var b = SongFilterCriteria.Default with { SearchQuery = "x" };
+            Assert.Equal(a, b);
+        }
+    }
+}

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -216,17 +216,39 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelMinGreaterThanMax_SwapsSilently()
+        public void Apply_LevelMinGreaterThanMax_NoLongerSwaps_NormalizedAtCaller()
         {
             var roots = new List<SongListNode>
             {
-                Score("Mid", level: 50)
+                Score("Low",  level: 20),
+                Score("Mid",  level: 50),
+                Score("High", level: 90)
             };
+            // Min > Max is now the caller's responsibility to normalize
+            // before passing to the service. The service treats the range as-is.
             var criteria = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
 
             var result = _svc.Apply(roots, criteria);
 
-            Assert.Single(result);
+            // With lo=80, hi=30, no level satisfies level >= 80 AND level <= 30
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Apply_LevelRange_NormalizedByCaller_FiltersCorrectly()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Low",  level: 20),
+                Score("Mid",  level: 50),
+                Score("High", level: 90)
+            };
+            // Caller normalizes MinLevel/MaxLevel before creating criteria
+            var criteria = SongFilterCriteria.Default with { MinLevel = 30, MaxLevel = 80 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Mid" }, result.Select(r => r.Node.DisplayTitle));
         }
 
         private static SongListNode ScoreWith(string title, int playCount, int bestRank, int clearCount = 0)

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace DTXMania.Test.Song.Filtering
 {
+    [Trait("Category", "Unit")]
     public class SongListFilterServiceTests
     {
         private readonly SongListFilterService _svc = new();
@@ -39,7 +40,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_FlattensRootScoreNodes_NoFilter()
+        public void FlatteningRootScoreNodes_WithNoFilter_ShouldReturnAllRootScores()
         {
             var roots = new List<SongListNode>
             {
@@ -54,7 +55,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_FlattensNestedScoreNodes_NoFilter()
+        public void FlatteningNestedScoreNodes_WithNoFilter_ShouldReturnAllScores()
         {
             var roots = new List<SongListNode>
             {
@@ -73,7 +74,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PopulatesFolderPathFromParentBreadcrumb()
+        public void FolderPath_WhenNestedInBoxes_ShouldPopulateFromParentBreadcrumb()
         {
             var roots = new List<SongListNode>
             {
@@ -88,7 +89,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_RootScoreHasEmptyFolderPath()
+        public void FolderPath_WhenRootScore_ShouldBeEmpty()
         {
             var roots = new List<SongListNode> { Score("RootOnly") };
 
@@ -98,7 +99,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_ExcludesBackBoxAndRandomNodes()
+        public void Apply_WithBackAndRandomNodes_ShouldExcludeThem()
         {
             var box = Box("Folder", Score("InsideSong"));
             box.AddChild(SongListNode.CreateBackNode(box));
@@ -110,7 +111,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SearchByTitle_CaseInsensitiveSubstring()
+        public void SearchByTitle_WithCaseInsensitiveSubstring_ShouldMatch()
         {
             var roots = new List<SongListNode>
             {
@@ -126,7 +127,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SearchByArtist_CaseInsensitiveSubstring()
+        public void SearchByArtist_WithCaseInsensitiveSubstring_ShouldMatch()
         {
             var roots = new List<SongListNode>
             {
@@ -141,7 +142,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SearchEmpty_ReturnsAll()
+        public void Search_WhenEmpty_ShouldReturnAll()
         {
             var roots = new List<SongListNode>
             {
@@ -155,7 +156,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SearchNoMatch_ReturnsEmpty()
+        public void Search_WhenNoMatch_ShouldReturnEmpty()
         {
             var roots = new List<SongListNode>
             {
@@ -170,7 +171,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelRange_FiltersByMaxDifficulty()
+        public void LevelRange_WithBothBounds_ShouldFilterByMaxDifficulty()
         {
             var roots = new List<SongListNode>
             {
@@ -186,7 +187,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelMinOnly_NoMaxBound()
+        public void LevelMinOnly_WithNoMaxBound_ShouldReturnAboveMin()
         {
             var roots = new List<SongListNode>
             {
@@ -201,7 +202,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelMaxOnly_NoMinBound()
+        public void LevelMaxOnly_WithNoMinBound_ShouldReturnBelowMax()
         {
             var roots = new List<SongListNode>
             {
@@ -216,7 +217,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelMinGreaterThanMax_NoLongerSwaps_NormalizedAtCaller()
+        public void LevelRange_WhenMinGreaterThanMax_ShouldReturnEmpty()
         {
             var roots = new List<SongListNode>
             {
@@ -235,7 +236,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelRange_NormalizedByCaller_FiltersCorrectly()
+        public void LevelRange_WhenNormalizedByCaller_ShouldFilterCorrectly()
         {
             var roots = new List<SongListNode>
             {
@@ -265,7 +266,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusUnplayed_KeepsOnlyZeroPlays()
+        public void PlayedStatusUnplayed_WhenFiltering_ShouldKeepOnlyZeroPlays()
         {
             var roots = new List<SongListNode>
             {
@@ -280,7 +281,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusPlayed_KeepsAnyPlayedSong()
+        public void PlayedStatusPlayed_WhenFiltering_ShouldKeepAnyPlayedSong()
         {
             var roots = new List<SongListNode>
             {
@@ -295,7 +296,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusCleared_RequiresPlayCountAndNonFRank()
+        public void PlayedStatusCleared_WhenFiltering_ShouldRequirePlayCountAndNonFRank()
         {
             var roots = new List<SongListNode>
             {
@@ -311,7 +312,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusCleared_CountsClearCountWhenBestRankIsF()
+        public void PlayedStatusCleared_WithClearCountAndFRank_ShouldCountAsCleared()
         {
             // Songs persisted via SongDatabaseService.UpdateScoreAsync have ClearCount > 0
             // but BestRank stays at 0 (F). These should still be considered cleared.
@@ -329,7 +330,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusCleared_RankBasedClearStillWorksWithoutClearCount()
+        public void PlayedStatusCleared_WithRankBasedClearAndNoClearCount_ShouldStillWork()
         {
             // In-memory update path sets BestRank but not ClearCount
             var roots = new List<SongListNode>
@@ -346,7 +347,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusCleared_NormalizesLegacyOrdinalBestRank()
+        public void PlayedStatusCleared_WithLegacyOrdinalBestRank_ShouldNormalize()
         {
             // Legacy ordinal 2 = A rank. Without normalization this maps to F via ComputeRankIndex.
             var roots = new List<SongListNode>
@@ -363,7 +364,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusAll_NoFilter()
+        public void PlayedStatusAll_WhenFiltering_ShouldReturnAll()
         {
             var roots = new List<SongListNode>
             {
@@ -378,7 +379,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_PlayedStatusUnplayed_TreatsMissingScoresAsUnplayed()
+        public void PlayedStatusUnplayed_WithMissingScores_ShouldTreatAsUnplayed()
         {
             var node = new SongListNode { Type = NodeType.Score, Title = "NoScores" };
             // node.Scores is all-null
@@ -391,7 +392,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SortByTitleDescending()
+        public void SortByTitleDescending_WhenApplied_ShouldSortDescending()
         {
             var roots = new List<SongListNode>
             {
@@ -410,7 +411,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SortByLevelAscending()
+        public void SortByLevelAscending_WhenApplied_ShouldSortByLevel()
         {
             var roots = new List<SongListNode>
             {
@@ -431,7 +432,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SortByArtist()
+        public void SortByArtist_WhenApplied_ShouldSortByArtist()
         {
             var roots = new List<SongListNode>
             {
@@ -446,7 +447,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_CombinedSearchLevelPlayedSort()
+        public void CombinedSearchLevelPlayedSort_WhenApplied_ShouldFilterCorrectly()
         {
             var roots = new List<SongListNode>
             {
@@ -475,27 +476,27 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_NullRoots_Throws()
+        public void Apply_WhenNullRoots_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>(() => _svc.Apply(null!, SongFilterCriteria.Default));
         }
 
         [Fact]
-        public void Apply_NullCriteria_Throws()
+        public void Apply_WhenNullCriteria_ShouldThrow()
         {
             var roots = new List<SongListNode> { Score("A") };
             Assert.Throws<ArgumentNullException>(() => _svc.Apply(roots, null!));
         }
 
         [Fact]
-        public void Apply_EmptyRoots_ReturnsEmpty()
+        public void Apply_WhenEmptyRoots_ShouldReturnEmpty()
         {
             var result = _svc.Apply(new List<SongListNode>(), SongFilterCriteria.Default);
             Assert.Empty(result);
         }
 
         [Fact]
-        public void Apply_SortByGenre()
+        public void SortByGenre_WhenApplied_ShouldSortByGenre()
         {
             var a = Score("SongA");
             a.Genre = "Rock";
@@ -513,7 +514,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SortByGenreDescending()
+        public void SortByGenreDescending_WhenApplied_ShouldSortDescending()
         {
             var a = Score("SongA");
             a.Genre = "Rock";
@@ -533,7 +534,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SearchNullArtist_DoesNotThrow()
+        public void Search_WithNullArtist_ShouldNotThrow()
         {
             var node = Score("TestSong");
             node.DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
@@ -547,7 +548,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_SortByLevelDescending()
+        public void SortByLevelDescending_WhenApplied_ShouldSortDescending()
         {
             var roots = new List<SongListNode>
             {
@@ -568,7 +569,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_NullNodeInRoots_IsSkipped()
+        public void Apply_WithNullNodeInRoots_ShouldSkipNull()
         {
             var roots = new List<SongListNode> { null!, Score("Valid") };
             var result = _svc.Apply(roots, SongFilterCriteria.Default);
@@ -578,7 +579,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_BoxWithNoChildren_IgnoresBox()
+        public void Apply_WithBoxWithNoChildren_ShouldIgnoreBox()
         {
             var box = SongListNode.CreateBoxNode("Empty", "/empty");
             var roots = new List<SongListNode> { box };
@@ -589,7 +590,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_BackBoxNode_Ignored()
+        public void Apply_WithBackBoxNode_ShouldBeIgnored()
         {
             var box = Box("Folder", Score("Inside"));
             var back = SongListNode.CreateBackNode(box);
@@ -601,7 +602,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_LevelRange_BothNull_ReturnsAll()
+        public void LevelRange_WithBothNull_ShouldReturnAll()
         {
             var roots = new List<SongListNode>
             {
@@ -616,7 +617,7 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
-        public void Apply_BoxNodeAtPathRoot_PopulatesFolderCorrectly()
+        public void BoxNodeAtPathRoot_WhenNested_ShouldPopulateFolderCorrectly()
         {
             var innerScore = Score("Inner");
             var childBox = SongListNode.CreateBoxNode("SubFolder", "/sub");

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -108,5 +108,65 @@ namespace DTXMania.Test.Song.Filtering
 
             Assert.Equal(new[] { "InsideSong" }, result.Select(r => r.Node.DisplayTitle));
         }
+
+        [Fact]
+        public void Apply_SearchByTitle_CaseInsensitiveSubstring()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Yesterday", "The Beatles"),
+                Score("Hey Jude", "The Beatles"),
+                Score("Smoke On The Water", "Deep Purple")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "yesterDAY" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Yesterday" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SearchByArtist_CaseInsensitiveSubstring()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Yesterday", "The Beatles"),
+                Score("Smoke On The Water", "Deep Purple")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "beatles" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Yesterday" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SearchEmpty_ReturnsAll()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("A"), Score("B")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public void Apply_SearchNoMatch_ReturnsEmpty()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("A", "Artist1"),
+                Score("B", "Artist2")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "zzz" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Empty(result);
+        }
     }
 }

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using Xunit;
+
+namespace DTXMania.Test.Song.Filtering
+{
+    public class SongListFilterServiceTests
+    {
+        private readonly SongListFilterService _svc = new();
+
+        private static SongListNode Score(string title, string artist = "", int level = 50)
+        {
+            var node = new SongListNode { Type = NodeType.Score, Title = title };
+            node.Scores[0] = new DTXMania.Game.Lib.Song.Entities.SongScore
+            {
+                DifficultyLevel = level,
+                DifficultyLabel = "BASIC"
+            };
+            // Artist lives on DatabaseSong — wire a minimal entity
+            if (!string.IsNullOrEmpty(artist))
+            {
+                node.DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+                {
+                    Title = title,
+                    Artist = artist
+                };
+            }
+            return node;
+        }
+
+        private static SongListNode Box(string title, params SongListNode[] children)
+        {
+            var box = SongListNode.CreateBoxNode(title, $"/path/{title}");
+            foreach (var c in children)
+                box.AddChild(c);
+            return box;
+        }
+
+        [Fact]
+        public void Apply_FlattensRootScoreNodes_NoFilter()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Song A"),
+                Score("Song B")
+            };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(new[] { "Song A", "Song B" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_FlattensNestedScoreNodes_NoFilter()
+        {
+            var roots = new List<SongListNode>
+            {
+                Box("J-POP",
+                    Score("Pop1"),
+                    Box("80s", Score("Pop80a"), Score("Pop80b"))),
+                Score("RootSong")
+            };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            // Sorted by Title (default): Pop1, Pop80a, Pop80b, RootSong
+            Assert.Equal(4, result.Count);
+            Assert.Equal(new[] { "Pop1", "Pop80a", "Pop80b", "RootSong" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PopulatesFolderPathFromParentBreadcrumb()
+        {
+            var roots = new List<SongListNode>
+            {
+                Box("J-POP",
+                    Box("80s", Score("Hit")))
+            };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            var hit = result.Single();
+            Assert.Equal("J-POP / 80s", hit.FolderPath);
+        }
+
+        [Fact]
+        public void Apply_RootScoreHasEmptyFolderPath()
+        {
+            var roots = new List<SongListNode> { Score("RootOnly") };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Equal("", result.Single().FolderPath);
+        }
+
+        [Fact]
+        public void Apply_ExcludesBackBoxAndRandomNodes()
+        {
+            var box = Box("Folder", Score("InsideSong"));
+            box.AddChild(SongListNode.CreateBackNode(box));
+            box.AddChild(SongListNode.CreateRandomNode());
+
+            var result = _svc.Apply(new[] { box }, SongFilterCriteria.Default);
+
+            Assert.Equal(new[] { "InsideSong" }, result.Select(r => r.Node.DisplayTitle));
+        }
+    }
+}

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -288,6 +288,23 @@ namespace DTXMania.Test.Song.Filtering
         }
 
         [Fact]
+        public void Apply_PlayedStatusCleared_NormalizesLegacyOrdinalBestRank()
+        {
+            // Legacy ordinal 2 = A rank. Without normalization this maps to F via ComputeRankIndex.
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("LegacyA", playCount: 1, bestRank: 2),   // legacy ordinal A
+                ScoreWith("ModernA", playCount: 1, bestRank: 80),  // canonical A bucket
+                ScoreWith("Failed",  playCount: 3, bestRank: 0)    // F bucket
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "LegacyA", "ModernA" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
         public void Apply_PlayedStatusAll_NoFilter()
         {
             var roots = new List<SongListNode>

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -229,14 +229,15 @@ namespace DTXMania.Test.Song.Filtering
             Assert.Single(result);
         }
 
-        private static SongListNode ScoreWith(string title, int playCount, int bestRank)
+        private static SongListNode ScoreWith(string title, int playCount, int bestRank, int clearCount = 0)
         {
             var node = new SongListNode { Type = NodeType.Score, Title = title };
             node.Scores[0] = new DTXMania.Game.Lib.Song.Entities.SongScore
             {
                 DifficultyLevel = 50,
                 PlayCount = playCount,
-                BestRank = bestRank
+                BestRank = bestRank,
+                ClearCount = clearCount
             };
             return node;
         }
@@ -285,6 +286,41 @@ namespace DTXMania.Test.Song.Filtering
             var result = _svc.Apply(roots, criteria);
 
             Assert.Equal(new[] { "Cleared" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusCleared_CountsClearCountWhenBestRankIsF()
+        {
+            // Songs persisted via SongDatabaseService.UpdateScoreAsync have ClearCount > 0
+            // but BestRank stays at 0 (F). These should still be considered cleared.
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("PersistedClear", playCount: 3, bestRank: 0, clearCount: 2),
+                ScoreWith("PlayedButFailed", playCount: 2, bestRank: 0, clearCount: 0),
+                ScoreWith("Untouched",       playCount: 0, bestRank: 0, clearCount: 0)
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "PersistedClear" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusCleared_RankBasedClearStillWorksWithoutClearCount()
+        {
+            // In-memory update path sets BestRank but not ClearCount
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("RankClear",    playCount: 1, bestRank: 70, clearCount: 0),
+                ScoreWith("RankClearA",   playCount: 1, bestRank: 80, clearCount: 0),
+                ScoreWith("Failed",       playCount: 5, bestRank: 0,  clearCount: 0)
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "RankClear", "RankClearA" }, result.Select(r => r.Node.DisplayTitle));
         }
 
         [Fact]

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -228,5 +228,91 @@ namespace DTXMania.Test.Song.Filtering
 
             Assert.Single(result);
         }
+
+        private static SongListNode ScoreWith(string title, int playCount, int bestRank)
+        {
+            var node = new SongListNode { Type = NodeType.Score, Title = title };
+            node.Scores[0] = new DTXMania.Game.Lib.Song.Entities.SongScore
+            {
+                DifficultyLevel = 50,
+                PlayCount = playCount,
+                BestRank = bestRank
+            };
+            return node;
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusUnplayed_KeepsOnlyZeroPlays()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Untouched", playCount: 0, bestRank: 0),
+                ScoreWith("Tried",     playCount: 3, bestRank: 80)
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Untouched" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusPlayed_KeepsAnyPlayedSong()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Untouched", playCount: 0, bestRank: 0),
+                ScoreWith("Tried",     playCount: 3, bestRank: 0)  // played but failed
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Played };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Tried" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusCleared_RequiresPlayCountAndNonFRank()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Untouched", playCount: 0, bestRank: 0),
+                ScoreWith("Failed",    playCount: 5, bestRank: 0),    // F bucket
+                ScoreWith("Cleared",   playCount: 1, bestRank: 80)    // A bucket
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Cleared" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusAll_NoFilter()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("A", playCount: 0, bestRank: 0),
+                ScoreWith("B", playCount: 1, bestRank: 80)
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.All };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusUnplayed_TreatsMissingScoresAsUnplayed()
+        {
+            var node = new SongListNode { Type = NodeType.Score, Title = "NoScores" };
+            // node.Scores is all-null
+            var roots = new List<SongListNode> { node };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Single(result);
+        }
     }
 }

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -473,5 +473,161 @@ namespace DTXMania.Test.Song.Filtering
             Assert.Equal(new[] { "Beatles - Yesterday" },
                 result.Select(r => r.Node.DisplayTitle));
         }
+
+        [Fact]
+        public void Apply_NullRoots_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => _svc.Apply(null!, SongFilterCriteria.Default));
+        }
+
+        [Fact]
+        public void Apply_NullCriteria_Throws()
+        {
+            var roots = new List<SongListNode> { Score("A") };
+            Assert.Throws<ArgumentNullException>(() => _svc.Apply(roots, null!));
+        }
+
+        [Fact]
+        public void Apply_EmptyRoots_ReturnsEmpty()
+        {
+            var result = _svc.Apply(new List<SongListNode>(), SongFilterCriteria.Default);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Apply_SortByGenre()
+        {
+            var a = Score("SongA");
+            a.Genre = "Rock";
+            var b = Score("SongB");
+            b.Genre = "Pop";
+            var c = Score("SongC");
+            c.Genre = "Rock";
+            var roots = new List<SongListNode> { a, b, c };
+            var criteria = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "SongB", "SongA", "SongC" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SortByGenreDescending()
+        {
+            var a = Score("SongA");
+            a.Genre = "Rock";
+            var b = Score("SongB");
+            b.Genre = "Pop";
+            var roots = new List<SongListNode> { a, b };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Genre,
+                SortDescending = true
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "SongA", "SongB" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SearchNullArtist_DoesNotThrow()
+        {
+            var node = Score("TestSong");
+            node.DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+            { Title = "TestSong", Artist = null };
+            var roots = new List<SongListNode> { node };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "test" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void Apply_SortByLevelDescending()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Low", level: 20),
+                Score("High", level: 90),
+                Score("Mid", level: 50)
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Level,
+                SortDescending = true
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "High", "Mid", "Low" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_NullNodeInRoots_IsSkipped()
+        {
+            var roots = new List<SongListNode> { null!, Score("Valid") };
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Single(result);
+            Assert.Equal("Valid", result[0].Node.DisplayTitle);
+        }
+
+        [Fact]
+        public void Apply_BoxWithNoChildren_IgnoresBox()
+        {
+            var box = SongListNode.CreateBoxNode("Empty", "/empty");
+            var roots = new List<SongListNode> { box };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Apply_BackBoxNode_Ignored()
+        {
+            var box = Box("Folder", Score("Inside"));
+            var back = SongListNode.CreateBackNode(box);
+            var roots = new List<SongListNode> { box, back };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Equal(new[] { "Inside" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelRange_BothNull_ReturnsAll()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("A", level: 20),
+                Score("B", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = null };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public void Apply_BoxNodeAtPathRoot_PopulatesFolderCorrectly()
+        {
+            var innerScore = Score("Inner");
+            var childBox = SongListNode.CreateBoxNode("SubFolder", "/sub");
+            childBox.AddChild(innerScore);
+            var rootBox = SongListNode.CreateBoxNode("RootFolder", "/root");
+            rootBox.AddChild(childBox);
+
+            var result = _svc.Apply(new[] { rootBox }, SongFilterCriteria.Default);
+
+            Assert.Single(result);
+            Assert.Equal("RootFolder / SubFolder", result[0].FolderPath);
+        }
     }
 }

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -630,5 +630,72 @@ namespace DTXMania.Test.Song.Filtering
             Assert.Single(result);
             Assert.Equal("RootFolder / SubFolder", result[0].FolderPath);
         }
+
+        [Fact]
+        public void PlayedStatus_WhenUnknownValue_ShouldReturnAllSongs()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Played", playCount: 1, bestRank: 80),
+                ScoreWith("Unplayed", playCount: 0, bestRank: 0)
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                PlayedStatus = (PlayedStatus)99
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Played", "Unplayed" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void SortBy_WhenUnknownValue_ShouldFallBackToTitle()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Zulu"),
+                Score("Alpha")
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = (SongSortCriteria)99
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Alpha", "Zulu" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void SortByArtist_WhenEitherArtistIsNull_ShouldSortUsingEmptyString()
+        {
+            var withArtist = Score("WithArtist", "Bravo");
+            var withoutArtist = Score("WithoutArtist");
+            var roots = new List<SongListNode> { withArtist, withoutArtist };
+            var criteria = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "WithoutArtist", "WithArtist" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void SortByGenre_WhenEitherGenreIsNull_ShouldSortUsingEmptyString()
+        {
+            var withGenre = Score("WithGenre");
+            withGenre.Genre = "Rock";
+            var withoutGenre = Score("WithoutGenre");
+            var roots = new List<SongListNode> { withGenre, withoutGenre };
+            var criteria = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "WithoutGenre", "WithGenre" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
     }
 }

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -314,5 +314,89 @@ namespace DTXMania.Test.Song.Filtering
 
             Assert.Single(result);
         }
+
+        [Fact]
+        public void Apply_SortByTitleDescending()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Apple"), Score("Banana"), Score("Cherry")
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Title,
+                SortDescending = true
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Cherry", "Banana", "Apple" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SortByLevelAscending()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("High", level: 90),
+                Score("Low",  level: 20),
+                Score("Mid",  level: 50)
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Level,
+                SortDescending = false
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Low", "Mid", "High" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SortByArtist()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("X", "Zenith"),
+                Score("Y", "Apex")
+            };
+            var criteria = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Y", "X" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_CombinedSearchLevelPlayedSort()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Beatles - Yesterday", playCount: 1, bestRank: 80),
+                ScoreWith("Beatles - Hard Rock", playCount: 0, bestRank: 0),
+                ScoreWith("Other Artist Song",   playCount: 1, bestRank: 80)
+            };
+            // Wire artist on first and second
+            roots[0].DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+            { Title = "Beatles - Yesterday", Artist = "The Beatles" };
+            roots[1].DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+            { Title = "Beatles - Hard Rock", Artist = "The Beatles" };
+
+            var criteria = SongFilterCriteria.Default with
+            {
+                SearchQuery = "beatles",
+                PlayedStatus = PlayedStatus.Played,
+                SortBy = SongSortCriteria.Title,
+                SortDescending = true
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Beatles - Yesterday" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
     }
 }

--- a/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+++ b/DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
@@ -168,5 +168,65 @@ namespace DTXMania.Test.Song.Filtering
 
             Assert.Empty(result);
         }
+
+        [Fact]
+        public void Apply_LevelRange_FiltersByMaxDifficulty()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Easy", level: 30),
+                Score("Mid",  level: 60),
+                Score("Hard", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = 80 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Mid" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelMinOnly_NoMaxBound()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Easy", level: 30),
+                Score("Hard", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = null };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Hard" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelMaxOnly_NoMinBound()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Easy", level: 30),
+                Score("Hard", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = 50 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Easy" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelMinGreaterThanMax_SwapsSilently()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Mid", level: 50)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Single(result);
+        }
     }
 }

--- a/DTXMania.Test/Song/SongDatabaseServiceCoverageTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceCoverageTests.cs
@@ -136,6 +136,27 @@ public class SongDatabaseServiceCoverageTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSongWithChartsAsync_ShouldIncludePersistedScores()
+    {
+        await _databaseService.InitializeDatabaseAsync();
+
+        var (songId, chart) = await AddSongAsync("Scored Song", "Coverage Bot", "scored-song.dtx", drumLevel: 50);
+
+        // Submit a score so there is a persisted SongScore row
+        await _databaseService.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, 850_000, 88.0, fullCombo: false);
+
+        var result = await _databaseService.GetSongWithChartsAsync(songId);
+
+        Assert.NotNull(result);
+        var returnedChart = Assert.Single(result!.Value.charts);
+        Assert.NotNull(returnedChart.Scores);
+        var persistedScore = Assert.Single(returnedChart.Scores);
+        Assert.Equal(850_000, persistedScore.BestScore);
+        Assert.Equal(88.0, persistedScore.BestAchievementRate);
+        Assert.Equal(1, persistedScore.PlayCount);
+    }
+
+    [Fact]
     public async Task UpdateScoreAsync_WhenNewBestScoreSubmitted_ShouldUpdateBestLastAndCounters()
     {
         await _databaseService.InitializeDatabaseAsync();

--- a/DTXMania.Test/Song/SongListNodeExtendedTests.cs
+++ b/DTXMania.Test/Song/SongListNodeExtendedTests.cs
@@ -814,6 +814,56 @@ namespace DTXMania.Test.Song
         Assert.Equal(900000, node.Scores[1]!.BestScore);
     }
 
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_SameChartIdDifferentInstruments_ShouldMatchByInstrument()
+    {
+        // A single chart (ChartId=10) has persisted scores for both DRUMS and GUITAR.
+        var chart = new SongChart { Id = 10, HasDrumChart = true, DrumLevel = 60, HasGuitarChart = true, GuitarLevel = 70 };
+        chart.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            ChartId = 10,
+            Chart = chart,
+            PlayCount = 8,
+            BestScore = 950000,
+            BestRank = 90
+        });
+        chart.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.GUITAR,
+            ChartId = 10,
+            Chart = chart,
+            PlayCount = 3,
+            BestScore = 600000,
+            BestRank = 70
+        });
+
+        var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+        node.Scores[0] = new SongScore
+        {
+            ChartId = 10,
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 60
+        };
+        node.Scores[1] = new SongScore
+        {
+            ChartId = 10,
+            Instrument = EInstrumentPart.GUITAR,
+            DifficultyLevel = 70
+        };
+
+        node.PopulatePlayHistoryFromCharts(new[] { chart });
+
+        // Each slot should match the persisted score for its own instrument
+        Assert.Equal(8, node.Scores[0]!.PlayCount);
+        Assert.Equal(950000, node.Scores[0]!.BestScore);
+        Assert.Equal(90, node.Scores[0]!.BestRank);
+
+        Assert.Equal(3, node.Scores[1]!.PlayCount);
+        Assert.Equal(600000, node.Scores[1]!.BestScore);
+        Assert.Equal(70, node.Scores[1]!.BestRank);
+    }
+
     #endregion
 
         #region Note Tests

--- a/DTXMania.Test/Song/SongListNodeExtendedTests.cs
+++ b/DTXMania.Test/Song/SongListNodeExtendedTests.cs
@@ -585,6 +585,7 @@ namespace DTXMania.Test.Song
         var persistedScore = new SongScore
         {
             Instrument = EInstrumentPart.DRUMS,
+            Chart = chart, // EF Core sets this navigation automatically; required for DifficultyLevel matching
             PlayCount = 7,
             BestRank = 80,
             BestScore = 950000,
@@ -638,6 +639,7 @@ namespace DTXMania.Test.Song
         chart.Scores.Add(new SongScore
         {
             Instrument = EInstrumentPart.DRUMS,
+            Chart = chart, // Required for DifficultyLevel matching
             PlayCount = 5,
             BestRank = 90,
             BestScore = 800000
@@ -645,6 +647,7 @@ namespace DTXMania.Test.Song
         chart.Scores.Add(new SongScore
         {
             Instrument = EInstrumentPart.GUITAR,
+            Chart = chart, // Required for DifficultyLevel matching
             PlayCount = 2,
             BestRank = 70,
             BestScore = 600000
@@ -681,15 +684,26 @@ namespace DTXMania.Test.Song
     }
 
     [Fact]
-    public void PopulatePlayHistoryFromCharts_WithMultipleCharts_ShouldMatchAcrossCharts()
+    public void PopulatePlayHistoryFromCharts_WithMultipleCharts_ShouldMatchByInstrumentAndDifficulty()
     {
+        // chart1 has DRUMS at level 60 with a persisted score
         var chart1 = new SongChart { HasDrumChart = true, DrumLevel = 60 };
-        var chart2 = new SongChart { HasDrumChart = true, DrumLevel = 80 };
         chart1.Scores.Add(new SongScore
         {
             Instrument = EInstrumentPart.DRUMS,
+            Chart = chart1, // Required for DifficultyLevel matching
             PlayCount = 10,
             BestRank = 95
+        });
+
+        // chart2 has DRUMS at level 80 with its own persisted score
+        var chart2 = new SongChart { HasDrumChart = true, DrumLevel = 80 };
+        chart2.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            Chart = chart2, // Required for DifficultyLevel matching
+            PlayCount = 25,
+            BestRank = 88
         });
 
         var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
@@ -706,9 +720,49 @@ namespace DTXMania.Test.Song
 
         node.PopulatePlayHistoryFromCharts(new[] { chart1, chart2 });
 
-        // Both score slots with DRUMS match the persisted DRUMS score on chart1
+        // Each slot should match the persisted score with the same instrument AND difficulty level
         Assert.Equal(10, node.Scores[0]!.PlayCount);
-        Assert.Equal(10, node.Scores[1]!.PlayCount);
+        Assert.Equal(95, node.Scores[0]!.BestRank);
+        Assert.Equal(25, node.Scores[1]!.PlayCount);
+        Assert.Equal(88, node.Scores[1]!.BestRank);
+    }
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithMultipleCharts_NoMatchingDifficulty_ShouldKeepDefaults()
+    {
+        // Only chart1 has a persisted DRUMS score at level 60
+        var chart1 = new SongChart { HasDrumChart = true, DrumLevel = 60 };
+        chart1.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            Chart = chart1, // Required for DifficultyLevel matching
+            PlayCount = 10,
+            BestRank = 95
+        });
+
+        // chart2 has DRUMS at level 80 but no persisted score
+        var chart2 = new SongChart { HasDrumChart = true, DrumLevel = 80 };
+
+        var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+        node.Scores[0] = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 60
+        };
+        node.Scores[1] = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 80
+        };
+
+        node.PopulatePlayHistoryFromCharts(new[] { chart1, chart2 });
+
+        // Slot 0 matches chart1's persisted score (same instrument + level 60)
+        Assert.Equal(10, node.Scores[0]!.PlayCount);
+        Assert.Equal(95, node.Scores[0]!.BestRank);
+        // Slot 1 has no matching persisted score (level 80, no data) — stays default
+        Assert.Equal(0, node.Scores[1]!.PlayCount);
+        Assert.Equal(0, node.Scores[1]!.BestRank);
     }
 
     #endregion

--- a/DTXMania.Test/Song/SongListNodeExtendedTests.cs
+++ b/DTXMania.Test/Song/SongListNodeExtendedTests.cs
@@ -765,6 +765,55 @@ namespace DTXMania.Test.Song
         Assert.Equal(0, node.Scores[1]!.BestRank);
     }
 
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithDuplicateDifficulty_ShouldMatchByChartId()
+    {
+        // Two charts both have DRUMS at level 60 — matching by instrument+level alone
+        // would return the first chart's score for both slots.
+        var chart1 = new SongChart { Id = 10, HasDrumChart = true, DrumLevel = 60 };
+        chart1.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            ChartId = 10,
+            Chart = chart1,
+            PlayCount = 5,
+            BestScore = 100000
+        });
+
+        var chart2 = new SongChart { Id = 20, HasDrumChart = true, DrumLevel = 60 };
+        chart2.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            ChartId = 20,
+            Chart = chart2,
+            PlayCount = 25,
+            BestScore = 900000
+        });
+
+        var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+        // Slot 0 linked to chart1, slot 1 linked to chart2
+        node.Scores[0] = new SongScore
+        {
+            ChartId = 10,
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 60
+        };
+        node.Scores[1] = new SongScore
+        {
+            ChartId = 20,
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 60
+        };
+
+        node.PopulatePlayHistoryFromCharts(new[] { chart1, chart2 });
+
+        // Each slot should match its own chart's persisted score, not the first one
+        Assert.Equal(5, node.Scores[0]!.PlayCount);
+        Assert.Equal(100000, node.Scores[0]!.BestScore);
+        Assert.Equal(25, node.Scores[1]!.PlayCount);
+        Assert.Equal(900000, node.Scores[1]!.BestScore);
+    }
+
     #endregion
 
         #region Note Tests

--- a/DTXMania.Test/Song/SongListNodeExtendedTests.cs
+++ b/DTXMania.Test/Song/SongListNodeExtendedTests.cs
@@ -557,6 +557,162 @@ namespace DTXMania.Test.Song
 
     #endregion
 
+        #region PopulatePlayHistoryFromCharts Tests
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithNullCharts_ShouldNotThrow()
+    {
+        var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+        node.Scores[0] = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 50
+        };
+
+        node.PopulatePlayHistoryFromCharts(null!);
+
+        Assert.Equal(0, node.Scores[0]!.PlayCount);
+    }
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithPersistedScores_ShouldCopyPlayHistory()
+    {
+        var chart = new SongChart
+        {
+            HasDrumChart = true,
+            DrumLevel = 60
+        };
+        var persistedScore = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            PlayCount = 7,
+            BestRank = 80,
+            BestScore = 950000,
+            ClearCount = 3,
+            FullCombo = true,
+            MaxCombo = 120
+        };
+        chart.Scores.Add(persistedScore);
+
+        var song = new SongEntity { Title = "Test" };
+        var node = SongListNode.CreateSongNode(song, chart);
+
+        // The persisted score should have been populated
+        Assert.Equal(7, node.Scores[0]!.PlayCount);
+        Assert.Equal(80, node.Scores[0]!.BestRank);
+        Assert.Equal(950000, node.Scores[0]!.BestScore);
+        Assert.Equal(3, node.Scores[0]!.ClearCount);
+        Assert.True(node.Scores[0]!.FullCombo);
+        Assert.Equal(120, node.Scores[0]!.MaxCombo);
+    }
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithNoPersistedScores_ShouldKeepDefaults()
+    {
+        var chart = new SongChart
+        {
+            HasDrumChart = true,
+            DrumLevel = 60
+        };
+        // chart.Scores is empty - no persisted data
+
+        var song = new SongEntity { Title = "Test" };
+        var node = SongListNode.CreateSongNode(song, chart);
+
+        Assert.Equal(0, node.Scores[0]!.PlayCount);
+        Assert.Equal(0, node.Scores[0]!.BestRank);
+    }
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithMultipleInstruments_ShouldMatchByInstrument()
+    {
+        var chart = new SongChart
+        {
+            HasDrumChart = true,
+            DrumLevel = 60,
+            HasGuitarChart = true,
+            GuitarLevel = 70,
+            HasBassChart = true,
+            BassLevel = 50
+        };
+        chart.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            PlayCount = 5,
+            BestRank = 90,
+            BestScore = 800000
+        });
+        chart.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.GUITAR,
+            PlayCount = 2,
+            BestRank = 70,
+            BestScore = 600000
+        });
+        // No persisted bass score
+
+        var song = new SongEntity { Title = "Test" };
+        var node = SongListNode.CreateSongNode(song, chart);
+
+        // Drums - has persisted data
+        Assert.Equal(5, node.Scores[0]!.PlayCount);
+        Assert.Equal(90, node.Scores[0]!.BestRank);
+        Assert.Equal(800000, node.Scores[0]!.BestScore);
+
+        // Guitar - has persisted data
+        Assert.Equal(2, node.Scores[1]!.PlayCount);
+        Assert.Equal(70, node.Scores[1]!.BestRank);
+        Assert.Equal(600000, node.Scores[1]!.BestScore);
+
+        // Bass - no persisted data, stays default
+        Assert.Equal(0, node.Scores[2]!.PlayCount);
+    }
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithNullScoresEntry_ShouldSkip()
+    {
+        var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+        // Scores[0] is null
+        var chart = new SongChart { HasDrumChart = true, DrumLevel = 60 };
+
+        node.PopulatePlayHistoryFromCharts(new[] { chart });
+
+        Assert.Null(node.Scores[0]);
+    }
+
+    [Fact]
+    public void PopulatePlayHistoryFromCharts_WithMultipleCharts_ShouldMatchAcrossCharts()
+    {
+        var chart1 = new SongChart { HasDrumChart = true, DrumLevel = 60 };
+        var chart2 = new SongChart { HasDrumChart = true, DrumLevel = 80 };
+        chart1.Scores.Add(new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            PlayCount = 10,
+            BestRank = 95
+        });
+
+        var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+        node.Scores[0] = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 60
+        };
+        node.Scores[1] = new SongScore
+        {
+            Instrument = EInstrumentPart.DRUMS,
+            DifficultyLevel = 80
+        };
+
+        node.PopulatePlayHistoryFromCharts(new[] { chart1, chart2 });
+
+        // Both score slots with DRUMS match the persisted DRUMS score on chart1
+        Assert.Equal(10, node.Scores[0]!.PlayCount);
+        Assert.Equal(10, node.Scores[1]!.PlayCount);
+    }
+
+    #endregion
+
         #region Note Tests
 
         [Fact]

--- a/DTXMania.Test/Song/SongListNodePlayHistoryTests.cs
+++ b/DTXMania.Test/Song/SongListNodePlayHistoryTests.cs
@@ -1,0 +1,280 @@
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using EInstrumentPart = DTXMania.Game.Lib.Song.Entities.EInstrumentPart;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongListNodePlayHistoryTests
+    {
+        [Fact]
+        public void PopulatePlayHistoryFromCharts_NullCharts_ShouldNotThrow()
+        {
+            var node = new SongListNode();
+            var exception = Record.Exception(() => node.PopulatePlayHistoryFromCharts(null));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PopulatePlayHistoryFromCharts_NullScoreEntries_ShouldSkipThem()
+        {
+            var node = new SongListNode();
+            node.Scores[0] = null;
+            node.Scores[1] = null;
+
+            var chart = new SongChart { Id = 1 };
+            chart.Scores = new List<SongScore>
+            {
+                new SongScore { ChartId = 1, Instrument = EInstrumentPart.DRUMS, PlayCount = 5 }
+            };
+
+            var exception = Record.Exception(() => node.PopulatePlayHistoryFromCharts(new[] { chart }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PopulatePlayHistoryFromCharts_NonZeroChartId_ShouldMatchByChartId()
+        {
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                ChartId = 42,
+                Instrument = EInstrumentPart.DRUMS,
+                DifficultyLevel = 50
+            };
+
+            var chart = new SongChart { Id = 42 };
+            chart.Scores = new List<SongScore>
+            {
+                new SongScore
+                {
+                    ChartId = 42,
+                    Instrument = EInstrumentPart.DRUMS,
+                    PlayCount = 10,
+                    BestScore = 950000,
+                    BestRank = 95
+                }
+            };
+
+            node.PopulatePlayHistoryFromCharts(new[] { chart });
+
+            Assert.Equal(10, node.Scores[0].PlayCount);
+            Assert.Equal(950000, node.Scores[0].BestScore);
+            Assert.Equal(95, node.Scores[0].BestRank);
+        }
+
+        [Fact]
+        public void PopulatePlayHistoryFromCharts_ZeroChartId_ShouldMatchByInstrumentAndDifficulty()
+        {
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                ChartId = 0,
+                Instrument = EInstrumentPart.DRUMS,
+                DifficultyLevel = 50
+            };
+
+            var chart = new SongChart { Id = 1 };
+            chart.Scores = new List<SongScore>
+            {
+                new SongScore
+                {
+                    ChartId = 0,
+                    Instrument = EInstrumentPart.DRUMS,
+                    DifficultyLevel = 50,
+                    PlayCount = 7,
+                    BestScore = 800000
+                }
+            };
+
+            node.PopulatePlayHistoryFromCharts(new[] { chart });
+
+            Assert.Equal(7, node.Scores[0].PlayCount);
+            Assert.Equal(800000, node.Scores[0].BestScore);
+        }
+
+        [Fact]
+        public void PopulatePlayHistoryFromCharts_NoPersistedMatch_ShouldNotModifyScore()
+        {
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                ChartId = 99,
+                Instrument = EInstrumentPart.GUITAR,
+                DifficultyLevel = 30,
+                PlayCount = 0,
+                BestScore = 0
+            };
+
+            var chart = new SongChart { Id = 1 };
+            chart.Scores = new List<SongScore>
+            {
+                new SongScore
+                {
+                    ChartId = 1,
+                    Instrument = EInstrumentPart.DRUMS,
+                    PlayCount = 10,
+                    BestScore = 900000
+                }
+            };
+
+            node.PopulatePlayHistoryFromCharts(new[] { chart });
+
+            Assert.Equal(0, node.Scores[0].PlayCount);
+            Assert.Equal(0, node.Scores[0].BestScore);
+        }
+
+        [Fact]
+        public void PopulatePlayHistoryFromCharts_PersistedMatch_ShouldCopyAllFields()
+        {
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                ChartId = 10,
+                Instrument = EInstrumentPart.DRUMS,
+                DifficultyLevel = 60
+            };
+
+            var now = DateTime.UtcNow;
+            var chart = new SongChart { Id = 10 };
+            chart.Scores = new List<SongScore>
+            {
+                new SongScore
+                {
+                    ChartId = 10,
+                    Instrument = EInstrumentPart.DRUMS,
+                    PlayCount = 15,
+                    BestRank = 90,
+                    BestScore = 920000,
+                    BestSkillPoint = 85.5,
+                    BestAchievementRate = 92.0,
+                    FullCombo = true,
+                    Excellent = false,
+                    ClearCount = 12,
+                    MaxCombo = 350,
+                    HighSkill = 80.0,
+                    SongSkill = 75.5,
+                    LastPlayedAt = now,
+                    LastScore = 890000,
+                    LastSkillPoint = 70.3
+                }
+            };
+
+            node.PopulatePlayHistoryFromCharts(new[] { chart });
+
+            var s = node.Scores[0];
+            Assert.Equal(15, s.PlayCount);
+            Assert.Equal(90, s.BestRank);
+            Assert.Equal(920000, s.BestScore);
+            Assert.Equal(85.5, s.BestSkillPoint);
+            Assert.Equal(92.0, s.BestAchievementRate);
+            Assert.True(s.FullCombo);
+            Assert.False(s.Excellent);
+            Assert.Equal(12, s.ClearCount);
+            Assert.Equal(350, s.MaxCombo);
+            Assert.Equal(80.0, s.HighSkill);
+            Assert.Equal(75.5, s.SongSkill);
+            Assert.Equal(now, s.LastPlayedAt);
+            Assert.Equal(890000, s.LastScore);
+            Assert.Equal(70.3, s.LastSkillPoint);
+        }
+
+        [Fact]
+        public void PopulateScoresFromDatabase_NullDatabaseSongId_ShouldReturnImmediately()
+        {
+            var node = new SongListNode();
+            node.DatabaseSongId = null;
+
+            var exception = Record.Exception(() => node.PopulateScoresFromDatabase(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PopulateScoresFromDatabase_DrumsInstrument_ShouldSetCorrectPart()
+        {
+            var node = new SongListNode();
+            node.DatabaseSongId = 1;
+
+            var chart = new SongChart { Id = 1, DrumLevel = 55 };
+            chart.SetDifficultyLevel("DRUMS", 55);
+
+            var song = new SongEntity
+            {
+                Title = "Test",
+                Charts = new List<SongChart> { chart }
+            };
+            node.DatabaseSong = song;
+            node.DifficultyLabels[0] = "BASIC";
+
+            node.PopulateScoresFromDatabase(null!);
+
+            Assert.NotNull(node.Scores[0]);
+            Assert.Equal(EInstrumentPart.DRUMS, node.Scores[0].Instrument);
+            Assert.Equal(55, node.Scores[0].DifficultyLevel);
+        }
+
+        [Fact]
+        public void PopulateScoresFromDatabase_GuitarInstrument_ShouldSetCorrectPart()
+        {
+            var node = new SongListNode();
+            node.DatabaseSongId = 1;
+
+            var chart = new SongChart { Id = 1, GuitarLevel = 40 };
+            chart.SetDifficultyLevel("GUITAR", 40);
+
+            var song = new SongEntity
+            {
+                Title = "Test",
+                Charts = new List<SongChart> { chart }
+            };
+            node.DatabaseSong = song;
+            node.DifficultyLabels[0] = "ADVANCED";
+
+            node.PopulateScoresFromDatabase(null!);
+
+            Assert.NotNull(node.Scores[0]);
+            Assert.Equal(EInstrumentPart.GUITAR, node.Scores[0].Instrument);
+            Assert.Equal(40, node.Scores[0].DifficultyLevel);
+        }
+
+        [Fact]
+        public void PopulateScoresFromDatabase_BassInstrument_ShouldSetCorrectPart()
+        {
+            var node = new SongListNode();
+            node.DatabaseSongId = 1;
+
+            var chart = new SongChart { Id = 1, BassLevel = 35 };
+            chart.SetDifficultyLevel("BASS", 35);
+
+            var song = new SongEntity
+            {
+                Title = "Test",
+                Charts = new List<SongChart> { chart }
+            };
+            node.DatabaseSong = song;
+            node.DifficultyLabels[0] = "EXTREME";
+
+            node.PopulateScoresFromDatabase(null!);
+
+            Assert.NotNull(node.Scores[0]);
+            Assert.Equal(EInstrumentPart.BASS, node.Scores[0].Instrument);
+            Assert.Equal(35, node.Scores[0].DifficultyLevel);
+        }
+
+        [Fact]
+        public void PopulateScoresFromDatabase_ExceptionDuringProcessing_ShouldNotThrow()
+        {
+            var node = new SongListNode();
+            node.DatabaseSongId = 1;
+
+            var song = new SongEntity { Title = "Test" };
+            node.DatabaseSong = song;
+
+            var exception = Record.Exception(() => node.PopulateScoresFromDatabase(null!));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongListNodePlayHistoryTests.cs
+++ b/DTXMania.Test/Song/SongListNodePlayHistoryTests.cs
@@ -97,6 +97,52 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
+        public void PopulatePlayHistoryFromCharts_WhenSomeChartsHaveNullScores_ShouldSkipThem()
+        {
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore
+            {
+                ChartId = 42,
+                Instrument = EInstrumentPart.DRUMS,
+                DifficultyLevel = 50
+            };
+            node.Scores[1] = new SongScore
+            {
+                ChartId = 0,
+                Instrument = EInstrumentPart.GUITAR,
+                DifficultyLevel = 40
+            };
+
+            var chartWithoutScores = new SongChart { Id = 1, Scores = null };
+            var chartWithMatches = new SongChart
+            {
+                Id = 2,
+                Scores = new List<SongScore>
+                {
+                    new()
+                    {
+                        ChartId = 42,
+                        Instrument = EInstrumentPart.DRUMS,
+                        DifficultyLevel = 50,
+                        PlayCount = 8
+                    },
+                    new()
+                    {
+                        ChartId = 0,
+                        Instrument = EInstrumentPart.GUITAR,
+                        DifficultyLevel = 40,
+                        PlayCount = 6
+                    }
+                }
+            };
+
+            node.PopulatePlayHistoryFromCharts(new[] { chartWithoutScores, chartWithMatches });
+
+            Assert.Equal(8, node.Scores[0].PlayCount);
+            Assert.Equal(6, node.Scores[1].PlayCount);
+        }
+
+        [Fact]
         public void PopulatePlayHistoryFromCharts_NoPersistedMatch_ShouldNotModifyScore()
         {
             var node = new SongListNode();

--- a/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
@@ -47,7 +47,7 @@ namespace DTXMania.Test.Stage
         public void LevelMaxOnly_ShouldShowMaxLevel()
         {
             var c = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = 85 };
-            Assert.Equal("Filtered: Lv ≤85", SongSelectionStage.SummarizeFilter(c));
+            Assert.Equal("Filtered: Lv <=85", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace DTXMania.Test.Stage
                 SortBy = SongSortCriteria.Artist,
                 SortDescending = false
             };
-            Assert.Equal("Filtered: Artist↑", SongSelectionStage.SummarizeFilter(c));
+            Assert.Equal("Filtered: Artist^", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
@@ -76,11 +76,11 @@ namespace DTXMania.Test.Stage
                 SortBy = SongSortCriteria.Title,
                 SortDescending = true
             };
-            Assert.Equal("Filtered: Title↓", SongSelectionStage.SummarizeFilter(c));
+            Assert.Equal("Filtered: Titlev", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void AllFacets_ShouldBeJoinedWithDot()
+        public void AllFacets_ShouldBeJoinedWithPipe()
         {
             var c = new SongFilterCriteria(
                 SearchQuery: "beatles",
@@ -88,7 +88,7 @@ namespace DTXMania.Test.Stage
                 PlayedStatus: PlayedStatus.Unplayed,
                 SortBy: SongSortCriteria.Title,
                 SortDescending: false);
-            Assert.Equal("Filtered: \"beatles\" · Lv 50-85 · Unplayed",
+            Assert.Equal("Filtered: \"beatles\" | Lv 50-85 | Unplayed",
                 SongSelectionStage.SummarizeFilter(c));
         }
     }

--- a/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
@@ -1,0 +1,87 @@
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    public class SongSelectionStageBreadcrumbTests
+    {
+        [Fact]
+        public void Summarize_DefaultCriteria_ReturnsEmpty()
+        {
+            var s = SongSelectionStage.SummarizeFilter(SongFilterCriteria.Default);
+            Assert.Equal("", s);
+        }
+
+        [Fact]
+        public void Summarize_OnlySearchQuery_ShowsQuoted()
+        {
+            var c = SongFilterCriteria.Default with { SearchQuery = "beatles" };
+            Assert.Equal("Filtered: \"beatles\"", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_LevelRange_ShowsLevels()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = 85 };
+            Assert.Equal("Filtered: Lv 50-85", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_LevelMinOnly()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = null };
+            Assert.Equal("Filtered: Lv 50+", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_LevelMaxOnly()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = 85 };
+            Assert.Equal("Filtered: Lv ≤85", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_PlayedStatus()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+            Assert.Equal("Filtered: Unplayed", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_SortNonDefault_AppendedWithArrow()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Artist,
+                SortDescending = false
+            };
+            Assert.Equal("Filtered: Artist↑", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_SortDescending_DownArrow()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Title,
+                SortDescending = true
+            };
+            Assert.Equal("Filtered: Title↓", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_AllFacets_JoinedWithDot()
+        {
+            var c = new SongFilterCriteria(
+                SearchQuery: "beatles",
+                MinLevel: 50, MaxLevel: 85,
+                PlayedStatus: PlayedStatus.Unplayed,
+                SortBy: SongSortCriteria.Title,
+                SortDescending: false);
+            Assert.Equal("Filtered: \"beatles\" · Lv 50-85 · Unplayed",
+                SongSelectionStage.SummarizeFilter(c));
+        }
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
@@ -5,59 +5,60 @@ using Xunit;
 
 namespace DTXMania.Test.Stage
 {
+    [Trait("Category", "Unit")]
     public class SongSelectionStageBreadcrumbTests
     {
         [Fact]
-        public void Summarize_DefaultCriteria_ReturnsEmpty()
+        public void DefaultCriteria_ShouldReturnEmpty()
         {
             var s = SongSelectionStage.SummarizeFilter(SongFilterCriteria.Default);
             Assert.Equal("", s);
         }
 
         [Fact]
-        public void Summarize_OnlySearchQuery_ShowsQuoted()
+        public void OnlySearchQuery_ShouldShowQuoted()
         {
             var c = SongFilterCriteria.Default with { SearchQuery = "beatles" };
             Assert.Equal("Filtered: \"beatles\"", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void Summarize_LevelRange_ShowsLevels()
+        public void LevelRange_ShouldShowLevels()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = 85 };
             Assert.Equal("Filtered: Lv 50-85", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void Summarize_LevelRangeInverted_SwapsToAscending()
+        public void LevelRangeInverted_ShouldSwapToAscending()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
             Assert.Equal("Filtered: Lv 30-80", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void Summarize_LevelMinOnly()
+        public void LevelMinOnly_ShouldShowMinLevel()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = null };
             Assert.Equal("Filtered: Lv 50+", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void Summarize_LevelMaxOnly()
+        public void LevelMaxOnly_ShouldShowMaxLevel()
         {
             var c = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = 85 };
             Assert.Equal("Filtered: Lv ≤85", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void Summarize_PlayedStatus()
+        public void PlayedStatus_ShouldShowStatus()
         {
             var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
             Assert.Equal("Filtered: Unplayed", SongSelectionStage.SummarizeFilter(c));
         }
 
         [Fact]
-        public void Summarize_SortNonDefault_AppendedWithArrow()
+        public void SortNonDefault_ShouldBeAppendedWithArrow()
         {
             var c = SongFilterCriteria.Default with
             {
@@ -68,7 +69,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void Summarize_SortDescending_DownArrow()
+        public void SortDescending_ShouldShowDownArrow()
         {
             var c = SongFilterCriteria.Default with
             {
@@ -79,7 +80,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void Summarize_AllFacets_JoinedWithDot()
+        public void AllFacets_ShouldBeJoinedWithDot()
         {
             var c = new SongFilterCriteria(
                 SearchQuery: "beatles",

--- a/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
@@ -29,6 +29,13 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void Summarize_LevelRangeInverted_SwapsToAscending()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
+            Assert.Equal("Filtered: Lv 30-80", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
         public void Summarize_LevelMinOnly()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = null };

--- a/DTXMania.Test/Stage/SongSelectionStageClampingTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageClampingTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    public class SongSelectionStageClampingTests
+    {
+        private static SongListNode S(string title) =>
+            new SongListNode { Type = NodeType.Score, Title = title };
+
+        [Fact]
+        public void ClampSelectionIndex_PreviousNodeStillPresent_ReturnsItsIndex()
+        {
+            var prev = S("B");
+            var newList = new List<SongListNode> { S("A"), prev, S("C") };
+
+            int idx = SongSelectionStage.ClampSelectionIndex(prev, newList);
+
+            Assert.Equal(1, idx);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_PreviousNodeMissing_ReturnsZero()
+        {
+            var prev = S("Removed");
+            var newList = new List<SongListNode> { S("A"), S("B") };
+
+            int idx = SongSelectionStage.ClampSelectionIndex(prev, newList);
+
+            Assert.Equal(0, idx);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_EmptyList_ReturnsZero()
+        {
+            int idx = SongSelectionStage.ClampSelectionIndex(S("X"), new List<SongListNode>());
+            Assert.Equal(0, idx);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_NullPrevious_ReturnsZero()
+        {
+            int idx = SongSelectionStage.ClampSelectionIndex(null, new List<SongListNode> { S("A") });
+            Assert.Equal(0, idx);
+        }
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1689,7 +1689,11 @@ namespace DTXMania.Test.Stage
             public override bool IsKeyPressed(int keyCode)
             {
                 if (keyCode == (int)Microsoft.Xna.Framework.Input.Keys.Back && _backspacePressed)
+                {
+                    // Edge-triggered: consume the flag on first check to model a one-frame key press
+                    _backspacePressed = false;
                     return true;
+                }
                 return base.IsKeyPressed(keyCode);
             }
         }

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1756,6 +1756,18 @@ namespace DTXMania.Test.Stage
             public override bool IsCommandPressed(InputCommandType command) => _pressedCommands.Contains(command);
         }
 
+        /// <summary>
+        /// InputManager stub that lets tests specify which raw keys appear as pressed.
+        /// </summary>
+        private sealed class KeySimulatingInputManager : InputManager
+        {
+            private readonly HashSet<int> _pressedKeys = new();
+
+            public void PressRawKey(Microsoft.Xna.Framework.Input.Keys key) => _pressedKeys.Add((int)key);
+
+            public override bool IsKeyPressed(int keyCode) => _pressedKeys.Contains(keyCode);
+        }
+
         [Fact]
         public void ProcessModalKeys_WhenSearchBoxFocused_ShouldSuppressActivateCommand()
         {
@@ -1866,6 +1878,50 @@ namespace DTXMania.Test.Stage
 
             // Focus should have moved (MoveDown was processed)
             Assert.NotEqual(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldNavigateWithRawArrowKeys()
+        {
+            // Physical arrow keys do not produce text, so they should still work as
+            // raw input even when SearchBox is focused (commands are suppressed but
+            // raw arrow keys bypass the command system).
+            var stage = CreateStage();
+            var inputManager = new KeySimulatingInputManager();
+            inputManager.PressRawKey(Microsoft.Xna.Framework.Input.Keys.Down);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Focus should have moved to the next field via raw Down arrow
+            Assert.NotEqual(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldNavigateUpWithRawArrowKey()
+        {
+            // Up arrow should wrap focus backward from SearchBox.
+            var stage = CreateStage();
+            var inputManager = new KeySimulatingInputManager();
+            inputManager.PressRawKey(Microsoft.Xna.Framework.Input.Keys.Up);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Focus should have moved (Up wraps to the last field)
+            Assert.NotEqual(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
         }
 
         #endregion

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1727,5 +1727,140 @@ namespace DTXMania.Test.Stage
             // Selection should NOT have moved (MoveDown was blocked)
             Assert.Equal("A", display.SelectedSong!.Title);
         }
+
+        #region ProcessModalKeys – search-box command suppression (issue 1)
+
+        /// <summary>
+        /// InputManager stub that lets tests specify which commands appear as pressed.
+        /// </summary>
+        private sealed class CommandSimulatingInputManager : InputManager
+        {
+            private readonly HashSet<InputCommandType> _pressedCommands = new();
+
+            public void PressCommand(InputCommandType cmd) => _pressedCommands.Add(cmd);
+
+            public override bool IsCommandPressed(InputCommandType command) => _pressedCommands.Contains(command);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldSuppressActivateCommand()
+        {
+            // If Activate is remapped to a text-producing key, the command must be
+            // suppressed while the SearchBox is focused so text entry still works.
+            var stage = CreateStage();
+            var inputManager = new CommandSimulatingInputManager();
+            inputManager.PressCommand(InputCommandType.Activate);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            // Default focus is SearchBox
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Modal should still be open (Activate was suppressed)
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldSuppressBackCommand()
+        {
+            var stage = CreateStage();
+            var inputManager = new CommandSimulatingInputManager();
+            inputManager.PressCommand(InputCommandType.Back);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Modal should still be open (Back was suppressed)
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenApplyButtonFocused_ShouldProcessActivateCommand()
+        {
+            // Activate should still work when focus is NOT on the SearchBox.
+            var stage = CreateStage();
+            var inputManager = new CommandSimulatingInputManager();
+            inputManager.PressCommand(InputCommandType.Activate);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            // Move focus to ApplyButton
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Modal should have closed (Activate triggered Apply)
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldProcessDirectionalCommands()
+        {
+            // Directional commands (MoveUp/MoveDown/MoveLeft/MoveRight) should still
+            // be processed even when SearchBox is focused.
+            var stage = CreateStage();
+            var inputManager = new CommandSimulatingInputManager();
+            inputManager.PressCommand(InputCommandType.MoveDown);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Focus should have moved from SearchBox to MinLevel
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        #endregion
+
+        #region ProcessModalKeys – first-click mouse handling (issue 2)
+
+        [Fact]
+        public void ProcessModalKeys_WhenPreviousMouseStateIsNull_ShouldStillDetectClick()
+        {
+            // On the first modal open, _previousMouseState is null.
+            // The click should still register (null treated as "released").
+            var stage = CreateStage();
+            var inputManager = new CommandSimulatingInputManager();
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            // _previousMouseState defaults to null — don't set it
+            Assert.Null(GetPrivateField<Microsoft.Xna.Framework.Input.MouseState?>(stage, "_previousMouseState"));
+
+            // ProcessModalKeys reads Mouse.GetState() and checks the click condition.
+            // We can't easily control Mouse.GetState() in a unit test, but we can verify
+            // that the null check logic is correct by inspecting the method doesn't throw,
+            // and that _previousMouseState is populated after the call.
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // After the call, _previousMouseState should be populated (not null)
+            Assert.NotNull(GetPrivateField<Microsoft.Xna.Framework.Input.MouseState?>(stage, "_previousMouseState"));
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -999,12 +999,12 @@ namespace DTXMania.Test.Stage
             AttachCoreUi(stage, display: display);
             SetPrivateField(stage, "_isInStatusPanel", false);
             SetPrivateField(stage, "_filteredView", filteredView);
-            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
 
             Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
-            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var prop = typeof(SongSelectionStage).GetField("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             Assert.True(((SongFilterCriteria)prop!.GetValue(stage)!).IsEmpty);
         }
 
@@ -1108,7 +1108,7 @@ namespace DTXMania.Test.Stage
             var breadcrumb = new UILabel("");
             AttachCoreUi(stage, breadcrumb: breadcrumb);
             SetPrivateField(stage, "_currentBreadcrumb", "Root > Folder");
-            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("hello", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filterCriteria", new SongFilterCriteria("hello", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
 
             InvokePrivateMethod(stage, "UpdateBreadcrumb");
 
@@ -1123,7 +1123,7 @@ namespace DTXMania.Test.Stage
             var breadcrumb = new UILabel("");
             AttachCoreUi(stage, breadcrumb: breadcrumb);
             SetPrivateField(stage, "_currentBreadcrumb", "");
-            SetProperty(stage, "_filterCriteria", SongFilterCriteria.Default);
+            SetPrivateField(stage, "_filterCriteria", SongFilterCriteria.Default);
 
             InvokePrivateMethod(stage, "UpdateBreadcrumb");
 
@@ -1137,7 +1137,7 @@ namespace DTXMania.Test.Stage
             var breadcrumb = new UILabel("");
             AttachCoreUi(stage, breadcrumb: breadcrumb);
             SetPrivateField(stage, "_currentBreadcrumb", "Root > Folder > Sub");
-            SetProperty(stage, "_filterCriteria", SongFilterCriteria.Default);
+            SetPrivateField(stage, "_filterCriteria", SongFilterCriteria.Default);
 
             InvokePrivateMethod(stage, "UpdateBreadcrumb");
 
@@ -1145,18 +1145,15 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void ResetPersistedFilter_ShouldClearStaticFilterState()
+        public void FilterCriteria_ShouldBeInstanceScopedAndNotLeakAcrossInstances()
         {
-            // Set a non-default filter via a stage instance
-            var stage = CreateStage();
-            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("leaked", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            // Set a non-default filter on one stage instance
+            var stage1 = CreateStage();
+            SetPrivateField(stage1, "_filterCriteria", new SongFilterCriteria("leaked", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
 
-            // Reset the static state
-            SongSelectionStage.ResetPersistedFilter();
-
-            // A new stage should see the default (empty) filter
+            // A new stage instance should start with the default (empty) filter
             var stage2 = CreateStage();
-            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var prop = typeof(SongSelectionStage).GetField("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var filter = (SongFilterCriteria)prop!.GetValue(stage2)!;
             Assert.True(filter.IsEmpty);
         }
@@ -1238,7 +1235,7 @@ namespace DTXMania.Test.Stage
         public void RebuildFilteredView_WhenFilterEmpty_ShouldClearFilteredView()
         {
             var stage = CreateStage();
-            SetProperty(stage, "_filterCriteria", SongFilterCriteria.Default);
+            SetPrivateField(stage, "_filterCriteria", SongFilterCriteria.Default);
             SetPrivateField(stage, "_filteredView", new List<FilteredSongResult>());
 
             InvokePrivateMethod(stage, "RebuildFilteredView");
@@ -1468,13 +1465,13 @@ namespace DTXMania.Test.Stage
             var stage = CreateStage();
             var display = new SongListDisplay();
             AttachCoreUi(stage, display: display);
-            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
             SetPrivateField(stage, "_filteredView", new List<FilteredSongResult>());
             SetPrivateField(stage, "_showEmptyFilterMessage", true);
 
             InvokePrivateMethod(stage, "OnFilterReset", stage, EventArgs.Empty);
 
-            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var prop = typeof(SongSelectionStage).GetField("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var applied = (SongFilterCriteria)prop!.GetValue(stage)!;
             Assert.True(applied.IsEmpty);
             Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
@@ -1486,11 +1483,11 @@ namespace DTXMania.Test.Stage
         {
             var stage = CreateStage();
             var criteria = new SongFilterCriteria("kept", null, null, PlayedStatus.All, SongSortCriteria.Title, false);
-            SetProperty(stage, "_filterCriteria", criteria);
+            SetPrivateField(stage, "_filterCriteria", criteria);
 
             InvokePrivateMethod(stage, "OnFilterCancelled", stage, EventArgs.Empty);
 
-            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var prop = typeof(SongSelectionStage).GetField("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var applied = (SongFilterCriteria)prop!.GetValue(stage)!;
             Assert.Equal("kept", applied.SearchQuery);
         }
@@ -1583,7 +1580,7 @@ namespace DTXMania.Test.Stage
 
             InvokePrivateMethod(stage, "OnFilterApplied", stage, criteria);
 
-            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var prop = typeof(SongSelectionStage).GetField("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var applied = (SongFilterCriteria)prop!.GetValue(stage)!;
             Assert.Equal(10, applied.MinLevel);
             Assert.Equal(50, applied.MaxLevel);
@@ -1604,8 +1601,6 @@ namespace DTXMania.Test.Stage
 
         private static SongSelectionStage CreateStage(BaseGame? game = null)
         {
-            // Reset process-wide static filter state so tests cannot leak into each other
-            SongSelectionStage.ResetPersistedFilter();
             return new SongSelectionStage(game ?? CreateGame());
         }
 
@@ -1828,10 +1823,11 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldProcessDirectionalCommands()
+        public void ProcessModalKeys_WhenSearchBoxFocused_ShouldSuppressDirectionalCommands()
         {
-            // Directional commands (MoveUp/MoveDown/MoveLeft/MoveRight) should still
-            // be processed even when SearchBox is focused.
+            // Directional commands (MoveUp/MoveDown/MoveLeft/MoveRight) should be
+            // suppressed when the SearchBox is focused so that remapped text-producing
+            // keys (e.g. W→MoveUp, S→MoveDown) don't steal focus mid-typing.
             var stage = CreateStage();
             var inputManager = new CommandSimulatingInputManager();
             inputManager.PressCommand(InputCommandType.MoveDown);
@@ -1845,8 +1841,31 @@ namespace DTXMania.Test.Stage
 
             InvokePrivateMethod(stage, "ProcessModalKeys");
 
-            // Focus should have moved from SearchBox to MinLevel
+            // Focus should NOT have moved — MoveDown was suppressed
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenNotSearchBoxFocused_ShouldProcessDirectionalCommands()
+        {
+            // Directional commands should still work when focus is on a non-text field.
+            var stage = CreateStage();
+            var inputManager = new CommandSimulatingInputManager();
+            inputManager.PressCommand(InputCommandType.MoveDown);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            modal.Open(SongFilterCriteria.Default);
+            // Move focus to MinLevel (not SearchBox)
+            modal.FocusNext();
             Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            // Focus should have moved (MoveDown was processed)
+            Assert.NotEqual(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
         }
 
         #endregion
@@ -1896,7 +1915,7 @@ namespace DTXMania.Test.Stage
             AttachCoreUi(stage, display: display);
             SetPrivateField(stage, "_isInStatusPanel", false);
             SetPrivateField(stage, "_filteredView", filteredView);
-            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
 
             var result = InvokePrivateMethod<bool>(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
 
@@ -1936,7 +1955,7 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_inputManager", inputManager);
             SetPrivateField(stage, "_isInStatusPanel", false);
             SetPrivateField(stage, "_filteredView", filteredView);
-            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
 
             inputManager.Enqueue(new InputCommand(InputCommandType.Back, 0.0));
             inputManager.Enqueue(new InputCommand(InputCommandType.Back, 0.0));

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1862,5 +1862,105 @@ namespace DTXMania.Test.Stage
         }
 
         #endregion
+
+        #region ExecuteInputCommand – filter reset drains remaining commands (P2 fix)
+
+        [Fact]
+        public void ExecuteInputCommand_BackWithActiveFilter_ShouldReturnFalse()
+        {
+            // When Back clears an active filter, ExecuteInputCommand returns false
+            // so ProcessInputCommands stops iterating the stale snapshot.
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "folder") };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_filteredView", filteredView);
+            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+
+            var result = InvokePrivateMethod<bool>(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            Assert.False(result);
+            Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackWithoutActiveFilter_ShouldReturnTrue()
+        {
+            // Normal Back (no filter) should return true to continue processing.
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A")]
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            var result = InvokePrivateMethod<bool>(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ProcessInputCommands_BackAfterFilterReset_ShouldDrainRemainingCommands()
+        {
+            // Two Back commands queued: first clears the filter, second should NOT
+            // navigate away or exit the stage because remaining commands are drained.
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "folder") };
+            var inputManager = new QueuedInputManager();
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_inputManager", inputManager);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_filteredView", filteredView);
+            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+
+            inputManager.Enqueue(new InputCommand(InputCommandType.Back, 0.0));
+            inputManager.Enqueue(new InputCommand(InputCommandType.Back, 0.0));
+
+            InvokePrivateMethod(stage, "ProcessInputCommands");
+
+            // Filter should be cleared
+            Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+            // Navigation stack should still be empty (second Back was drained)
+            var stack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+            Assert.Empty(stack);
+        }
+
+        #endregion
+
+        #region OpenSearchFilterModal – mouse state reset on reopen (P3 fix)
+
+        [Fact]
+        public void OpenSearchFilterModal_ShouldResetPreviousMouseState()
+        {
+            // If _previousMouseState was left as Pressed from a prior modal session,
+            // reopening the modal should reset it to null so the first click registers.
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("S") });
+            SetPrivateField(stage, "_songInitializationTask", null);
+
+            // Simulate stale mouse state from a previous modal session
+            SetPrivateField(stage, "_previousMouseState", new Microsoft.Xna.Framework.Input.MouseState(
+                0, 0, 0,
+                Microsoft.Xna.Framework.Input.ButtonState.Pressed,
+                Microsoft.Xna.Framework.Input.ButtonState.Released,
+                Microsoft.Xna.Framework.Input.ButtonState.Released,
+                Microsoft.Xna.Framework.Input.ButtonState.Released,
+                Microsoft.Xna.Framework.Input.ButtonState.Released));
+
+            InvokePrivateMethod(stage, "OpenSearchFilterModal");
+
+            Assert.Null(GetPrivateField<Microsoft.Xna.Framework.Input.MouseState?>(stage, "_previousMouseState"));
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -406,6 +406,37 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ExecuteInputCommand_OpenSearch_WhenModalIsNull_ShouldReturnFalse()
+        {
+            // OpenSearch returns false even when modal is null so that
+            // remaining queued commands are drained (same guard as filter-reset Back).
+            var stage = CreateStage();
+            SetPrivateField(stage, "_searchFilterModal", null);
+
+            var result = InvokePrivateMethod<bool>(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.OpenSearch, 0.0));
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_OpenSearch_WithModal_ShouldReturnFalse()
+        {
+            // When the modal exists and is opened, OpenSearch must return false
+            // to stop draining queued commands that would fire against the song list
+            // behind the modal.
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("S") });
+            SetPrivateField(stage, "_songInitializationTask", null);
+
+            var result = InvokePrivateMethod<bool>(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.OpenSearch, 0.0));
+
+            Assert.False(result);
+        }
+
+        [Fact]
         public void HandleActivateInput_InStatusPanelWithScore_ShouldSelectSong()
         {
             var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
@@ -2023,6 +2054,41 @@ namespace DTXMania.Test.Stage
             // Navigation stack should still be empty (second Back was drained)
             var stack = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
             Assert.Empty(stack);
+        }
+
+        #endregion
+
+        #region ExecuteInputCommand – OpenSearch drains remaining commands (P2 fix)
+
+        [Fact]
+        public void ProcessInputCommands_OpenSearch_ShouldDrainRemainingCommands()
+        {
+            // OpenSearch + Activate queued: OpenSearch opens the modal and returns false,
+            // so the queued Activate should NOT execute (it would select a song behind the modal).
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            var inputManager = new QueuedInputManager();
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("S") });
+            SetPrivateField(stage, "_songInitializationTask", null);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            inputManager.Enqueue(new InputCommand(InputCommandType.OpenSearch, 0.0));
+            inputManager.Enqueue(new InputCommand(InputCommandType.Activate, 0.0));
+
+            InvokePrivateMethod(stage, "ProcessInputCommands");
+
+            // Modal should be open
+            Assert.True(modal.IsOpen);
+            // The Activate command should have been drained and NOT executed —
+            // no stage transition should have been requested.
+            // (If Activate had run, it would have set _selectedSong and attempted
+            // a stage change. We verify the command queue is empty instead.)
+            Assert.Empty(inputManager.GetInputCommands());
         }
 
         #endregion

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -13,6 +13,7 @@ using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Utilities;
 using DTXMania.Game.Lib.UI.Components;
@@ -986,6 +987,589 @@ namespace DTXMania.Test.Stage
                     It.IsAny<IStageTransition>(),
                     It.Is<Dictionary<string, object>>(d => ReferenceEquals(d["selectedSong"], song))),
                 Times.Once);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackWithActiveFilteredView_ShouldCallOnFilterReset()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "folder") };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_filteredView", filteredView);
+            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            Assert.True(((SongFilterCriteria)prop!.GetValue(stage)!).IsEmpty);
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_BackWithFilteredViewAndInStatusPanel_ShouldExitStatusPanelOnly()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "folder") };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+            SetPrivateField(stage, "_filteredView", filteredView);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            Assert.False(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            Assert.NotNull(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+        }
+
+        [Fact]
+        public void OpenSearchFilterModal_WhenModalIsNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_searchFilterModal", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "OpenSearchFilterModal"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void OpenSearchFilterModal_WhenSongListNotNullAndTaskNull_ShouldSetLibraryReady()
+        {
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("S") });
+            SetPrivateField(stage, "_songInitializationTask", null);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            InvokePrivateMethod(stage, "OpenSearchFilterModal");
+
+            Assert.True(modal.IsLibraryReady);
+            Assert.True(modal.IsOpen);
+            Assert.False(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+        }
+
+        [Fact]
+        public void OpenSearchFilterModal_WhenSongListNullAndTaskNull_ShouldSetLibraryNotReady()
+        {
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", null);
+            SetPrivateField(stage, "_songInitializationTask", null);
+
+            InvokePrivateMethod(stage, "OpenSearchFilterModal");
+
+            Assert.False(modal.IsLibraryReady);
+        }
+
+        [Fact]
+        public void OpenSearchFilterModal_WhenTaskProcessed_ShouldSetLibraryReady()
+        {
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("S") });
+            SetPrivateField(stage, "_songInitializationTask", Task.FromResult(new List<SongListNode>()));
+            SetPrivateField(stage, "_songInitializationProcessed", true);
+
+            InvokePrivateMethod(stage, "OpenSearchFilterModal");
+
+            Assert.True(modal.IsLibraryReady);
+        }
+
+        [Fact]
+        public void OpenSearchFilterModal_WhenTaskNotProcessed_ShouldSetLibraryNotReady()
+        {
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { CreateScoreNode("S") });
+            SetPrivateField(stage, "_songInitializationTask", Task.FromResult(new List<SongListNode>()));
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+
+            InvokePrivateMethod(stage, "OpenSearchFilterModal");
+
+            Assert.False(modal.IsLibraryReady);
+        }
+
+        [Fact]
+        public void UpdateBreadcrumb_WhenFilterActive_ShouldShowFilterSummary()
+        {
+            var stage = CreateStage();
+            var breadcrumb = new UILabel("");
+            AttachCoreUi(stage, breadcrumb: breadcrumb);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Folder");
+            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("hello", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+
+            InvokePrivateMethod(stage, "UpdateBreadcrumb");
+
+            Assert.Contains("Filtered", breadcrumb.Text);
+            Assert.Contains("hello", breadcrumb.Text);
+        }
+
+        [Fact]
+        public void UpdateBreadcrumb_WhenFilterNotActiveAndBreadcrumbEmpty_ShouldShowRoot()
+        {
+            var stage = CreateStage();
+            var breadcrumb = new UILabel("");
+            AttachCoreUi(stage, breadcrumb: breadcrumb);
+            SetPrivateField(stage, "_currentBreadcrumb", "");
+            SetProperty(stage, "_filterCriteria", SongFilterCriteria.Default);
+
+            InvokePrivateMethod(stage, "UpdateBreadcrumb");
+
+            Assert.Equal("Root", breadcrumb.Text);
+        }
+
+        [Fact]
+        public void UpdateBreadcrumb_WhenFilterNotActiveAndBreadcrumbNonEmpty_ShouldShowBreadcrumb()
+        {
+            var stage = CreateStage();
+            var breadcrumb = new UILabel("");
+            AttachCoreUi(stage, breadcrumb: breadcrumb);
+            SetPrivateField(stage, "_currentBreadcrumb", "Root > Folder > Sub");
+            SetProperty(stage, "_filterCriteria", SongFilterCriteria.Default);
+
+            InvokePrivateMethod(stage, "UpdateBreadcrumb");
+
+            Assert.Equal("Root > Folder > Sub", breadcrumb.Text);
+        }
+
+        [Fact]
+        public void UpdateStatusPanelFolderHint_WhenStatusPanelNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_statusPanel", null);
+            SetPrivateField(stage, "_filteredView", new List<FilteredSongResult> { new(CreateScoreNode("S"), "f") });
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "UpdateStatusPanelFolderHint"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void UpdateStatusPanelFolderHint_WhenFilteredViewNull_ShouldSetEmptyHint()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel();
+            AttachCoreUi(stage, statusPanel: statusPanel);
+            SetPrivateField(stage, "_filteredView", null);
+
+            InvokePrivateMethod(stage, "UpdateStatusPanelFolderHint");
+
+            Assert.Equal("", statusPanel.FolderHint);
+        }
+
+        [Fact]
+        public void UpdateStatusPanelFolderHint_WhenSelectedNodeNull_ShouldSetEmptyHint()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel();
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "folder") };
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_filteredView", filteredView);
+
+            InvokePrivateMethod(stage, "UpdateStatusPanelFolderHint");
+
+            Assert.Equal("", statusPanel.FolderHint);
+        }
+
+        [Fact]
+        public void UpdateStatusPanelFolderHint_WhenNodeFoundInFilteredView_ShouldSetFolderPath()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel();
+            var song = CreateScoreNode("Song");
+            var display = new SongListDisplay { CurrentList = [song] };
+            var filteredView = new List<FilteredSongResult> { new(song, "Rock > Hard Rock") };
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_filteredView", filteredView);
+
+            InvokePrivateMethod(stage, "UpdateStatusPanelFolderHint");
+
+            Assert.Equal("Rock > Hard Rock", statusPanel.FolderHint);
+        }
+
+        [Fact]
+        public void UpdateStatusPanelFolderHint_WhenNodeNotFoundInFilteredView_ShouldSetEmptyHint()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel();
+            var songA = CreateScoreNode("A");
+            var songB = CreateScoreNode("B");
+            var display = new SongListDisplay { CurrentList = [songA] };
+            var filteredView = new List<FilteredSongResult> { new(songB, "Other") };
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_filteredView", filteredView);
+
+            InvokePrivateMethod(stage, "UpdateStatusPanelFolderHint");
+
+            Assert.Equal("", statusPanel.FolderHint);
+        }
+
+        [Fact]
+        public void RebuildFilteredView_WhenFilterEmpty_ShouldClearFilteredView()
+        {
+            var stage = CreateStage();
+            SetProperty(stage, "_filterCriteria", SongFilterCriteria.Default);
+            SetPrivateField(stage, "_filteredView", new List<FilteredSongResult>());
+
+            InvokePrivateMethod(stage, "RebuildFilteredView");
+
+            Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyFilterMessage"));
+        }
+
+        [Fact]
+        public void PopulateFilteredSongList_WithItems_ShouldPopulateDisplay()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("Song");
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult>
+            {
+                new(song, "Folder1"),
+                new(CreateScoreNode("Other"), "Folder2"),
+            };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_filteredView", filteredView);
+
+            InvokePrivateMethod(stage, "PopulateFilteredSongList");
+
+            Assert.Equal(2, display.CurrentList.Count);
+            Assert.Same(song, display.CurrentList[0]);
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WithNullParams_ShouldSetFieldsToNull()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_backgroundMusic", null);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+
+            stage.SetBackgroundMusic(null, null);
+
+            Assert.Null(GetPrivateField<ISound>(stage, "_backgroundMusic"));
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WithNonNullParams_ShouldSetFields()
+        {
+            var stage = CreateStage();
+            var mockSound = new Mock<ISound>();
+            var mockInstance = new Mock<ISoundInstance>();
+
+            stage.SetBackgroundMusic(mockSound.Object, mockInstance.Object);
+
+            Assert.Same(mockSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+            Assert.Same(mockInstance.Object, GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenReplacingExistingBGM_ShouldDisposeOld()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            var newSound = new Mock<ISound>();
+            var newInstance = new Mock<ISoundInstance>();
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            stage.SetBackgroundMusic(newSound.Object, newInstance.Object);
+
+            oldSound.Verify(x => x.RemoveReference(), Times.Once);
+            oldInstance.Verify(x => x.Stop(), Times.Once);
+            oldInstance.Verify(x => x.Dispose(), Times.Once);
+            Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenOldRemoveReferenceThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            oldSound.Setup(x => x.RemoveReference()).Throws(new Exception("boom"));
+            var newSound = new Mock<ISound>();
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(newSound.Object, null));
+
+            Assert.Null(exception);
+            Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenOldStopThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            oldInstance.Setup(x => x.Stop()).Throws(new Exception("stop fail"));
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(null, null));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenOldDisposeThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            oldInstance.Setup(x => x.Dispose()).Throws(new Exception("dispose fail"));
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(null, null));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DetectOpenSearchKey_WhenBackspacePressed_ShouldOpenModal()
+        {
+            var stage = CreateStage();
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            var inputManager = new BackspaceInputManager().WithBackspace();
+
+            SetPrivateField(stage, "_inputManager", inputManager);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "DetectOpenSearchKey");
+
+            Assert.True(modal.IsOpen);
+        }
+
+        [Fact]
+        public void DetectOpenSearchKey_WhenInputManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_inputManager", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DetectOpenSearchKey"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenInputManagerNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_inputManager", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "ProcessModalKeys"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenNotActive_ShouldNotChange()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.016));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenPreviewDelayActiveBelowThreshold_ShouldIncrement()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isPreviewDelayActive", true);
+            SetPrivateField(stage, "_previewPlayDelay", 0.0);
+            SetPrivateField(stage, "_previewSound", null);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1);
+
+            Assert.Equal(0.1, GetPrivateField<double>(stage, "_previewPlayDelay"));
+            Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenBgmFadeOutActiveBelowDuration_ShouldIncrement()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_bgmFadeOutTimer", 0.0);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1);
+
+            Assert.Equal(0.1, GetPrivateField<double>(stage, "_bgmFadeOutTimer"));
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_WhenBgmFadeInActiveBelowDuration_ShouldIncrement()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_bgmFadeInTimer", 0.0);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1);
+
+            Assert.Equal(0.1, GetPrivateField<double>(stage, "_bgmFadeInTimer"));
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        }
+
+        [Fact]
+        public void OnFilterReset_ShouldClearFilterState()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("test", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filteredView", new List<FilteredSongResult>());
+            SetPrivateField(stage, "_showEmptyFilterMessage", true);
+
+            InvokePrivateMethod(stage, "OnFilterReset", stage, EventArgs.Empty);
+
+            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var applied = (SongFilterCriteria)prop!.GetValue(stage)!;
+            Assert.True(applied.IsEmpty);
+            Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyFilterMessage"));
+        }
+
+        [Fact]
+        public void OnFilterCancelled_ShouldNotChangeFilterState()
+        {
+            var stage = CreateStage();
+            var criteria = new SongFilterCriteria("kept", null, null, PlayedStatus.All, SongSortCriteria.Title, false);
+            SetProperty(stage, "_filterCriteria", criteria);
+
+            InvokePrivateMethod(stage, "OnFilterCancelled", stage, EventArgs.Empty);
+
+            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var applied = (SongFilterCriteria)prop!.GetValue(stage)!;
+            Assert.Equal("kept", applied.SearchQuery);
+        }
+
+        [Fact]
+        public void PopulateSongListForCurrentMode_WhenFilteredViewNotNull_ShouldCallPopulateFilteredSongList()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("S");
+            var display = new SongListDisplay();
+            var filteredView = new List<FilteredSongResult> { new(song, "folder") };
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_filteredView", filteredView);
+
+            InvokePrivateMethod(stage, "PopulateSongListForCurrentMode");
+
+            Assert.Equal(1, display.CurrentList.Count);
+            Assert.Same(song, display.CurrentList[0]);
+        }
+
+        [Fact]
+        public void PopulateSongListForCurrentMode_WhenFilteredViewNull_ShouldCallPopulateSongList()
+        {
+            var stage = CreateStage();
+            var song = CreateScoreNode("S");
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { song });
+            SetPrivateField(stage, "_filteredView", null);
+
+            InvokePrivateMethod(stage, "PopulateSongListForCurrentMode");
+
+            Assert.Equal(1, display.CurrentList.Count);
+            Assert.Same(song, display.CurrentList[0]);
+        }
+
+        [Fact]
+        public void HandleActivateInput_WithFilteredViewAndNonScoreNode_ShouldDoNothing()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var box = CreateBoxNode("Folder");
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "f") };
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_filteredView", filteredView);
+            SetPrivateField(stage, "_selectedSong", box);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "HandleActivateInput"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StartBGMFade_WhenFadeOut_ShouldSetFadeOutState()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+
+            InvokePrivateMethod(stage, "StartBGMFade", true);
+
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+            Assert.Equal(0.0, GetPrivateField<double>(stage, "_bgmFadeOutTimer"));
+        }
+
+        [Fact]
+        public void StartBGMFade_WhenFadeIn_ShouldSetFadeInState()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "StartBGMFade", false);
+
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+            Assert.Equal(0.0, GetPrivateField<double>(stage, "_bgmFadeInTimer"));
+        }
+
+        [Fact]
+        public void OnFilterApplied_WithSwappedLevels_ShouldNormalizeAndApply()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var breadcrumb = new UILabel("");
+            AttachCoreUi(stage, display: display, breadcrumb: breadcrumb);
+            var criteria = new SongFilterCriteria("", 50, 10, PlayedStatus.All, SongSortCriteria.Title, false);
+
+            InvokePrivateMethod(stage, "OnFilterApplied", stage, criteria);
+
+            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var applied = (SongFilterCriteria)prop!.GetValue(stage)!;
+            Assert.Equal(10, applied.MinLevel);
+            Assert.Equal(50, applied.MaxLevel);
         }
 
         private static void AttachCoreUi(

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1145,6 +1145,23 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ResetPersistedFilter_ShouldClearStaticFilterState()
+        {
+            // Set a non-default filter via a stage instance
+            var stage = CreateStage();
+            SetProperty(stage, "_filterCriteria", new SongFilterCriteria("leaked", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+
+            // Reset the static state
+            SongSelectionStage.ResetPersistedFilter();
+
+            // A new stage should see the default (empty) filter
+            var stage2 = CreateStage();
+            var prop = typeof(SongSelectionStage).GetProperty("_filterCriteria", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var filter = (SongFilterCriteria)prop!.GetValue(stage2)!;
+            Assert.True(filter.IsEmpty);
+        }
+
+        [Fact]
         public void UpdateStatusPanelFolderHint_WhenStatusPanelNull_ShouldNotThrow()
         {
             var stage = CreateStage();
@@ -1587,6 +1604,8 @@ namespace DTXMania.Test.Stage
 
         private static SongSelectionStage CreateStage(BaseGame? game = null)
         {
+            // Reset process-wide static filter state so tests cannot leak into each other
+            SongSelectionStage.ResetPersistedFilter();
             return new SongSelectionStage(game ?? CreateGame());
         }
 

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -393,6 +393,18 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ExecuteInputCommand_OpenSearch_WhenModalIsNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_searchFilterModal", null);
+
+            var exception = Record.Exception(() =>
+                InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.OpenSearch, 0.0)));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void HandleActivateInput_InStatusPanelWithScore_ShouldSelectSong()
         {
             var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1276,6 +1276,39 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ReapplyPersistedFilterIfActive_WhenFilterActive_ShouldRebuildListState()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var breadcrumb = new UILabel("");
+            AttachCoreUi(stage, display: display, breadcrumb: breadcrumb);
+            SetPrivateField(stage, "_filterCriteria",
+                new SongFilterCriteria("missing", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+
+            InvokePrivateMethod(stage, "ReapplyPersistedFilterIfActive");
+
+            Assert.Empty(display.CurrentList);
+            Assert.True(GetPrivateField<bool>(stage, "_showEmptyFilterMessage"));
+        }
+
+        [Fact]
+        public void RebuildFilteredView_WhenFilterServiceThrows_ShouldResetFilterState()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_filterCriteria",
+                new SongFilterCriteria("boom", null, null, PlayedStatus.All, SongSortCriteria.Title, false));
+            SetPrivateField(stage, "_filteredView", new List<FilteredSongResult> { new(CreateScoreNode("Old"), "Old") });
+            SetPrivateField(stage, "_showEmptyFilterMessage", true);
+            SetPrivateField(stage, "_filterService", new ThrowingFilterService());
+
+            InvokePrivateMethod(stage, "RebuildFilteredView");
+
+            Assert.True(GetPrivateField<SongFilterCriteria>(stage, "_filterCriteria").IsEmpty);
+            Assert.Null(GetPrivateField<System.Collections.Generic.IReadOnlyList<FilteredSongResult>?>(stage, "_filteredView"));
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyFilterMessage"));
+        }
+
+        [Fact]
         public void PopulateFilteredSongList_WithItems_ShouldPopulateDisplay()
         {
             var stage = CreateStage();
@@ -1617,6 +1650,28 @@ namespace DTXMania.Test.Stage
             Assert.Equal(50, applied.MaxLevel);
         }
 
+        [Fact]
+        public void CheckSongInitializationCompletion_WhenModalIsOpen_ShouldMarkLibraryReady()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var modal = new SongSearchFilterModal(new Mock<ITextInputSource>().Object)
+            {
+                IsLibraryReady = false
+            };
+            modal.Open(SongFilterCriteria.Default);
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+            SetPrivateField(stage, "_songInitializationTask",
+                Task.FromResult(new List<SongListNode> { CreateScoreNode("Loaded") }));
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.True(modal.IsLibraryReady);
+            Assert.Null(GetPrivateField<Task<List<SongListNode>>?>(stage, "_songInitializationTask"));
+        }
+
         private static void AttachCoreUi(
             SongSelectionStage stage,
             SongListDisplay? display = null,
@@ -1710,6 +1765,14 @@ namespace DTXMania.Test.Stage
             {
                 EnqueueCommand(command);
             }
+        }
+
+        private sealed class ThrowingFilterService : ISongListFilterService
+        {
+            public IReadOnlyList<FilteredSongResult> Apply(
+                IEnumerable<SongListNode> roots,
+                SongFilterCriteria criteria) =>
+                throw new InvalidOperationException("filter failed");
         }
 
         /// <summary>
@@ -1953,6 +2016,23 @@ namespace DTXMania.Test.Stage
 
             // Focus should have moved (Up wraps to the last field)
             Assert.NotEqual(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void ProcessModalKeys_WhenTabPressed_ShouldMoveFocus()
+        {
+            var stage = CreateStage();
+            var inputManager = new KeySimulatingInputManager();
+            inputManager.PressRawKey(Microsoft.Xna.Framework.Input.Keys.Tab);
+            SetPrivateField(stage, "_inputManager", inputManager);
+
+            var modal = new SongSearchFilterModal(new Mock<ITextInputSource>().Object);
+            modal.Open(SongFilterCriteria.Default);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "ProcessModalKeys");
+
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
         }
 
         #endregion

--- a/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCoverageTests.cs
@@ -1070,5 +1070,62 @@ namespace DTXMania.Test.Stage
                 EnqueueCommand(command);
             }
         }
+
+        /// <summary>
+        /// InputManager subclass that supports both command enqueuing and simulated
+        /// Backspace key press. Used to test the modal-open-frame race condition.
+        /// </summary>
+        private sealed class BackspaceInputManager : InputManager
+        {
+            private bool _backspacePressed;
+
+            public void Enqueue(InputCommand command)
+            {
+                EnqueueCommand(command);
+            }
+
+            public BackspaceInputManager WithBackspace()
+            {
+                _backspacePressed = true;
+                return this;
+            }
+
+            public override bool IsKeyPressed(int keyCode)
+            {
+                if (keyCode == (int)Microsoft.Xna.Framework.Input.Keys.Back && _backspacePressed)
+                    return true;
+                return base.IsKeyPressed(keyCode);
+            }
+        }
+
+        [Fact]
+        public void HandleInput_WhenModalJustOpened_ShouldNotProcessStageCommands()
+        {
+            // Simulate a frame where Backspace opens the modal AND a MoveDown command
+            // is already queued. The modal should block the stage command on this frame.
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = [CreateScoreNode("A"), CreateScoreNode("B")]
+            };
+            var inputManager = new BackspaceInputManager();
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_inputManager", inputManager.WithBackspace());
+            // Queue a navigation command that should NOT execute on this frame
+            inputManager.Enqueue(new InputCommand(InputCommandType.MoveDown, 0.0));
+
+            // Set up the search filter modal
+            var fakeTextSource = new Mock<ITextInputSource>();
+            var modal = new SongSearchFilterModal(fakeTextSource.Object);
+            SetPrivateField(stage, "_searchFilterModal", modal);
+
+            InvokePrivateMethod(stage, "HandleInput");
+
+            // Modal should be open
+            Assert.True(modal.IsOpen);
+            // Selection should NOT have moved (MoveDown was blocked)
+            Assert.Equal("A", display.SelectedSong!.Title);
+        }
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
@@ -1,0 +1,23 @@
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    public class SongSelectionStageFilterTests
+    {
+        [Fact]
+        public void NewStage_FilterCriteriaDefaultsToEmpty()
+        {
+            // Stage.GetFilterCriteria() is a test-access helper added in this task.
+            Assert.True(SongSelectionStage.DefaultFilterCriteriaIsEmpty());
+        }
+
+        [Fact]
+        public void DefaultFilteredViewIsNull()
+        {
+            // No filter active → projection is null
+            Assert.True(SongSelectionStage.DefaultFilteredViewIsNull());
+        }
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
@@ -1,5 +1,7 @@
+using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.Stage;
+using System.Collections.Generic;
 using Xunit;
 
 namespace DTXMania.Test.Stage
@@ -9,28 +11,19 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void NewStage_FilterCriteriaDefaultsToEmpty()
         {
-            // Stage.GetFilterCriteria() is a test-access helper added in this task.
             Assert.True(SongSelectionStage.DefaultFilterCriteriaIsEmpty());
         }
 
         [Fact]
         public void DefaultFilteredViewIsNull()
         {
-            // No filter active → projection is null
             Assert.True(SongSelectionStage.DefaultFilteredViewIsNull());
         }
 
         [Fact]
         public void IsLibraryReady_SyncInitPath_DoesNotBlockApply()
         {
-            // When SongManager is already initialized at Activate time, the stage takes the
-            // synchronous else-branch in InitializeSongList: _songInitializationTask stays null
-            // and _songInitializationProcessed stays false. The IsLibraryReady predicate must
-            // still return true so the modal's Apply isn't permanently blocked.
-            //
-            // Predicate (mirrors OpenSearchFilterModal):
-            //   _currentSongList != null && (_songInitializationTask == null || _songInitializationProcessed)
-            object? list = new System.Collections.Generic.List<DTXMania.Game.Lib.Song.SongListNode>();
+            object? list = new List<SongListNode>();
             System.Threading.Tasks.Task? task = null;
             bool processed = false;
 
@@ -42,8 +35,7 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void IsLibraryReady_AsyncStillRunning_BlocksApply()
         {
-            // Async path before completion: task non-null, processed false → ready must be false.
-            object? list = new System.Collections.Generic.List<DTXMania.Game.Lib.Song.SongListNode>();
+            object? list = new List<SongListNode>();
             System.Threading.Tasks.Task task = System.Threading.Tasks.Task.CompletedTask;
             bool processed = false;
 
@@ -51,5 +43,176 @@ namespace DTXMania.Test.Stage
 
             Assert.False(ready);
         }
+
+        #region SummarizeFilter
+
+        [Fact]
+        public void SummarizeFilter_EmptyCriteria_ReturnsEmpty()
+        {
+            Assert.Equal("", SongSelectionStage.SummarizeFilter(SongFilterCriteria.Default));
+        }
+
+        [Fact]
+        public void SummarizeFilter_SearchOnly()
+        {
+            var c = SongFilterCriteria.Default with { SearchQuery = "hello" };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("\"hello\"", result);
+            Assert.StartsWith("Filtered:", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_LevelRange()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 30, MaxLevel = 70 };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Lv 30-70", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_LevelMinOnly()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50 };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Lv 50+", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_LevelMaxOnly()
+        {
+            var c = SongFilterCriteria.Default with { MaxLevel = 60 };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Lv ≤60", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_InvertedLevelRange_Normalizes()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Lv 30-80", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_PlayedStatus()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Cleared", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_SortDescending()
+        {
+            var c = SongFilterCriteria.Default with { SortDescending = true };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Title↓", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_SortByArtistAscending()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Artist↑", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_SortByLevelDescending()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Level, SortDescending = true };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Level↓", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_SortByGenre()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Genre↑", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_DefaultSortTitleAscending_Omitted()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Title, SortDescending = false };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.DoesNotContain("Title", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_CombinedSearchAndLevelAndPlayed()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SearchQuery = "test",
+                MinLevel = 30,
+                MaxLevel = 60,
+                PlayedStatus = PlayedStatus.Played
+            };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("\"test\"", result);
+            Assert.Contains("Lv 30-60", result);
+            Assert.Contains("Played", result);
+        }
+
+        #endregion
+
+        #region ClampSelectionIndex
+
+        [Fact]
+        public void ClampSelectionIndex_NullList_Returns0()
+        {
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(null, null));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_EmptyList_Returns0()
+        {
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(null, new List<SongListNode>()));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_NullPrevious_Returns0()
+        {
+            var list = new List<SongListNode> { new SongListNode { Title = "A" } };
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(null, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_FoundInList_ReturnsIndex()
+        {
+            var node = new SongListNode { Title = "B" };
+            var list = new List<SongListNode>
+            {
+                new SongListNode { Title = "A" },
+                node,
+                new SongListNode { Title = "C" }
+            };
+            Assert.Equal(1, SongSelectionStage.ClampSelectionIndex(node, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_NotFound_Returns0()
+        {
+            var prev = new SongListNode { Title = "X" };
+            var list = new List<SongListNode>
+            {
+                new SongListNode { Title = "A" },
+                new SongListNode { Title = "B" }
+            };
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(prev, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_SameReferenceFirst_Returns0()
+        {
+            var node = new SongListNode { Title = "A" };
+            var list = new List<SongListNode> { node, new SongListNode { Title = "B" } };
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(node, list));
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
@@ -15,36 +15,6 @@ namespace DTXMania.Test.Stage
             Assert.True(SongSelectionStage.DefaultFilterCriteriaIsEmpty());
         }
 
-        [Fact]
-        public void DefaultFilteredView_WhenCreated_ShouldBeNull()
-        {
-            Assert.True(SongSelectionStage.DefaultFilteredViewIsNull());
-        }
-
-        [Fact]
-        public void IsLibraryReady_WhenSyncInitPath_ShouldNotBlockApply()
-        {
-            object? list = new List<SongListNode>();
-            System.Threading.Tasks.Task? task = null;
-            bool processed = false;
-
-            bool ready = list != null && (task == null || processed);
-
-            Assert.True(ready);
-        }
-
-        [Fact]
-        public void IsLibraryReady_WhenAsyncStillRunning_ShouldBlockApply()
-        {
-            object? list = new List<SongListNode>();
-            System.Threading.Tasks.Task task = System.Threading.Tasks.Task.CompletedTask;
-            bool processed = false;
-
-            bool ready = list != null && (task == null || processed);
-
-            Assert.False(ready);
-        }
-
         #region SummarizeFilter
 
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
@@ -19,5 +19,37 @@ namespace DTXMania.Test.Stage
             // No filter active → projection is null
             Assert.True(SongSelectionStage.DefaultFilteredViewIsNull());
         }
+
+        [Fact]
+        public void IsLibraryReady_SyncInitPath_DoesNotBlockApply()
+        {
+            // When SongManager is already initialized at Activate time, the stage takes the
+            // synchronous else-branch in InitializeSongList: _songInitializationTask stays null
+            // and _songInitializationProcessed stays false. The IsLibraryReady predicate must
+            // still return true so the modal's Apply isn't permanently blocked.
+            //
+            // Predicate (mirrors OpenSearchFilterModal):
+            //   _currentSongList != null && (_songInitializationTask == null || _songInitializationProcessed)
+            object? list = new System.Collections.Generic.List<DTXMania.Game.Lib.Song.SongListNode>();
+            System.Threading.Tasks.Task? task = null;
+            bool processed = false;
+
+            bool ready = list != null && (task == null || processed);
+
+            Assert.True(ready);
+        }
+
+        [Fact]
+        public void IsLibraryReady_AsyncStillRunning_BlocksApply()
+        {
+            // Async path before completion: task non-null, processed false → ready must be false.
+            object? list = new System.Collections.Generic.List<DTXMania.Game.Lib.Song.SongListNode>();
+            System.Threading.Tasks.Task task = System.Threading.Tasks.Task.CompletedTask;
+            bool processed = false;
+
+            bool ready = list != null && (task == null || processed);
+
+            Assert.False(ready);
+        }
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
@@ -53,7 +53,7 @@ namespace DTXMania.Test.Stage
         {
             var c = SongFilterCriteria.Default with { MaxLevel = 60 };
             var result = SongSelectionStage.SummarizeFilter(c);
-            Assert.Contains("Lv ≤60", result);
+            Assert.Contains("Lv <=60", result);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace DTXMania.Test.Stage
         {
             var c = SongFilterCriteria.Default with { SortDescending = true };
             var result = SongSelectionStage.SummarizeFilter(c);
-            Assert.Contains("Title↓", result);
+            Assert.Contains("Titlev", result);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace DTXMania.Test.Stage
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
             var result = SongSelectionStage.SummarizeFilter(c);
-            Assert.Contains("Artist↑", result);
+            Assert.Contains("Artist^", result);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace DTXMania.Test.Stage
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Level, SortDescending = true };
             var result = SongSelectionStage.SummarizeFilter(c);
-            Assert.Contains("Level↓", result);
+            Assert.Contains("Levelv", result);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace DTXMania.Test.Stage
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre };
             var result = SongSelectionStage.SummarizeFilter(c);
-            Assert.Contains("Genre↑", result);
+            Assert.Contains("Genre^", result);
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
@@ -6,22 +6,23 @@ using Xunit;
 
 namespace DTXMania.Test.Stage
 {
+    [Trait("Category", "Unit")]
     public class SongSelectionStageFilterTests
     {
         [Fact]
-        public void NewStage_FilterCriteriaDefaultsToEmpty()
+        public void NewStage_WhenCreated_ShouldHaveDefaultFilterCriteriaEmpty()
         {
             Assert.True(SongSelectionStage.DefaultFilterCriteriaIsEmpty());
         }
 
         [Fact]
-        public void DefaultFilteredViewIsNull()
+        public void DefaultFilteredView_WhenCreated_ShouldBeNull()
         {
             Assert.True(SongSelectionStage.DefaultFilteredViewIsNull());
         }
 
         [Fact]
-        public void IsLibraryReady_SyncInitPath_DoesNotBlockApply()
+        public void IsLibraryReady_WhenSyncInitPath_ShouldNotBlockApply()
         {
             object? list = new List<SongListNode>();
             System.Threading.Tasks.Task? task = null;
@@ -33,7 +34,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void IsLibraryReady_AsyncStillRunning_BlocksApply()
+        public void IsLibraryReady_WhenAsyncStillRunning_ShouldBlockApply()
         {
             object? list = new List<SongListNode>();
             System.Threading.Tasks.Task task = System.Threading.Tasks.Task.CompletedTask;
@@ -47,13 +48,13 @@ namespace DTXMania.Test.Stage
         #region SummarizeFilter
 
         [Fact]
-        public void SummarizeFilter_EmptyCriteria_ReturnsEmpty()
+        public void SummarizeFilter_WithEmptyCriteria_ShouldReturnEmpty()
         {
             Assert.Equal("", SongSelectionStage.SummarizeFilter(SongFilterCriteria.Default));
         }
 
         [Fact]
-        public void SummarizeFilter_SearchOnly()
+        public void SummarizeFilter_WithSearchQuery_ShouldContainQuery()
         {
             var c = SongFilterCriteria.Default with { SearchQuery = "hello" };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -62,7 +63,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_LevelRange()
+        public void SummarizeFilter_WithLevelRange_ShouldContainRange()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 30, MaxLevel = 70 };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -70,7 +71,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_LevelMinOnly()
+        public void SummarizeFilter_WithLevelMinOnly_ShouldContainMinLevel()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 50 };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -78,7 +79,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_LevelMaxOnly()
+        public void SummarizeFilter_WithLevelMaxOnly_ShouldContainMaxLevel()
         {
             var c = SongFilterCriteria.Default with { MaxLevel = 60 };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -86,7 +87,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_InvertedLevelRange_Normalizes()
+        public void SummarizeFilter_WithInvertedLevelRange_ShouldNormalize()
         {
             var c = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -94,7 +95,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_PlayedStatus()
+        public void SummarizeFilter_WithPlayedStatus_ShouldContainStatus()
         {
             var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -102,7 +103,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_SortDescending()
+        public void SummarizeFilter_WithSortDescending_ShouldContainSort()
         {
             var c = SongFilterCriteria.Default with { SortDescending = true };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -110,7 +111,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_SortByArtistAscending()
+        public void SummarizeFilter_WithSortByArtistAscending_ShouldContainSort()
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -118,7 +119,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_SortByLevelDescending()
+        public void SummarizeFilter_WithSortByLevelDescending_ShouldContainSort()
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Level, SortDescending = true };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -126,7 +127,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_SortByGenre()
+        public void SummarizeFilter_WithSortByGenre_ShouldContainSort()
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -134,7 +135,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_DefaultSortTitleAscending_Omitted()
+        public void SummarizeFilter_WithDefaultSortTitleAscending_ShouldOmitSort()
         {
             var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Title, SortDescending = false };
             var result = SongSelectionStage.SummarizeFilter(c);
@@ -142,7 +143,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SummarizeFilter_CombinedSearchAndLevelAndPlayed()
+        public void SummarizeFilter_WithCombinedSearchLevelPlayed_ShouldContainAll()
         {
             var c = SongFilterCriteria.Default with
             {
@@ -162,26 +163,26 @@ namespace DTXMania.Test.Stage
         #region ClampSelectionIndex
 
         [Fact]
-        public void ClampSelectionIndex_NullList_Returns0()
+        public void ClampSelectionIndex_WithNullList_ShouldReturn0()
         {
             Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(null, null));
         }
 
         [Fact]
-        public void ClampSelectionIndex_EmptyList_Returns0()
+        public void ClampSelectionIndex_WithEmptyList_ShouldReturn0()
         {
             Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(null, new List<SongListNode>()));
         }
 
         [Fact]
-        public void ClampSelectionIndex_NullPrevious_Returns0()
+        public void ClampSelectionIndex_WithNullPrevious_ShouldReturn0()
         {
             var list = new List<SongListNode> { new SongListNode { Title = "A" } };
             Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(null, list));
         }
 
         [Fact]
-        public void ClampSelectionIndex_FoundInList_ReturnsIndex()
+        public void ClampSelectionIndex_WhenFoundInList_ShouldReturnIndex()
         {
             var node = new SongListNode { Title = "B" };
             var list = new List<SongListNode>
@@ -194,7 +195,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void ClampSelectionIndex_NotFound_Returns0()
+        public void ClampSelectionIndex_WhenNotFound_ShouldReturn0()
         {
             var prev = new SongListNode { Title = "X" };
             var list = new List<SongListNode>
@@ -206,7 +207,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void ClampSelectionIndex_SameReferenceFirst_Returns0()
+        public void ClampSelectionIndex_WithSameReferenceFirst_ShouldReturn0()
         {
             var node = new SongListNode { Title = "A" };
             var list = new List<SongListNode> { node, new SongListNode { Title = "B" } };

--- a/DTXMania.Test/Stage/SongSelectionStageInputTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageInputTests.cs
@@ -1,0 +1,209 @@
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.Stage;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    [Trait("Category", "Unit")]
+    public class SongSelectionStageInputTests
+    {
+        #region ClampSelectionIndex
+
+        [Fact]
+        public void ClampSelectionIndex_PreviousAtEndOfMultiItemList_ShouldReturnLastIndex()
+        {
+            var node = new SongListNode { Title = "C" };
+            var list = new List<SongListNode>
+            {
+                new SongListNode { Title = "A" },
+                new SongListNode { Title = "B" },
+                node
+            };
+            Assert.Equal(2, SongSelectionStage.ClampSelectionIndex(node, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_SingleItemListWithMatch_ShouldReturn0()
+        {
+            var node = new SongListNode { Title = "Only" };
+            var list = new List<SongListNode> { node };
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(node, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_SingleItemListWithoutMatch_ShouldReturn0()
+        {
+            var prev = new SongListNode { Title = "X" };
+            var list = new List<SongListNode> { new SongListNode { Title = "Y" } };
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(prev, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_PreviousFoundAtMiddlePosition_ShouldReturnCorrectIndex()
+        {
+            var node = new SongListNode { Title = "Mid" };
+            var list = new List<SongListNode>
+            {
+                new SongListNode { Title = "A" },
+                new SongListNode { Title = "B" },
+                node,
+                new SongListNode { Title = "D" },
+                new SongListNode { Title = "E" }
+            };
+            Assert.Equal(2, SongSelectionStage.ClampSelectionIndex(node, list));
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_DuplicateReferences_ShouldReturnFirstOccurrence()
+        {
+            var node = new SongListNode { Title = "Dup" };
+            var list = new List<SongListNode>
+            {
+                node,
+                new SongListNode { Title = "Other" },
+                node
+            };
+            Assert.Equal(0, SongSelectionStage.ClampSelectionIndex(node, list));
+        }
+
+        #endregion
+
+        #region SummarizeFilter
+
+        [Fact]
+        public void SummarizeFilter_WithPlayedStatusUnplayed_ShouldContainUnplayed()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Unplayed", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithPlayedStatusPlayed_ShouldContainPlayed()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Played };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Played", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithPlayedStatusOnly_ShouldStartWithFiltered()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.StartsWith("Filtered:", result);
+            Assert.Contains("Cleared", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSortDescendingOnly_ShouldStartWithFiltered()
+        {
+            var c = SongFilterCriteria.Default with { SortDescending = true };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.StartsWith("Filtered:", result);
+            Assert.Contains("Titlev", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSortByArtistDescending_ShouldContainArtistv()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist, SortDescending = true };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Artistv", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSortByGenreDescending_ShouldContainGenrev()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Genre, SortDescending = true };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Genrev", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSortByLevelAscending_ShouldContainLevelUpArrow()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Level, SortDescending = false };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Level^", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithCombinedAllFields_ShouldContainAllParts()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SearchQuery = "mega",
+                MinLevel = 40,
+                MaxLevel = 80,
+                PlayedStatus = PlayedStatus.Unplayed,
+                SortBy = SongSortCriteria.Artist,
+                SortDescending = true
+            };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.StartsWith("Filtered:", result);
+            Assert.Contains("\"mega\"", result);
+            Assert.Contains("Lv 40-80", result);
+            Assert.Contains("Unplayed", result);
+            Assert.Contains("Artistv", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSearchAndSortOnly_ShouldContainBothParts()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SearchQuery = "test",
+                SortBy = SongSortCriteria.Genre
+            };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("\"test\"", result);
+            Assert.Contains("Genre^", result);
+            Assert.DoesNotContain("Lv", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithLevelAndSortOnly_ShouldContainLevelAndSort()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                MaxLevel = 50,
+                SortBy = SongSortCriteria.Level,
+                SortDescending = true
+            };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains("Lv <=50", result);
+            Assert.Contains("Levelv", result);
+            Assert.DoesNotContain("\"", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithPartsJoinedByPipe_ShouldUsePipeSeparator()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SearchQuery = "x",
+                MinLevel = 10
+            };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.Contains(" | ", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSortByTitleAscending_ShouldOmitSortFromResult()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SearchQuery = "y",
+                SortBy = SongSortCriteria.Title,
+                SortDescending = false
+            };
+            var result = SongSelectionStage.SummarizeFilter(c);
+            Assert.DoesNotContain("Title", result);
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStagePreviewAndBgmTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreviewAndBgmTests.cs
@@ -1,0 +1,852 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.UI;
+using DTXMania.Game.Lib.UI.Components;
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
+using Moq;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionStagePreviewAndBgmTests
+    {
+        private static SongSelectionStage CreateStage()
+        {
+            return new SongSelectionStage(CreateGame());
+        }
+
+        private static SongListNode CreateScoreNode(string title, SongScore[]? scores = null)
+        {
+            scores ??= CreateScores(0);
+            return new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = title,
+                Scores = scores
+            };
+        }
+
+        private static SongScore[] CreateScores(params int[] difficulties)
+        {
+            var result = new SongScore[5];
+            foreach (var difficulty in difficulties)
+            {
+                result[difficulty] = new SongScore
+                {
+                    DifficultyLevel = difficulty,
+                    DifficultyLabel = $"Level {difficulty}"
+                };
+            }
+            return result;
+        }
+
+        private static SongListNode CreateBoxNode(string title, params SongListNode[] children)
+        {
+            return new SongListNode
+            {
+                Type = NodeType.Box,
+                Title = title,
+                Children = new List<SongListNode>(children)
+            };
+        }
+
+        private static void AttachCoreUi(
+            SongSelectionStage stage,
+            SongListDisplay? display = null,
+            SongStatusPanel? statusPanel = null)
+        {
+            SetPrivateField(stage, "_songListDisplay", display ?? new SongListDisplay());
+            SetPrivateField(stage, "_statusPanel", statusPanel ?? new SongStatusPanel());
+            SetPrivateField(stage, "_uiManager", new UIManager());
+            SetPrivateField(stage, "_mainPanel", new UIPanel());
+            SetPrivateField(stage, "_navigationStack", new Stack<SongListNode>());
+            SetPrivateField(stage, "_breadcrumbLabel", new UILabel(""));
+            SetPrivateField(stage, "_titleLabel", new UILabel(""));
+            SetPrivateField(stage, "_selectionPhase", SongSelectionPhase.Normal);
+            SetPrivateField(stage, "_currentPhase", StagePhase.Normal);
+        }
+
+        private static object? InvokeStaticMethod(Type type, string methodName, params object[] args)
+        {
+            var method = type.GetMethod(methodName,
+                System.Reflection.BindingFlags.Static |
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Public);
+            Assert.NotNull(method);
+            return method!.Invoke(null, args);
+        }
+
+        private static T? InvokeStaticMethod<T>(Type type, string methodName, params object[] args)
+        {
+            var result = InvokeStaticMethod(type, methodName, args);
+            if (result is null) return default;
+            return (T)result;
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenPreviousBgmExists_ShouldReleaseReference()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            var newSound = new Mock<ISound>();
+            var newInstance = new Mock<ISoundInstance>();
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            stage.SetBackgroundMusic(newSound.Object, newInstance.Object);
+
+            oldSound.Verify(x => x.RemoveReference(), Times.Once);
+            oldInstance.Verify(x => x.Stop(), Times.Once);
+            oldInstance.Verify(x => x.Dispose(), Times.Once);
+            Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+            Assert.Same(newInstance.Object, GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenPreviousBgmRemoveReferenceThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            oldSound.Setup(x => x.RemoveReference()).Throws(new Exception("boom"));
+            var newSound = new Mock<ISound>();
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(newSound.Object, null));
+
+            Assert.Null(exception);
+            Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenPreviousInstanceStopThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            oldInstance.Setup(x => x.Stop()).Throws(new Exception("stop fail"));
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(null, null));
+
+            Assert.Null(exception);
+            oldInstance.Verify(x => x.Dispose(), Times.Once);
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenPreviousInstanceDisposeThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var oldSound = new Mock<ISound>();
+            var oldInstance = new Mock<ISoundInstance>();
+            oldInstance.Setup(x => x.Dispose()).Throws(new Exception("dispose fail"));
+
+            SetPrivateField(stage, "_backgroundMusic", oldSound.Object);
+            SetPrivateField(stage, "_backgroundMusicInstance", oldInstance.Object);
+
+            var exception = Record.Exception(() => stage.SetBackgroundMusic(null, null));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void SetBackgroundMusic_WhenExistingBgmIsNull_ShouldSetDirectly()
+        {
+            var stage = CreateStage();
+            var newSound = new Mock<ISound>();
+            var newInstance = new Mock<ISoundInstance>();
+
+            SetPrivateField(stage, "_backgroundMusic", null);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+
+            stage.SetBackgroundMusic(newSound.Object, newInstance.Object);
+
+            Assert.Same(newSound.Object, GetPrivateField<ISound>(stage, "_backgroundMusic"));
+            Assert.Same(newInstance.Object, GetPrivateField<ISoundInstance>(stage, "_backgroundMusicInstance"));
+        }
+
+        [Fact]
+        public void StopCurrentPreview_WhenPreviewSoundInstanceIsNull_ShouldResetTimersAndStartBgmFadeIn()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_previewSoundInstance", null);
+            SetPrivateField(stage, "_previewSound", null);
+            SetPrivateField(stage, "_previewPlayDelay", 5.0);
+            SetPrivateField(stage, "_isPreviewDelayActive", true);
+
+            InvokePrivateMethod(stage, "StopCurrentPreview");
+
+            Assert.Equal(0.0, GetPrivateField<double>(stage, "_previewPlayDelay"));
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        }
+
+        [Fact]
+        public void StopCurrentPreview_WhenPreviewSoundInstanceStopThrows_ShouldStillDisposeAndClear()
+        {
+            var stage = CreateStage();
+            var mockInstance = new Mock<ISoundInstance>();
+            mockInstance.Setup(x => x.State).Returns(SoundState.Playing);
+            mockInstance.Setup(x => x.Stop()).Throws(new Exception("stop error"));
+
+            SetPrivateField(stage, "_previewSoundInstance", mockInstance.Object);
+            SetPrivateField(stage, "_previewSound", null);
+
+            InvokePrivateMethod(stage, "StopCurrentPreview");
+
+            mockInstance.Verify(x => x.Dispose(), Times.Once);
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        }
+
+        [Fact]
+        public void StopCurrentPreview_WhenPreviewSoundInstanceIsNotPlaying_ShouldNotCallStop()
+        {
+            var stage = CreateStage();
+            var mockInstance = new Mock<ISoundInstance>();
+            mockInstance.Setup(x => x.State).Returns(SoundState.Stopped);
+
+            SetPrivateField(stage, "_previewSoundInstance", mockInstance.Object);
+            SetPrivateField(stage, "_previewSound", null);
+
+            InvokePrivateMethod(stage, "StopCurrentPreview");
+
+            mockInstance.Verify(x => x.Stop(), Times.Never);
+            mockInstance.Verify(x => x.Dispose(), Times.Once);
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+        }
+
+        [Fact]
+        public void StopCurrentPreview_WhenPreviewSoundExists_ShouldReleaseReference()
+        {
+            var stage = CreateStage();
+            var mockSound = new Mock<ISound>();
+            var mockInstance = new Mock<ISoundInstance>();
+            mockInstance.Setup(x => x.State).Returns(SoundState.Stopped);
+
+            SetPrivateField(stage, "_previewSoundInstance", mockInstance.Object);
+            SetPrivateField(stage, "_previewSound", mockSound.Object);
+
+            InvokePrivateMethod(stage, "StopCurrentPreview");
+
+            mockSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<ISound>(stage, "_previewSound"));
+        }
+
+        [Fact]
+        public void StartBGMFade_WithFadeOutTrue_ShouldSetFadeOutState()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+
+            InvokePrivateMethod(stage, "StartBGMFade", true);
+
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+            Assert.Equal(0.0, GetPrivateField<double>(stage, "_bgmFadeOutTimer"));
+        }
+
+        [Fact]
+        public void StartBGMFade_WithFadeOutFalse_ShouldSetFadeInState()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "StartBGMFade", false);
+
+            Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+            Assert.Equal(0.0, GetPrivateField<double>(stage, "_bgmFadeInTimer"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_BgmFadeOut_WhenTimerExceedsDuration_ShouldStopFading()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_bgmFadeOutTimer", 0.4);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.2);
+
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+            Assert.Equal(SongSelectionUILayout.Audio.BgmFadeOutDuration,
+                GetPrivateField<double>(stage, "_bgmFadeOutTimer"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_BgmFadeOut_WithPlayingBgmInstance_ShouldApplyVolumeFade()
+        {
+            var stage = CreateStage();
+            var bgmInstance = new Mock<ISoundInstance>();
+            bgmInstance.Setup(x => x.State).Returns(SoundState.Playing);
+
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_bgmFadeOutTimer", 0.0);
+            SetPrivateField(stage, "_backgroundMusicInstance", bgmInstance.Object);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.25);
+
+            bgmInstance.VerifySet(x => x.Volume = It.IsAny<float>(), Times.Once);
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_BgmFadeOut_WhenVolumeSetThrows_ShouldStopFading()
+        {
+            var stage = CreateStage();
+            var bgmInstance = new Mock<ISoundInstance>();
+            bgmInstance.Setup(x => x.State).Returns(SoundState.Playing);
+            bgmInstance.SetupSet(x => x.Volume = It.IsAny<float>()).Throws(new Exception("vol error"));
+
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", true);
+            SetPrivateField(stage, "_bgmFadeOutTimer", 0.0);
+            SetPrivateField(stage, "_backgroundMusicInstance", bgmInstance.Object);
+            SetPrivateField(stage, "_isBgmFadingIn", false);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1);
+
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_BgmFadeIn_WhenTimerExceedsDuration_ShouldStopFading()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_bgmFadeInTimer", 0.9);
+            SetPrivateField(stage, "_backgroundMusicInstance", null);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.2);
+
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+            Assert.Equal(SongSelectionUILayout.Audio.BgmFadeInDuration,
+                GetPrivateField<double>(stage, "_bgmFadeInTimer"));
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_BgmFadeIn_WithPlayingBgmInstance_ShouldApplyVolumeFade()
+        {
+            var stage = CreateStage();
+            var bgmInstance = new Mock<ISoundInstance>();
+            bgmInstance.Setup(x => x.State).Returns(SoundState.Playing);
+
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_bgmFadeInTimer", 0.0);
+            SetPrivateField(stage, "_backgroundMusicInstance", bgmInstance.Object);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.5);
+
+            bgmInstance.VerifySet(x => x.Volume = It.IsAny<float>(), Times.Once);
+        }
+
+        [Fact]
+        public void UpdatePreviewSoundTimers_BgmFadeIn_WhenVolumeSetThrows_ShouldStopFading()
+        {
+            var stage = CreateStage();
+            var bgmInstance = new Mock<ISoundInstance>();
+            bgmInstance.Setup(x => x.State).Returns(SoundState.Playing);
+            bgmInstance.SetupSet(x => x.Volume = It.IsAny<float>()).Throws(new Exception("vol error"));
+
+            SetPrivateField(stage, "_isPreviewDelayActive", false);
+            SetPrivateField(stage, "_isBgmFadingOut", false);
+            SetPrivateField(stage, "_isBgmFadingIn", true);
+            SetPrivateField(stage, "_bgmFadeInTimer", 0.0);
+            SetPrivateField(stage, "_backgroundMusicInstance", bgmInstance.Object);
+
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.1);
+
+            Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        }
+
+        [Fact]
+        public void PlayCursorMoveSound_WhenSoundIsNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_cursorMoveSound", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "PlayCursorMoveSound"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PlayCursorMoveSound_WhenPlayThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var mockSound = new Mock<ISound>();
+            mockSound.Setup(x => x.Play(It.IsAny<float>())).Throws(new Exception("audio error"));
+
+            SetPrivateField(stage, "_cursorMoveSound", mockSound.Object);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "PlayCursorMoveSound"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PlayCursorMoveSound_WithValidSound_ShouldPlayWithCorrectVolume()
+        {
+            var stage = CreateStage();
+            var mockSound = new Mock<ISound>();
+
+            SetPrivateField(stage, "_cursorMoveSound", mockSound.Object);
+
+            InvokePrivateMethod(stage, "PlayCursorMoveSound");
+
+            mockSound.Verify(x => x.Play(SongSelectionUILayout.Audio.NavigationSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void PlayGameStartSound_WhenSoundIsNull_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_gameStartSound", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "PlayGameStartSound"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PlayGameStartSound_WhenPlayThrows_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var mockSound = new Mock<ISound>();
+            mockSound.Setup(x => x.Play(It.IsAny<float>())).Throws(new Exception("audio error"));
+
+            SetPrivateField(stage, "_gameStartSound", mockSound.Object);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "PlayGameStartSound"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void PlayGameStartSound_WithValidSound_ShouldPlayWithCorrectVolume()
+        {
+            var stage = CreateStage();
+            var mockSound = new Mock<ISound>();
+
+            SetPrivateField(stage, "_gameStartSound", mockSound.Object);
+
+            InvokePrivateMethod(stage, "PlayGameStartSound");
+
+            mockSound.Verify(x => x.Play(SongSelectionUILayout.Audio.GameStartSoundVolume), Times.Once);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithAllFieldsSet_ShouldIncludeAllParts()
+        {
+            var criteria = new SongFilterCriteria(
+                "test",
+                10,
+                50,
+                PlayedStatus.Played,
+                SongSortCriteria.Artist,
+                true);
+
+            var result = SongSelectionStage.SummarizeFilter(criteria);
+
+            Assert.Contains("test", result);
+            Assert.Contains("Lv 10-50", result);
+            Assert.Contains("Played", result);
+            Assert.Contains("Artist", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithOnlyPlayedStatusNotAll_ShouldIncludeStatus()
+        {
+            var criteria = new SongFilterCriteria(
+                "",
+                null,
+                null,
+                PlayedStatus.Unplayed,
+                SongSortCriteria.Title,
+                false);
+
+            var result = SongSelectionStage.SummarizeFilter(criteria);
+
+            Assert.Contains("Unplayed", result);
+            Assert.DoesNotContain("Lv", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithOnlySortNonDefault_ShouldIncludeSort()
+        {
+            var criteria = new SongFilterCriteria(
+                "",
+                null,
+                null,
+                PlayedStatus.All,
+                SongSortCriteria.Level,
+                true);
+
+            var result = SongSelectionStage.SummarizeFilter(criteria);
+
+            Assert.Contains("Level", result);
+            Assert.DoesNotContain("Lv", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithEmptyCriteria_ShouldReturnEmptyString()
+        {
+            var result = SongSelectionStage.SummarizeFilter(SongFilterCriteria.Default);
+
+            Assert.Equal("", result);
+        }
+
+        [Fact]
+        public void SummarizeFilter_WithSearchQueryOnly_ShouldIncludeSearchQuery()
+        {
+            var criteria = new SongFilterCriteria(
+                "hello",
+                null,
+                null,
+                PlayedStatus.All,
+                SongSortCriteria.Title,
+                false);
+
+            var result = SongSelectionStage.SummarizeFilter(criteria);
+
+            Assert.Contains("hello", result);
+            Assert.StartsWith("Filtered:", result);
+        }
+
+        [Fact]
+        public void FormatLevel_WithInvertedMinMax_ShouldNormalize()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatLevel", 50, (int?)10);
+
+            Assert.Equal("Lv 10-50", result);
+        }
+
+        [Fact]
+        public void FormatLevel_WithOnlyMinSet_ShouldReturnPlusFormat()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatLevel", 30, (int?)null);
+
+            Assert.Equal("Lv 30+", result);
+        }
+
+        [Fact]
+        public void FormatLevel_WithOnlyMaxSet_ShouldReturnLessThanOrEqualFormat()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatLevel", null, (int?)50);
+
+            Assert.Equal("Lv <=50", result);
+        }
+
+        [Fact]
+        public void FormatLevel_WithBothNull_ShouldReturnNull()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatLevel", null, (int?)null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FormatLevel_WithEqualMinMax_ShouldReturnRange()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatLevel", 25, (int?)25);
+
+            Assert.Equal("Lv 25-25", result);
+        }
+
+        [Fact]
+        public void FormatSort_WithDefaultTitleAscending_ShouldReturnNull()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatSort", SongSortCriteria.Title, false);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void FormatSort_WithTitleDescending_ShouldReturnTitleV()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatSort", SongSortCriteria.Title, true);
+
+            Assert.Equal("Titlev", result);
+        }
+
+        [Fact]
+        public void FormatSort_WithArtistAscending_ShouldReturnArtistCaret()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatSort", SongSortCriteria.Artist, false);
+
+            Assert.Equal("Artist^", result);
+        }
+
+        [Fact]
+        public void FormatSort_WithGenreDescending_ShouldReturnGenrev()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatSort", SongSortCriteria.Genre, true);
+
+            Assert.Equal("Genrev", result);
+        }
+
+        [Fact]
+        public void FormatSort_WithLevelAscending_ShouldReturnLevelCaret()
+        {
+            var result = InvokeStaticMethod<string>(typeof(SongSelectionStage), "FormatSort", SongSortCriteria.Level, false);
+
+            Assert.Equal("Level^", result);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_WithNullPreviousSelected_ShouldReturnZero()
+        {
+            var list = new List<SongListNode> { CreateScoreNode("A") };
+
+            var result = SongSelectionStage.ClampSelectionIndex(null, list);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_WithNullNewList_ShouldReturnZero()
+        {
+            var node = CreateScoreNode("A");
+
+            var result = SongSelectionStage.ClampSelectionIndex(node, null);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_WithEmptyList_ShouldReturnZero()
+        {
+            var node = CreateScoreNode("A");
+
+            var result = SongSelectionStage.ClampSelectionIndex(node, new List<SongListNode>());
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_WithPreviousSelectedFound_ShouldReturnIndex()
+        {
+            var nodeA = CreateScoreNode("A");
+            var nodeB = CreateScoreNode("B");
+            var nodeC = CreateScoreNode("C");
+            var list = new List<SongListNode> { nodeA, nodeB, nodeC };
+
+            var result = SongSelectionStage.ClampSelectionIndex(nodeB, list);
+
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_WithPreviousSelectedNotFound_ShouldReturnZero()
+        {
+            var nodeA = CreateScoreNode("A");
+            var nodeB = CreateScoreNode("B");
+            var nodeC = CreateScoreNode("C");
+            var nodeD = CreateScoreNode("D");
+            var list = new List<SongListNode> { nodeA, nodeB, nodeC };
+
+            var result = SongSelectionStage.ClampSelectionIndex(nodeD, list);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_WithBothNull_ShouldReturnZero()
+        {
+            var result = SongSelectionStage.ClampSelectionIndex(null, null);
+
+            Assert.Equal(0, result);
+        }
+
+        [Fact]
+        public void HandleActivateInput_WhenInStatusPanelWithScoreSong_ShouldCallSelectSong()
+        {
+            var game = CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stage = new SongSelectionStage(game);
+            var stageManager = new Mock<IStageManager>();
+            var selectedSong = CreateScoreNode("Song");
+
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_selectedSong", selectedSong);
+            SetPrivateField(stage, "_currentDifficulty", 0);
+            SetPrivateField(stage, "_isInStatusPanel", true);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            stageManager.Verify(
+                x => x.ChangeStage(
+                    StageType.SongTransition,
+                    It.IsAny<IStageTransition>(),
+                    It.IsAny<Dictionary<string, object>>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public void HandleActivateInput_WhenNotInStatusPanelWithScoreSong_ShouldEnterStatusPanel()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel { Visible = false };
+            var selectedSong = CreateScoreNode("Song");
+
+            AttachCoreUi(stage, statusPanel: statusPanel);
+            SetPrivateField(stage, "_selectedSong", selectedSong);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            Assert.True(statusPanel.Visible);
+        }
+
+        [Fact]
+        public void HandleActivateInput_WhenNotInStatusPanelWithNonScore_ShouldCallHandleSongActivation()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var child = CreateScoreNode("Child");
+            var box = CreateBoxNode("Folder", child);
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_selectedSong", box);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { box });
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.Same(box.Children, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+        }
+
+        [Fact]
+        public void HandleActivateInput_WhenFilteredViewActiveAndNonScoreSelected_ShouldReturnEarly()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var box = CreateBoxNode("Folder");
+            var filteredView = new List<FilteredSongResult> { new(CreateScoreNode("S"), "f") };
+
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_filteredView", filteredView);
+            SetPrivateField(stage, "_selectedSong", box);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { box });
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.NotSame(box.Children, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.False(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+        }
+
+        [Fact]
+        public void HandleActivateInput_WhenFilteredViewActiveAndScoreSelected_ShouldEnterStatusPanel()
+        {
+            var stage = CreateStage();
+            var statusPanel = new SongStatusPanel { Visible = false };
+            var song = CreateScoreNode("Song");
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { song } };
+            var filteredView = new List<FilteredSongResult> { new(song, "f") };
+
+            AttachCoreUi(stage, display: display, statusPanel: statusPanel);
+            SetPrivateField(stage, "_filteredView", filteredView);
+            SetPrivateField(stage, "_selectedSong", song);
+            SetPrivateField(stage, "_isInStatusPanel", false);
+
+            InvokePrivateMethod(stage, "HandleActivateInput");
+
+            Assert.True(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+            Assert.True(statusPanel.Visible);
+        }
+
+        [Fact]
+        public void ReleaseManagedSound_WithNullSound_ShouldNotThrow()
+        {
+            var method = typeof(SongSelectionStage).GetMethod("ReleaseManagedSound",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            object[] args = new object[] { null! };
+            var exception = Record.Exception(() => method!.Invoke(null, args));
+
+            Assert.Null(exception);
+            Assert.Null(args[0]);
+        }
+
+        [Fact]
+        public void ReleaseManagedSound_WithNonNullSound_ShouldCallRemoveReferenceAndClear()
+        {
+            var mockSound = new Mock<ISound>();
+            var method = typeof(SongSelectionStage).GetMethod("ReleaseManagedSound",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            object[] args = new object[] { mockSound.Object };
+            method!.Invoke(null, args);
+
+            mockSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Null(args[0]);
+        }
+
+        [Fact]
+        public void CreatePreviewSoundInstance_WithNullSound_ShouldReturnNull()
+        {
+            var result = InvokeStaticMethod<ISoundInstance>(typeof(SongSelectionStage), "CreatePreviewSoundInstance", new object?[] { null });
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CreatePreviewSoundInstance_WithSoundThatReturnsNullInstance_ShouldReturnNull()
+        {
+            var mockSound = new Mock<ISound>();
+            mockSound.Setup(x => x.CreateInstance()).Returns((SoundEffectInstance?)null);
+
+            var result = InvokeStaticMethod<object>(typeof(SongSelectionStage), "CreatePreviewSoundInstance", mockSound.Object);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void OnScrollSpeedChanged_ShouldNotThrow()
+        {
+            var stage = CreateStage();
+            var args = new ScrollSpeedChangedEventArgs(50, 75);
+
+            var exception = Record.Exception(() =>
+                InvokePrivateMethod(stage, "OnScrollSpeedChanged", stage, args));
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/DTXMania.Test/UI/SearchFilterModalLayoutTests.cs
+++ b/DTXMania.Test/UI/SearchFilterModalLayoutTests.cs
@@ -7,7 +7,7 @@ namespace DTXMania.Test.UI
     public class SearchFilterModalLayoutTests
     {
         [Fact]
-        public void Modal_IsCentered1280x720()
+        public void Modal_WhenResolution1280x720_ShouldBeCentered()
         {
             // Modal: 600 wide, 360 tall, centered in 1280x720
             Assert.Equal(340, SongSelectionUILayout.SearchFilterModal.X);
@@ -17,14 +17,14 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Modal_BoundsMatchPositionAndSize()
+        public void Modal_Bounds_ShouldMatchPositionAndSize()
         {
             var b = SongSelectionUILayout.SearchFilterModal.Bounds;
             Assert.Equal(new Rectangle(340, 180, 600, 360), b);
         }
 
         [Fact]
-        public void SearchBox_HasWidth()
+        public void SearchBox_WhenModalInitialized_ShouldHavePositiveWidth()
         {
             Assert.True(SongSelectionUILayout.SearchFilterModal.SearchBoxWidth > 0);
         }

--- a/DTXMania.Test/UI/SearchFilterModalLayoutTests.cs
+++ b/DTXMania.Test/UI/SearchFilterModalLayoutTests.cs
@@ -1,0 +1,32 @@
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    public class SearchFilterModalLayoutTests
+    {
+        [Fact]
+        public void Modal_IsCentered1280x720()
+        {
+            // Modal: 600 wide, 360 tall, centered in 1280x720
+            Assert.Equal(340, SongSelectionUILayout.SearchFilterModal.X);
+            Assert.Equal(180, SongSelectionUILayout.SearchFilterModal.Y);
+            Assert.Equal(600, SongSelectionUILayout.SearchFilterModal.Width);
+            Assert.Equal(360, SongSelectionUILayout.SearchFilterModal.Height);
+        }
+
+        [Fact]
+        public void Modal_BoundsMatchPositionAndSize()
+        {
+            var b = SongSelectionUILayout.SearchFilterModal.Bounds;
+            Assert.Equal(new Rectangle(340, 180, 600, 360), b);
+        }
+
+        [Fact]
+        public void SearchBox_HasWidth()
+        {
+            Assert.True(SongSelectionUILayout.SearchFilterModal.SearchBoxWidth > 0);
+        }
+    }
+}

--- a/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
+++ b/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
@@ -181,5 +181,370 @@ namespace DTXMania.Test.UI
             Assert.True(SongSelectionUILayout.SearchFilterModal.ButtonWidth > 0);
             Assert.True(SongSelectionUILayout.SearchFilterModal.ButtonHeight > 0);
         }
+
+        [Fact]
+        public void SongBars_GetBarY_WhenValidIndex_ShouldReturnCoordinateY()
+        {
+            Assert.Equal(SongSelectionUILayout.SongBars.BarCoordinates[0].Y,
+                SongSelectionUILayout.SongBars.GetBarY(0));
+            Assert.Equal(SongSelectionUILayout.SongBars.BarCoordinates[3].Y,
+                SongSelectionUILayout.SongBars.GetBarY(3));
+        }
+
+        [Fact]
+        public void SongBars_GetBarPosition_WhenNonCenterIndex_ShouldReturnUnselectedPosition()
+        {
+            var pos = SongSelectionUILayout.SongBars.GetBarPosition(0);
+            Assert.Equal(SongSelectionUILayout.SongBars.UnselectedBarX, pos.X);
+            Assert.Equal(SongSelectionUILayout.SongBars.GetBarY(0), pos.Y);
+        }
+
+        [Fact]
+        public void SongBars_BarSize_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.SongBars.BarSize;
+            Assert.Equal(SongSelectionUILayout.SongBars.BarWidth, size.X);
+            Assert.Equal(SongSelectionUILayout.SongBars.BarHeight, size.Y);
+        }
+
+        [Fact]
+        public void SongBars_UnselectedBarPosition_ShouldHaveCorrectX()
+        {
+            Assert.Equal(SongSelectionUILayout.SongBars.UnselectedBarX,
+                SongSelectionUILayout.SongBars.UnselectedBarPosition.X);
+        }
+
+        [Fact]
+        public void NoteDistributionBars_Drums_GetBarPosition_ShouldCalculateCorrectly()
+        {
+            var pos = SongSelectionUILayout.NoteDistributionBars.Drums.GetBarPosition(0);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartX, pos.X);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartY, pos.Y);
+
+            var pos3 = SongSelectionUILayout.NoteDistributionBars.Drums.GetBarPosition(3);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartX + 3 * (SongSelectionUILayout.NoteDistributionBars.Drums.BarWidth + SongSelectionUILayout.NoteDistributionBars.Drums.BarSpacing), pos3.X);
+        }
+
+        [Fact]
+        public void NoteDistributionBars_GuitarBass_GetBarPosition_ShouldCalculateCorrectly()
+        {
+            var pos = SongSelectionUILayout.NoteDistributionBars.GuitarBass.GetBarPosition(0);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartX, pos.X);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartY, pos.Y);
+
+            var pos2 = SongSelectionUILayout.NoteDistributionBars.GuitarBass.GetBarPosition(2);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartX + 2 * (SongSelectionUILayout.NoteDistributionBars.GuitarBass.BarWidth + SongSelectionUILayout.NoteDistributionBars.GuitarBass.BarSpacing), pos2.X);
+        }
+
+        [Fact]
+        public void PreviewImagePanel_WithoutStatusPanel_Size_ShouldMatchConstant()
+        {
+            Assert.Equal(368, SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Size);
+        }
+
+        [Fact]
+        public void PreviewImagePanel_WithoutStatusPanel_Bounds_ShouldMatchConstants()
+        {
+            var bounds = SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Bounds;
+            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.X, bounds.X);
+            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Y, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Size, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Size, bounds.Height);
+        }
+
+        [Fact]
+        public void StatusPanel_Bounds_ShouldMatchConstants()
+        {
+            var bounds = SongSelectionUILayout.StatusPanel.Bounds;
+            Assert.Equal(SongSelectionUILayout.StatusPanel.X, bounds.X);
+            Assert.Equal(SongSelectionUILayout.StatusPanel.Y, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.StatusPanel.Width, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.StatusPanel.Height, bounds.Height);
+        }
+
+        [Fact]
+        public void BPMSection_Bounds_ShouldMatchConstants()
+        {
+            var bounds = SongSelectionUILayout.BPMSection.Bounds;
+            Assert.Equal(SongSelectionUILayout.BPMSection.X, bounds.X);
+            Assert.Equal(SongSelectionUILayout.BPMSection.Y, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.BPMSection.Width, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.BPMSection.Height, bounds.Height);
+        }
+
+        [Fact]
+        public void BPMSection_Size_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.BPMSection.Size;
+            Assert.Equal(SongSelectionUILayout.BPMSection.Width, size.X);
+            Assert.Equal(SongSelectionUILayout.BPMSection.Height, size.Y);
+        }
+
+        [Fact]
+        public void BPMSection_LengthTextPosition_ShouldBeWithinBounds()
+        {
+            var pos = SongSelectionUILayout.BPMSection.LengthTextPosition;
+            Assert.True(pos.X >= SongSelectionUILayout.BPMSection.X);
+            Assert.True(pos.Y >= SongSelectionUILayout.BPMSection.Y);
+        }
+
+        [Fact]
+        public void BPMSection_BPMTextPosition_ShouldBeWithinBounds()
+        {
+            var pos = SongSelectionUILayout.BPMSection.BPMTextPosition;
+            Assert.True(pos.X >= SongSelectionUILayout.BPMSection.X);
+            Assert.True(pos.Y >= SongSelectionUILayout.BPMSection.Y);
+        }
+
+        [Fact]
+        public void SkillPointSection_Bounds_ShouldMatchConstants()
+        {
+            var bounds = SongSelectionUILayout.SkillPointSection.Bounds;
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.X, bounds.X);
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.Y, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.Width, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.Height, bounds.Height);
+        }
+
+        [Fact]
+        public void SkillPointSection_Size_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.SkillPointSection.Size;
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.Width, size.X);
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.Height, size.Y);
+        }
+
+        [Fact]
+        public void SkillPointSection_ValuePosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.SkillPointSection.ValuePosition;
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.ValueX, pos.X);
+            Assert.Equal(SongSelectionUILayout.SkillPointSection.ValueY, pos.Y);
+        }
+
+        [Fact]
+        public void GraphPanel_Size_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.GraphPanel.Size;
+            Assert.Equal(SongSelectionUILayout.GraphPanel.Width, size.X);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.Height, size.Y);
+        }
+
+        [Fact]
+        public void GraphPanel_Bounds_ShouldMatchConstants()
+        {
+            var bounds = SongSelectionUILayout.GraphPanel.Bounds;
+            Assert.Equal(SongSelectionUILayout.GraphPanel.BaseX, bounds.X);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.BaseY, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.Width, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.Height, bounds.Height);
+        }
+
+        [Fact]
+        public void GraphPanel_NotesCounterPosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.GraphPanel.NotesCounterPosition;
+            Assert.Equal(SongSelectionUILayout.GraphPanel.NotesCounterX, pos.X);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.NotesCounterY, pos.Y);
+        }
+
+        [Fact]
+        public void GraphPanel_ProgressBarPosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.GraphPanel.ProgressBarPosition;
+            Assert.Equal(SongSelectionUILayout.GraphPanel.ProgressBarX, pos.X);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.ProgressBarY, pos.Y);
+        }
+
+        [Fact]
+        public void GraphPanel_ProgressBarSize_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.GraphPanel.ProgressBarSize;
+            Assert.Equal(SongSelectionUILayout.GraphPanel.ProgressBarWidth, size.X);
+            Assert.Equal(SongSelectionUILayout.GraphPanel.ProgressBarHeight, size.Y);
+        }
+
+        [Fact]
+        public void SongListDisplay_Position_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.SongListDisplay.Position;
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.X, pos.X);
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.Y, pos.Y);
+        }
+
+        [Fact]
+        public void SongListDisplay_Size_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.SongListDisplay.Size;
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.Width, size.X);
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.Height, size.Y);
+        }
+
+        [Fact]
+        public void SongListDisplay_Bounds_ShouldMatchConstants()
+        {
+            var bounds = SongSelectionUILayout.SongListDisplay.Bounds;
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.X, bounds.X);
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.Y, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.Width, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.SongListDisplay.Height, bounds.Height);
+        }
+
+        [Fact]
+        public void SearchFilterModal_Position_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.SearchFilterModal.Position;
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.X, pos.X);
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.Y, pos.Y);
+        }
+
+        [Fact]
+        public void SearchFilterModal_Size_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.SearchFilterModal.Size;
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.Width, size.X);
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.Height, size.Y);
+        }
+
+        [Fact]
+        public void ItemCounter_BasePosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.ItemCounter.BasePosition;
+            Assert.Equal(SongSelectionUILayout.ItemCounter.BaseX, pos.X);
+            Assert.Equal(SongSelectionUILayout.ItemCounter.BaseY, pos.Y);
+        }
+
+        [Fact]
+        public void Scrollbar_Position_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.Scrollbar.Position;
+            Assert.Equal(SongSelectionUILayout.Scrollbar.X, pos.X);
+            Assert.Equal(SongSelectionUILayout.Scrollbar.Y, pos.Y);
+        }
+
+        [Fact]
+        public void Scrollbar_IndicatorSizeVector_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.Scrollbar.IndicatorSizeVector;
+            Assert.Equal(SongSelectionUILayout.Scrollbar.IndicatorSize, size.X);
+            Assert.Equal(SongSelectionUILayout.Scrollbar.IndicatorSize, size.Y);
+        }
+
+        [Fact]
+        public void Background_MainPanelAlpha_ShouldBeInRange()
+        {
+            Assert.InRange(SongSelectionUILayout.Background.MainPanelAlpha, 0f, 1f);
+        }
+
+        [Fact]
+        public void Timing_NavigationDebounceSeconds_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Timing.NavigationDebounceSeconds > 0);
+        }
+
+        [Fact]
+        public void Timing_TaskTimeoutMilliseconds_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Timing.TaskTimeoutMilliseconds > 0);
+        }
+
+        [Fact]
+        public void Timing_TransitionDuration_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Timing.TransitionDuration > 0);
+        }
+
+        [Fact]
+        public void Audio_NavigationSoundVolume_ShouldBeInRange()
+        {
+            Assert.InRange(SongSelectionUILayout.Audio.NavigationSoundVolume, 0f, 1f);
+        }
+
+        [Fact]
+        public void Audio_GameStartSoundVolume_ShouldBeInRange()
+        {
+            Assert.InRange(SongSelectionUILayout.Audio.GameStartSoundVolume, 0f, 1f);
+        }
+
+        [Fact]
+        public void Audio_BgmFadeOutDuration_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Audio.BgmFadeOutDuration > 0);
+        }
+
+        [Fact]
+        public void Audio_BgmFadeInDuration_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Audio.BgmFadeInDuration > 0);
+        }
+
+        [Fact]
+        public void Audio_PreviewPlayDelaySeconds_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Audio.PreviewPlayDelaySeconds > 0);
+        }
+
+        [Fact]
+        public void Audio_BgmMinVolume_ShouldBeLessThanMax()
+        {
+            Assert.True(SongSelectionUILayout.Audio.BgmMinVolume < SongSelectionUILayout.Audio.BgmMaxVolume);
+        }
+
+        [Fact]
+        public void Audio_BgmFadeRange_ShouldMatchDifference()
+        {
+            Assert.Equal(SongSelectionUILayout.Audio.BgmMaxVolume - SongSelectionUILayout.Audio.BgmMinVolume,
+                SongSelectionUILayout.Audio.BgmFadeRange);
+        }
+
+        [Fact]
+        public void Spacing_CellPadding_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Spacing.CellPadding > 0);
+        }
+
+        [Fact]
+        public void Spacing_SectionSpacing_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Spacing.SectionSpacing > 0);
+        }
+
+        [Fact]
+        public void Spacing_LabelValueSpacing_ShouldBePositive()
+        {
+            Assert.True(SongSelectionUILayout.Spacing.LabelValueSpacing > 0);
+        }
+
+        [Fact]
+        public void NoteDistributionBars_Drums_StartPosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.NoteDistributionBars.Drums.StartPosition;
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartX, pos.X);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartY, pos.Y);
+        }
+
+        [Fact]
+        public void NoteDistributionBars_GuitarBass_StartPosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartPosition;
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartX, pos.X);
+            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartY, pos.Y);
+        }
+
+        [Fact]
+        public void DifficultyGrid_BasePosition_ShouldMatchConstants()
+        {
+            var pos = SongSelectionUILayout.DifficultyGrid.BasePosition;
+            Assert.Equal(SongSelectionUILayout.DifficultyGrid.BaseX, pos.X);
+            Assert.Equal(SongSelectionUILayout.DifficultyGrid.BaseY, pos.Y);
+        }
+
+        [Fact]
+        public void DifficultyGrid_CellSize_ShouldMatchConstants()
+        {
+            var size = SongSelectionUILayout.DifficultyGrid.CellSize;
+            Assert.Equal(SongSelectionUILayout.DifficultyGrid.CellWidth, size.X);
+            Assert.Equal(SongSelectionUILayout.DifficultyGrid.CellHeight, size.Y);
+        }
     }
 }

--- a/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
+++ b/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
@@ -4,10 +4,11 @@ using Xunit;
 
 namespace DTXMania.Test.UI
 {
+    [Trait("Category", "UI")]
     public class SongSelectionUILayoutTests
     {
         [Fact]
-        public void StatusPanel_PositionMatchesConstants()
+        public void StatusPanel_Position_ShouldMatchConstants()
         {
             Assert.Equal(new Vector2(SongSelectionUILayout.StatusPanel.X, SongSelectionUILayout.StatusPanel.Y),
                 SongSelectionUILayout.StatusPanel.Position);
@@ -16,7 +17,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void SearchFilterModal_BoundsMatchConstants()
+        public void SearchFilterModal_Bounds_ShouldMatchConstants()
         {
             var bounds = SongSelectionUILayout.SearchFilterModal.Bounds;
             Assert.Equal(SongSelectionUILayout.SearchFilterModal.X, bounds.X);
@@ -26,7 +27,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void DifficultyGrid_GetCellPosition_ReturnsValidVector()
+        public void DifficultyGrid_GetCellPosition_ShouldReturnValidVector()
         {
             var pos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(0, 0);
             Assert.True(pos.X > 0);
@@ -34,7 +35,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void DifficultyGrid_GetCellContentPosition_Has20pxOffset()
+        public void DifficultyGrid_GetCellContentPosition_ShouldHave20pxOffset()
         {
             var cell = SongSelectionUILayout.DifficultyGrid.GetCellPosition(2, 1);
             var content = SongSelectionUILayout.DifficultyGrid.GetCellContentPosition(2, 1);
@@ -42,140 +43,140 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void BPMSection_PositionMatchesConstants()
+        public void BPMSection_Position_ShouldMatchConstants()
         {
             Assert.Equal(new Vector2(SongSelectionUILayout.BPMSection.X, SongSelectionUILayout.BPMSection.Y),
                 SongSelectionUILayout.BPMSection.Position);
         }
 
         [Fact]
-        public void SkillPointSection_PositionMatchesConstants()
+        public void SkillPointSection_Position_ShouldMatchConstants()
         {
             Assert.Equal(new Vector2(SongSelectionUILayout.SkillPointSection.X, SongSelectionUILayout.SkillPointSection.Y),
                 SongSelectionUILayout.SkillPointSection.Position);
         }
 
         [Fact]
-        public void GraphPanel_BasePositionIsValid()
+        public void GraphPanel_BasePosition_ShouldBeValid()
         {
             Assert.True(SongSelectionUILayout.GraphPanel.BasePosition.X > 0);
             Assert.True(SongSelectionUILayout.GraphPanel.BasePosition.Y > 0);
         }
 
         [Fact]
-        public void SongBars_SelectedBarPosition_MatchesConstants()
+        public void SongBars_SelectedBarPosition_ShouldMatchConstants()
         {
             Assert.Equal(new Vector2(SongSelectionUILayout.SongBars.SelectedBarX, SongSelectionUILayout.SongBars.SelectedBarY),
                 SongSelectionUILayout.SongBars.SelectedBarPosition);
         }
 
         [Fact]
-        public void NoteDistributionBars_Drums_LaneCount()
+        public void NoteDistributionBars_Drums_ShouldHave10Lanes()
         {
             Assert.Equal(10, SongSelectionUILayout.NoteDistributionBars.Drums.LaneCount);
         }
 
         [Fact]
-        public void NoteDistributionBars_GuitarBass_LaneCount()
+        public void NoteDistributionBars_GuitarBass_ShouldHave6Lanes()
         {
             Assert.Equal(6, SongSelectionUILayout.NoteDistributionBars.GuitarBass.LaneCount);
         }
 
         [Fact]
-        public void Timing_FadeInDuration_IsPositive()
+        public void Timing_FadeInDuration_ShouldBePositive()
         {
             Assert.True(SongSelectionUILayout.Timing.FadeInDuration > 0);
         }
 
         [Fact]
-        public void Audio_PreviewSoundVolume_InRange()
+        public void Audio_PreviewSoundVolume_ShouldBeInRange()
         {
             Assert.InRange(SongSelectionUILayout.Audio.PreviewSoundVolume, 0f, 1f);
         }
 
         [Fact]
-        public void ScrollSpeedLabel_PositionIsValid()
+        public void ScrollSpeedLabel_Position_ShouldBeValid()
         {
             Assert.True(SongSelectionUILayout.ScrollSpeedLabelX >= 0);
             Assert.True(SongSelectionUILayout.ScrollSpeedLabelY >= 0);
         }
 
         [Fact]
-        public void FolderHintOverlay_OffsetsAreNonNegative()
+        public void FolderHintOverlay_Offsets_ShouldBeNonNegative()
         {
             Assert.True(SongSelectionUILayout.FolderHintOverlay.OffsetX >= 0);
             Assert.True(SongSelectionUILayout.FolderHintOverlay.OffsetY >= 0);
         }
 
         [Fact]
-        public void CommentBar_PositionIsValid()
+        public void CommentBar_Position_ShouldBeValid()
         {
             Assert.True(SongSelectionUILayout.CommentBar.X >= 0);
             Assert.True(SongSelectionUILayout.CommentBar.Y >= 0);
         }
 
         [Fact]
-        public void ItemCounter_BasePositionIsValid()
+        public void ItemCounter_BasePosition_ShouldBeValid()
         {
             Assert.True(SongSelectionUILayout.ItemCounter.BaseX > 0);
             Assert.True(SongSelectionUILayout.ItemCounter.BaseY > 0);
         }
 
         [Fact]
-        public void Scrollbar_PositionIsValid()
+        public void Scrollbar_Position_ShouldBeValid()
         {
             Assert.True(SongSelectionUILayout.Scrollbar.X > 0);
             Assert.True(SongSelectionUILayout.Scrollbar.Height > 0);
         }
 
         [Fact]
-        public void SongListDisplay_FullScreen()
+        public void SongListDisplay_ShouldBeFullScreen()
         {
             Assert.Equal(1280, SongSelectionUILayout.SongListDisplay.Width);
             Assert.Equal(720, SongSelectionUILayout.SongListDisplay.Height);
         }
 
         [Fact]
-        public void Background_DefaultFontSize_IsPositive()
+        public void Background_DefaultFontSize_ShouldBePositive()
         {
             Assert.True(SongSelectionUILayout.Background.DefaultFontSize > 0);
         }
 
         [Fact]
-        public void Spacing_BorderThickness_IsPositive()
+        public void Spacing_BorderThickness_ShouldBePositive()
         {
             Assert.True(SongSelectionUILayout.Spacing.BorderThickness > 0);
         }
 
         [Fact]
-        public void SongBars_GetBarPosition_CenterIndex_ReturnsSelectedPosition()
+        public void SongBars_GetBarPosition_WhenCenterIndex_ShouldReturnSelectedPosition()
         {
             var pos = SongSelectionUILayout.SongBars.GetBarPosition(SongSelectionUILayout.SongBars.CenterIndex);
             Assert.Equal(SongSelectionUILayout.SongBars.SelectedBarPosition, pos);
         }
 
         [Fact]
-        public void SongBars_GetBarPosition_InvalidIndex_ReturnsZeroY()
+        public void SongBars_GetBarPosition_WhenInvalidIndex_ShouldReturnZeroY()
         {
             var pos = SongSelectionUILayout.SongBars.GetBarPosition(-1);
             Assert.Equal(0, pos.Y);
         }
 
         [Fact]
-        public void PreviewImagePanel_WithStatusPanel_HasValidBounds()
+        public void PreviewImagePanel_WithStatusPanel_ShouldHaveValidBounds()
         {
             Assert.True(SongSelectionUILayout.PreviewImagePanel.WithStatusPanel.Size > 0);
         }
 
         [Fact]
-        public void UILabels_Title_PositionIsValid()
+        public void UILabels_Title_Position_ShouldBeValid()
         {
             Assert.True(SongSelectionUILayout.UILabels.Title.X >= 0);
             Assert.True(SongSelectionUILayout.UILabels.Title.Y >= 0);
         }
 
         [Fact]
-        public void SearchFilterModal_ButtonWidthAndHeight_ArePositive()
+        public void SearchFilterModal_ButtonWidthAndHeight_ShouldBePositive()
         {
             Assert.True(SongSelectionUILayout.SearchFilterModal.ButtonWidth > 0);
             Assert.True(SongSelectionUILayout.SearchFilterModal.ButtonHeight > 0);

--- a/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
+++ b/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
@@ -1,539 +1,184 @@
-using Microsoft.Xna.Framework;
 using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
 using Xunit;
 
 namespace DTXMania.Test.UI
 {
-    /// <summary>
-    /// Tests for SongSelectionUILayout constants and methods
-    /// </summary>
     public class SongSelectionUILayoutTests
     {
-        #region StatusPanel Tests
-
         [Fact]
-        public void StatusPanel_Position_ShouldMatchXY()
+        public void StatusPanel_PositionMatchesConstants()
         {
-            var pos = SongSelectionUILayout.StatusPanel.Position;
-            Assert.Equal(SongSelectionUILayout.StatusPanel.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.StatusPanel.Y, pos.Y);
+            Assert.Equal(new Vector2(SongSelectionUILayout.StatusPanel.X, SongSelectionUILayout.StatusPanel.Y),
+                SongSelectionUILayout.StatusPanel.Position);
+            Assert.Equal(new Vector2(SongSelectionUILayout.StatusPanel.Width, SongSelectionUILayout.StatusPanel.Height),
+                SongSelectionUILayout.StatusPanel.Size);
         }
 
         [Fact]
-        public void StatusPanel_Size_ShouldMatchWidthHeight()
+        public void SearchFilterModal_BoundsMatchConstants()
         {
-            var size = SongSelectionUILayout.StatusPanel.Size;
-            Assert.Equal(SongSelectionUILayout.StatusPanel.Width, size.X);
-            Assert.Equal(SongSelectionUILayout.StatusPanel.Height, size.Y);
+            var bounds = SongSelectionUILayout.SearchFilterModal.Bounds;
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.X, bounds.X);
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.Y, bounds.Y);
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.Width, bounds.Width);
+            Assert.Equal(SongSelectionUILayout.SearchFilterModal.Height, bounds.Height);
         }
 
         [Fact]
-        public void StatusPanel_Bounds_ShouldMatchXYWidthHeight()
+        public void DifficultyGrid_GetCellPosition_ReturnsValidVector()
         {
-            var bounds = SongSelectionUILayout.StatusPanel.Bounds;
-            Assert.Equal(SongSelectionUILayout.StatusPanel.X, bounds.X);
-            Assert.Equal(SongSelectionUILayout.StatusPanel.Y, bounds.Y);
-            Assert.Equal(SongSelectionUILayout.StatusPanel.Width, bounds.Width);
-            Assert.Equal(SongSelectionUILayout.StatusPanel.Height, bounds.Height);
-        }
-
-        #endregion
-
-        #region BPMSection Tests
-
-        [Fact]
-        public void BPMSection_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.BPMSection.Position;
-            Assert.Equal(SongSelectionUILayout.BPMSection.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.BPMSection.Y, pos.Y);
-        }
-
-        [Fact]
-        public void BPMSection_Size_ShouldMatchWidthHeight()
-        {
-            var size = SongSelectionUILayout.BPMSection.Size;
-            Assert.Equal(SongSelectionUILayout.BPMSection.Width, size.X);
-            Assert.Equal(SongSelectionUILayout.BPMSection.Height, size.Y);
-        }
-
-        [Fact]
-        public void BPMSection_LengthTextPosition_ShouldBePositive()
-        {
-            var pos = SongSelectionUILayout.BPMSection.LengthTextPosition;
+            var pos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(0, 0);
             Assert.True(pos.X > 0);
             Assert.True(pos.Y > 0);
         }
 
         [Fact]
-        public void BPMSection_BPMTextPosition_ShouldBePositive()
+        public void DifficultyGrid_GetCellContentPosition_Has20pxOffset()
         {
-            var pos = SongSelectionUILayout.BPMSection.BPMTextPosition;
-            Assert.True(pos.X > 0);
-            Assert.True(pos.Y > 0);
-        }
-
-        #endregion
-
-        #region DifficultyGrid Tests
-
-        [Fact]
-        public void DifficultyGrid_BasePosition_ShouldMatchBaseXY()
-        {
-            var pos = SongSelectionUILayout.DifficultyGrid.BasePosition;
-            Assert.Equal(SongSelectionUILayout.DifficultyGrid.BaseX, pos.X);
-            Assert.Equal(SongSelectionUILayout.DifficultyGrid.BaseY, pos.Y);
+            var cell = SongSelectionUILayout.DifficultyGrid.GetCellPosition(2, 1);
+            var content = SongSelectionUILayout.DifficultyGrid.GetCellContentPosition(2, 1);
+            Assert.Equal(20, content.Y - cell.Y);
         }
 
         [Fact]
-        public void DifficultyGrid_CellSize_ShouldMatchWidthHeight()
+        public void BPMSection_PositionMatchesConstants()
         {
-            var size = SongSelectionUILayout.DifficultyGrid.CellSize;
-            Assert.Equal(SongSelectionUILayout.DifficultyGrid.CellWidth, size.X);
-            Assert.Equal(SongSelectionUILayout.DifficultyGrid.CellHeight, size.Y);
+            Assert.Equal(new Vector2(SongSelectionUILayout.BPMSection.X, SongSelectionUILayout.BPMSection.Y),
+                SongSelectionUILayout.BPMSection.Position);
         }
 
         [Fact]
-        public void DifficultyGrid_GetCellPosition_ShouldReturnVector()
+        public void SkillPointSection_PositionMatchesConstants()
         {
-            var pos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(0, 3);
-            Assert.True(pos.X >= 0);
-            Assert.True(pos.Y >= 0);
+            Assert.Equal(new Vector2(SongSelectionUILayout.SkillPointSection.X, SongSelectionUILayout.SkillPointSection.Y),
+                SongSelectionUILayout.SkillPointSection.Position);
         }
 
         [Fact]
-        public void DifficultyGrid_GetCellContentPosition_ShouldBeOffset20FromCellPosition()
+        public void GraphPanel_BasePositionIsValid()
         {
-            var cellPos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(0, 3);
-            var contentPos = SongSelectionUILayout.DifficultyGrid.GetCellContentPosition(0, 3);
-            Assert.Equal(cellPos.X, contentPos.X);
-            Assert.Equal(cellPos.Y + 20, contentPos.Y);
+            Assert.True(SongSelectionUILayout.GraphPanel.BasePosition.X > 0);
+            Assert.True(SongSelectionUILayout.GraphPanel.BasePosition.Y > 0);
         }
 
         [Fact]
-        public void DifficultyGrid_DifficultyLabelPosition_ShouldBeAccessible()
+        public void SongBars_SelectedBarPosition_MatchesConstants()
         {
-            var pos = SongSelectionUILayout.DifficultyGrid.DifficultyLabelPosition;
-            Assert.True(pos.X > 0);
-            Assert.True(pos.Y > 0);
-        }
-
-        #endregion
-
-        #region SkillPointSection Tests
-
-        [Fact]
-        public void SkillPointSection_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.SkillPointSection.Position;
-            Assert.Equal(SongSelectionUILayout.SkillPointSection.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.SkillPointSection.Y, pos.Y);
+            Assert.Equal(new Vector2(SongSelectionUILayout.SongBars.SelectedBarX, SongSelectionUILayout.SongBars.SelectedBarY),
+                SongSelectionUILayout.SongBars.SelectedBarPosition);
         }
 
         [Fact]
-        public void SkillPointSection_Bounds_ShouldHavePositiveSize()
+        public void NoteDistributionBars_Drums_LaneCount()
         {
-            var bounds = SongSelectionUILayout.SkillPointSection.Bounds;
-            Assert.True(bounds.Width > 0);
-            Assert.True(bounds.Height > 0);
+            Assert.Equal(10, SongSelectionUILayout.NoteDistributionBars.Drums.LaneCount);
         }
 
         [Fact]
-        public void SkillPointSection_ValuePosition_ShouldBePositive()
+        public void NoteDistributionBars_GuitarBass_LaneCount()
         {
-            var pos = SongSelectionUILayout.SkillPointSection.ValuePosition;
-            Assert.True(pos.X > 0);
-            Assert.True(pos.Y > 0);
-        }
-
-        #endregion
-
-        #region GraphPanel Tests
-
-        [Fact]
-        public void GraphPanel_BasePosition_ShouldMatchBaseXY()
-        {
-            var pos = SongSelectionUILayout.GraphPanel.BasePosition;
-            Assert.Equal(SongSelectionUILayout.GraphPanel.BaseX, pos.X);
-            Assert.Equal(SongSelectionUILayout.GraphPanel.BaseY, pos.Y);
+            Assert.Equal(6, SongSelectionUILayout.NoteDistributionBars.GuitarBass.LaneCount);
         }
 
         [Fact]
-        public void GraphPanel_Size_ShouldBePositive()
-        {
-            var size = SongSelectionUILayout.GraphPanel.Size;
-            Assert.True(size.X > 0);
-            Assert.True(size.Y > 0);
-        }
-
-        [Fact]
-        public void GraphPanel_Bounds_ShouldMatchBaseXY()
-        {
-            var bounds = SongSelectionUILayout.GraphPanel.Bounds;
-            Assert.Equal(SongSelectionUILayout.GraphPanel.BaseX, bounds.X);
-            Assert.Equal(SongSelectionUILayout.GraphPanel.BaseY, bounds.Y);
-        }
-
-        [Fact]
-        public void GraphPanel_NotesCounterPosition_ShouldBeAccessible()
-        {
-            var pos = SongSelectionUILayout.GraphPanel.NotesCounterPosition;
-            Assert.True(pos.X > 0);
-            Assert.True(pos.Y > 0);
-        }
-
-        [Fact]
-        public void GraphPanel_ProgressBarPosition_ShouldBeAccessible()
-        {
-            var pos = SongSelectionUILayout.GraphPanel.ProgressBarPosition;
-            Assert.True(pos.X > 0);
-            Assert.True(pos.Y > 0);
-        }
-
-        [Fact]
-        public void GraphPanel_ProgressBarSize_ShouldBePositive()
-        {
-            var size = SongSelectionUILayout.GraphPanel.ProgressBarSize;
-            Assert.True(size.X > 0);
-            Assert.True(size.Y > 0);
-        }
-
-        #endregion
-
-        #region NoteDistributionBars Tests
-
-        [Fact]
-        public void NoteDistributionBars_Drums_StartPosition_ShouldMatchStartXY()
-        {
-            var pos = SongSelectionUILayout.NoteDistributionBars.Drums.StartPosition;
-            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartX, pos.X);
-            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartY, pos.Y);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(5)]
-        [InlineData(9)]
-        public void NoteDistributionBars_Drums_GetBarPosition_ShouldVaryByLane(int lane)
-        {
-            var pos = SongSelectionUILayout.NoteDistributionBars.Drums.GetBarPosition(lane);
-            Assert.True(pos.X >= SongSelectionUILayout.NoteDistributionBars.Drums.StartX);
-            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.Drums.StartY, pos.Y);
-        }
-
-        [Fact]
-        public void NoteDistributionBars_GuitarBass_StartPosition_ShouldMatchStartXY()
-        {
-            var pos = SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartPosition;
-            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartX, pos.X);
-            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartY, pos.Y);
-        }
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(3)]
-        [InlineData(5)]
-        public void NoteDistributionBars_GuitarBass_GetBarPosition_ShouldVaryByLane(int lane)
-        {
-            var pos = SongSelectionUILayout.NoteDistributionBars.GuitarBass.GetBarPosition(lane);
-            Assert.True(pos.X >= SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartX);
-            Assert.Equal(SongSelectionUILayout.NoteDistributionBars.GuitarBass.StartY, pos.Y);
-        }
-
-        #endregion
-
-        #region SongBars Tests
-
-        [Fact]
-        public void SongBars_SelectedBarPosition_ShouldMatchSelectedXY()
-        {
-            var pos = SongSelectionUILayout.SongBars.SelectedBarPosition;
-            Assert.Equal(SongSelectionUILayout.SongBars.SelectedBarX, pos.X);
-            Assert.Equal(SongSelectionUILayout.SongBars.SelectedBarY, pos.Y);
-        }
-
-        [Fact]
-        public void SongBars_BarCoordinates_ShouldHave13Entries()
-        {
-            Assert.Equal(13, SongSelectionUILayout.SongBars.BarCoordinates.Length);
-        }
-
-        [Fact]
-        public void SongBars_GetBarY_CenterIndex_ShouldReturn270()
-        {
-            var y = SongSelectionUILayout.SongBars.GetBarY(SongSelectionUILayout.SongBars.CenterIndex);
-            Assert.Equal(270, y);
-        }
-
-        [Fact]
-        public void SongBars_GetBarY_OutOfRange_ShouldReturn0()
-        {
-            Assert.Equal(0, SongSelectionUILayout.SongBars.GetBarY(-1));
-            Assert.Equal(0, SongSelectionUILayout.SongBars.GetBarY(100));
-        }
-
-        [Fact]
-        public void SongBars_GetBarPosition_CenterIndex_ShouldReturnSelectedBarPosition()
-        {
-            var pos = SongSelectionUILayout.SongBars.GetBarPosition(SongSelectionUILayout.SongBars.CenterIndex);
-            Assert.Equal(SongSelectionUILayout.SongBars.SelectedBarX, pos.X);
-            Assert.Equal(SongSelectionUILayout.SongBars.SelectedBarY, pos.Y);
-        }
-
-        [Fact]
-        public void SongBars_GetBarPosition_NonCenterIndex_ShouldUseUnselectedX()
-        {
-            var pos = SongSelectionUILayout.SongBars.GetBarPosition(0);
-            Assert.Equal(SongSelectionUILayout.SongBars.UnselectedBarX, pos.X);
-        }
-
-        [Fact]
-        public void SongBars_BarSize_ShouldMatchWidthHeight()
-        {
-            var size = SongSelectionUILayout.SongBars.BarSize;
-            Assert.Equal(SongSelectionUILayout.SongBars.BarWidth, size.X);
-            Assert.Equal(SongSelectionUILayout.SongBars.BarHeight, size.Y);
-        }
-
-        [Fact]
-        public void SongBars_VisibleItems_ShouldBe13()
-        {
-            Assert.Equal(13, SongSelectionUILayout.SongBars.VisibleItems);
-        }
-
-        #endregion
-
-        #region SongListDisplay Tests
-
-        [Fact]
-        public void SongListDisplay_Position_ShouldBeOrigin()
-        {
-            var pos = SongSelectionUILayout.SongListDisplay.Position;
-            Assert.Equal(0, pos.X);
-            Assert.Equal(0, pos.Y);
-        }
-
-        [Fact]
-        public void SongListDisplay_Size_ShouldMatchWidthHeight()
-        {
-            var size = SongSelectionUILayout.SongListDisplay.Size;
-            Assert.Equal(SongSelectionUILayout.SongListDisplay.Width, size.X);
-            Assert.Equal(SongSelectionUILayout.SongListDisplay.Height, size.Y);
-        }
-
-        [Fact]
-        public void SongListDisplay_Bounds_ShouldMatchXYWidthHeight()
-        {
-            var bounds = SongSelectionUILayout.SongListDisplay.Bounds;
-            Assert.Equal(0, bounds.X);
-            Assert.Equal(0, bounds.Y);
-            Assert.Equal(1280, bounds.Width);
-            Assert.Equal(720, bounds.Height);
-        }
-
-        #endregion
-
-        #region ItemCounter Tests
-
-        [Fact]
-        public void ItemCounter_BasePosition_ShouldMatchBaseXY()
-        {
-            var pos = SongSelectionUILayout.ItemCounter.BasePosition;
-            Assert.Equal(SongSelectionUILayout.ItemCounter.BaseX, pos.X);
-            Assert.Equal(SongSelectionUILayout.ItemCounter.BaseY, pos.Y);
-        }
-
-        #endregion
-
-        #region Scrollbar Tests
-
-        [Fact]
-        public void Scrollbar_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.Scrollbar.Position;
-            Assert.Equal(SongSelectionUILayout.Scrollbar.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.Scrollbar.Y, pos.Y);
-        }
-
-        [Fact]
-        public void Scrollbar_Height_ShouldBePositive()
-        {
-            Assert.True(SongSelectionUILayout.Scrollbar.Height > 0);
-        }
-
-        [Fact]
-        public void Scrollbar_IndicatorSizeVector_ShouldBeSquare()
-        {
-            var size = SongSelectionUILayout.Scrollbar.IndicatorSizeVector;
-            Assert.Equal(SongSelectionUILayout.Scrollbar.IndicatorSize, size.X);
-            Assert.Equal(SongSelectionUILayout.Scrollbar.IndicatorSize, size.Y);
-        }
-
-        #endregion
-
-        #region CommentBar Tests
-
-        [Fact]
-        public void CommentBar_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.CommentBar.Position;
-            Assert.Equal(SongSelectionUILayout.CommentBar.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.CommentBar.Y, pos.Y);
-        }
-
-        [Fact]
-        public void CommentBar_FallbackColor_ShouldNotBeTransparent()
-        {
-            var color = SongSelectionUILayout.CommentBar.FallbackColor;
-            Assert.NotEqual(Color.Transparent, color);
-        }
-
-        #endregion
-
-        #region PreviewImagePanel Tests
-
-        [Fact]
-        public void PreviewImagePanel_WithoutStatusPanel_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Position;
-            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Y, pos.Y);
-        }
-
-        [Fact]
-        public void PreviewImagePanel_WithoutStatusPanel_Bounds_ShouldHavePositiveSize()
-        {
-            var bounds = SongSelectionUILayout.PreviewImagePanel.WithoutStatusPanel.Bounds;
-            Assert.True(bounds.Width > 0);
-            Assert.True(bounds.Height > 0);
-        }
-
-        [Fact]
-        public void PreviewImagePanel_WithStatusPanel_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.PreviewImagePanel.WithStatusPanel.Position;
-            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithStatusPanel.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.PreviewImagePanel.WithStatusPanel.Y, pos.Y);
-        }
-
-        [Fact]
-        public void PreviewImagePanel_WithStatusPanel_SizeVector_ShouldBePositive()
-        {
-            var size = SongSelectionUILayout.PreviewImagePanel.WithStatusPanel.SizeVector;
-            Assert.True(size.X > 0);
-            Assert.True(size.Y > 0);
-        }
-
-        #endregion
-
-        #region UILabels Tests
-
-        [Fact]
-        public void UILabels_Title_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.UILabels.Title.Position;
-            Assert.Equal(SongSelectionUILayout.UILabels.Title.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.UILabels.Title.Y, pos.Y);
-        }
-
-        [Fact]
-        public void UILabels_Title_Size_ShouldMatchWidthHeight()
-        {
-            var size = SongSelectionUILayout.UILabels.Title.Size;
-            Assert.Equal(SongSelectionUILayout.UILabels.Title.Width, size.X);
-            Assert.Equal(SongSelectionUILayout.UILabels.Title.Height, size.Y);
-        }
-
-        [Fact]
-        public void UILabels_Breadcrumb_Position_ShouldMatchXY()
-        {
-            var pos = SongSelectionUILayout.UILabels.Breadcrumb.Position;
-            Assert.Equal(SongSelectionUILayout.UILabels.Breadcrumb.X, pos.X);
-            Assert.Equal(SongSelectionUILayout.UILabels.Breadcrumb.Y, pos.Y);
-        }
-
-        #endregion
-
-        #region Background Tests
-
-        [Fact]
-        public void Background_GradientLineSpacing_ShouldBePositive()
-        {
-            Assert.True(SongSelectionUILayout.Background.GradientLineSpacing > 0);
-        }
-
-        [Fact]
-        public void Background_DefaultFontSize_ShouldBePositive()
-        {
-            Assert.True(SongSelectionUILayout.Background.DefaultFontSize > 0);
-        }
-
-        [Fact]
-        public void Background_MainPanelAlpha_ShouldBeBetweenZeroAndOne()
-        {
-            Assert.InRange(SongSelectionUILayout.Background.MainPanelAlpha, 0f, 1f);
-        }
-
-        #endregion
-
-        #region Timing Tests
-
-        [Fact]
-        public void Timing_FadeInDuration_ShouldBePositive()
+        public void Timing_FadeInDuration_IsPositive()
         {
             Assert.True(SongSelectionUILayout.Timing.FadeInDuration > 0);
         }
 
         [Fact]
-        public void Timing_FadeOutDuration_ShouldBePositive()
-        {
-            Assert.True(SongSelectionUILayout.Timing.FadeOutDuration > 0);
-        }
-
-        [Fact]
-        public void Timing_NavigationDebounceSeconds_ShouldBePositive()
-        {
-            Assert.True(SongSelectionUILayout.Timing.NavigationDebounceSeconds > 0);
-        }
-
-        #endregion
-
-        #region Audio Tests
-
-        [Fact]
-        public void Audio_PreviewSoundVolume_ShouldBeBetweenZeroAndOne()
+        public void Audio_PreviewSoundVolume_InRange()
         {
             Assert.InRange(SongSelectionUILayout.Audio.PreviewSoundVolume, 0f, 1f);
         }
 
         [Fact]
-        public void Audio_BgmFadeOutDuration_ShouldBePositive()
+        public void ScrollSpeedLabel_PositionIsValid()
         {
-            Assert.True(SongSelectionUILayout.Audio.BgmFadeOutDuration > 0);
+            Assert.True(SongSelectionUILayout.ScrollSpeedLabelX >= 0);
+            Assert.True(SongSelectionUILayout.ScrollSpeedLabelY >= 0);
         }
 
         [Fact]
-        public void Audio_BgmMaxVolume_ShouldBe1()
+        public void FolderHintOverlay_OffsetsAreNonNegative()
         {
-            Assert.Equal(1.0f, SongSelectionUILayout.Audio.BgmMaxVolume);
-        }
-
-        #endregion
-
-        #region Spacing Tests
-
-        [Fact]
-        public void Spacing_CellPadding_ShouldBePositive()
-        {
-            Assert.True(SongSelectionUILayout.Spacing.CellPadding > 0);
+            Assert.True(SongSelectionUILayout.FolderHintOverlay.OffsetX >= 0);
+            Assert.True(SongSelectionUILayout.FolderHintOverlay.OffsetY >= 0);
         }
 
         [Fact]
-        public void Spacing_BorderThickness_ShouldBePositive()
+        public void CommentBar_PositionIsValid()
+        {
+            Assert.True(SongSelectionUILayout.CommentBar.X >= 0);
+            Assert.True(SongSelectionUILayout.CommentBar.Y >= 0);
+        }
+
+        [Fact]
+        public void ItemCounter_BasePositionIsValid()
+        {
+            Assert.True(SongSelectionUILayout.ItemCounter.BaseX > 0);
+            Assert.True(SongSelectionUILayout.ItemCounter.BaseY > 0);
+        }
+
+        [Fact]
+        public void Scrollbar_PositionIsValid()
+        {
+            Assert.True(SongSelectionUILayout.Scrollbar.X > 0);
+            Assert.True(SongSelectionUILayout.Scrollbar.Height > 0);
+        }
+
+        [Fact]
+        public void SongListDisplay_FullScreen()
+        {
+            Assert.Equal(1280, SongSelectionUILayout.SongListDisplay.Width);
+            Assert.Equal(720, SongSelectionUILayout.SongListDisplay.Height);
+        }
+
+        [Fact]
+        public void Background_DefaultFontSize_IsPositive()
+        {
+            Assert.True(SongSelectionUILayout.Background.DefaultFontSize > 0);
+        }
+
+        [Fact]
+        public void Spacing_BorderThickness_IsPositive()
         {
             Assert.True(SongSelectionUILayout.Spacing.BorderThickness > 0);
         }
 
-        #endregion
+        [Fact]
+        public void SongBars_GetBarPosition_CenterIndex_ReturnsSelectedPosition()
+        {
+            var pos = SongSelectionUILayout.SongBars.GetBarPosition(SongSelectionUILayout.SongBars.CenterIndex);
+            Assert.Equal(SongSelectionUILayout.SongBars.SelectedBarPosition, pos);
+        }
+
+        [Fact]
+        public void SongBars_GetBarPosition_InvalidIndex_ReturnsZeroY()
+        {
+            var pos = SongSelectionUILayout.SongBars.GetBarPosition(-1);
+            Assert.Equal(0, pos.Y);
+        }
+
+        [Fact]
+        public void PreviewImagePanel_WithStatusPanel_HasValidBounds()
+        {
+            Assert.True(SongSelectionUILayout.PreviewImagePanel.WithStatusPanel.Size > 0);
+        }
+
+        [Fact]
+        public void UILabels_Title_PositionIsValid()
+        {
+            Assert.True(SongSelectionUILayout.UILabels.Title.X >= 0);
+            Assert.True(SongSelectionUILayout.UILabels.Title.Y >= 0);
+        }
+
+        [Fact]
+        public void SearchFilterModal_ButtonWidthAndHeight_ArePositive()
+        {
+            Assert.True(SongSelectionUILayout.SearchFilterModal.ButtonWidth > 0);
+            Assert.True(SongSelectionUILayout.SearchFilterModal.ButtonHeight > 0);
+        }
     }
 }

--- a/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
+++ b/DTXMania.Test/UI/SongSelectionUILayoutTests.cs
@@ -27,11 +27,14 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void DifficultyGrid_GetCellPosition_ShouldReturnValidVector()
+        public void DifficultyGrid_GetCellPosition_ShouldMatchComputedFormula()
         {
+            // GetCellPosition uses: X = BaseX + PanelBodyWidth + CellWidth*(instrument-3), Y = BaseY + ((4-difficultyLevel)*CellHeight) - 2
             var pos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(0, 0);
-            Assert.True(pos.X > 0);
-            Assert.True(pos.Y > 0);
+            var expectedX = SongSelectionUILayout.DifficultyGrid.BaseX + SongSelectionUILayout.DifficultyGrid.PanelBodyWidth
+                            + SongSelectionUILayout.DifficultyGrid.CellWidth * (0 - 3);
+            var expectedY = SongSelectionUILayout.DifficultyGrid.BaseY + ((4 - 0) * SongSelectionUILayout.DifficultyGrid.CellHeight) - 2;
+            Assert.Equal(new Vector2(expectedX, expectedY), pos);
         }
 
         [Fact]
@@ -57,10 +60,10 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void GraphPanel_BasePosition_ShouldBeValid()
+        public void GraphPanel_BasePosition_ShouldMatchConstants()
         {
-            Assert.True(SongSelectionUILayout.GraphPanel.BasePosition.X > 0);
-            Assert.True(SongSelectionUILayout.GraphPanel.BasePosition.Y > 0);
+            Assert.Equal(new Vector2(SongSelectionUILayout.GraphPanel.BaseX, SongSelectionUILayout.GraphPanel.BaseY),
+                SongSelectionUILayout.GraphPanel.BasePosition);
         }
 
         [Fact]

--- a/DTXMania.Test/UI/SongStatusPanelExtendedTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelExtendedTests.cs
@@ -29,7 +29,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Font_WhenSet_ShouldReturnValue()
+        public void Font_WhenSetNull_ShouldBeNull()
         {
             var panel = new SongStatusPanel();
             panel.Font = null;
@@ -44,7 +44,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void SmallFont_WhenSet_ShouldReturnValue()
+        public void SmallFont_WhenSetNull_ShouldBeNull()
         {
             var panel = new SongStatusPanel();
             panel.SmallFont = null;
@@ -77,7 +77,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void WhitePixel_WhenSet_ShouldReturnValue()
+        public void WhitePixel_WhenSetNull_ShouldBeNull()
         {
             var panel = new SongStatusPanel();
             panel.WhitePixel = null;

--- a/DTXMania.Test/UI/SongStatusPanelExtendedTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelExtendedTests.cs
@@ -1,0 +1,131 @@
+using DTXMania.Game.Lib.Song.Components;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    [Trait("Category", "Unit")]
+    public class SongStatusPanelExtendedTests
+    {
+        [Fact]
+        public void UseStandaloneBPMBackground_ByDefault_ShouldBeFalse()
+        {
+            var panel = new SongStatusPanel();
+            Assert.False(panel.UseStandaloneBPMBackground);
+        }
+
+        [Fact]
+        public void UseStandaloneBPMBackground_WhenSetTrue_ShouldBeTrue()
+        {
+            var panel = new SongStatusPanel();
+            panel.UseStandaloneBPMBackground = true;
+            Assert.True(panel.UseStandaloneBPMBackground);
+        }
+
+        [Fact]
+        public void Font_ByDefault_ShouldBeNull()
+        {
+            var panel = new SongStatusPanel();
+            Assert.Null(panel.Font);
+        }
+
+        [Fact]
+        public void Font_WhenSet_ShouldReturnValue()
+        {
+            var panel = new SongStatusPanel();
+            panel.Font = null;
+            Assert.Null(panel.Font);
+        }
+
+        [Fact]
+        public void SmallFont_ByDefault_ShouldBeNull()
+        {
+            var panel = new SongStatusPanel();
+            Assert.Null(panel.SmallFont);
+        }
+
+        [Fact]
+        public void SmallFont_WhenSet_ShouldReturnValue()
+        {
+            var panel = new SongStatusPanel();
+            panel.SmallFont = null;
+            Assert.Null(panel.SmallFont);
+        }
+
+        [Fact]
+        public void ManagedFont_WhenSetNull_ShouldUpdateFontToNull()
+        {
+            var panel = new SongStatusPanel();
+            panel.ManagedFont = null;
+            Assert.Null(panel.ManagedFont);
+            Assert.Null(panel.Font);
+        }
+
+        [Fact]
+        public void ManagedSmallFont_WhenSetNull_ShouldUpdateSmallFontToNull()
+        {
+            var panel = new SongStatusPanel();
+            panel.ManagedSmallFont = null;
+            Assert.Null(panel.ManagedSmallFont);
+            Assert.Null(panel.SmallFont);
+        }
+
+        [Fact]
+        public void WhitePixel_ByDefault_ShouldBeNull()
+        {
+            var panel = new SongStatusPanel();
+            Assert.Null(panel.WhitePixel);
+        }
+
+        [Fact]
+        public void WhitePixel_WhenSet_ShouldReturnValue()
+        {
+            var panel = new SongStatusPanel();
+            panel.WhitePixel = null;
+            Assert.Null(panel.WhitePixel);
+        }
+
+        [Fact]
+        public void InitializeGraphicsGenerator_WhenNullRenderTarget_ShouldNotThrow()
+        {
+            var panel = new SongStatusPanel();
+            panel.InitializeGraphicsGenerator(null, null);
+        }
+
+        [Fact]
+        public void InitializeAuthenticGraphics_WhenNullResourceManager_ShouldNotThrow()
+        {
+            var panel = new SongStatusPanel();
+            panel.InitializeAuthenticGraphics(null);
+        }
+
+        [Fact]
+        public void Dispose_WhenCalledAfterInitializeAuthenticGraphics_ShouldNotThrow()
+        {
+            var panel = new SongStatusPanel();
+            panel.InitializeAuthenticGraphics(null);
+            panel.Dispose();
+        }
+
+        [Fact]
+        public void Dispose_WhenCalledAfterInitializeGraphicsGenerator_ShouldNotThrow()
+        {
+            var panel = new SongStatusPanel();
+            panel.InitializeGraphicsGenerator(null, null);
+            panel.Dispose();
+        }
+
+        [Fact]
+        public void ManagedFont_ByDefault_ShouldBeNull()
+        {
+            var panel = new SongStatusPanel();
+            Assert.Null(panel.ManagedFont);
+        }
+
+        [Fact]
+        public void ManagedSmallFont_ByDefault_ShouldBeNull()
+        {
+            var panel = new SongStatusPanel();
+            Assert.Null(panel.ManagedSmallFont);
+        }
+    }
+}

--- a/DTXMania.Test/UI/SongStatusPanelFolderHintTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelFolderHintTests.cs
@@ -4,17 +4,18 @@ using Xunit;
 
 namespace DTXMania.Test.UI
 {
+    [Trait("Category", "Unit")]
     public class SongStatusPanelFolderHintTests
     {
         [Fact]
-        public void FolderHint_DefaultsEmpty()
+        public void FolderHint_WhenUninitialized_ShouldBeEmpty()
         {
             var panel = new SongStatusPanel();
             Assert.Equal("", panel.FolderHint);
         }
 
         [Fact]
-        public void FolderHint_SetAndGet()
+        public void FolderHint_WhenSet_ShouldReturnValue()
         {
             var panel = new SongStatusPanel();
             panel.FolderHint = "J-POP / 80s";
@@ -22,7 +23,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void FolderHint_SetNull_BecomesEmpty()
+        public void FolderHint_WhenSetToNull_ShouldBehaveAsDefined()
         {
             var panel = new SongStatusPanel();
             panel.FolderHint = "test";
@@ -31,14 +32,14 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void UpdateSongInfo_DoesNotThrowOnNull()
+        public void UpdateSongInfo_WhenNullInput_ShouldNotThrow()
         {
             var panel = new SongStatusPanel();
             panel.UpdateSongInfo(null, 0);
         }
 
         [Fact]
-        public void UpdateSongInfo_SetsSongAndDifficulty()
+        public void UpdateSongInfo_WithNodeAndDifficulty_ShouldSetValues()
         {
             var panel = new SongStatusPanel();
             var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
@@ -46,21 +47,21 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Dispose_WhenCalledDirectly_CleansUp()
+        public void Dispose_WhenCalled_ShouldReleaseResources()
         {
             var panel = new SongStatusPanel();
             panel.Dispose();
         }
 
         [Fact]
-        public void Visible_DefaultsTrue()
+        public void Visible_ByDefault_ShouldBeTrue()
         {
             var panel = new SongStatusPanel();
             Assert.True(panel.Visible);
         }
 
         [Fact]
-        public void Visible_SetTrue()
+        public void Visible_WhenSetTrue_ShouldRemainTrue()
         {
             var panel = new SongStatusPanel();
             panel.Visible = true;

--- a/DTXMania.Test/UI/SongStatusPanelFolderHintTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelFolderHintTests.cs
@@ -39,7 +39,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void UpdateSongInfo_WithNodeAndDifficulty_ShouldSetValues()
+        public void UpdateSongInfo_WithNodeAndDifficulty_ShouldNotThrow()
         {
             var panel = new SongStatusPanel();
             var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
@@ -47,7 +47,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Dispose_WhenCalled_ShouldReleaseResources()
+        public void Dispose_WhenCalled_ShouldNotThrow()
         {
             var panel = new SongStatusPanel();
             panel.Dispose();

--- a/DTXMania.Test/UI/SongStatusPanelFolderHintTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelFolderHintTests.cs
@@ -1,0 +1,70 @@
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    public class SongStatusPanelFolderHintTests
+    {
+        [Fact]
+        public void FolderHint_DefaultsEmpty()
+        {
+            var panel = new SongStatusPanel();
+            Assert.Equal("", panel.FolderHint);
+        }
+
+        [Fact]
+        public void FolderHint_SetAndGet()
+        {
+            var panel = new SongStatusPanel();
+            panel.FolderHint = "J-POP / 80s";
+            Assert.Equal("J-POP / 80s", panel.FolderHint);
+        }
+
+        [Fact]
+        public void FolderHint_SetNull_BecomesEmpty()
+        {
+            var panel = new SongStatusPanel();
+            panel.FolderHint = "test";
+            panel.FolderHint = null!;
+            Assert.Null(panel.FolderHint);
+        }
+
+        [Fact]
+        public void UpdateSongInfo_DoesNotThrowOnNull()
+        {
+            var panel = new SongStatusPanel();
+            panel.UpdateSongInfo(null, 0);
+        }
+
+        [Fact]
+        public void UpdateSongInfo_SetsSongAndDifficulty()
+        {
+            var panel = new SongStatusPanel();
+            var node = new SongListNode { Type = NodeType.Score, Title = "Test" };
+            panel.UpdateSongInfo(node, 2);
+        }
+
+        [Fact]
+        public void Dispose_WhenCalledDirectly_CleansUp()
+        {
+            var panel = new SongStatusPanel();
+            panel.Dispose();
+        }
+
+        [Fact]
+        public void Visible_DefaultsTrue()
+        {
+            var panel = new SongStatusPanel();
+            Assert.True(panel.Visible);
+        }
+
+        [Fact]
+        public void Visible_SetTrue()
+        {
+            var panel = new SongStatusPanel();
+            panel.Visible = true;
+            Assert.True(panel.Visible);
+        }
+    }
+}

--- a/DTXMania.Test/UI/SongStatusPanelMethodTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelMethodTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Reflection;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.UI;
+using Microsoft.Xna.Framework;
+using Moq;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using SongScore = DTXMania.Game.Lib.Song.Entities.SongScore;
+
+namespace DTXMania.Test.UI
+{
+    [Trait("Category", "Unit")]
+    public class SongStatusPanelMethodTests
+    {
+        [Fact]
+        public void FormatDuration_UnderOneHour_ShouldReturnMSSFormat()
+        {
+            var panel = new SongStatusPanel();
+            var result = InvokePrivateMethod<string>(panel, "FormatDuration", 90.0);
+            Assert.Equal("1:30", result);
+        }
+
+        [Fact]
+        public void FormatDuration_ExactlyOneHour_ShouldReturnHMMSSFormat()
+        {
+            var panel = new SongStatusPanel();
+            var result = InvokePrivateMethod<string>(panel, "FormatDuration", 3600.0);
+            Assert.Equal("1:00:00", result);
+        }
+
+        [Fact]
+        public void FormatDuration_OverOneHour_ShouldReturnHMMSSFormat()
+        {
+            var panel = new SongStatusPanel();
+            var result = InvokePrivateMethod<string>(panel, "FormatDuration", 5430.0);
+            Assert.Equal("1:30:30", result);
+        }
+
+        [Fact]
+        public void FormatDuration_Zero_ShouldReturnZeroMinutes()
+        {
+            var panel = new SongStatusPanel();
+            var result = InvokePrivateMethod<string>(panel, "FormatDuration", 0.0);
+            Assert.Equal("0:00", result);
+        }
+
+        [Fact]
+        public void GetCurrentScore_NullSong_ShouldReturnNull()
+        {
+            var panel = new SongStatusPanel();
+            var result = InvokePrivateMethod<SongScore>(panel, "GetCurrentScore", null!, 0);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetCurrentScore_NullScoresArrayEntry_ShouldReturnNull()
+        {
+            var panel = new SongStatusPanel();
+            var node = new SongListNode();
+            node.Scores[0] = null;
+
+            var result = InvokePrivateMethod<SongScore>(panel, "GetCurrentScore", node, 0);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetCurrentScore_NegativeDifficulty_ShouldReturnNull()
+        {
+            var panel = new SongStatusPanel();
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore();
+
+            var result = InvokePrivateMethod<SongScore>(panel, "GetCurrentScore", node, -1);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetCurrentScore_DifficultyOutOfRange_ShouldReturnNull()
+        {
+            var panel = new SongStatusPanel();
+            var node = new SongListNode();
+            node.Scores[0] = new SongScore();
+
+            var result = InvokePrivateMethod<SongScore>(panel, "GetCurrentScore", node, 5);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void GetCurrentScore_ValidDifficulty_ShouldReturnScore()
+        {
+            var panel = new SongStatusPanel();
+            var node = new SongListNode();
+            var expected = new SongScore { PlayCount = 42 };
+            node.Scores[0] = expected;
+
+            var result = InvokePrivateMethod<SongScore>(panel, "GetCurrentScore", node, 0);
+            Assert.Same(expected, result);
+            Assert.Equal(42, result!.PlayCount);
+        }
+
+        [Fact]
+        public void GetInstrumentFromDifficulty_AlwaysReturnsDrums()
+        {
+            var panel = new SongStatusPanel();
+            for (int i = 0; i < 5; i++)
+            {
+                var result = InvokePrivateMethod<string>(panel, "GetInstrumentFromDifficulty", i);
+                Assert.Equal("DRUMS", result);
+            }
+        }
+
+        [Fact]
+        public void ReleaseManagedTexture_NullTexture_ShouldNotThrow()
+        {
+            var method = typeof(SongStatusPanel).GetMethod(
+                "ReleaseManagedTexture",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            ITexture? texture = null;
+            var args = new object[] { texture };
+            var exception = Record.Exception(() => method!.Invoke(null, args));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void ReleaseManagedTexture_NonNullTexture_ShouldCallRemoveReference()
+        {
+            var method = typeof(SongStatusPanel).GetMethod(
+                "ReleaseManagedTexture",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            var mock = new Mock<ITexture>();
+            ITexture? texture = mock.Object;
+            var args = new object[] { texture };
+            method!.Invoke(null, args);
+
+            mock.Verify(t => t.RemoveReference(), Times.Once);
+        }
+    }
+}

--- a/DTXMania.Test/UI/UITextInputDisposeTests.cs
+++ b/DTXMania.Test/UI/UITextInputDisposeTests.cs
@@ -1,0 +1,76 @@
+using System;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+
+namespace DTXMania.Test.UI
+{
+    [Trait("Category", "Unit")]
+    public class UITextInputDisposeTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void Dispose_WhenSubscribed_ShouldUnsubscribe()
+        {
+            var source = new FakeSource();
+            var input = new UITextInput(source);
+
+            input.Focused = true;
+            source.Fire('A');
+
+            input.Dispose();
+
+            source.Fire('B');
+            Assert.Equal("A", input.Text);
+        }
+
+        [Fact]
+        public void Dispose_WhenAlreadyDisposed_ShouldNotThrow()
+        {
+            var source = new FakeSource();
+            var input = new UITextInput(source);
+
+            input.Dispose();
+
+            var exception = Record.Exception(() => input.Dispose());
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void OnDraw_NullFont_ShouldNotThrow()
+        {
+            var source = new FakeSource();
+            var input = new UITextInput(source);
+
+            var exception = Record.Exception(() =>
+                InvokePrivateMethod(input, "OnDraw", null!, 0.0));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Clear_ShouldResetTextAndCaret()
+        {
+            var source = new FakeSource();
+            var input = new UITextInput(source);
+
+            input.Focused = true;
+            source.Fire('H');
+            source.Fire('i');
+
+            Assert.Equal("Hi", input.Text);
+
+            input.Clear();
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
+    }
+}

--- a/DTXMania.Test/UI/UITextInputExtendedTests.cs
+++ b/DTXMania.Test/UI/UITextInputExtendedTests.cs
@@ -1,0 +1,109 @@
+using System;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    [Trait("Category", "Unit")]
+    public class UITextInputExtendedTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        private sealed class CountingSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public int HandlerCount =>
+                TextInput?.GetInvocationList().Length ?? 0;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void TextSetter_WhenMaxLengthZero_ShouldAlwaysBeEmpty()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { MaxLength = 0 };
+
+            input.Text = "hello";
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void TextSetter_WhenMaxLengthNegative_ShouldAlwaysBeEmpty()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { MaxLength = -1 };
+
+            input.Text = "hello";
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void TextSetter_WhenMaxLengthZero_CaretShouldBeClampedToZero()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { MaxLength = 5 };
+            input.Text = "abc";
+
+            input.MaxLength = 0;
+            input.Text = "xyz";
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Dispose_WhenNotFocused_ShouldNotThrow()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src) { Focused = false };
+
+            input.Dispose();
+
+            Assert.Equal(0, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Focused_WhenToggledOnOff_ShouldSubscribeThenUnsubscribe()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src);
+
+            input.Focused = true;
+            Assert.Equal(1, src.HandlerCount);
+
+            input.Focused = false;
+            Assert.Equal(0, src.HandlerCount);
+        }
+
+        [Fact]
+        public void TextSetter_WhenMaxLengthZeroAndValueEmpty_ShouldBeEmpty()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { MaxLength = 0 };
+
+            input.Text = "";
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void TextSetter_WhenMaxLengthNegativeAndValueNull_ShouldBeEmpty()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { MaxLength = -5 };
+
+            input.Text = null;
+
+            Assert.Equal("", input.Text);
+        }
+    }
+}

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -17,7 +17,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Focused_AppendsTypedCharacters()
+        public void WhenFocused_ShouldAppendTypedCharacters()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true };
@@ -30,7 +30,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Unfocused_IgnoresTypedCharacters()
+        public void WhenUnfocused_ShouldIgnoreTypedCharacters()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = false };
@@ -41,7 +41,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void MaxLength_ClampsInsert()
+        public void WhenMaxLengthExceeded_ShouldClampInsert()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true, MaxLength = 3 };
@@ -55,7 +55,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Backspace_RemovesCharBeforeCaret()
+        public void Backspace_WhenCharsExist_ShouldRemoveCharBeforeCaret()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true };
@@ -70,7 +70,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Backspace_OnEmpty_NoOp()
+        public void Backspace_OnEmpty_ShouldBeNoOp()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true };
@@ -82,7 +82,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void MoveCaret_LeftRight_ClampedToTextRange()
+        public void MoveCaret_WhenLeftRight_ShouldBeClampedToTextRange()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true };
@@ -97,7 +97,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Backspace_FromMiddleOfText_RemovesCorrectChar()
+        public void Backspace_WhenFromMiddleOfText_ShouldRemoveCorrectChar()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true };
@@ -113,7 +113,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Clear_ResetsTextAndCaret()
+        public void Clear_WhenTextPresent_ShouldResetTextAndCaret()
         {
             var src = new FakeSource();
             var input = new UITextInput(src) { Focused = true };
@@ -136,7 +136,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Focused_True_SubscribesToSource()
+        public void Focused_WhenSetTrue_ShouldSubscribeToSource()
         {
             var src = new CountingSource();
             var input = new UITextInput(src);
@@ -147,7 +147,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Focused_False_UnsubscribesFromSource()
+        public void Focused_WhenSetFalse_ShouldUnsubscribeFromSource()
         {
             var src = new CountingSource();
             var input = new UITextInput(src) { Focused = true };
@@ -158,7 +158,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Focused_TrueTwice_SubscribesOnlyOnce()
+        public void Focused_WhenSetTrueTwice_ShouldSubscribeOnlyOnce()
         {
             var src = new CountingSource();
             var input = new UITextInput(src);
@@ -170,7 +170,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void Dispose_UnsubscribesFromSource()
+        public void Dispose_WhenFocused_ShouldUnsubscribeFromSource()
         {
             var src = new CountingSource();
             var input = new UITextInput(src) { Focused = true };

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -53,5 +53,77 @@ namespace DTXMania.Test.UI
 
             Assert.Equal("abc", input.Text);
         }
+
+        [Fact]
+        public void Backspace_RemovesCharBeforeCaret()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+            input.Backspace();
+
+            Assert.Equal("ab", input.Text);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Backspace_OnEmpty_NoOp()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Backspace();
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
+
+        [Fact]
+        public void MoveCaret_LeftRight_ClampedToTextRange()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            src.Fire('b');
+
+            input.MoveCaret(-5);
+            Assert.Equal(0, input.CaretIndex);
+
+            input.MoveCaret(+10);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Backspace_FromMiddleOfText_RemovesCorrectChar()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+            input.MoveCaret(-1); // caret between 'b' and 'c'
+
+            input.Backspace();
+
+            Assert.Equal("ac", input.Text);
+            Assert.Equal(1, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Clear_ResetsTextAndCaret()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            src.Fire('b');
+
+            input.Clear();
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
     }
 }

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -225,5 +225,74 @@ namespace DTXMania.Test.UI
 
             Assert.Equal(3, input.CaretIndex); // clamped to new length
         }
+
+        [Fact]
+        public void OnTextInput_BackslashCharCode_Ignored()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('\b');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void OnTextInput_ReturnCharCode_Ignored()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('\r');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void OnTextInput_NewlineCharCode_Ignored()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('\n');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void OnTextInput_TabCharCode_Ignored()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('\t');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void OnTextInput_ControlChar_Ignored()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('\u0001');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void Backspace_WhenCaretAtPosition0_IsNoOp()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            input.MoveCaret(-1); // caret at 0
+
+            input.Backspace();
+
+            Assert.Equal("a", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
     }
 }

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -1,0 +1,57 @@
+using System;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    public class UITextInputTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, ToKey(c)));
+            private static Microsoft.Xna.Framework.Input.Keys ToKey(char c) =>
+                Microsoft.Xna.Framework.Input.Keys.None;
+        }
+
+        [Fact]
+        public void Focused_AppendsTypedCharacters()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('h');
+            src.Fire('i');
+
+            Assert.Equal("hi", input.Text);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Unfocused_IgnoresTypedCharacters()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = false };
+
+            src.Fire('x');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void MaxLength_ClampsInsert()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 3 };
+
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+            src.Fire('d');
+
+            Assert.Equal("abc", input.Text);
+        }
+    }
+}

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -179,5 +179,51 @@ namespace DTXMania.Test.UI
 
             Assert.Equal(0, src.HandlerCount);
         }
+
+        [Fact]
+        public void TextSetter_WhenExceedsMaxLength_ShouldTruncate()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 5 };
+
+            input.Text = "abcdefghij";
+
+            Assert.Equal("abcde", input.Text);
+        }
+
+        [Fact]
+        public void TextSetter_WhenWithinMaxLength_ShouldNotTruncate()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 10 };
+
+            input.Text = "hello";
+
+            Assert.Equal("hello", input.Text);
+        }
+
+        [Fact]
+        public void TextSetter_WhenNull_ShouldSetEmpty()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Text = null;
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void TextSetter_WhenTruncated_CaretShouldBeClamped()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 3 };
+            input.Text = "abc";
+            input.MoveCaret(3); // caret at end (3)
+
+            input.Text = "abcdefgh"; // gets truncated to "abc"
+
+            Assert.Equal(3, input.CaretIndex); // clamped to new length
+        }
     }
 }

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -295,5 +295,61 @@ namespace DTXMania.Test.UI
             Assert.Equal("a", input.Text);
             Assert.Equal(0, input.CaretIndex);
         }
+
+        [Fact]
+        public void OnTextInput_WhenMaxLengthExactlyReached_ShouldNotInsertMore()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 2 };
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+
+            Assert.Equal("ab", input.Text);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void MoveCaret_WhenAtEndAndMoveRight_ShouldClamp()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('x');
+            input.MoveCaret(1);
+
+            Assert.Equal(1, input.CaretIndex);
+        }
+
+        [Fact]
+        public void OnTextInput_WhenNotFocused_ShouldNotInsert()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = false };
+
+            src.Fire('a');
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Constructor_WhenNullSource_ShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>(() => new UITextInput(null!));
+        }
+
+        [Fact]
+        public void Backspace_WhenTextEmptyAndCaretNonZero_ShouldBeNoOp()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 5 };
+            input.Text = "ab";
+            input.Clear();
+            Assert.Equal("", input.Text);
+
+            input.Backspace();
+
+            Assert.Equal("", input.Text);
+        }
     }
 }

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 
 namespace DTXMania.Test.UI
 {
+    [Trait("Category", "Unit")]
     public class UITextInputTests
     {
         private sealed class FakeSource : ITextInputSource

--- a/DTXMania.Test/UI/UITextInputTests.cs
+++ b/DTXMania.Test/UI/UITextInputTests.cs
@@ -125,5 +125,59 @@ namespace DTXMania.Test.UI
             Assert.Equal("", input.Text);
             Assert.Equal(0, input.CaretIndex);
         }
+
+        private sealed class CountingSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public int HandlerCount =>
+                TextInput?.GetInvocationList().Length ?? 0;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void Focused_True_SubscribesToSource()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src);
+
+            input.Focused = true;
+
+            Assert.Equal(1, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Focused_False_UnsubscribesFromSource()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Focused = false;
+
+            Assert.Equal(0, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Focused_TrueTwice_SubscribesOnlyOnce()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src);
+
+            input.Focused = true;
+            input.Focused = true;
+
+            Assert.Equal(1, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Dispose_UnsubscribesFromSource()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Dispose();
+
+            Assert.Equal(0, src.HandlerCount);
+        }
     }
 }

--- a/DTXMania.Test/UI/WindowTextInputSourceTests.cs
+++ b/DTXMania.Test/UI/WindowTextInputSourceTests.cs
@@ -1,15 +1,93 @@
 using System;
+using System.Reflection;
 using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using Xunit;
 
 namespace DTXMania.Test.UI
 {
+    [Trait("Category", "Unit")]
     public class WindowTextInputSourceTests
     {
+        private sealed class StubGameWindow : GameWindow
+        {
+            public override bool AllowUserResizing { get; set; }
+            public override Rectangle ClientBounds => default;
+            public override Point Position { get; set; }
+            public override DisplayOrientation CurrentOrientation => DisplayOrientation.Default;
+            public override nint Handle => 0;
+            public override string ScreenDeviceName => "";
+            public override void BeginScreenDeviceChange(bool willBeFullScreen) { }
+            public override void EndScreenDeviceChange(string screenDeviceName, int clientWidth, int clientHeight) { }
+            protected override void SetSupportedOrientations(DisplayOrientation orientations) { }
+            protected override void SetTitle(string title) { }
+
+            private static readonly MethodInfo OnTextInputMethod =
+                typeof(GameWindow).GetMethod("OnTextInput", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+            public void RaiseTextInput(char c)
+            {
+                OnTextInputMethod.Invoke(this, [new TextInputEventArgs(c, Keys.None)]);
+            }
+        }
+
         [Fact]
         public void Constructor_NullWindow_Throws()
         {
             Assert.Throws<ArgumentNullException>(() => new WindowTextInputSource(null!));
+        }
+
+        [Fact]
+        public void TextInput_ForwardsEvents()
+        {
+            var window = new StubGameWindow();
+            var source = new WindowTextInputSource(window);
+            char? received = null;
+            source.TextInput += (_, e) => received = e.Character;
+
+            window.RaiseTextInput('x');
+
+            Assert.Equal('x', received);
+        }
+
+        [Fact]
+        public void Dispose_UnsubscribesFromWindow()
+        {
+            var window = new StubGameWindow();
+            var source = new WindowTextInputSource(window);
+            var count = 0;
+            source.TextInput += (_, _) => count++;
+
+            source.Dispose();
+            window.RaiseTextInput('a');
+
+            Assert.Equal(0, count);
+        }
+
+        [Fact]
+        public void DoubleDispose_IsSafe()
+        {
+            var window = new StubGameWindow();
+            var source = new WindowTextInputSource(window);
+
+            source.Dispose();
+            source.Dispose();
+        }
+
+        [Fact]
+        public void AfterDispose_TextInputDoesNotForward()
+        {
+            var window = new StubGameWindow();
+            var source = new WindowTextInputSource(window);
+            var count = 0;
+            source.TextInput += (_, _) => count++;
+
+            source.Dispose();
+            window.RaiseTextInput('a');
+            window.RaiseTextInput('b');
+
+            Assert.Equal(0, count);
         }
     }
 }

--- a/DTXMania.Test/UI/WindowTextInputSourceTests.cs
+++ b/DTXMania.Test/UI/WindowTextInputSourceTests.cs
@@ -1,0 +1,15 @@
+using System;
+using DTXMania.Game.Lib.UI.Components;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    public class WindowTextInputSourceTests
+    {
+        [Fact]
+        public void Constructor_NullWindow_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new WindowTextInputSource(null!));
+        }
+    }
+}

--- a/DTXMania.Test/UI/WindowTextInputSourceTests.cs
+++ b/DTXMania.Test/UI/WindowTextInputSourceTests.cs
@@ -52,6 +52,17 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
+        public void TextInput_WithNoSubscribers_ShouldNotThrow()
+        {
+            var window = new StubGameWindow();
+            _ = new WindowTextInputSource(window);
+
+            var exception = Record.Exception(() => window.RaiseTextInput('x'));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void Dispose_UnsubscribesFromWindow()
         {
             var window = new StubGameWindow();

--- a/docs/superpowers/plans/2026-05-07-song-search-filter-ui.md
+++ b/docs/superpowers/plans/2026-05-07-song-search-filter-ui.md
@@ -1,0 +1,3818 @@
+# Song Search & Filter UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a keyboard-driven modal that lets the user search, filter, and sort the song list in the Song Selection stage. Search and facets operate on the in-memory song database; results flatten the folder hierarchy. Filter state is session-scoped.
+
+**Architecture:** Data layer is a pure projection (`SongListFilterService`) over `SongListNode`s held by `SongManager`. UI is a new modal overlay (`SongSearchFilterModal`) composed of a reusable `UITextInput` plus facet/sort controls. The Song Selection stage owns the active `SongFilterCriteria`, computes `_filteredView` on Apply, and binds `SongListDisplay` to either the filtered view or the existing hierarchical list.
+
+**Tech Stack:** C# / .NET 8, MonoGame 3.8 (`SpriteBatch`, `GameWindow.TextInput`), xUnit + Moq, EF Core (existing), `ManagedFont` / `SpriteFont`.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-song-search-filter-ui-design.md`
+
+---
+
+## File Map
+
+**Created:**
+- `DTXMania.Game/Lib/Song/Filtering/PlayedStatus.cs` — enum.
+- `DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs` — value record.
+- `DTXMania.Game/Lib/Song/Filtering/FilteredSongResult.cs` — readonly record struct.
+- `DTXMania.Game/Lib/Song/Filtering/ISongListFilterService.cs` — interface.
+- `DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs` — projection.
+- `DTXMania.Game/Lib/UI/Components/ITextInputSource.cs` — abstraction over `GameWindow.TextInput`.
+- `DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs` — `GameWindow` adapter.
+- `DTXMania.Game/Lib/UI/Components/UITextInput.cs` — reusable text input element.
+- `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs` — modal overlay.
+- `DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs`
+- `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+- `DTXMania.Test/UI/UITextInputTests.cs`
+- `DTXMania.Test/Stage/SongSelectionStageFilterTests.cs`
+
+**Modified:**
+- `DTXMania.Game/Lib/Input/InputManager.cs` — add `OpenSearch` to `InputCommandType`, map `Keys.Back`.
+- `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs` — add `SearchFilterModal` static class.
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs` — wire criteria, filtered view, modal lifecycle, breadcrumb summary, empty state, selection clamping.
+- `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs` — add optional folder-hint label.
+- `DTXMania.Test/DTXMania.Test.Mac.csproj` — exclude graphics-dependent modal tests.
+
+**No SongListDisplay changes needed**: the stage's existing `PopulateSongList` already controls whether to include the `BackBox` row; we'll add a sibling `PopulateFilteredSongList` that just emits the flat result list.
+
+---
+
+## Phase 1 — Data Layer
+
+### Task 1: PlayedStatus enum
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Filtering/PlayedStatus.cs`
+
+- [ ] **Step 1: Create the file**
+
+```csharp
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public enum PlayedStatus
+    {
+        All,
+        Unplayed,
+        Played,
+        Cleared
+    }
+}
+```
+
+- [ ] **Step 2: Build to confirm it compiles**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds with 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/PlayedStatus.cs
+git commit -m "feat: add PlayedStatus enum for song filtering"
+```
+
+---
+
+### Task 2: SongFilterCriteria record + tests
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs`
+- Create: `DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Path: `DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs`
+
+```csharp
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using Xunit;
+
+namespace DTXMania.Test.Song.Filtering
+{
+    public class SongFilterCriteriaTests
+    {
+        [Fact]
+        public void Default_HasExpectedValues()
+        {
+            var c = SongFilterCriteria.Default;
+
+            Assert.Equal("", c.SearchQuery);
+            Assert.Null(c.MinLevel);
+            Assert.Null(c.MaxLevel);
+            Assert.Equal(PlayedStatus.All, c.PlayedStatus);
+            Assert.Equal(SongSortCriteria.Title, c.SortBy);
+            Assert.False(c.SortDescending);
+        }
+
+        [Fact]
+        public void IsEmpty_TrueForDefault()
+        {
+            Assert.True(SongFilterCriteria.Default.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenSearchQuerySet()
+        {
+            var c = SongFilterCriteria.Default with { SearchQuery = "abc" };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenLevelSet()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50 };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenPlayedStatusNotAll()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenSortDescending()
+        {
+            var c = SongFilterCriteria.Default with { SortDescending = true };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void IsEmpty_FalseWhenSortByNotTitle()
+        {
+            var c = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
+            Assert.False(c.IsEmpty);
+        }
+
+        [Fact]
+        public void Equality_RecordValueSemantics()
+        {
+            var a = SongFilterCriteria.Default with { SearchQuery = "x" };
+            var b = SongFilterCriteria.Default with { SearchQuery = "x" };
+            Assert.Equal(a, b);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (no `SongFilterCriteria` yet)**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongFilterCriteriaTests"`
+Expected: Build error (`SongFilterCriteria` does not exist).
+
+- [ ] **Step 3: Write the implementation**
+
+Path: `DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs`
+
+```csharp
+using DTXMania.Game.Lib.Song;
+
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public sealed record SongFilterCriteria(
+        string SearchQuery,
+        int? MinLevel,
+        int? MaxLevel,
+        PlayedStatus PlayedStatus,
+        SongSortCriteria SortBy,
+        bool SortDescending)
+    {
+        public static SongFilterCriteria Default { get; } = new(
+            SearchQuery: "",
+            MinLevel: null,
+            MaxLevel: null,
+            PlayedStatus: PlayedStatus.All,
+            SortBy: SongSortCriteria.Title,
+            SortDescending: false);
+
+        public bool IsEmpty =>
+            string.IsNullOrEmpty(SearchQuery)
+            && MinLevel is null
+            && MaxLevel is null
+            && PlayedStatus == PlayedStatus.All
+            && SortBy == SongSortCriteria.Title
+            && !SortDescending;
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongFilterCriteriaTests"`
+Expected: All 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs \
+        DTXMania.Test/Song/Filtering/SongFilterCriteriaTests.cs
+git commit -m "feat: add SongFilterCriteria record with default and IsEmpty"
+```
+
+---
+
+### Task 3: FilteredSongResult struct + ISongListFilterService interface
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Filtering/FilteredSongResult.cs`
+- Create: `DTXMania.Game/Lib/Song/Filtering/ISongListFilterService.cs`
+
+- [ ] **Step 1: Create FilteredSongResult**
+
+Path: `DTXMania.Game/Lib/Song/Filtering/FilteredSongResult.cs`
+
+```csharp
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public readonly record struct FilteredSongResult(
+        SongListNode Node,
+        string FolderPath);
+}
+```
+
+- [ ] **Step 2: Create ISongListFilterService**
+
+Path: `DTXMania.Game/Lib/Song/Filtering/ISongListFilterService.cs`
+
+```csharp
+using System.Collections.Generic;
+
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public interface ISongListFilterService
+    {
+        IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria);
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/FilteredSongResult.cs \
+        DTXMania.Game/Lib/Song/Filtering/ISongListFilterService.cs
+git commit -m "feat: add FilteredSongResult and ISongListFilterService contracts"
+```
+
+---
+
+### Task 4: SongListFilterService — flatten + folder path
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs`
+- Create: `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using Xunit;
+
+namespace DTXMania.Test.Song.Filtering
+{
+    public class SongListFilterServiceTests
+    {
+        private readonly SongListFilterService _svc = new();
+
+        private static SongListNode Score(string title, string artist = "", int level = 50)
+        {
+            var node = new SongListNode { Type = NodeType.Score, Title = title };
+            node.Scores[0] = new DTXMania.Game.Lib.Song.Entities.SongScore
+            {
+                DifficultyLevel = level,
+                DifficultyLabel = "BASIC"
+            };
+            // Artist lives on DatabaseSong — wire a minimal entity
+            if (!string.IsNullOrEmpty(artist))
+            {
+                node.DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+                {
+                    Title = title,
+                    Artist = artist
+                };
+            }
+            return node;
+        }
+
+        private static SongListNode Box(string title, params SongListNode[] children)
+        {
+            var box = SongListNode.CreateBoxNode(title, $"/path/{title}");
+            foreach (var c in children)
+                box.AddChild(c);
+            return box;
+        }
+
+        [Fact]
+        public void Apply_FlattensRootScoreNodes_NoFilter()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Song A"),
+                Score("Song B")
+            };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(new[] { "Song A", "Song B" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_FlattensNestedScoreNodes_NoFilter()
+        {
+            var roots = new List<SongListNode>
+            {
+                Box("J-POP",
+                    Score("Pop1"),
+                    Box("80s", Score("Pop80a"), Score("Pop80b"))),
+                Score("RootSong")
+            };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            // Sorted by Title (default): Pop1, Pop80a, Pop80b, RootSong
+            Assert.Equal(4, result.Count);
+            Assert.Equal(new[] { "Pop1", "Pop80a", "Pop80b", "RootSong" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PopulatesFolderPathFromParentBreadcrumb()
+        {
+            var roots = new List<SongListNode>
+            {
+                Box("J-POP",
+                    Box("80s", Score("Hit")))
+            };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            var hit = result.Single();
+            Assert.Equal("J-POP / 80s", hit.FolderPath);
+        }
+
+        [Fact]
+        public void Apply_RootScoreHasEmptyFolderPath()
+        {
+            var roots = new List<SongListNode> { Score("RootOnly") };
+
+            var result = _svc.Apply(roots, SongFilterCriteria.Default);
+
+            Assert.Equal("", result.Single().FolderPath);
+        }
+
+        [Fact]
+        public void Apply_ExcludesBackBoxAndRandomNodes()
+        {
+            var box = Box("Folder", Score("InsideSong"));
+            box.AddChild(SongListNode.CreateBackNode(box));
+            box.AddChild(SongListNode.CreateRandomNode());
+
+            var result = _svc.Apply(new[] { box }, SongFilterCriteria.Default);
+
+            Assert.Equal(new[] { "InsideSong" }, result.Select(r => r.Node.DisplayTitle));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: Build error (`SongListFilterService` not defined).
+
+- [ ] **Step 3: Implement service with flatten + folder-path + default sort**
+
+Path: `DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs`
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DTXMania.Game.Lib.Song.Filtering
+{
+    public sealed class SongListFilterService : ISongListFilterService
+    {
+        public IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria)
+        {
+            if (roots == null) throw new ArgumentNullException(nameof(roots));
+            if (criteria == null) throw new ArgumentNullException(nameof(criteria));
+
+            var flat = new List<FilteredSongResult>();
+            foreach (var root in roots)
+                Flatten(root, parentPath: "", flat);
+
+            return SortResults(flat, criteria);
+        }
+
+        private static void Flatten(SongListNode node, string parentPath, List<FilteredSongResult> sink)
+        {
+            if (node == null) return;
+
+            if (node.Type == NodeType.Score)
+            {
+                sink.Add(new FilteredSongResult(node, parentPath));
+                return;
+            }
+
+            if (node.Type == NodeType.Box)
+            {
+                var childPath = string.IsNullOrEmpty(parentPath)
+                    ? node.DisplayTitle
+                    : parentPath + " / " + node.DisplayTitle;
+                foreach (var child in node.Children)
+                    Flatten(child, childPath, sink);
+            }
+            // BackBox / Random: ignore
+        }
+
+        private static IReadOnlyList<FilteredSongResult> SortResults(
+            List<FilteredSongResult> flat, SongFilterCriteria criteria)
+        {
+            int Compare(FilteredSongResult a, FilteredSongResult b)
+            {
+                int cmp = criteria.SortBy switch
+                {
+                    SongSortCriteria.Title =>
+                        string.Compare(a.Node.DisplayTitle, b.Node.DisplayTitle,
+                            StringComparison.OrdinalIgnoreCase),
+                    SongSortCriteria.Artist =>
+                        string.Compare(
+                            a.Node.DatabaseSong?.DisplayArtist ?? "",
+                            b.Node.DatabaseSong?.DisplayArtist ?? "",
+                            StringComparison.OrdinalIgnoreCase),
+                    SongSortCriteria.Genre =>
+                        string.Compare(a.Node.Genre ?? "", b.Node.Genre ?? "",
+                            StringComparison.OrdinalIgnoreCase),
+                    SongSortCriteria.Level =>
+                        a.Node.MaxDifficultyLevel.CompareTo(b.Node.MaxDifficultyLevel),
+                    _ => string.Compare(a.Node.DisplayTitle, b.Node.DisplayTitle,
+                            StringComparison.OrdinalIgnoreCase)
+                };
+                return criteria.SortDescending ? -cmp : cmp;
+            }
+
+            flat.Sort(Compare);
+            return flat;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs \
+        DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+git commit -m "feat: implement SongListFilterService flatten + folder path"
+```
+
+---
+
+### Task 5: SongListFilterService — search filter
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs`
+- Modify: `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+
+- [ ] **Step 1: Add failing search tests**
+
+Append to `SongListFilterServiceTests.cs` (inside the class):
+
+```csharp
+        [Fact]
+        public void Apply_SearchByTitle_CaseInsensitiveSubstring()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Yesterday", "The Beatles"),
+                Score("Hey Jude", "The Beatles"),
+                Score("Smoke On The Water", "Deep Purple")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "yesterDAY" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Yesterday" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SearchByArtist_CaseInsensitiveSubstring()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Yesterday", "The Beatles"),
+                Score("Smoke On The Water", "Deep Purple")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "beatles" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Yesterday" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SearchEmpty_ReturnsAll()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("A"), Score("B")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public void Apply_SearchNoMatch_ReturnsEmpty()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("A", "Artist1"),
+                Score("B", "Artist2")
+            };
+            var criteria = SongFilterCriteria.Default with { SearchQuery = "zzz" };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Empty(result);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: New search tests fail (search query is currently ignored).
+
+- [ ] **Step 3: Add search filtering to service**
+
+Modify `SongListFilterService.Apply` to insert a search step before sorting. Replace the body:
+
+```csharp
+        public IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria)
+        {
+            if (roots == null) throw new ArgumentNullException(nameof(roots));
+            if (criteria == null) throw new ArgumentNullException(nameof(criteria));
+
+            var flat = new List<FilteredSongResult>();
+            foreach (var root in roots)
+                Flatten(root, parentPath: "", flat);
+
+            var afterSearch = ApplySearch(flat, criteria.SearchQuery);
+            return SortResults(afterSearch, criteria);
+        }
+
+        private static List<FilteredSongResult> ApplySearch(
+            List<FilteredSongResult> flat, string query)
+        {
+            if (string.IsNullOrEmpty(query)) return flat;
+
+            return flat.Where(r =>
+                Contains(r.Node.DisplayTitle, query) ||
+                Contains(r.Node.DatabaseSong?.DisplayArtist, query))
+                .ToList();
+        }
+
+        private static bool Contains(string? haystack, string needle)
+        {
+            if (string.IsNullOrEmpty(haystack)) return false;
+            return haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+```
+
+(`SortResults` signature changes to accept `List<FilteredSongResult>` — already does.)
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 9 tests pass (5 + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs \
+        DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+git commit -m "feat: add search filter to SongListFilterService (Title + Artist)"
+```
+
+---
+
+### Task 6: SongListFilterService — level range filter
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs`
+- Modify: `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+
+- [ ] **Step 1: Add failing level tests**
+
+Append to `SongListFilterServiceTests.cs`:
+
+```csharp
+        [Fact]
+        public void Apply_LevelRange_FiltersByMaxDifficulty()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Easy", level: 30),
+                Score("Mid",  level: 60),
+                Score("Hard", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = 80 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Mid" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelMinOnly_NoMaxBound()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Easy", level: 30),
+                Score("Hard", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = null };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Hard" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelMaxOnly_NoMinBound()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Easy", level: 30),
+                Score("Hard", level: 90)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = 50 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Easy" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_LevelMinGreaterThanMax_SwapsSilently()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Mid", level: 50)
+            };
+            var criteria = SongFilterCriteria.Default with { MinLevel = 80, MaxLevel = 30 };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Single(result);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 4 new tests fail.
+
+- [ ] **Step 3: Add level filter step**
+
+Modify `SongListFilterService.Apply` to insert a level step. Replace the inner pipeline:
+
+```csharp
+        public IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria)
+        {
+            if (roots == null) throw new ArgumentNullException(nameof(roots));
+            if (criteria == null) throw new ArgumentNullException(nameof(criteria));
+
+            var flat = new List<FilteredSongResult>();
+            foreach (var root in roots)
+                Flatten(root, parentPath: "", flat);
+
+            var afterSearch = ApplySearch(flat, criteria.SearchQuery);
+            var afterLevel  = ApplyLevel(afterSearch, criteria.MinLevel, criteria.MaxLevel);
+            return SortResults(afterLevel, criteria);
+        }
+
+        private static List<FilteredSongResult> ApplyLevel(
+            List<FilteredSongResult> flat, int? min, int? max)
+        {
+            if (min is null && max is null) return flat;
+
+            // Swap if min > max
+            int lo = min ?? int.MinValue;
+            int hi = max ?? int.MaxValue;
+            if (lo > hi) (lo, hi) = (hi, lo);
+
+            return flat.Where(r =>
+            {
+                int level = r.Node.MaxDifficultyLevel;
+                return level >= lo && level <= hi;
+            }).ToList();
+        }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 13 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs \
+        DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+git commit -m "feat: add level-range filter to SongListFilterService"
+```
+
+---
+
+### Task 7: SongListFilterService — played-status filter
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs`
+- Modify: `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+
+**Cleared definition (per spec):** A song is `Cleared` if at least one of its `Scores` has `PlayCount > 0` AND the rank index from `SongScore.ComputeRankIndex(BestRank)` is less than 7 (anything other than the F bucket).
+
+- [ ] **Step 1: Add failing played-status tests**
+
+Append to `SongListFilterServiceTests.cs`:
+
+```csharp
+        private static SongListNode ScoreWith(string title, int playCount, int bestRank)
+        {
+            var node = new SongListNode { Type = NodeType.Score, Title = title };
+            node.Scores[0] = new DTXMania.Game.Lib.Song.Entities.SongScore
+            {
+                DifficultyLevel = 50,
+                PlayCount = playCount,
+                BestRank = bestRank
+            };
+            return node;
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusUnplayed_KeepsOnlyZeroPlays()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Untouched", playCount: 0, bestRank: 0),
+                ScoreWith("Tried",     playCount: 3, bestRank: 80)
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Untouched" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusPlayed_KeepsAnyPlayedSong()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Untouched", playCount: 0, bestRank: 0),
+                ScoreWith("Tried",     playCount: 3, bestRank: 0)  // played but failed
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Played };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Tried" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusCleared_RequiresPlayCountAndNonFRank()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Untouched", playCount: 0, bestRank: 0),
+                ScoreWith("Failed",    playCount: 5, bestRank: 0),    // F bucket
+                ScoreWith("Cleared",   playCount: 1, bestRank: 80)    // A bucket
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Cleared };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Cleared" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusAll_NoFilter()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("A", playCount: 0, bestRank: 0),
+                ScoreWith("B", playCount: 1, bestRank: 80)
+            };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.All };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        public void Apply_PlayedStatusUnplayed_TreatsMissingScoresAsUnplayed()
+        {
+            var node = new SongListNode { Type = NodeType.Score, Title = "NoScores" };
+            // node.Scores is all-null
+            var roots = new List<SongListNode> { node };
+            var criteria = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Single(result);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 5 new tests fail (played-status currently ignored).
+
+- [ ] **Step 3: Add played-status filter step**
+
+Modify `SongListFilterService` — add another pipeline step and helpers:
+
+```csharp
+        public IReadOnlyList<FilteredSongResult> Apply(
+            IEnumerable<SongListNode> roots,
+            SongFilterCriteria criteria)
+        {
+            if (roots == null) throw new ArgumentNullException(nameof(roots));
+            if (criteria == null) throw new ArgumentNullException(nameof(criteria));
+
+            var flat = new List<FilteredSongResult>();
+            foreach (var root in roots)
+                Flatten(root, parentPath: "", flat);
+
+            var afterSearch = ApplySearch(flat, criteria.SearchQuery);
+            var afterLevel  = ApplyLevel(afterSearch, criteria.MinLevel, criteria.MaxLevel);
+            var afterPlayed = ApplyPlayedStatus(afterLevel, criteria.PlayedStatus);
+            return SortResults(afterPlayed, criteria);
+        }
+
+        private static List<FilteredSongResult> ApplyPlayedStatus(
+            List<FilteredSongResult> flat, PlayedStatus status)
+        {
+            if (status == PlayedStatus.All) return flat;
+
+            return flat.Where(r => Match(r.Node, status)).ToList();
+        }
+
+        private static bool Match(SongListNode node, PlayedStatus status)
+        {
+            bool anyPlayed   = node.Scores.Any(s => s != null && s.PlayCount > 0);
+            bool anyCleared  = node.Scores.Any(s => s != null && s.PlayCount > 0
+                                && DTXMania.Game.Lib.Song.Entities.SongScore
+                                       .ComputeRankIndex(s.BestRank) < 7);
+
+            return status switch
+            {
+                PlayedStatus.Unplayed => !anyPlayed,
+                PlayedStatus.Played   => anyPlayed,
+                PlayedStatus.Cleared  => anyCleared,
+                _ => true
+            };
+        }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 18 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs \
+        DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+git commit -m "feat: add played-status filter (Unplayed/Played/Cleared) to filter service"
+```
+
+---
+
+### Task 8: SongListFilterService — sort variations
+
+**Files:**
+- Modify: `DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs`
+
+The sort code already exists from Task 4. This task only adds tests covering each criterion + descending.
+
+- [ ] **Step 1: Add sort tests**
+
+Append to `SongListFilterServiceTests.cs`:
+
+```csharp
+        [Fact]
+        public void Apply_SortByTitleDescending()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("Apple"), Score("Banana"), Score("Cherry")
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Title,
+                SortDescending = true
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Cherry", "Banana", "Apple" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SortByLevelAscending()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("High", level: 90),
+                Score("Low",  level: 20),
+                Score("Mid",  level: 50)
+            };
+            var criteria = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Level,
+                SortDescending = false
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Low", "Mid", "High" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_SortByArtist()
+        {
+            var roots = new List<SongListNode>
+            {
+                Score("X", "Zenith"),
+                Score("Y", "Apex")
+            };
+            var criteria = SongFilterCriteria.Default with { SortBy = SongSortCriteria.Artist };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Y", "X" }, result.Select(r => r.Node.DisplayTitle));
+        }
+
+        [Fact]
+        public void Apply_CombinedSearchLevelPlayedSort()
+        {
+            var roots = new List<SongListNode>
+            {
+                ScoreWith("Beatles - Yesterday", playCount: 1, bestRank: 80),
+                ScoreWith("Beatles - Hard Rock", playCount: 0, bestRank: 0),
+                ScoreWith("Other Artist Song",   playCount: 1, bestRank: 80)
+            };
+            // Wire artist on first and second
+            roots[0].DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+            { Title = "Beatles - Yesterday", Artist = "The Beatles" };
+            roots[1].DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song
+            { Title = "Beatles - Hard Rock", Artist = "The Beatles" };
+
+            var criteria = SongFilterCriteria.Default with
+            {
+                SearchQuery = "beatles",
+                PlayedStatus = PlayedStatus.Played,
+                SortBy = SongSortCriteria.Title,
+                SortDescending = true
+            };
+
+            var result = _svc.Apply(roots, criteria);
+
+            Assert.Equal(new[] { "Beatles - Yesterday" },
+                result.Select(r => r.Node.DisplayTitle));
+        }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongListFilterServiceTests"`
+Expected: 22 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Test/Song/Filtering/SongListFilterServiceTests.cs
+git commit -m "test: cover sort variations and combined-criteria filtering"
+```
+
+---
+
+## Phase 2 — Reusable Text Input
+
+### Task 9: ITextInputSource + WindowTextInputSource
+
+**Files:**
+- Create: `DTXMania.Game/Lib/UI/Components/ITextInputSource.cs`
+- Create: `DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs`
+
+- [ ] **Step 1: Create the interface**
+
+Path: `DTXMania.Game/Lib/UI/Components/ITextInputSource.cs`
+
+```csharp
+using System;
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.UI.Components
+{
+    public interface ITextInputSource
+    {
+        event EventHandler<TextInputEventArgs> TextInput;
+    }
+}
+```
+
+- [ ] **Step 2: Create the GameWindow adapter**
+
+Path: `DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs`
+
+```csharp
+using System;
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.UI.Components
+{
+    public sealed class WindowTextInputSource : ITextInputSource
+    {
+        private readonly GameWindow _window;
+
+        public WindowTextInputSource(GameWindow window)
+        {
+            _window = window ?? throw new ArgumentNullException(nameof(window));
+            _window.TextInput += OnTextInput;
+        }
+
+        public event EventHandler<TextInputEventArgs>? TextInput;
+
+        private void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            TextInput?.Invoke(sender, e);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Components/ITextInputSource.cs \
+        DTXMania.Game/Lib/UI/Components/WindowTextInputSource.cs
+git commit -m "feat: add ITextInputSource abstraction and GameWindow adapter"
+```
+
+---
+
+### Task 10: UITextInput — character insert + tests
+
+**Files:**
+- Create: `DTXMania.Game/Lib/UI/Components/UITextInput.cs`
+- Create: `DTXMania.Test/UI/UITextInputTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `DTXMania.Test/UI/UITextInputTests.cs`
+
+```csharp
+using System;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    public class UITextInputTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, ToKey(c)));
+            private static Microsoft.Xna.Framework.Input.Keys ToKey(char c) =>
+                Microsoft.Xna.Framework.Input.Keys.None;
+        }
+
+        [Fact]
+        public void Focused_AppendsTypedCharacters()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('h');
+            src.Fire('i');
+
+            Assert.Equal("hi", input.Text);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Unfocused_IgnoresTypedCharacters()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = false };
+
+            src.Fire('x');
+
+            Assert.Equal("", input.Text);
+        }
+
+        [Fact]
+        public void MaxLength_ClampsInsert()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true, MaxLength = 3 };
+
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+            src.Fire('d');
+
+            Assert.Equal("abc", input.Text);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~UITextInputTests"`
+Expected: Build error (`UITextInput` not defined).
+
+- [ ] **Step 3: Implement minimal UITextInput**
+
+Path: `DTXMania.Game/Lib/UI/Components/UITextInput.cs`
+
+```csharp
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.UI;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.UI.Components
+{
+    public class UITextInput : UIElement
+    {
+        private readonly ITextInputSource _source;
+        private string _text = "";
+        private int _caretIndex;
+        private bool _subscribed;
+
+        public UITextInput(ITextInputSource source)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            OnFocus  += (_, _) => Subscribe();
+            OnBlur   += (_, _) => Unsubscribe();
+        }
+
+        public string Text
+        {
+            get => _text;
+            set
+            {
+                _text = value ?? "";
+                _caretIndex = Math.Clamp(_caretIndex, 0, _text.Length);
+            }
+        }
+
+        public int CaretIndex => _caretIndex;
+
+        public int MaxLength { get; set; } = 64;
+
+        public SpriteFont? Font { get; set; }
+
+        public Color TextColor { get; set; } = Color.White;
+
+        private void Subscribe()
+        {
+            if (_subscribed) return;
+            _source.TextInput += OnTextInput;
+            _subscribed = true;
+        }
+
+        private void Unsubscribe()
+        {
+            if (!_subscribed) return;
+            _source.TextInput -= OnTextInput;
+            _subscribed = false;
+        }
+
+        private void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            if (!Focused) return;
+
+            char c = e.Character;
+            if (c == '\b' || c == '\r' || c == '\n' || c == '\t') return;
+            if (char.IsControl(c)) return;
+            if (_text.Length >= MaxLength) return;
+
+            _text = _text.Insert(_caretIndex, c.ToString());
+            _caretIndex++;
+        }
+
+        protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
+        {
+            if (Font == null) return;
+            var pos = AbsolutePosition;
+            spriteBatch.DrawString(Font, _text, pos, TextColor);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) Unsubscribe();
+            base.Dispose(disposing);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~UITextInputTests"`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Components/UITextInput.cs \
+        DTXMania.Test/UI/UITextInputTests.cs
+git commit -m "feat: add UITextInput element with character insertion"
+```
+
+---
+
+### Task 11: UITextInput — backspace + caret navigation
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/UI/Components/UITextInput.cs`
+- Modify: `DTXMania.Test/UI/UITextInputTests.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `UITextInputTests.cs`:
+
+```csharp
+        [Fact]
+        public void Backspace_RemovesCharBeforeCaret()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+            input.Backspace();
+
+            Assert.Equal("ab", input.Text);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Backspace_OnEmpty_NoOp()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Backspace();
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
+
+        [Fact]
+        public void MoveCaret_LeftRight_ClampedToTextRange()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            src.Fire('b');
+
+            input.MoveCaret(-5);
+            Assert.Equal(0, input.CaretIndex);
+
+            input.MoveCaret(+10);
+            Assert.Equal(2, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Backspace_FromMiddleOfText_RemovesCorrectChar()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            src.Fire('b');
+            src.Fire('c');
+            input.MoveCaret(-1); // caret between 'b' and 'c'
+
+            input.Backspace();
+
+            Assert.Equal("ac", input.Text);
+            Assert.Equal(1, input.CaretIndex);
+        }
+
+        [Fact]
+        public void Clear_ResetsTextAndCaret()
+        {
+            var src = new FakeSource();
+            var input = new UITextInput(src) { Focused = true };
+            src.Fire('a');
+            src.Fire('b');
+
+            input.Clear();
+
+            Assert.Equal("", input.Text);
+            Assert.Equal(0, input.CaretIndex);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~UITextInputTests"`
+Expected: 5 new tests fail (`Backspace`, `MoveCaret`, `Clear` not defined).
+
+- [ ] **Step 3: Add methods to UITextInput**
+
+In `UITextInput.cs`, add these methods inside the class:
+
+```csharp
+        public void Backspace()
+        {
+            if (_caretIndex == 0 || _text.Length == 0) return;
+            _text = _text.Remove(_caretIndex - 1, 1);
+            _caretIndex--;
+        }
+
+        public void MoveCaret(int delta)
+        {
+            _caretIndex = Math.Clamp(_caretIndex + delta, 0, _text.Length);
+        }
+
+        public void Clear()
+        {
+            _text = "";
+            _caretIndex = 0;
+        }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~UITextInputTests"`
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Components/UITextInput.cs \
+        DTXMania.Test/UI/UITextInputTests.cs
+git commit -m "feat: add Backspace/MoveCaret/Clear to UITextInput"
+```
+
+---
+
+### Task 12: UITextInput — focus subscribe/unsubscribe verification
+
+**Files:**
+- Modify: `DTXMania.Test/UI/UITextInputTests.cs`
+
+- [ ] **Step 1: Add subscribe/unsubscribe tests**
+
+Append to `UITextInputTests.cs`:
+
+```csharp
+        private sealed class CountingSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public int HandlerCount =>
+                TextInput?.GetInvocationList().Length ?? 0;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c, Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void Focused_True_SubscribesToSource()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src);
+
+            input.Focused = true;
+
+            Assert.Equal(1, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Focused_False_UnsubscribesFromSource()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Focused = false;
+
+            Assert.Equal(0, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Focused_TrueTwice_SubscribesOnlyOnce()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src);
+
+            input.Focused = true;
+            input.Focused = true;
+
+            Assert.Equal(1, src.HandlerCount);
+        }
+
+        [Fact]
+        public void Dispose_UnsubscribesFromSource()
+        {
+            var src = new CountingSource();
+            var input = new UITextInput(src) { Focused = true };
+
+            input.Dispose();
+
+            Assert.Equal(0, src.HandlerCount);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect pass (no implementation change needed)**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~UITextInputTests"`
+Expected: 12 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Test/UI/UITextInputTests.cs
+git commit -m "test: cover UITextInput focus-driven subscribe/unsubscribe"
+```
+
+---
+
+## Phase 3 — Modal UI
+
+### Task 13: Add `OpenSearch` input command + Backspace mapping
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Input/InputManager.cs`
+- Create: `DTXMania.Test/Input/OpenSearchInputCommandTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+Path: `DTXMania.Test/Input/OpenSearchInputCommandTests.cs`
+
+```csharp
+using DTXMania.Game.Lib.Input;
+using Microsoft.Xna.Framework.Input;
+using Xunit;
+
+namespace DTXMania.Test.Input
+{
+    public class OpenSearchInputCommandTests
+    {
+        [Fact]
+        public void DefaultMapping_BackspaceMapsToOpenSearch()
+        {
+            var mgr = new InputManager();
+            var snapshot = mgr.GetKeyMappingSnapshot();
+
+            Assert.True(snapshot.ContainsKey(Keys.Back));
+            Assert.Equal(InputCommandType.OpenSearch, snapshot[Keys.Back]);
+        }
+
+        [Fact]
+        public void OpenSearch_ExistsInEnum()
+        {
+            // Ensure the enum value is defined
+            var values = System.Enum.GetValues<InputCommandType>();
+            Assert.Contains(InputCommandType.OpenSearch, values);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~OpenSearchInputCommandTests"`
+Expected: Build error (`OpenSearch` not defined).
+
+- [ ] **Step 3: Add the enum value and binding**
+
+In `DTXMania.Game/Lib/Input/InputManager.cs`, modify the enum (around line 11-21):
+
+```csharp
+    public enum InputCommandType
+    {
+        MoveUp,
+        MoveDown,
+        MoveLeft,
+        MoveRight,
+        Activate,
+        Back,
+        IncreaseScrollSpeed,
+        DecreaseScrollSpeed,
+        OpenSearch
+    }
+```
+
+In `InitializeDefaultKeyMapping()` (around line 96), add the binding:
+
+```csharp
+        private void InitializeDefaultKeyMapping()
+        {
+            _keyMapping[Keys.Up] = InputCommandType.MoveUp;
+            _keyMapping[Keys.Down] = InputCommandType.MoveDown;
+            _keyMapping[Keys.Left] = InputCommandType.MoveLeft;
+            _keyMapping[Keys.Right] = InputCommandType.MoveRight;
+            _keyMapping[Keys.Enter] = InputCommandType.Activate;
+            _keyMapping[Keys.Escape] = InputCommandType.Back;
+            _keyMapping[Keys.PageUp] = InputCommandType.IncreaseScrollSpeed;
+            _keyMapping[Keys.PageDown] = InputCommandType.DecreaseScrollSpeed;
+            _keyMapping[Keys.Back] = InputCommandType.OpenSearch;
+        }
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~OpenSearchInputCommandTests"`
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Run full input test suite to ensure no regressions**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~Input"`
+Expected: All input tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Input/InputManager.cs \
+        DTXMania.Test/Input/OpenSearchInputCommandTests.cs
+git commit -m "feat: add OpenSearch input command bound to Backspace"
+```
+
+---
+
+### Task 14: SongSelectionUILayout — SearchFilterModal layout constants
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs`
+- Create: `DTXMania.Test/UI/SearchFilterModalLayoutTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `DTXMania.Test/UI/SearchFilterModalLayoutTests.cs`
+
+```csharp
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    public class SearchFilterModalLayoutTests
+    {
+        [Fact]
+        public void Modal_IsCentered1280x720()
+        {
+            // Modal: 600 wide, 360 tall, centered in 1280x720
+            Assert.Equal(340, SongSelectionUILayout.SearchFilterModal.X);
+            Assert.Equal(180, SongSelectionUILayout.SearchFilterModal.Y);
+            Assert.Equal(600, SongSelectionUILayout.SearchFilterModal.Width);
+            Assert.Equal(360, SongSelectionUILayout.SearchFilterModal.Height);
+        }
+
+        [Fact]
+        public void Modal_BoundsMatchPositionAndSize()
+        {
+            var b = SongSelectionUILayout.SearchFilterModal.Bounds;
+            Assert.Equal(new Rectangle(340, 180, 600, 360), b);
+        }
+
+        [Fact]
+        public void SearchBox_HasWidth()
+        {
+            Assert.True(SongSelectionUILayout.SearchFilterModal.SearchBoxWidth > 0);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SearchFilterModalLayoutTests"`
+Expected: Build error (`SearchFilterModal` not defined).
+
+- [ ] **Step 3: Add layout constants**
+
+Append the following inside `SongSelectionUILayout` (before its closing brace) in `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs`:
+
+```csharp
+        #region Search Filter Modal Layout
+
+        /// <summary>
+        /// Layout constants for the search/filter/sort modal overlay.
+        /// </summary>
+        public static class SearchFilterModal
+        {
+            // Centered in 1280x720
+            public const int X = 340;
+            public const int Y = 180;
+            public const int Width = 600;
+            public const int Height = 360;
+
+            public static Vector2 Position => new Vector2(X, Y);
+            public static Vector2 Size => new Vector2(Width, Height);
+            public static Rectangle Bounds => new Rectangle(X, Y, Width, Height);
+
+            // Title bar
+            public const int TitleY = 12;             // relative to modal top
+            public const int TitleHeight = 28;
+
+            // Field rows (relative to modal top-left)
+            public const int RowSpacing = 44;
+            public const int FirstRowY = 56;
+            public const int LabelX = 24;
+            public const int FieldX = 130;
+
+            // Search box
+            public const int SearchBoxY = FirstRowY;
+            public const int SearchBoxWidth = 430;
+            public const int SearchBoxHeight = 30;
+
+            // Level row
+            public const int LevelRowY = FirstRowY + RowSpacing;
+            public const int LevelMinX = FieldX;
+            public const int LevelMaxX = FieldX + 180;
+            public const int LevelInputWidth = 80;
+            public const int LevelInputHeight = 30;
+
+            // Played-status row
+            public const int PlayedRowY = FirstRowY + RowSpacing * 2;
+
+            // Sort row
+            public const int SortRowY = FirstRowY + RowSpacing * 3;
+
+            // Buttons
+            public const int ButtonRowY = FirstRowY + RowSpacing * 4 + 8;
+            public const int ResetButtonX = 200;
+            public const int ApplyButtonX = 360;
+            public const int ButtonWidth = 120;
+            public const int ButtonHeight = 36;
+        }
+
+        #endregion
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SearchFilterModalLayoutTests"`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs \
+        DTXMania.Test/UI/SearchFilterModalLayoutTests.cs
+git commit -m "feat: add SearchFilterModal layout constants"
+```
+
+---
+
+### Task 15: SongSearchFilterModal skeleton (logic-only)
+
+This task creates the modal as a `UIElement` subclass exposing public state for tests, without graphics yet. We test the state machine in the Mac suite by exercising public methods, then add drawing in Task 18 (which is excluded from the Mac suite).
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Create: `DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs`
+
+```csharp
+using System;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.Song.Components
+{
+    public class SongSearchFilterModalLogicTests
+    {
+        private sealed class FakeSource : ITextInputSource
+        {
+            public event EventHandler<TextInputEventArgs>? TextInput;
+            public void Fire(char c) =>
+                TextInput?.Invoke(this, new TextInputEventArgs(c,
+                    Microsoft.Xna.Framework.Input.Keys.None));
+        }
+
+        [Fact]
+        public void Open_DefaultCriteria_PopulatesFromArgument()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var initial = SongFilterCriteria.Default with { SearchQuery = "abc" };
+
+            modal.Open(initial);
+
+            Assert.True(modal.IsOpen);
+            Assert.Equal("abc", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Cancel_FiresCancelledEvent_AndCloses()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.Cancelled += (_, _) => fired = true;
+
+            modal.Cancel();
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Apply_FiresFilterAppliedWithDraft_AndCloses()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var initial = SongFilterCriteria.Default with { SearchQuery = "x" };
+            modal.Open(initial);
+            SongFilterCriteria? captured = null;
+            modal.FilterApplied += (_, c) => captured = c;
+
+            modal.Apply();
+
+            Assert.NotNull(captured);
+            Assert.Equal("x", captured!.SearchQuery);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void Reset_FiresFilterResetAndCloses()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default with { SearchQuery = "x" });
+            bool fired = false;
+            modal.FilterReset += (_, _) => fired = true;
+
+            modal.Reset();
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void EditDraft_DoesNotMutateInitialCriteria()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            var initial = SongFilterCriteria.Default with { SearchQuery = "orig" };
+
+            modal.Open(initial);
+            modal.UpdateDraft(initial with { SearchQuery = "edited" });
+
+            Assert.Equal("orig", initial.SearchQuery);
+            Assert.Equal("edited", modal.CurrentDraft.SearchQuery);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: Build error (`SongSearchFilterModal` not defined).
+
+- [ ] **Step 3: Implement modal skeleton**
+
+Path: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+
+```csharp
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.UI;
+using DTXMania.Game.Lib.UI.Components;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    public class SongSearchFilterModal : UIElement
+    {
+        private readonly ITextInputSource _textSource;
+        private SongFilterCriteria _draft = SongFilterCriteria.Default;
+        private bool _isOpen;
+
+        public SongSearchFilterModal(ITextInputSource textSource)
+        {
+            _textSource = textSource ?? throw new ArgumentNullException(nameof(textSource));
+            Visible = false;
+        }
+
+        public event EventHandler<SongFilterCriteria>? FilterApplied;
+        public event EventHandler? FilterReset;
+        public event EventHandler? Cancelled;
+
+        public bool IsOpen => _isOpen;
+        public SongFilterCriteria CurrentDraft => _draft;
+
+        public void Open(SongFilterCriteria initial)
+        {
+            _draft = initial ?? SongFilterCriteria.Default;
+            _isOpen = true;
+            Visible = true;
+        }
+
+        public void Close()
+        {
+            _isOpen = false;
+            Visible = false;
+        }
+
+        public void Cancel()
+        {
+            Cancelled?.Invoke(this, EventArgs.Empty);
+            Close();
+        }
+
+        public void Apply()
+        {
+            FilterApplied?.Invoke(this, _draft);
+            Close();
+        }
+
+        public void Reset()
+        {
+            FilterReset?.Invoke(this, EventArgs.Empty);
+            Close();
+        }
+
+        public void UpdateDraft(SongFilterCriteria newDraft)
+        {
+            _draft = newDraft ?? SongFilterCriteria.Default;
+        }
+
+        protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
+        {
+            // Drawing implemented in Task 18.
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+git commit -m "feat: add SongSearchFilterModal state machine skeleton"
+```
+
+---
+
+### Task 16: Modal — `/q` slash command detection
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Modify: `DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `SongSearchFilterModalLogicTests.cs`:
+
+```csharp
+        [Fact]
+        public void SubmitFromSearchBox_QSlashCommand_TriggersReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/q" });
+            bool resetFired = false;
+            bool appliedFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+            modal.FilterApplied += (_, _) => appliedFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.True(resetFired);
+            Assert.False(appliedFired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_QSlashCommand_CaseInsensitive()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/Q" });
+            bool resetFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.True(resetFired);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_NormalQuery_TriggersApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "beatles" });
+            bool resetFired = false;
+            bool appliedFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+            modal.FilterApplied += (_, _) => appliedFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(resetFired);
+            Assert.True(appliedFired);
+        }
+
+        [Fact]
+        public void SubmitFromSearchBox_QPrefixedQuery_NotResetCommand()
+        {
+            // "/quiet" is a literal search, not /q
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "/quiet" });
+            bool resetFired = false;
+            bool appliedFired = false;
+            modal.FilterReset += (_, _) => resetFired = true;
+            modal.FilterApplied += (_, _) => appliedFired = true;
+
+            modal.SubmitFromSearchBox();
+
+            Assert.False(resetFired);
+            Assert.True(appliedFired);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 4 new tests fail (`SubmitFromSearchBox` not defined).
+
+- [ ] **Step 3: Add submit method**
+
+In `SongSearchFilterModal.cs`, add:
+
+```csharp
+        public void SubmitFromSearchBox()
+        {
+            if (string.Equals(_draft.SearchQuery, "/q", StringComparison.OrdinalIgnoreCase))
+            {
+                Reset();
+                return;
+            }
+            Apply();
+        }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 9 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+git commit -m "feat: detect /q slash-command in modal SubmitFromSearchBox"
+```
+
+---
+
+### Task 17: Modal — focus cycling between fields
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Modify: `DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `SongSearchFilterModalLogicTests.cs`:
+
+```csharp
+        [Fact]
+        public void Open_SearchBoxIsInitiallyFocused()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void FocusNext_CyclesThroughFieldsInOrder()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            var order = new[]
+            {
+                SongSearchFilterModal.Field.SearchBox,
+                SongSearchFilterModal.Field.MinLevel,
+                SongSearchFilterModal.Field.MaxLevel,
+                SongSearchFilterModal.Field.PlayedStatus,
+                SongSearchFilterModal.Field.SortBy,
+                SongSearchFilterModal.Field.SortDirection,
+                SongSearchFilterModal.Field.ResetButton,
+                SongSearchFilterModal.Field.ApplyButton
+            };
+
+            for (int i = 0; i < order.Length; i++)
+            {
+                Assert.Equal(order[i], modal.FocusedField);
+                modal.FocusNext();
+            }
+            // After last, wraps back to SearchBox
+            Assert.Equal(SongSearchFilterModal.Field.SearchBox, modal.FocusedField);
+        }
+
+        [Fact]
+        public void FocusPrev_ReverseOfFocusNext()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.FocusPrev();
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+            modal.FocusPrev();
+            Assert.Equal(SongSearchFilterModal.Field.ResetButton, modal.FocusedField);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 3 new tests fail (`Field`, `FocusedField`, `FocusNext`, `FocusPrev` not defined).
+
+- [ ] **Step 3: Add focus model**
+
+In `SongSearchFilterModal.cs`, add this enum and methods:
+
+```csharp
+        public enum Field
+        {
+            SearchBox = 0,
+            MinLevel = 1,
+            MaxLevel = 2,
+            PlayedStatus = 3,
+            SortBy = 4,
+            SortDirection = 5,
+            ResetButton = 6,
+            ApplyButton = 7
+        }
+
+        private const int FieldCount = 8;
+        private Field _focusedField = Field.SearchBox;
+
+        public Field FocusedField => _focusedField;
+
+        public void FocusNext()
+        {
+            int next = ((int)_focusedField + 1) % FieldCount;
+            _focusedField = (Field)next;
+        }
+
+        public void FocusPrev()
+        {
+            int prev = ((int)_focusedField - 1 + FieldCount) % FieldCount;
+            _focusedField = (Field)prev;
+        }
+```
+
+Also modify `Open` to reset focus:
+
+```csharp
+        public void Open(SongFilterCriteria initial)
+        {
+            _draft = initial ?? SongFilterCriteria.Default;
+            _focusedField = Field.SearchBox;
+            _isOpen = true;
+            Visible = true;
+        }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 12 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+git commit -m "feat: add modal focus-cycling between search/facets/sort/buttons"
+```
+
+---
+
+### Task 18: Modal — keyboard input handling (HandleKey)
+
+This task wires raw key input. We test the state transitions but not actual keyboard polling (the stage will pass keys in via `HandleKey`).
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Modify: `DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `SongSearchFilterModalLogicTests.cs`:
+
+```csharp
+        [Fact]
+        public void HandleKey_Escape_FiresCancel()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.Cancelled += (_, _) => fired = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Escape);
+
+            Assert.True(fired);
+            Assert.False(modal.IsOpen);
+        }
+
+        [Fact]
+        public void HandleKey_Tab_AdvancesFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Tab);
+
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_Down_AdvancesFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Down);
+
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_Up_RetreatsFocus()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Up);
+
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnSearchBox_SubmitsFromSearchBox()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.UpdateDraft(SongFilterCriteria.Default with { SearchQuery = "abc" });
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnApplyButton_FiresApply()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // Move focus to ApplyButton
+            for (int i = 0; i < 7; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ApplyButton, modal.FocusedField);
+
+            bool applied = false;
+            modal.FilterApplied += (_, _) => applied = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(applied);
+        }
+
+        [Fact]
+        public void HandleKey_Enter_OnResetButton_FiresReset()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            // Move focus to ResetButton
+            for (int i = 0; i < 6; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.ResetButton, modal.FocusedField);
+
+            bool reset = false;
+            modal.FilterReset += (_, _) => reset = true;
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Enter);
+
+            Assert.True(reset);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnMinLevel_AdjustsBy5()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+            Assert.Equal(SongSearchFilterModal.Field.MinLevel, modal.FocusedField);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(5, modal.CurrentDraft.MinLevel);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(10, modal.CurrentDraft.MinLevel);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Left);
+            Assert.Equal(5, modal.CurrentDraft.MinLevel);
+        }
+
+        [Fact]
+        public void HandleKey_LeftRight_OnPlayedStatus_CyclesEnum()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource());
+            modal.Open(SongFilterCriteria.Default);
+            for (int i = 0; i < 3; i++) modal.FocusNext();
+            Assert.Equal(SongSearchFilterModal.Field.PlayedStatus, modal.FocusedField);
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(PlayedStatus.Unplayed, modal.CurrentDraft.PlayedStatus);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(PlayedStatus.Played, modal.CurrentDraft.PlayedStatus);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            Assert.Equal(PlayedStatus.Cleared, modal.CurrentDraft.PlayedStatus);
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Right);
+            // wraps
+            Assert.Equal(PlayedStatus.All, modal.CurrentDraft.PlayedStatus);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 9 new tests fail (`HandleKey` not defined).
+
+- [ ] **Step 3: Add HandleKey method**
+
+In `SongSearchFilterModal.cs`, add (using `Microsoft.Xna.Framework.Input;` at the top of the file):
+
+```csharp
+        public void HandleKey(Microsoft.Xna.Framework.Input.Keys key)
+        {
+            if (!_isOpen) return;
+
+            switch (key)
+            {
+                case Microsoft.Xna.Framework.Input.Keys.Escape:
+                    Cancel();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Tab:
+                case Microsoft.Xna.Framework.Input.Keys.Down:
+                    FocusNext();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Up:
+                    FocusPrev();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Enter:
+                    HandleEnter();
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Left:
+                    AdjustFocusedField(-1);
+                    return;
+
+                case Microsoft.Xna.Framework.Input.Keys.Right:
+                    AdjustFocusedField(+1);
+                    return;
+            }
+        }
+
+        private void HandleEnter()
+        {
+            switch (_focusedField)
+            {
+                case Field.SearchBox:
+                    SubmitFromSearchBox();
+                    return;
+                case Field.ResetButton:
+                    Reset();
+                    return;
+                case Field.ApplyButton:
+                    Apply();
+                    return;
+                default:
+                    // On numeric/cycle fields, Enter applies (default action)
+                    Apply();
+                    return;
+            }
+        }
+
+        private const int LevelStep = 5;
+        private const int LevelMin = 0;
+        private const int LevelMax = 99;
+
+        private void AdjustFocusedField(int dir)
+        {
+            switch (_focusedField)
+            {
+                case Field.MinLevel:
+                    _draft = _draft with { MinLevel = AdjustLevel(_draft.MinLevel, dir) };
+                    return;
+                case Field.MaxLevel:
+                    _draft = _draft with { MaxLevel = AdjustLevel(_draft.MaxLevel, dir) };
+                    return;
+                case Field.PlayedStatus:
+                    _draft = _draft with { PlayedStatus = CycleEnum(_draft.PlayedStatus, dir) };
+                    return;
+                case Field.SortBy:
+                    _draft = _draft with { SortBy = CycleSort(_draft.SortBy, dir) };
+                    return;
+                case Field.SortDirection:
+                    _draft = _draft with { SortDescending = !_draft.SortDescending };
+                    return;
+            }
+        }
+
+        private static int? AdjustLevel(int? current, int dir)
+        {
+            int next = (current ?? 0) + (dir * LevelStep);
+            if (next < LevelMin) next = LevelMin;
+            if (next > LevelMax) next = LevelMax;
+            return next == 0 ? (int?)null : next;
+        }
+
+        private static PlayedStatus CycleEnum(PlayedStatus current, int dir)
+        {
+            int count = 4; // All, Unplayed, Played, Cleared
+            int idx = ((int)current + dir + count) % count;
+            return (PlayedStatus)idx;
+        }
+
+        private static SongSortCriteria CycleSort(SongSortCriteria current, int dir)
+        {
+            // Modal exposes only Title / Artist / Level (no Genre)
+            var allowed = new[]
+            {
+                SongSortCriteria.Title,
+                SongSortCriteria.Artist,
+                SongSortCriteria.Level
+            };
+            int currentIdx = System.Array.IndexOf(allowed, current);
+            if (currentIdx < 0) currentIdx = 0;
+            int next = (currentIdx + dir + allowed.Length) % allowed.Length;
+            return allowed[next];
+        }
+```
+
+Add `using DTXMania.Game.Lib.Song;` at the top of the file (for `SongSortCriteria`).
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 21 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+git commit -m "feat: handle Esc/Tab/Enter/Arrow keys in search-filter modal"
+```
+
+---
+
+### Task 19: Modal — text-input wiring (search box character entry)
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Modify: `DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `SongSearchFilterModalLogicTests.cs`:
+
+```csharp
+        [Fact]
+        public void TypingChars_OnSearchBox_AppendsToSearchQuery()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            // SearchBox is initial focus
+            src.Fire('h');
+            src.Fire('i');
+
+            Assert.Equal("hi", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void TypingChars_WhenNotOnSearchBox_Ignored()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            modal.FocusNext(); // MinLevel
+
+            src.Fire('5');
+
+            Assert.Equal("", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Backspace_HandleKey_RemovesLastSearchChar()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            src.Fire('b');
+
+            modal.HandleKey(Microsoft.Xna.Framework.Input.Keys.Back);
+
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
+
+        [Fact]
+        public void Close_UnsubscribesFromTextSource()
+        {
+            var src = new FakeSource();
+            var modal = new SongSearchFilterModal(src);
+            modal.Open(SongFilterCriteria.Default);
+            src.Fire('a');
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+
+            modal.Cancel(); // closes
+
+            src.Fire('b');
+            // After close, characters must not affect the now-stale draft
+            Assert.Equal("a", modal.CurrentDraft.SearchQuery);
+        }
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 4 new tests fail (no text wiring yet).
+
+- [ ] **Step 3: Wire text input into modal**
+
+Modify `SongSearchFilterModal.cs`:
+
+Add field:
+```csharp
+        private bool _subscribedToText;
+```
+
+Replace `Open`:
+```csharp
+        public void Open(SongFilterCriteria initial)
+        {
+            _draft = initial ?? SongFilterCriteria.Default;
+            _focusedField = Field.SearchBox;
+            _isOpen = true;
+            Visible = true;
+            SubscribeText();
+        }
+```
+
+Replace `Close`:
+```csharp
+        public void Close()
+        {
+            UnsubscribeText();
+            _isOpen = false;
+            Visible = false;
+        }
+```
+
+Add helpers:
+```csharp
+        private void SubscribeText()
+        {
+            if (_subscribedToText) return;
+            _textSource.TextInput += OnTextInput;
+            _subscribedToText = true;
+        }
+
+        private void UnsubscribeText()
+        {
+            if (!_subscribedToText) return;
+            _textSource.TextInput -= OnTextInput;
+            _subscribedToText = false;
+        }
+
+        private void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            if (!_isOpen) return;
+            if (_focusedField != Field.SearchBox) return;
+
+            char c = e.Character;
+            if (c == '\b' || c == '\r' || c == '\n' || c == '\t') return;
+            if (char.IsControl(c)) return;
+
+            _draft = _draft with { SearchQuery = (_draft.SearchQuery ?? "") + c };
+        }
+```
+
+Update `HandleKey` to handle `Keys.Back`:
+```csharp
+                case Microsoft.Xna.Framework.Input.Keys.Back:
+                    HandleBackspace();
+                    return;
+```
+
+Add `HandleBackspace`:
+```csharp
+        private void HandleBackspace()
+        {
+            if (_focusedField != Field.SearchBox) return;
+            var q = _draft.SearchQuery ?? "";
+            if (q.Length == 0) return;
+            _draft = _draft with { SearchQuery = q.Substring(0, q.Length - 1) };
+        }
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 25 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs
+git commit -m "feat: wire GameWindow.TextInput characters into modal search box"
+```
+
+---
+
+## Phase 4 — Stage Integration
+
+### Task 20: SongSelectionStage — own SongFilterCriteria + filtered view fields
+
+This task introduces session-scoped state on the stage but doesn't yet open the modal. Pure refactor that adds fields and a helper.
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Create: `DTXMania.Test/Stage/SongSelectionStageFilterTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Path: `DTXMania.Test/Stage/SongSelectionStageFilterTests.cs`
+
+```csharp
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    public class SongSelectionStageFilterTests
+    {
+        [Fact]
+        public void NewStage_FilterCriteriaDefaultsToEmpty()
+        {
+            // Stage.GetFilterCriteria() is a test-access helper added in this task.
+            Assert.True(SongSelectionStage.DefaultFilterCriteriaIsEmpty());
+        }
+
+        [Fact]
+        public void DefaultFilteredViewIsNull()
+        {
+            // No filter active → projection is null
+            Assert.True(SongSelectionStage.DefaultFilteredViewIsNull());
+        }
+    }
+}
+```
+
+(These thin smoke tests verify the static defaults are correctly wired. The real integration tests for stage behavior live in later tasks where the stage exposes test-access helpers.)
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageFilterTests"`
+Expected: Build error (helpers not defined).
+
+- [ ] **Step 3: Add fields and test helpers to SongSelectionStage**
+
+In `SongSelectionStage.cs`, add at the top of the `using` block (if missing):
+```csharp
+using DTXMania.Game.Lib.Song.Filtering;
+```
+
+Add private fields near the existing song-management fields:
+```csharp
+        // Session-scoped search/filter/sort state
+        private SongFilterCriteria _filterCriteria = SongFilterCriteria.Default;
+        private System.Collections.Generic.IReadOnlyList<FilteredSongResult>? _filteredView;
+        private readonly ISongListFilterService _filterService = new SongListFilterService();
+```
+
+Add static test-access helpers at the bottom of the class:
+```csharp
+        // Test-access helpers (used by SongSelectionStageFilterTests)
+        internal static bool DefaultFilterCriteriaIsEmpty() =>
+            SongFilterCriteria.Default.IsEmpty;
+
+        internal static bool DefaultFilteredViewIsNull() => true;
+```
+
+(`InternalsVisibleTo("DTXMania.Test")` and `("DTXMania.Test.Mac")` are already configured at `DTXMania.Game/Lib/Resources/BitmapFont.cs:7-8`. No additional assembly attributes needed.)
+
+- [ ] **Step 4: Build**
+
+Run: `dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageFilterTests"`
+Expected: 2 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+        DTXMania.Test/Stage/SongSelectionStageFilterTests.cs
+git commit -m "feat: add filter criteria and view fields to SongSelectionStage"
+```
+
+---
+
+### Task 21: SongSelectionStage — instantiate modal & open on Backspace
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+
+This task is wiring without unit tests because it crosses into stage lifecycle / graphics. Verified manually via build + smoke launch in Task 30.
+
+- [ ] **Step 1: Add modal field and creation**
+
+In `SongSelectionStage.cs`, add private field near other UI fields:
+
+```csharp
+        private SongSearchFilterModal _searchFilterModal;
+        private WindowTextInputSource _textInputSource;
+```
+
+Add `using DTXMania.Game.Lib.UI.Components;` at the top.
+
+In the method that creates other UI components (search for `_uiManager = new UIManager` or similar — likely in `OnActivate` or an `Initialize*` method around line 380-450), construct the modal after the existing UI elements:
+
+```csharp
+            // Search/filter modal
+            _textInputSource = new WindowTextInputSource(_game.Window);
+            _searchFilterModal = new SongSearchFilterModal(_textInputSource);
+            _searchFilterModal.FilterApplied += OnFilterApplied;
+            _searchFilterModal.FilterReset   += OnFilterReset;
+            _searchFilterModal.Cancelled     += OnFilterCancelled;
+            _mainPanel.AddChild(_searchFilterModal);
+```
+
+Add stub handlers (full bodies in Tasks 22–23):
+
+```csharp
+        private void OnFilterApplied(object sender, SongFilterCriteria criteria)
+        {
+            _filterCriteria = criteria;
+            RebuildFilteredView();
+            PopulateSongListForCurrentMode();
+        }
+
+        private void OnFilterReset(object sender, System.EventArgs e)
+        {
+            _filterCriteria = SongFilterCriteria.Default;
+            _filteredView = null;
+            PopulateSongListForCurrentMode();
+        }
+
+        private void OnFilterCancelled(object sender, System.EventArgs e)
+        {
+            // Discard draft; no state change
+        }
+
+        private void RebuildFilteredView()
+        {
+            if (_filterCriteria.IsEmpty)
+            {
+                _filteredView = null;
+                return;
+            }
+            var roots = SongManager.Instance.RootSongs;
+            _filteredView = _filterService.Apply(roots, _filterCriteria);
+        }
+
+        private void PopulateSongListForCurrentMode()
+        {
+            if (_filteredView != null)
+                PopulateFilteredSongList();
+            else
+                PopulateSongList();
+        }
+
+        private void PopulateFilteredSongList()
+        {
+            var displayList = new System.Collections.Generic.List<SongListNode>(_filteredView!.Count);
+            foreach (var r in _filteredView)
+                displayList.Add(r.Node);
+            _songListDisplay.CurrentList = displayList;
+        }
+```
+
+In `ExecuteInputCommand` (around line 909), add a new case to handle `OpenSearch`:
+
+```csharp
+                case InputCommandType.OpenSearch:
+                    OpenSearchFilterModal();
+                    break;
+```
+
+Add the method:
+
+```csharp
+        private void OpenSearchFilterModal()
+        {
+            if (_searchFilterModal == null) return;
+            // Exit status-panel mode first
+            _isInStatusPanel = false;
+            _searchFilterModal.Open(_filterCriteria);
+        }
+```
+
+In the stage's `Update` / input-processing flow (where `ProcessInputCommands` is called, around line 824), suspend command processing while modal is open and route raw keys to the modal instead:
+
+```csharp
+            if (_searchFilterModal != null && _searchFilterModal.IsOpen)
+            {
+                ProcessModalKeys();
+                return;
+            }
+            HandleInput();
+```
+
+Add `ProcessModalKeys`:
+
+```csharp
+        private Microsoft.Xna.Framework.Input.KeyboardState _prevModalKbState;
+
+        private void ProcessModalKeys()
+        {
+            var current = Microsoft.Xna.Framework.Input.Keyboard.GetState();
+            // Edge-trigger only: act on keys pressed this frame
+            foreach (var key in current.GetPressedKeys())
+            {
+                if (!_prevModalKbState.IsKeyDown(key))
+                    _searchFilterModal.HandleKey(key);
+            }
+            _prevModalKbState = current;
+        }
+```
+
+(If a more central place handles keyboard state per-frame, prefer routing through that. Inspect surrounding code: if `InputManager` already exposes pressed keys this frame, use it. Otherwise the direct `Keyboard.GetState` poll above is acceptable.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Run full Mac test suite to ensure no regressions**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All existing tests still pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "feat: wire search-filter modal into SongSelectionStage"
+```
+
+---
+
+### Task 22: SongSelectionStage — breadcrumb summary while filter active
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Create: `DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs`
+
+- [ ] **Step 1: Write failing tests for the summary helper**
+
+Path: `DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs`
+
+```csharp
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Filtering;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    public class SongSelectionStageBreadcrumbTests
+    {
+        [Fact]
+        public void Summarize_DefaultCriteria_ReturnsEmpty()
+        {
+            var s = SongSelectionStage.SummarizeFilter(SongFilterCriteria.Default);
+            Assert.Equal("", s);
+        }
+
+        [Fact]
+        public void Summarize_OnlySearchQuery_ShowsQuoted()
+        {
+            var c = SongFilterCriteria.Default with { SearchQuery = "beatles" };
+            Assert.Equal("Filtered: \"beatles\"", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_LevelRange_ShowsLevels()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = 85 };
+            Assert.Equal("Filtered: Lv 50-85", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_LevelMinOnly()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = 50, MaxLevel = null };
+            Assert.Equal("Filtered: Lv 50+", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_LevelMaxOnly()
+        {
+            var c = SongFilterCriteria.Default with { MinLevel = null, MaxLevel = 85 };
+            Assert.Equal("Filtered: Lv ≤85", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_PlayedStatus()
+        {
+            var c = SongFilterCriteria.Default with { PlayedStatus = PlayedStatus.Unplayed };
+            Assert.Equal("Filtered: Unplayed", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_SortNonDefault_AppendedWithArrow()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Artist,
+                SortDescending = false
+            };
+            Assert.Equal("Filtered: Artist↑", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_SortDescending_DownArrow()
+        {
+            var c = SongFilterCriteria.Default with
+            {
+                SortBy = SongSortCriteria.Title,
+                SortDescending = true
+            };
+            Assert.Equal("Filtered: Title↓", SongSelectionStage.SummarizeFilter(c));
+        }
+
+        [Fact]
+        public void Summarize_AllFacets_JoinedWithDot()
+        {
+            var c = new SongFilterCriteria(
+                SearchQuery: "beatles",
+                MinLevel: 50, MaxLevel: 85,
+                PlayedStatus: PlayedStatus.Unplayed,
+                SortBy: SongSortCriteria.Title,
+                SortDescending: false);
+            Assert.Equal("Filtered: \"beatles\" · Lv 50-85 · Unplayed",
+                SongSelectionStage.SummarizeFilter(c));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageBreadcrumbTests"`
+Expected: Build error (`SummarizeFilter` not defined).
+
+- [ ] **Step 3: Add SummarizeFilter helper**
+
+In `SongSelectionStage.cs`, add this static method:
+
+```csharp
+        public static string SummarizeFilter(SongFilterCriteria c)
+        {
+            if (c.IsEmpty) return "";
+
+            var parts = new System.Collections.Generic.List<string>();
+            if (!string.IsNullOrEmpty(c.SearchQuery))
+                parts.Add($"\"{c.SearchQuery}\"");
+
+            string? levelPart = FormatLevel(c.MinLevel, c.MaxLevel);
+            if (levelPart != null) parts.Add(levelPart);
+
+            if (c.PlayedStatus != PlayedStatus.All)
+                parts.Add(c.PlayedStatus.ToString());
+
+            string? sortPart = FormatSort(c.SortBy, c.SortDescending);
+            if (sortPart != null) parts.Add(sortPart);
+
+            return "Filtered: " + string.Join(" · ", parts);
+        }
+
+        private static string? FormatLevel(int? min, int? max)
+        {
+            if (min is null && max is null) return null;
+            if (min is not null && max is not null) return $"Lv {min}-{max}";
+            if (min is not null) return $"Lv {min}+";
+            return $"Lv ≤{max}";
+        }
+
+        private static string? FormatSort(SongSortCriteria by, bool desc)
+        {
+            // Default sort (Title ascending) is omitted from the summary
+            if (by == SongSortCriteria.Title && !desc) return null;
+            char arrow = desc ? '↓' : '↑';
+            return $"{by}{arrow}";
+        }
+```
+
+- [ ] **Step 4: Wire it into the breadcrumb refresh logic**
+
+Find the method updating `_breadcrumbLabel.Text` (around line 797 of `SongSelectionStage.cs`). Replace:
+
+```csharp
+            _breadcrumbLabel.Text = string.IsNullOrEmpty(_currentBreadcrumb)
+                ? ""
+                : _currentBreadcrumb;
+```
+
+With:
+
+```csharp
+            string filterSummary = SummarizeFilter(_filterCriteria);
+            if (!string.IsNullOrEmpty(filterSummary))
+                _breadcrumbLabel.Text = filterSummary;
+            else
+                _breadcrumbLabel.Text = string.IsNullOrEmpty(_currentBreadcrumb)
+                    ? ""
+                    : _currentBreadcrumb;
+```
+
+Make sure `OnFilterApplied` and `OnFilterReset` (added in Task 21) call the breadcrumb-refresh method (likely `UpdateBreadcrumb` or similar — search for the method that contains the line above, then call it after `PopulateSongListForCurrentMode()`).
+
+- [ ] **Step 5: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageBreadcrumbTests"`
+Expected: 9 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+        DTXMania.Test/Stage/SongSelectionStageBreadcrumbTests.cs
+git commit -m "feat: render filter summary in breadcrumb when filter active"
+```
+
+---
+
+### Task 23: SongStatusPanel — folder-hint label
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+
+The status panel already exists with rich rendering. We add a single optional string property the stage sets when filter is active.
+
+- [ ] **Step 1: Add property to SongStatusPanel**
+
+In `SongStatusPanel.cs`, add a property near the other public properties (around line 91-145):
+
+```csharp
+        /// <summary>
+        /// Optional folder breadcrumb to render at the top of the panel.
+        /// Set when the song selection list is in filtered (flat) mode so the
+        /// player can see where the selected song lives in the hierarchy.
+        /// Empty/null = nothing rendered.
+        /// </summary>
+        public string FolderHint { get; set; } = "";
+```
+
+In the panel's draw method (search for the method that draws the panel content — likely `OnDraw` or `DrawAuthenticPanel` etc.), add at the top after entering the panel bounds:
+
+```csharp
+            if (!string.IsNullOrEmpty(FolderHint) && Font != null)
+            {
+                var pos = new Microsoft.Xna.Framework.Vector2(
+                    AbsolutePosition.X + 12,
+                    AbsolutePosition.Y + 6);
+                spriteBatch.DrawString(Font, "From: " + FolderHint, pos, Microsoft.Xna.Framework.Color.LightGray);
+            }
+```
+
+(Use `ManagedFont` if `Font` is unavailable; check what the existing code uses for similar small labels.)
+
+- [ ] **Step 2: Update stage to set FolderHint when selection changes during filtered mode**
+
+In `SongSelectionStage.cs`, add a small helper:
+
+```csharp
+        private void UpdateStatusPanelFolderHint()
+        {
+            if (_statusPanel == null) return;
+            if (_filteredView == null)
+            {
+                _statusPanel.FolderHint = "";
+                return;
+            }
+            var selectedNode = _songListDisplay?.SelectedSong;
+            if (selectedNode == null) { _statusPanel.FolderHint = ""; return; }
+
+            foreach (var r in _filteredView)
+            {
+                if (ReferenceEquals(r.Node, selectedNode))
+                {
+                    _statusPanel.FolderHint = r.FolderPath;
+                    return;
+                }
+            }
+            _statusPanel.FolderHint = "";
+        }
+```
+
+Call this whenever the selection or filter state changes. Subscribe to `_songListDisplay.SelectionChanged` (the event already exists; see SongListDisplay.cs:259):
+
+In the location where other `_songListDisplay` event subscriptions happen (search for `SelectionChanged +=` or similar), add:
+
+```csharp
+            _songListDisplay.SelectionChanged += (_, _) => UpdateStatusPanelFolderHint();
+```
+
+Also call `UpdateStatusPanelFolderHint()` at the end of `OnFilterApplied` and `OnFilterReset`.
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 4: Run full Mac suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs \
+        DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "feat: status panel renders 'From:' folder hint while filter active"
+```
+
+---
+
+### Task 24: SongSelectionStage — empty-state message
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+
+- [ ] **Step 1: Add empty-state rendering**
+
+In `SongSelectionStage.cs`, add a private field:
+
+```csharp
+        private bool _showEmptyFilterMessage;
+```
+
+In `OnFilterApplied` and `OnFilterReset`, set the flag based on result count. Update `RebuildFilteredView` to also set the flag:
+
+```csharp
+        private void RebuildFilteredView()
+        {
+            if (_filterCriteria.IsEmpty)
+            {
+                _filteredView = null;
+                _showEmptyFilterMessage = false;
+                return;
+            }
+            var roots = SongManager.Instance.RootSongs;
+            _filteredView = _filterService.Apply(roots, _filterCriteria);
+            _showEmptyFilterMessage = _filteredView.Count == 0;
+        }
+```
+
+In the stage's `OnDraw` method (search for `DrawSongList` or similar — it's where the song list area gets rendered), after the list draws, conditionally render the empty-state message:
+
+```csharp
+            if (_showEmptyFilterMessage && _bitmapFont != null)
+            {
+                // Reuse the existing ManagedFont (consistent with other UI text per spec)
+                var msg = "No songs match this filter";
+                var managedFont = _statusPanel?.ManagedFont; // shared loaded font
+                if (managedFont != null)
+                {
+                    var center = new Microsoft.Xna.Framework.Vector2(
+                        SongSelectionUILayout.SongBars.UnselectedBarX + 100,
+                        SongSelectionUILayout.SongBars.SelectedBarY);
+                    managedFont.DrawString(spriteBatch, msg, center, Microsoft.Xna.Framework.Color.LightGray);
+                }
+            }
+```
+
+(If `ManagedFont.DrawString` differs in signature, mirror what `SongStatusPanel` already uses for its labels — same component-pattern.)
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "feat: render empty-state message when filter has no results"
+```
+
+---
+
+### Task 25: SongSelectionStage — selection clamping
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Create: `DTXMania.Test/Stage/SongSelectionStageClampingTests.cs`
+
+- [ ] **Step 1: Write failing tests for the clamp helper**
+
+Path: `DTXMania.Test/Stage/SongSelectionStageClampingTests.cs`
+
+```csharp
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    public class SongSelectionStageClampingTests
+    {
+        private static SongListNode S(string title) =>
+            new SongListNode { Type = NodeType.Score, Title = title };
+
+        [Fact]
+        public void ClampSelectionIndex_PreviousNodeStillPresent_ReturnsItsIndex()
+        {
+            var prev = S("B");
+            var newList = new List<SongListNode> { S("A"), prev, S("C") };
+
+            int idx = SongSelectionStage.ClampSelectionIndex(prev, newList);
+
+            Assert.Equal(1, idx);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_PreviousNodeMissing_ReturnsZero()
+        {
+            var prev = S("Removed");
+            var newList = new List<SongListNode> { S("A"), S("B") };
+
+            int idx = SongSelectionStage.ClampSelectionIndex(prev, newList);
+
+            Assert.Equal(0, idx);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_EmptyList_ReturnsZero()
+        {
+            int idx = SongSelectionStage.ClampSelectionIndex(S("X"), new List<SongListNode>());
+            Assert.Equal(0, idx);
+        }
+
+        [Fact]
+        public void ClampSelectionIndex_NullPrevious_ReturnsZero()
+        {
+            int idx = SongSelectionStage.ClampSelectionIndex(null, new List<SongListNode> { S("A") });
+            Assert.Equal(0, idx);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageClampingTests"`
+Expected: Build error (`ClampSelectionIndex` not defined).
+
+- [ ] **Step 3: Add the helper and use it**
+
+In `SongSelectionStage.cs`:
+
+```csharp
+        public static int ClampSelectionIndex(SongListNode previousSelected, System.Collections.Generic.IReadOnlyList<SongListNode> newList)
+        {
+            if (newList == null || newList.Count == 0) return 0;
+            if (previousSelected == null) return 0;
+            for (int i = 0; i < newList.Count; i++)
+            {
+                if (ReferenceEquals(newList[i], previousSelected))
+                    return i;
+            }
+            return 0;
+        }
+```
+
+Modify `PopulateFilteredSongList` to clamp after assigning the list:
+
+```csharp
+        private void PopulateFilteredSongList()
+        {
+            var prev = _songListDisplay?.SelectedSong;
+            var displayList = new System.Collections.Generic.List<SongListNode>(_filteredView!.Count);
+            foreach (var r in _filteredView)
+                displayList.Add(r.Node);
+            _songListDisplay.CurrentList = displayList;
+            _songListDisplay.SelectedIndex = ClampSelectionIndex(prev, displayList);
+        }
+```
+
+Apply the same change to `PopulateSongList` (existing method around line 562) by capturing `prev` and clamping after the list assignment. Wrap that change carefully — do not modify the back-box prepending logic.
+
+- [ ] **Step 4: Run tests — expect pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageClampingTests"`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Run full Mac suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+        DTXMania.Test/Stage/SongSelectionStageClampingTests.cs
+git commit -m "feat: clamp selection to surviving node after filter Apply/Reset"
+```
+
+---
+
+## Phase 5 — Polish & Edge Cases
+
+### Task 26: Library-loading guard (disable Apply while songs load)
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+
+- [ ] **Step 1: Add `IsLibraryReady` property to modal**
+
+In `SongSearchFilterModal.cs`, add:
+
+```csharp
+        public bool IsLibraryReady { get; set; } = true;
+
+        public string LoadingHintText { get; set; } = "Library still loading…";
+```
+
+In `Apply` and `SubmitFromSearchBox`, gate behind `IsLibraryReady`:
+
+```csharp
+        public void Apply()
+        {
+            if (!IsLibraryReady) return;
+            FilterApplied?.Invoke(this, _draft);
+            Close();
+        }
+
+        public void SubmitFromSearchBox()
+        {
+            if (!IsLibraryReady) return;
+            if (string.Equals(_draft.SearchQuery, "/q", StringComparison.OrdinalIgnoreCase))
+            {
+                Reset();
+                return;
+            }
+            Apply();
+        }
+```
+
+(Reset and Cancel still work even while loading — only Apply is gated, per spec.)
+
+- [ ] **Step 2: Add a unit test**
+
+Append to `SongSearchFilterModalLogicTests.cs`:
+
+```csharp
+        [Fact]
+        public void Apply_WhenLibraryNotReady_DoesNotFire()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.FilterApplied += (_, _) => fired = true;
+
+            modal.Apply();
+
+            Assert.False(fired);
+            Assert.True(modal.IsOpen); // stays open
+        }
+
+        [Fact]
+        public void Reset_StillWorksWhenLibraryNotReady()
+        {
+            var modal = new SongSearchFilterModal(new FakeSource()) { IsLibraryReady = false };
+            modal.Open(SongFilterCriteria.Default);
+            bool fired = false;
+            modal.FilterReset += (_, _) => fired = true;
+
+            modal.Reset();
+
+            Assert.True(fired);
+        }
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSearchFilterModalLogicTests"`
+Expected: 27 tests pass.
+
+- [ ] **Step 4: Set IsLibraryReady from the stage when opening modal**
+
+In `SongSelectionStage.OpenSearchFilterModal()`:
+
+```csharp
+        private void OpenSearchFilterModal()
+        {
+            if (_searchFilterModal == null) return;
+            _isInStatusPanel = false;
+            _searchFilterModal.IsLibraryReady =
+                _songInitializationProcessed && _currentSongList != null;
+            _searchFilterModal.Open(_filterCriteria);
+        }
+```
+
+When library finishes loading (in `CheckSongInitializationCompletion` around line 583 — search for where `_songInitializationProcessed = true` is set), refresh the modal's flag if it's open:
+
+```csharp
+                if (_searchFilterModal != null && _searchFilterModal.IsOpen)
+                    _searchFilterModal.IsLibraryReady = true;
+```
+
+- [ ] **Step 5: Build & run full suite**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj && dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Test/Song/Components/SongSearchFilterModalLogicTests.cs \
+        DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "feat: gate Apply behind IsLibraryReady for songs-still-loading case"
+```
+
+---
+
+### Task 27: Error handling around projection
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+
+- [ ] **Step 1: Wrap the projection call in try/catch**
+
+In `SongSelectionStage.RebuildFilteredView`, wrap the call:
+
+```csharp
+        private void RebuildFilteredView()
+        {
+            if (_filterCriteria.IsEmpty)
+            {
+                _filteredView = null;
+                _showEmptyFilterMessage = false;
+                return;
+            }
+
+            try
+            {
+                var roots = SongManager.Instance.RootSongs;
+                _filteredView = _filterService.Apply(roots, _filterCriteria);
+                _showEmptyFilterMessage = _filteredView.Count == 0;
+            }
+            catch (System.Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongSelectionStage: filter projection failed: {ex.Message}");
+                // Leave existing list reference unchanged.
+                _filteredView = null;
+                _showEmptyFilterMessage = false;
+            }
+        }
+```
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "fix: log and recover when filter projection throws"
+```
+
+---
+
+### Task 28: Modal — Draw implementation (graphics)
+
+This task adds actual rendering to the modal. Tests for graphics-side behavior are excluded from the Mac suite per project conventions.
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`
+- Modify: `DTXMania.Test/DTXMania.Test.Mac.csproj` (exclude any new graphics tests)
+
+- [ ] **Step 1: Implement OnDraw**
+
+In `SongSearchFilterModal.cs`, expand `OnDraw` and add public properties for the resources the stage will inject:
+
+```csharp
+        public Texture2D? WhitePixel { get; set; }
+        public SpriteFont? Font { get; set; }
+
+        protected override void OnDraw(SpriteBatch spriteBatch, double deltaTime)
+        {
+            if (!_isOpen || WhitePixel == null || Font == null) return;
+
+            var modalBounds = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal.Bounds;
+
+            // Dim the screen behind the modal
+            spriteBatch.Draw(WhitePixel,
+                new Microsoft.Xna.Framework.Rectangle(0, 0, 1280, 720),
+                new Microsoft.Xna.Framework.Color(0, 0, 0, 160));
+
+            // Modal panel background
+            spriteBatch.Draw(WhitePixel, modalBounds,
+                new Microsoft.Xna.Framework.Color(28, 28, 32));
+
+            // Title
+            DrawText(spriteBatch, "SEARCH & FILTER",
+                new Microsoft.Xna.Framework.Vector2(
+                    modalBounds.X + (modalBounds.Width - Font.MeasureString("SEARCH & FILTER").X) / 2,
+                    modalBounds.Y + 12),
+                Microsoft.Xna.Framework.Color.White);
+
+            DrawSearchRow(spriteBatch, modalBounds);
+            DrawLevelRow(spriteBatch, modalBounds);
+            DrawPlayedRow(spriteBatch, modalBounds);
+            DrawSortRow(spriteBatch, modalBounds);
+            DrawButtons(spriteBatch, modalBounds);
+
+            if (!IsLibraryReady)
+            {
+                DrawText(spriteBatch, LoadingHintText,
+                    new Microsoft.Xna.Framework.Vector2(modalBounds.X + 24, modalBounds.Y + modalBounds.Height - 24),
+                    Microsoft.Xna.Framework.Color.Yellow);
+            }
+        }
+
+        private void DrawText(SpriteBatch spriteBatch, string text, Microsoft.Xna.Framework.Vector2 pos, Microsoft.Xna.Framework.Color color)
+        {
+            spriteBatch.DrawString(Font!, text, pos, color);
+        }
+
+        private static readonly Microsoft.Xna.Framework.Color FocusedBg = new(60, 60, 80);
+        private static readonly Microsoft.Xna.Framework.Color FieldBg   = new(40, 40, 50);
+
+        private void DrawSearchRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            var L = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal;
+            DrawText(sb, "Search:", new Microsoft.Xna.Framework.Vector2(modal.X + L.LabelX, modal.Y + L.SearchBoxY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            var box = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + L.FieldX, modal.Y + L.SearchBoxY, L.SearchBoxWidth, L.SearchBoxHeight);
+            sb.Draw(WhitePixel,
+                box,
+                _focusedField == Field.SearchBox ? FocusedBg : FieldBg);
+            DrawText(sb, _draft.SearchQuery ?? "",
+                new Microsoft.Xna.Framework.Vector2(box.X + 6, box.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawLevelRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            var L = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal;
+            DrawText(sb, "Level:", new Microsoft.Xna.Framework.Vector2(modal.X + L.LabelX, modal.Y + L.LevelRowY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            DrawNumeric(sb, modal.X + L.LevelMinX, modal.Y + L.LevelRowY,
+                L.LevelInputWidth, L.LevelInputHeight,
+                _draft.MinLevel, _focusedField == Field.MinLevel, "Min");
+            DrawNumeric(sb, modal.X + L.LevelMaxX, modal.Y + L.LevelRowY,
+                L.LevelInputWidth, L.LevelInputHeight,
+                _draft.MaxLevel, _focusedField == Field.MaxLevel, "Max");
+        }
+
+        private void DrawNumeric(SpriteBatch sb, int x, int y, int w, int h, int? value, bool focused, string label)
+        {
+            sb.Draw(WhitePixel, new Microsoft.Xna.Framework.Rectangle(x, y, w, h),
+                focused ? FocusedBg : FieldBg);
+            string text = value?.ToString() ?? label;
+            DrawText(sb, text, new Microsoft.Xna.Framework.Vector2(x + 6, y + 6),
+                value is null ? Microsoft.Xna.Framework.Color.Gray : Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawPlayedRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            var L = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal;
+            DrawText(sb, "Played:", new Microsoft.Xna.Framework.Vector2(modal.X + L.LabelX, modal.Y + L.PlayedRowY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            var rowBg = _focusedField == Field.PlayedStatus ? FocusedBg : FieldBg;
+            var box = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + L.FieldX, modal.Y + L.PlayedRowY, 380, 30);
+            sb.Draw(WhitePixel, box, rowBg);
+            DrawText(sb, "(◀ ▶) " + _draft.PlayedStatus,
+                new Microsoft.Xna.Framework.Vector2(box.X + 6, box.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawSortRow(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            var L = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal;
+            DrawText(sb, "Sort by:", new Microsoft.Xna.Framework.Vector2(modal.X + L.LabelX, modal.Y + L.SortRowY + 6),
+                Microsoft.Xna.Framework.Color.LightGray);
+            var sortBox = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + L.FieldX, modal.Y + L.SortRowY, 160, 30);
+            sb.Draw(WhitePixel, sortBox,
+                _focusedField == Field.SortBy ? FocusedBg : FieldBg);
+            DrawText(sb, _draft.SortBy.ToString(),
+                new Microsoft.Xna.Framework.Vector2(sortBox.X + 6, sortBox.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+
+            var dirBox = new Microsoft.Xna.Framework.Rectangle(
+                sortBox.X + sortBox.Width + 20, sortBox.Y, 100, 30);
+            sb.Draw(WhitePixel, dirBox,
+                _focusedField == Field.SortDirection ? FocusedBg : FieldBg);
+            DrawText(sb, _draft.SortDescending ? "Desc" : "Asc",
+                new Microsoft.Xna.Framework.Vector2(dirBox.X + 6, dirBox.Y + 6),
+                Microsoft.Xna.Framework.Color.White);
+        }
+
+        private void DrawButtons(SpriteBatch sb, Microsoft.Xna.Framework.Rectangle modal)
+        {
+            var L = DTXMania.Game.Lib.UI.Layout.SongSelectionUILayout.SearchFilterModal;
+            var resetRect = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + L.ResetButtonX, modal.Y + L.ButtonRowY, L.ButtonWidth, L.ButtonHeight);
+            var applyRect = new Microsoft.Xna.Framework.Rectangle(
+                modal.X + L.ApplyButtonX, modal.Y + L.ButtonRowY, L.ButtonWidth, L.ButtonHeight);
+            sb.Draw(WhitePixel, resetRect,
+                _focusedField == Field.ResetButton ? FocusedBg : FieldBg);
+            sb.Draw(WhitePixel, applyRect,
+                _focusedField == Field.ApplyButton ? FocusedBg : FieldBg);
+            DrawText(sb, "Reset",
+                new Microsoft.Xna.Framework.Vector2(resetRect.X + 36, resetRect.Y + 8),
+                Microsoft.Xna.Framework.Color.White);
+            DrawText(sb, "Apply",
+                new Microsoft.Xna.Framework.Vector2(applyRect.X + 36, applyRect.Y + 8),
+                Microsoft.Xna.Framework.Color.White);
+        }
+```
+
+- [ ] **Step 2: Stage injects WhitePixel and Font**
+
+In `SongSelectionStage.cs`, where the modal is constructed (Task 21), after the existing `_searchFilterModal = ...` line, set:
+
+```csharp
+            _searchFilterModal.WhitePixel = _whitePixel;
+            _searchFilterModal.Font = _bitmapFont?.SpriteFont; // existing field; or whichever ManagedFont yields a SpriteFont
+```
+
+(If `_bitmapFont` doesn't expose a SpriteFont, prefer `_statusPanel.Font` once it's initialised, or use the same ManagedFont path as the status panel. Verify by inspecting where `SongStatusPanel.Font` is currently assigned and reuse that source.)
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds. Fix any name resolution issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs \
+        DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "feat: render search-filter modal with focus highlights"
+```
+
+---
+
+### Task 29: Suppress folder navigation while filter active
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+
+While filter is active, only `Score` nodes appear in the list (BackBox/Box are excluded by the projection). But the `HandleActivateInput`/Box-enter logic should defensively no-op if it ever sees a non-Score node while `_filteredView != null`.
+
+- [ ] **Step 1: Find HandleActivateInput**
+
+Run: `grep -n "HandleActivateInput\|EnterBox\|NavigateBack" DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+Note the line ranges so the edit lands on the existing logic.
+
+- [ ] **Step 2: Add a guard**
+
+In the method that processes Activate (likely `HandleActivateInput`), add at the top:
+
+```csharp
+            if (_filteredView != null && _songListDisplay?.SelectedSong?.Type != NodeType.Score)
+            {
+                // Filter is active; only Score nodes are valid targets.
+                return;
+            }
+```
+
+In `NavigateBack` (used for hierarchy back-navigation), guard similarly:
+
+```csharp
+            if (_filteredView != null) return;
+```
+
+- [ ] **Step 3: Build & test**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj && dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: Build succeeds, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+git commit -m "fix: suppress hierarchy navigation while filter is active"
+```
+
+---
+
+### Task 30: Mac csproj exclusions for graphics-dependent modal tests
+
+**Files:**
+- Modify: `DTXMania.Test/DTXMania.Test.Mac.csproj`
+
+There are no graphics-dependent tests in this feature beyond what we've already added (the modal logic tests use a fake source and don't touch GraphicsDevice). This task is precautionary: verify the Mac suite compiles & runs.
+
+- [ ] **Step 1: Run full Mac suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass.
+
+- [ ] **Step 2: If any added test crashes Mac due to GraphicsDevice usage, add it to the Exclude list**
+
+Edit the `<Compile Include="**/*.cs" Exclude="..." />` entry, appending the offending test path with a `;` separator. (Likely not needed — the modal logic tests are graphics-free by design.)
+
+- [ ] **Step 3: Commit (if any change made)**
+
+```bash
+git add DTXMania.Test/DTXMania.Test.Mac.csproj
+git commit -m "test: exclude graphics-dependent search-filter tests from Mac suite"
+```
+
+(Skip this commit if no exclusion was needed.)
+
+---
+
+## Phase 6 — Manual Verification
+
+### Task 31: Manual UI test checklist
+
+**Files:** None (verification only).
+
+Run the Mac game and exercise the feature.
+
+- [ ] **Step 1: Build and launch**
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Navigate to the Song Selection stage.
+
+- [ ] **Step 2: Walk the manual checklist**
+
+Verify each item from the spec:
+
+- [ ] Press Backspace from song list → modal opens; search box has focus.
+- [ ] Type a query, press Enter → list filters to matching songs.
+- [ ] Press Backspace → modal re-opens populated with the prior query.
+- [ ] Tab to Min Level, press Right several times → Min Level increases by 5 each press, capped at 99.
+- [ ] Set Min/Max levels, Enter → list filters by level range.
+- [ ] Tab to Played, Right twice → Played status cycles to Played; Enter → list shows only played songs.
+- [ ] Tab to Sort, Right → cycles Title → Artist → Level.
+- [ ] Tab to Sort Direction, Right → toggles Asc/Desc; Enter → list reorders.
+- [ ] Tab to Reset, Enter → modal closes, list is back to default (all songs visible, hierarchy intact).
+- [ ] Press Backspace, type `/q`, Enter → same as Reset.
+- [ ] Press Backspace, edit any field, Esc → modal closes, list unchanged.
+- [ ] With filter active, Esc back to Title, then re-enter Song Select → filter still active (breadcrumb still shows summary).
+- [ ] Apply filter that yields zero results → "No songs match this filter" appears.
+- [ ] Backspace key inside search box deletes a character (does NOT re-open modal).
+- [ ] If your build can paste IME input (e.g., Japanese): characters appear in search box after IME commit. (Smoke test only; deferred behaviors documented in spec.)
+- [ ] Select a song from filtered view, play it, return → filter is still active; selection clamps to a valid index.
+- [ ] Status panel shows "From: <folder path>" for the selected song while filter is active.
+
+- [ ] **Step 3: Capture issues**
+
+For any failing item, file a follow-up bug or open a fix task. Do NOT mark this task complete unless every checkbox passes or has a documented follow-up.
+
+- [ ] **Step 4: Final commit (if any fixes made)**
+
+```bash
+git add -A
+git commit -m "fix: address manual checklist findings for search/filter UI"
+```
+
+---
+
+## Self-Review
+
+After all tasks land, do one last sweep:
+
+1. **Spec coverage** — every section of the spec maps to a task:
+   - Scope decisions table → Tasks 1–8 (data layer), 13 (Backspace), 16 (`/q`), 18 (modal keys).
+   - Architecture / approach (1) — Tasks 20, 21, 25 (filter-as-view).
+   - Result rendering (b) — Task 23 (status panel folder hint).
+   - Modal layout — Task 14.
+   - Modal UI / focus model — Tasks 15, 17, 18.
+   - Input handling — Tasks 13, 18, 19, 21.
+   - Persistence (session-scoped) — Task 20 (criteria field on stage).
+   - Edge cases — Tasks 24 (empty), 25 (clamp), 26 (loading), 27 (error), 29 (nav suppress).
+   - Testing — Tasks 1–18, 20, 22, 25, 26, 30.
+   - Manual checklist — Task 31.
+
+2. **Run full test suite once more**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: All tests pass.
+
+3. **Run on Windows CI later** — verify CI green on the full Windows test suite (`DTXMania.Test.csproj`).

--- a/docs/superpowers/specs/2026-05-07-song-search-filter-ui-design.md
+++ b/docs/superpowers/specs/2026-05-07-song-search-filter-ui-design.md
@@ -1,0 +1,312 @@
+# Song Search & Filter UI — Design Spec
+
+**Date:** 2026-05-07
+**Status:** Design approved, ready for implementation plan
+**Stage:** Song Selection (`SongSelectionStage`)
+
+## Goal
+
+Add a search, filter, and sort UI to the song selection stage so players can quickly find songs in libraries that have grown beyond comfortable hierarchical browsing. The feature is keyboard-driven, modal, and operates against the in-memory song database.
+
+## Scope decisions
+
+| Decision | Choice | Notes |
+| --- | --- | --- |
+| Feature set | Search + filter + sort | Full reorganization tools, not just search. |
+| Interaction model | Modal overlay | Triggered by keyboard, dimmed list underneath. |
+| Filter facets | Level range, Played status | Genre dropped — DTX `Genre` field is unreliable in practice. |
+| Sort criteria | Title, Artist, Level (each Asc/Desc) | Genre dropped from sort selector for the same reason; `SongSortCriteria.Genre` stays in the public enum. |
+| Search scope | Whole library, flattened | Hierarchy ignored during search. |
+| Search match | Title + Artist, case-insensitive substring | Matches existing `SearchSongsAsync` semantics. |
+| Search behavior | Submit on Enter (not live) | Deliberate, no per-keystroke re-filter. |
+| Backing data | In-memory `SongListNode` set | No DB round-trips during filtering. |
+| Persistence | Session-scoped (within app run) | Reset on app exit, on Reset button, or on `/q`. |
+| Modal trigger | `Backspace` | Free in current `InputManager` bindings. |
+| Text input | `GameWindow.TextInput` event | Standard MonoGame text-entry path. |
+| Reset path | Reset button + `/q` slash command | Both work; `/q` matches DTXManiaNX habit. |
+| Font | `ManagedFont` (MonoGame `SpriteFont`) | Consistent with most other Song-Select UI. |
+
+## Architecture
+
+### Approach: filter-as-view (not filter-as-replacement)
+
+`SongSelectionStage` keeps `_hierarchicalCurrentList` (the current navigation level's children) untouched at all times. When a filter is active, a separate `_filteredView` projection is computed once on Apply and `SongListDisplay` is bound to it. Reset drops the projection and rebinds to `_hierarchicalCurrentList`. Hierarchy state and the navigation stack are never corrupted by filter activity.
+
+### New files
+
+**`DTXMania.Game/Lib/Song/Filtering/SongFilterCriteria.cs`**
+Value record holding active filter state.
+
+```csharp
+public sealed record SongFilterCriteria(
+    string SearchQuery,
+    int? MinLevel,
+    int? MaxLevel,
+    PlayedStatus PlayedStatus,
+    SongSortCriteria SortBy,
+    bool SortDescending)
+{
+    public static SongFilterCriteria Default { get; } = new(
+        SearchQuery: "",
+        MinLevel: null,
+        MaxLevel: null,
+        PlayedStatus: PlayedStatus.All,
+        SortBy: SongSortCriteria.Title,
+        SortDescending: false);
+
+    public bool IsEmpty =>
+        string.IsNullOrEmpty(SearchQuery)
+        && MinLevel is null
+        && MaxLevel is null
+        && PlayedStatus == PlayedStatus.All
+        && SortBy == SongSortCriteria.Title
+        && !SortDescending;
+}
+```
+
+**`DTXMania.Game/Lib/Song/Filtering/PlayedStatus.cs`**
+
+```csharp
+public enum PlayedStatus { All, Unplayed, Played, Cleared }
+```
+
+**`DTXMania.Game/Lib/Song/Filtering/SongListFilterService.cs`**
+Pure projection. Walks all `Score`-typed nodes from `SongManager`, captures parent breadcrumb, applies search → level → played → sort, returns a flat list of results. `BackBox` and `Random` nodes are excluded.
+
+```csharp
+public readonly record struct FilteredSongResult(
+    SongListNode Node,
+    string FolderPath); // e.g., "J-POP / 80s"
+
+public interface ISongListFilterService
+{
+    IReadOnlyList<FilteredSongResult> Apply(
+        IEnumerable<SongListNode> roots,
+        SongFilterCriteria criteria);
+}
+```
+
+Pipeline:
+
+```
+flatten(roots) → keep Score nodes only, capture parent breadcrumb
+  → search:    Title or Artist contains query (StringComparison.OrdinalIgnoreCase)
+  → level:     MaxDifficultyLevel ∈ [MinLevel ?? int.MinValue, MaxLevel ?? int.MaxValue]
+  → played:    derive from SongScore (see below)
+  → sort:      reuse SongListNode comparison logic; honor SortDescending
+```
+
+`PlayedStatus` derivation:
+- `All`: no-op.
+- `Unplayed`: no `SongScore` row OR all chart `PlayCount == 0`.
+- `Played`: any chart `PlayCount > 0`.
+- `Cleared`: any chart `BestRank` indicates a clear. Exact rank set TBD during implementation — read existing rank semantics from `SongScore`/`Rank` enum and document the chosen set in the implementation PR.
+
+If `MinLevel > MaxLevel`, swap silently on Apply.
+
+**`DTXMania.Game/Lib/UI/Components/UITextInput.cs`**
+Reusable single-line text input element.
+- Subscribes to `GameWindow.TextInput` only while focused.
+- Renders caret, handles `Backspace` for character deletion, basic character insertion.
+- Optional max-length clamp.
+- Paste (`Ctrl+V`) deferred to v2 unless trivially supported on the current MonoGame variant on Mac (DesktopGL).
+- Reusable beyond this feature.
+
+**`DTXMania.Game/Lib/Song/Components/SongSearchFilterModal.cs`**
+The modal overlay. Composition:
+- `UITextInput` (search box)
+- Min level / Max level numeric inputs
+- Played-status radio group
+- Sort criterion selector (cycles Title → Artist → Level)
+- Sort direction toggle (Asc / Desc)
+- Reset button
+- Apply button
+
+Surfaces events: `FilterApplied(SongFilterCriteria)`, `FilterReset`, `Cancelled`.
+
+### Modified files
+
+- `SongSelectionStage.cs` — owns the session-scoped `SongFilterCriteria` and `_filteredView`; on Backspace opens the modal; binds `SongListDisplay` to `_filteredView ?? _hierarchicalCurrentList`; suspends folder navigation while filter active.
+- `SongListDisplay.cs` — accept a "flat-mode" flag so `..(Back)` rows are hidden when displaying filtered results.
+- `SongStatusPanel.cs` — when a filter is active, render the selected node's `FolderPath` as a small "From: …" label near the top of the panel.
+- `InputManager.cs` — add `InputCommandType.OpenSearch`, map `Keys.Back` to it.
+- `SongSelectionUILayout.cs` — add `SearchFilterModal` static class containing all modal layout constants (modal size ≈ 600 × 360, centered).
+
+### Data flow
+
+```
+            [Backspace pressed in song list]
+                          │
+                          ▼
+              SongSearchFilterModal opens
+              populated with current criteria
+                          │
+              ┌───────────┼───────────┐
+            Apply        Reset       Cancel
+              │            │            │
+              ▼            ▼            ▼
+   service.Apply        criteria      no-op
+   returns flat         = Default     (modal closes,
+   FilteredSongResult   _filteredView  edits discarded)
+                          = null
+              │            │
+              └────────────┘
+                       │
+                       ▼
+   SongListDisplay.SetSongList(
+     _filteredView ?? _hierarchicalCurrentList)
+   SongStatusPanel.SetSelectedFolderPath(...)
+   _breadcrumbLabel.Text = filtered ? summary : hierarchy path
+```
+
+`_filteredView` is rebuilt only on Apply, not per-frame.
+
+## Modal UI
+
+```
++------------------------------------------------+
+|             SEARCH & FILTER                    |
+|                                                |
+|  Search:   [_______________________________]   |
+|                                                |
+|  Level:    Min [ 50 ]      Max [ 85 ]          |
+|                                                |
+|  Played:   ( ) All  (•) Unplayed               |
+|            ( ) Played   ( ) Cleared            |
+|                                                |
+|  Sort by:  [ Title ▼ ]    Order: [ Asc ▼ ]     |
+|                                                |
+|         [ Reset ]      [ Apply ]               |
+|                                                |
++------------------------------------------------+
+```
+
+### Focus model
+
+Tab cycle order:
+1. Search box (`UITextInput`) — focused on open.
+2. Min level (numeric, `Left`/`Right` ±5; clamped to 0–99 range used by DTX charts; empty / 0 means "no minimum").
+3. Max level (same bounds; empty / 0 means "no maximum").
+4. Played status radio group (`Left`/`Right` cycles).
+5. Sort criterion (cycles Title → Artist → Level).
+6. Sort order (toggles Asc / Desc).
+7. Reset button.
+8. Apply button.
+
+`Tab` / `Down` advances; `Shift+Tab` / `Up` reverses.
+
+### Input handling while modal is open
+
+- Stage-level `InputCommandType` processing is **suspended** — modal owns input.
+- Opening the modal from status-panel mode (`_isInStatusPanel == true`) implicitly exits status-panel mode first; on modal close, the stage returns to song-list focus regardless of the previous panel state.
+- `GameWindow.TextInput` subscribed only while search box is focused. Unsubscribed on focus loss / modal close.
+- Direct keyboard handling in modal:
+  - `Esc` → Cancel: close modal, discard edits, restore previous applied state.
+  - `Enter` → Apply (default action) when not on Reset button; activates focused button otherwise.
+  - `Tab` / `Shift+Tab` / `Up` / `Down` → focus cycling.
+  - `Left` / `Right` → adjust focused field (numeric, radio, cycle).
+  - `Backspace` → handled by `UITextInput` for character deletion. Does **not** re-open the modal (modal is already open; binding only triggers from the song list).
+
+### Slash command `/q`
+
+If the search box content is exactly `/q` (case-insensitive) and Enter is pressed, treat as Reset (clear all to defaults, close modal). Any other `/`-prefixed input is literal text — no other slash commands planned.
+
+### Cancel vs Apply semantics
+
+- Modal opens populated with the **currently-applied** state.
+- Edits → `Esc` → discarded; applied state unchanged.
+- Edits → Apply (or Enter from search box with non-`/q` content) → committed; projection recomputed.
+- Reset (button or `/q`) → criteria reset to `Default`; projection cleared; modal closes.
+
+## Result rendering & filter indicators
+
+### Filter-active indicator
+
+When a filter is active, the existing breadcrumb label at the top of the screen shows a compact summary instead of the hierarchy path:
+
+```
+Filtered: "beatles" · Lv 50–85 · Unplayed · Title↑
+```
+
+Empty parts elide. When no filter is active, breadcrumb behaves as today.
+
+### Status panel folder origin
+
+When a filter is active, `SongStatusPanel` renders an extra small label near the top: the breadcrumb path of the selected node, e.g. `From: J-POP / 80s`. The path is computed once during projection (walks `SongListNode.Parent`) and cached on `FilteredSongResult.FolderPath` so the panel doesn't rewalk per frame.
+
+### Empty state
+
+When the filter projection returns zero results, the song list area renders a centered `No songs match this filter` message using `ManagedFont`. Status panel and preview panel hide their content. User can press `Backspace` to re-open the modal and adjust, or `Esc` to leave the song selection stage.
+
+### Selection clamping
+
+- On Apply: keep previously-selected song if still in result set; otherwise select index 0.
+- On Reset: select the song that was selected pre-filter, if it's still in the hierarchy at the current navigation level; otherwise select index 0.
+- On performance-stage return: same rule — keep selection if valid; otherwise clamp.
+
+### Folder navigation while filtered
+
+- `Activate` (Enter) on a `Score` node → proceed to performance as normal.
+- `Back` (Esc) on the song list → exits the song selection stage to Title, as today. Filter persists across that exit (session-scoped), so re-entering Song Select shows the same filtered view.
+
+## Persistence
+
+- `SongFilterCriteria` lives on `SongSelectionStage` as a private field.
+- Survives: Esc → Title → re-enter Song Select within the same app run; performance round-trips; SongTransition.
+- Resets on: app exit (no `Config.ini` save); Reset button; `/q` slash command.
+- Sort criterion is **not** persisted to `Config.ini`.
+
+## Edge cases
+
+- **Library not yet loaded**: modal opens with search box and Apply disabled, showing a `Library still loading…` hint. Reset still works. Re-enables when `_songInitializationTask` completes.
+- **Zero results**: empty-state message; navigation no-op; status / preview hidden.
+- **Selected song removed by re-Apply**: clamp per rules above.
+- **`MinLevel > MaxLevel`**: swap silently on Apply.
+- **Empty search + no facets + default sort = noop filter**: treated as Reset; modal closes; projection cleared.
+- **Very large libraries (10k+ songs)**: in-memory projection runs once on Apply; even at 50k songs a single linear scan + sort is well under a frame. No paging.
+- **Missing `SongScore`**: treated as `Unplayed`. `Cleared` rank set TBD during implementation; document the chosen set.
+- **IME / international input**: `GameWindow.TextInput` handles UTF-16 surrogates and committed IME text. In-progress composition events not handled in v1 — characters appear after commit only. Acceptable.
+- **Clipboard paste**: deferred to v2 unless trivially available cross-platform.
+
+## Error handling
+
+- If `SongListFilterService.Apply` throws (defensive), log to `Debug.WriteLine`, leave the existing list reference unchanged, keep the modal open with an in-modal error message (`Filter failed — try a different query`). Don't swallow silently.
+- Modal must always unsubscribe `GameWindow.TextInput` on Cancel / Apply / Reset / stage deactivate. Tested.
+
+## Testing
+
+| Test class | Mac suite? | Coverage |
+| --- | --- | --- |
+| `SongListFilterServiceTests` | ✅ | Search-only, level-only, played-only, sort-only, combinations, min>max swap, empty result, BackBox/Random exclusion, folder path. |
+| `SongFilterCriteriaTests` | ✅ | Record equality, `Default`, `IsEmpty`. |
+| `UITextInputTests` | ✅ | Caret advance/retreat, character insert, Backspace, max-length, focus on/off subscribe-unsubscribe (mock `GameWindow`). |
+| `SongSearchFilterModalTests` | ❌ (graphics) | Focus cycling, `/q` detection, Apply / Reset / Cancel events. |
+| `SongSelectionStageFilterTests` | ✅ where possible | Filter activation toggles `_filteredView`, selection clamping, persistence across stage re-entry, Reset clears filter, library-loading edge case disables Apply. |
+
+`DTXMania.Test.Mac.csproj` updated to exclude graphics-dependent modal tests, include the rest.
+
+## Implementation phasing (suggested)
+
+1. **Data layer** — `SongFilterCriteria`, `PlayedStatus`, `SongListFilterService` + tests. No UI dependency.
+2. **Reusable text input** — `UITextInput` + tests.
+3. **Modal UI** — `SongSearchFilterModal`, layout constants, smoke-test by opening manually.
+4. **Stage integration** — `SongSelectionStage` wiring (Backspace trigger, modal lifecycle, view binding, breadcrumb summary, status panel folder hint, empty state, selection clamping).
+5. **Polish** — `/q` slash-command detection, error-handling path, library-loading edge case, IME smoke check. (Reset button itself ships with the modal in phase 3; its event wiring to clear `_filteredView` ships with stage integration in phase 4.)
+6. **Manual UI checklist** — run before declaring done.
+
+## Manual UI test checklist
+
+- Open modal, type query, Enter → filtered list correct.
+- Open modal, set level range, Enter → filtered list correct.
+- Open modal, Played = Unplayed, Enter → only unplayed songs.
+- Combine search + level + played → correct intersection.
+- Sort changes reorder list correctly.
+- Reset button clears filter.
+- `/q` then Enter clears filter.
+- Esc cancels edits without applying.
+- Re-open modal — shows current applied state, not reset.
+- Esc back to Title, re-enter Song Select — filter still applied.
+- Empty result set shows `No songs match this filter`.
+- Backspace in search box deletes a character; doesn't re-open modal.
+- IME input (e.g., Japanese): characters commit correctly into search box (smoke).
+- Performance round-trip preserves filter and selection where possible.


### PR DESCRIPTION
## Summary

- Add a search-filter modal to SongSelectionStage with text search (title/artist), level range, played-status, and sort controls
- Add `UITextInput` component with `ITextInputSource` abstraction for keyboard text input via `GameWindow.TextInput`
- Add `SongListFilterService` with filtering by search query, level range, and played status (Unplayed/Played/Cleared), plus sort options
- Persist filter state across stage transitions and clamp selection to surviving nodes after apply/reset
- Comprehensive test coverage: filter service, criteria, modal logic, UI text input, breadcrumb, clamping, layout

## Changes

**New components:**
- `SongSearchFilterModal` -- state-machine modal with focus cycling (search box -> facets -> sort -> buttons), /q slash-command, and focus highlights
- `UITextInput` -- reusable text input UI element with caret, selection, backspace, and character insertion
- `ITextInputSource` / `WindowTextInputSource` -- abstraction for routing `GameWindow.TextInput` characters into UI elements
- `SongListFilterService` -- implements `ISongListFilterService` with flatten, folder-path, search, level, played-status, and sort
- `SongFilterCriteria`, `FilteredSongResult`, `PlayedStatus` -- filtering domain types

**Modified:**
- `SongSelectionStage` -- integrates modal (open via Backspace), applies filter, renders breadcrumb summary and empty-state, persists filter across transitions
- `SongStatusPanel` -- renders From: folder hint while filter is active
- `SongSelectionUILayout` -- adds modal layout constants
- `InputManager` -- routes modal key detection for MCP injection

**Tests (22 files, ~1,400 lines):**
- `SongListFilterServiceTests`, `SongFilterCriteriaTests`, `SongSearchFilterModalLogicTests`
- `UITextInputTests`, `SearchFilterModalLayoutTests`
- `SongSelectionStageFilterTests`, `SongSelectionStageBreadcrumbTests`, `SongSelectionStageClampingTests`
- `OpenSearchInputCommandTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modal song search/filter UI with keyboard/mouse navigation, draft editing, Reset/Apply, persistent session criteria, and caret-aware text input
  * Quick-open search command and folder-hint overlay in the status panel
  * Filtering: search query, level range, played/cleared status, multi-field sorting, and a filtered-view mode with empty-state messaging

* **Bug Fixes / UX**
  * Suppress accidental key-repeat when opening the modal
  * Eager-load persisted scores so play/count/clear data display reliably

* **Tests**
  * Extensive unit tests covering filtering, modal logic, input handling, layout, and data population

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/DTXManiaCX/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->