### PR TITLE
test: raise unit test coverage toward 90%

### DIFF
--- a/DTXMania.Game/Lib/Resources/ManagedFont.cs
+++ b/DTXMania.Game/Lib/Resources/ManagedFont.cs
@@ -386,7 +386,6 @@ namespace DTXMania.Game.Lib.Resources
             }
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         public void DrawStringWithOutline(SpriteBatch spriteBatch, string text, Vector2 position,
                                          XnaColor textColor, XnaColor outlineColor, int outlineThickness = 1)
@@ -432,7 +431,6 @@ namespace DTXMania.Game.Lib.Resources
             }
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         public void DrawStringWithShadow(SpriteBatch spriteBatch, string text, Vector2 position,
                                         XnaColor textColor, XnaColor shadowColor, Vector2 shadowOffset)

--- a/DTXMania.Game/Lib/Resources/ManagedFont.cs
+++ b/DTXMania.Game/Lib/Resources/ManagedFont.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework.Content;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -385,6 +386,8 @@ namespace DTXMania.Game.Lib.Resources
             }
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         public void DrawStringWithOutline(SpriteBatch spriteBatch, string text, Vector2 position,
                                          XnaColor textColor, XnaColor outlineColor, int outlineThickness = 1)
         {
@@ -429,6 +432,8 @@ namespace DTXMania.Game.Lib.Resources
             }
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         public void DrawStringWithShadow(SpriteBatch spriteBatch, string text, Vector2 position,
                                         XnaColor textColor, XnaColor shadowColor, Vector2 shadowOffset)
         {

--- a/DTXMania.Game/Lib/Resources/ManagedSpriteTexture.cs
+++ b/DTXMania.Game/Lib/Resources/ManagedSpriteTexture.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DTXMania.Game.Lib.Resources
 {
@@ -103,8 +104,9 @@ namespace DTXMania.Game.Lib.Resources
         #region Drawing Methods
 
         /// <summary>
-        /// Draw specific sprite by index
+        /// Draw specific sprite by index. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position)
         {
             if (Texture == null)
@@ -116,8 +118,9 @@ namespace DTXMania.Game.Lib.Resources
         }
 
         /// <summary>
-        /// Draw specific sprite by index with scaling
+        /// Draw specific sprite by index with scaling. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position, Vector2 scale)
         {
             if (Texture == null)
@@ -132,9 +135,10 @@ namespace DTXMania.Game.Lib.Resources
         }
 
         /// <summary>
-        /// Draw specific sprite by index with full control
+        /// Draw specific sprite by index with full control. Pure draw method; no logic to assert.
         /// </summary>
-        public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position, Vector2 scale, 
+        [ExcludeFromCodeCoverage]
+        public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position, Vector2 scale,
                               float rotation, Vector2 origin, Color tintColor)
         {
             if (Texture == null)
@@ -149,8 +153,9 @@ namespace DTXMania.Game.Lib.Resources
         }
 
         /// <summary>
-        /// Draw specific sprite by row and column
+        /// Draw specific sprite by row and column. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int row, int col, Vector2 position)
         {
             if (Texture == null)
@@ -162,8 +167,9 @@ namespace DTXMania.Game.Lib.Resources
         }
 
         /// <summary>
-        /// Draw sprite to destination rectangle
+        /// Draw sprite to destination rectangle. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Rectangle destinationRectangle)
         {
             if (Texture == null)
@@ -175,8 +181,9 @@ namespace DTXMania.Game.Lib.Resources
         }
 
         /// <summary>
-        /// Draw specific sprite by row and column with depth control
+        /// Draw specific sprite by row and column with depth control. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int row, int col, Vector2 position, float depth)
         {
             if (Texture == null)

--- a/DTXMania.Game/Lib/Resources/ManagedSpriteTexture.cs
+++ b/DTXMania.Game/Lib/Resources/ManagedSpriteTexture.cs
@@ -103,9 +103,6 @@ namespace DTXMania.Game.Lib.Resources
 
         #region Drawing Methods
 
-        /// <summary>
-        /// Draw specific sprite by index. Pure draw method; no logic to assert.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position)
         {
@@ -117,9 +114,6 @@ namespace DTXMania.Game.Lib.Resources
             spriteBatch.Draw(Texture, position, sourceRect, color);
         }
 
-        /// <summary>
-        /// Draw specific sprite by index with scaling. Pure draw method; no logic to assert.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position, Vector2 scale)
         {
@@ -134,9 +128,6 @@ namespace DTXMania.Game.Lib.Resources
             spriteBatch.Draw(Texture, position, sourceRect, color, rotation, Vector2.Zero, finalScale, SpriteEffects.None, 0f);
         }
 
-        /// <summary>
-        /// Draw specific sprite by index with full control. Pure draw method; no logic to assert.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Vector2 position, Vector2 scale,
                               float rotation, Vector2 origin, Color tintColor)
@@ -152,9 +143,6 @@ namespace DTXMania.Game.Lib.Resources
             spriteBatch.Draw(Texture, position, sourceRect, finalColor, finalRotation, origin, finalScale, SpriteEffects.None, 0f);
         }
 
-        /// <summary>
-        /// Draw specific sprite by row and column. Pure draw method; no logic to assert.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int row, int col, Vector2 position)
         {
@@ -166,9 +154,6 @@ namespace DTXMania.Game.Lib.Resources
             spriteBatch.Draw(Texture, position, sourceRect, color);
         }
 
-        /// <summary>
-        /// Draw sprite to destination rectangle. Pure draw method; no logic to assert.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int spriteIndex, Rectangle destinationRectangle)
         {
@@ -180,9 +165,6 @@ namespace DTXMania.Game.Lib.Resources
             spriteBatch.Draw(Texture, destinationRectangle, sourceRect, color);
         }
 
-        /// <summary>
-        /// Draw specific sprite by row and column with depth control. Pure draw method; no logic to assert.
-        /// </summary>
         [ExcludeFromCodeCoverage]
         public void DrawSprite(SpriteBatch spriteBatch, int row, int col, Vector2 position, float depth)
         {

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -742,7 +742,9 @@ namespace DTXMania.Game.Lib.Song.Components
 
         /// <summary>
         /// Draw simple BPM background fallback
+        /// Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         private void DrawSimpleBPMBackground(SpriteBatch spriteBatch, Vector2 position, Vector2 size)
         {
             if (_whitePixel != null)
@@ -804,7 +806,9 @@ namespace DTXMania.Game.Lib.Song.Components
 
         /// <summary>
         /// Draw fallback graph panel background when authentic texture is unavailable
+        /// Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         private void DrawFallbackGraphPanelBackground(SpriteBatch spriteBatch, Vector2 position, Vector2 size)
         {
             if (_whitePixel != null)

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -742,7 +742,6 @@ namespace DTXMania.Game.Lib.Song.Components
 
         /// <summary>
         /// Draw simple BPM background fallback
-        /// Pure draw method; no logic to assert.
         /// </summary>
         [ExcludeFromCodeCoverage]
         private void DrawSimpleBPMBackground(SpriteBatch spriteBatch, Vector2 position, Vector2 size)
@@ -806,7 +805,6 @@ namespace DTXMania.Game.Lib.Song.Components
 
         /// <summary>
         /// Draw fallback graph panel background when authentic texture is unavailable
-        /// Pure draw method; no logic to assert.
         /// </summary>
         [ExcludeFromCodeCoverage]
         private void DrawFallbackGraphPanelBackground(SpriteBatch spriteBatch, Vector2 position, Vector2 size)

--- a/DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
@@ -123,7 +123,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
             _activeEffects.Clear();
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         public void Draw(SpriteBatch spriteBatch)
         {
@@ -134,13 +133,16 @@ namespace DTXMania.Game.Lib.Stage.Performance
             {
                 var frameIndex = effect.FrameIndex;
 
-                // Validate frame index before drawing - this is the critical check
-                if (frameIndex >= 0 && frameIndex < _hitEffectTexture.TotalSprites)
+                if (IsValidFrameIndex(frameIndex, _hitEffectTexture.TotalSprites))
                 {
                     _hitEffectTexture.DrawSprite(spriteBatch, frameIndex, effect.Position);
                 }
-                // Don't log errors here to avoid spam, just silently skip invalid frames
             }
+        }
+
+        internal static bool IsValidFrameIndex(int frameIndex, int totalSprites)
+        {
+            return frameIndex >= 0 && frameIndex < totalSprites;
         }
 
         private class EffectInstance

--- a/DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
@@ -123,7 +123,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
             _activeEffects.Clear();
         }
 
-        [ExcludeFromCodeCoverage]
         public void Draw(SpriteBatch spriteBatch)
         {
             if (!_effectsEnabled || _hitEffectTexture == null || _hitEffectTexture.TotalSprites <= 0)

--- a/DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
@@ -2,6 +2,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.UI.Layout;
 
@@ -122,15 +123,17 @@ namespace DTXMania.Game.Lib.Stage.Performance
             _activeEffects.Clear();
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         public void Draw(SpriteBatch spriteBatch)
         {
             if (!_effectsEnabled || _hitEffectTexture == null || _hitEffectTexture.TotalSprites <= 0)
                 return;
-                
+
             foreach (var effect in _activeEffects)
             {
                 var frameIndex = effect.FrameIndex;
-                
+
                 // Validate frame index before drawing - this is the critical check
                 if (frameIndex >= 0 && frameIndex < _hitEffectTexture.TotalSprites)
                 {

--- a/DTXMania.Game/Lib/Stage/Performance/GaugeDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/GaugeDisplay.cs
@@ -197,7 +197,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawFrame(SpriteBatch spriteBatch, Rectangle frameRect)
         {

--- a/DTXMania.Game/Lib/Stage/Performance/GaugeDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/GaugeDisplay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Resources;
@@ -196,6 +197,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawFrame(SpriteBatch spriteBatch, Rectangle frameRect)
         {
             // Draw frame as four rectangles (top, bottom, left, right)

--- a/DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -192,10 +193,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         /// <summary>
         /// Renders active notes on screen
+        /// Pure draw method; no logic to assert.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
         /// <param name="activeNotes">Notes currently visible on screen</param>
         /// <param name="currentSongTimeMs">Current song time in milliseconds</param>
+        [ExcludeFromCodeCoverage]
         public void DrawNotes(SpriteBatch spriteBatch, IEnumerable<Note> activeNotes, double currentSongTimeMs)
         {
             if (!IsReady || spriteBatch == null || activeNotes == null)
@@ -323,10 +326,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         /// <summary>
         /// Draws overlay animations for all active notes in effects pass (called from PerformanceStage)
+        /// Pure draw method; no logic to assert.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing (additive blend mode)</param>
         /// <param name="activeNotes">Notes currently visible on screen</param>
         /// <param name="currentSongTimeMs">Current song time in milliseconds</param>
+        [ExcludeFromCodeCoverage]
         public void DrawNoteOverlays(SpriteBatch spriteBatch, IEnumerable<Note> activeNotes, double currentSongTimeMs)
         {
             if (!IsReady || spriteBatch == null || activeNotes == null)

--- a/DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs
@@ -193,7 +193,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         /// <summary>
         /// Renders active notes on screen
-        /// Pure draw method; no logic to assert.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
         /// <param name="activeNotes">Notes currently visible on screen</param>
@@ -326,7 +325,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         /// <summary>
         /// Draws overlay animations for all active notes in effects pass (called from PerformanceStage)
-        /// Pure draw method; no logic to assert.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing (additive blend mode)</param>
         /// <param name="activeNotes">Notes currently visible on screen</param>

--- a/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -158,8 +159,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         /// <summary>
         /// Draws pad indicators for all lanes
+        /// Pure draw method; no logic to assert.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
+        [ExcludeFromCodeCoverage]
         public void Draw(SpriteBatch spriteBatch)
         {
             if (spriteBatch == null || _disposed)
@@ -175,6 +178,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         #region Virtual Hooks
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         protected virtual void DrawPadSpriteCore(ITexture texture, SpriteBatch spriteBatch, Rectangle destRect, Rectangle sourceRect, Color tint)
         {
             texture.Draw(
@@ -195,6 +200,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
             return texture;
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         protected virtual void DrawFallbackTextureCore(SpriteBatch spriteBatch, Texture2D texture, Rectangle destRect, Color color)
         {
             spriteBatch.Draw(texture, destRect, null, color, 0f, Vector2.Zero, SpriteEffects.None, BaseDepth);

--- a/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs
@@ -159,7 +159,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         /// <summary>
         /// Draws pad indicators for all lanes
-        /// Pure draw method; no logic to assert.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
         [ExcludeFromCodeCoverage]
@@ -178,7 +177,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         #region Virtual Hooks
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         protected virtual void DrawPadSpriteCore(ITexture texture, SpriteBatch spriteBatch, Rectangle destRect, Rectangle sourceRect, Color tint)
         {
@@ -200,7 +198,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
             return texture;
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         protected virtual void DrawFallbackTextureCore(SpriteBatch spriteBatch, Texture2D texture, Rectangle destRect, Color color)
         {

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -723,7 +723,6 @@ namespace DTXMania.Game.Lib.Stage
         /// <summary>
         /// Draws scrolling notes.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         private void DrawNotes()
         {
             if (_noteRenderer == null || _chartManager == null || _songTimer == null || _currentGameTime == null)
@@ -744,7 +743,6 @@ namespace DTXMania.Game.Lib.Stage
         /// <summary>
         /// Draws note overlay animations in effects pass.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         private void DrawNoteOverlays()
         {
             if (_noteRenderer == null || _chartManager == null || _songTimer == null || _currentGameTime == null)

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -233,8 +233,10 @@ namespace DTXMania.Game.Lib.Stage
         }
 
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
-        {            
+        {
             if (_spriteBatch == null)
                 return;
 
@@ -720,8 +722,9 @@ namespace DTXMania.Game.Lib.Stage
         }
 
         /// <summary>
-        /// Draws scrolling notes
+        /// Draws scrolling notes. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         private void DrawNotes()
         {
             if (_noteRenderer == null || _chartManager == null || _songTimer == null || _currentGameTime == null)
@@ -740,8 +743,9 @@ namespace DTXMania.Game.Lib.Stage
         }
 
         /// <summary>
-        /// Draws note overlay animations in effects pass
+        /// Draws note overlay animations in effects pass. Pure draw method; no logic to assert.
         /// </summary>
+        [ExcludeFromCodeCoverage]
         private void DrawNoteOverlays()
         {
             if (_noteRenderer == null || _chartManager == null || _songTimer == null || _currentGameTime == null)
@@ -1499,6 +1503,8 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawPads()
         {
             if (_padRenderer == null)
@@ -1507,18 +1513,24 @@ namespace DTXMania.Game.Lib.Stage
             _padRenderer.Draw(_spriteBatch);
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawHitEffects()
         {
             // Draw hit effects using EffectsManager
             _effectsManager?.Draw(_spriteBatch);
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawJudgementTexts()
         {
             // Draw judgement text popups using JudgementTextPopupManager
             _judgementTextPopupManager?.Draw(_spriteBatch);
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawUIElements()
         {
             // Draw shutters first (overlay elements)

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -233,7 +233,6 @@ namespace DTXMania.Game.Lib.Stage
         }
 
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
@@ -722,7 +721,7 @@ namespace DTXMania.Game.Lib.Stage
         }
 
         /// <summary>
-        /// Draws scrolling notes. Pure draw method; no logic to assert.
+        /// Draws scrolling notes.
         /// </summary>
         [ExcludeFromCodeCoverage]
         private void DrawNotes()
@@ -743,7 +742,7 @@ namespace DTXMania.Game.Lib.Stage
         }
 
         /// <summary>
-        /// Draws note overlay animations in effects pass. Pure draw method; no logic to assert.
+        /// Draws note overlay animations in effects pass.
         /// </summary>
         [ExcludeFromCodeCoverage]
         private void DrawNoteOverlays()
@@ -1503,7 +1502,6 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawPads()
         {
@@ -1513,7 +1511,6 @@ namespace DTXMania.Game.Lib.Stage
             _padRenderer.Draw(_spriteBatch);
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawHitEffects()
         {
@@ -1521,7 +1518,6 @@ namespace DTXMania.Game.Lib.Stage
             _effectsManager?.Draw(_spriteBatch);
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawJudgementTexts()
         {
@@ -1529,7 +1525,6 @@ namespace DTXMania.Game.Lib.Stage
             _judgementTextPopupManager?.Draw(_spriteBatch);
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawUIElements()
         {

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -99,6 +99,8 @@ namespace DTXMania.Game.Lib.Stage
             _uiManager?.Update(deltaTime);
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
             if (_spriteBatch == null)
@@ -223,13 +225,15 @@ namespace DTXMania.Game.Lib.Stage
 
         #region Drawing
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawBackground()
         {
             var viewport = GetBackgroundViewport();
 
             // Draw DTXManiaNX authentic background graphics (8_background.jpg)
             DrawStageBackground(_spriteBatch);
-            
+
             // Draw fallback if no background loaded
             if (!IsBackgroundReady)
             {

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -99,7 +99,6 @@ namespace DTXMania.Game.Lib.Stage
             _uiManager?.Update(deltaTime);
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
@@ -225,7 +224,6 @@ namespace DTXMania.Game.Lib.Stage
 
         #region Drawing
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawBackground()
         {

--- a/DTXMania.Game/Lib/Stage/SongTransitionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongTransitionStage.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -579,11 +580,13 @@ namespace DTXMania.Game.Lib.Stage
             UpdatePhase();
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
             if (_spriteBatch == null)
                 return;
-            
+
             _spriteBatch.Begin();
             
             // Draw background
@@ -640,6 +643,8 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawText()
         {
             try
@@ -675,11 +680,13 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
         
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawDifficultyBackground()
         {
             if (_whitePixel == null)
                 return;
-            
+
             try
             {
                 // Draw grey background rectangle using layout configuration
@@ -696,6 +703,8 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
         
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawDifficultySprite()
         {
             if (_difficultySprite == null)

--- a/DTXMania.Game/Lib/Stage/SongTransitionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongTransitionStage.cs
@@ -580,7 +580,6 @@ namespace DTXMania.Game.Lib.Stage
             UpdatePhase();
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
@@ -643,7 +642,6 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawText()
         {
@@ -680,7 +678,6 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
         
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawDifficultyBackground()
         {
@@ -703,7 +700,6 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
         
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawDifficultySprite()
         {

--- a/DTXMania.Game/Lib/Stage/TitleStage.cs
+++ b/DTXMania.Game/Lib/Stage/TitleStage.cs
@@ -139,7 +139,6 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
@@ -570,7 +569,6 @@ namespace DTXMania.Game.Lib.Stage
 
         // Background drawing is now handled by BaseStage
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawVersionInfo()
         {
@@ -627,7 +625,6 @@ namespace DTXMania.Game.Lib.Stage
             DrawMenuCursor(baseY, animationOffset);
         }
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawMenuItemFromTexture(int menuIndex, int x, int y, int textureRow)
         {
@@ -724,7 +721,6 @@ namespace DTXMania.Game.Lib.Stage
 
 
 
-        /// <summary>Pure draw method; no logic to assert.</summary>
         [ExcludeFromCodeCoverage]
         private void DrawTextRect(int x, int y, int width, int height, Color color)
         {

--- a/DTXMania.Game/Lib/Stage/TitleStage.cs
+++ b/DTXMania.Game/Lib/Stage/TitleStage.cs
@@ -8,6 +8,7 @@ using DTXMania.Game.Lib.UI;
 using DTXMania.Game;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DTXMania.Game.Lib.Stage
 {
@@ -138,6 +139,8 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         protected override void OnDraw(double deltaTime)
         {
             if (_spriteBatch == null)
@@ -567,6 +570,8 @@ namespace DTXMania.Game.Lib.Stage
 
         // Background drawing is now handled by BaseStage
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawVersionInfo()
         {
             // Draw version info in top-left corner (DTXMania pattern)
@@ -622,6 +627,8 @@ namespace DTXMania.Game.Lib.Stage
             DrawMenuCursor(baseY, animationOffset);
         }
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawMenuItemFromTexture(int menuIndex, int x, int y, int textureRow)
         {
             if (_menuTexture == null)
@@ -717,6 +724,8 @@ namespace DTXMania.Game.Lib.Stage
 
 
 
+        /// <summary>Pure draw method; no logic to assert.</summary>
+        [ExcludeFromCodeCoverage]
         private void DrawTextRect(int x, int y, int width, int height, Color color)
         {
             if (_whitePixel != null)

--- a/DTXMania.Test/Resources/ManagedFontCollectionDefinition.cs
+++ b/DTXMania.Test/Resources/ManagedFontCollectionDefinition.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace DTXMania.Test.Resources;
+
+[CollectionDefinition("ManagedFont", DisableParallelization = true)]
+public sealed class ManagedFontCollectionDefinition
+{
+}

--- a/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
@@ -17,6 +17,7 @@ namespace DTXMania.Test.Stage.Performance
     /// These tests use FormatterServices to bypass the graphics-requiring constructors
     /// and test the pure state/logic portions of these components.
     /// </summary>
+    [Collection("ManagedFont")]
     [Trait("Category", "Performance")]
     public class DisplayComponentStateTests
     {

--- a/DTXMania.Test/Stage/Performance/PerformanceRendererStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceRendererStateTests.cs
@@ -525,6 +525,21 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Null(exception);
         }
 
+        [Theory]
+        [InlineData(-1, 4, false)]
+        [InlineData(0, 4, true)]
+        [InlineData(3, 4, true)]
+        [InlineData(4, 4, false)]
+        [InlineData(100, 4, false)]
+        [InlineData(0, 0, false)]
+        [InlineData(0, 1, true)]
+        public void IsValidFrameIndex_ShouldValidateBounds(int frameIndex, int totalSprites, bool expected)
+        {
+            var result = EffectsManager.IsValidFrameIndex(frameIndex, totalSprites);
+
+            Assert.Equal(expected, result);
+        }
+
         [Fact]
         public void Dispose_ShouldDisposeHitTextureAndClearActiveEffects()
         {

--- a/DTXMania.Test/Utilities/AppPathsCollectionDefinition.cs
+++ b/DTXMania.Test/Utilities/AppPathsCollectionDefinition.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace DTXMania.Test.Utilities;
+
+[CollectionDefinition("AppPaths", DisableParallelization = true)]
+public sealed class AppPathsCollectionDefinition
+{
+}

--- a/DTXMania.Test/Utilities/AppPathsTests.cs
+++ b/DTXMania.Test/Utilities/AppPathsTests.cs
@@ -6,6 +6,7 @@ using DTXMania.Game.Lib.Utilities;
 
 namespace DTXMania.Test.Utilities;
 
+[Collection("AppPaths")]
 public class AppPathsTests
 {
     [Fact]

--- a/DTXMania.Test/Utilities/AppPathsTests.cs
+++ b/DTXMania.Test/Utilities/AppPathsTests.cs
@@ -118,6 +118,69 @@ public class AppPathsTests
     }
 
     [Fact]
+    public void GetAppDataRoot_ShouldReturnRootedPathEndingInAppName()
+    {
+        var root = AppPaths.GetAppDataRoot();
+
+        Assert.False(string.IsNullOrWhiteSpace(root));
+        Assert.True(Path.IsPathRooted(root));
+        Assert.Equal("DTXManiaCX", Path.GetFileName(root.TrimEnd(Path.DirectorySeparatorChar)));
+    }
+
+    [Fact]
+    public void GetAppDataRoot_OnRepeatedCalls_ShouldBeIdempotent()
+    {
+        var a = AppPaths.GetAppDataRoot();
+        var b = AppPaths.GetAppDataRoot();
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void GetHomeDirectoryInternal_ShouldResolveNonEmptyHomeDirectory()
+    {
+        var method = typeof(AppPaths).GetMethod("GetHomeDirectory", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var home = (string)method!.Invoke(null, null)!;
+
+        Assert.False(string.IsNullOrWhiteSpace(home));
+        Assert.True(Path.IsPathRooted(home));
+    }
+
+    [Fact]
+    public void ExpandHomePath_WhenHomeDirectoryUnavailable_ShouldReturnOriginalPath()
+    {
+        var method = typeof(AppPaths).GetMethod("ExpandHomePath", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var savedHome = Environment.GetEnvironmentVariable("HOME");
+        var savedUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        try
+        {
+            Environment.SetEnvironmentVariable("HOME", "");
+            Environment.SetEnvironmentVariable("USERPROFILE", "");
+
+            // When UserProfile + Personal + HOME all yield an empty string the helper
+            // bails out and returns the original tilde-prefixed path unchanged.
+            var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var personal = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            if (!string.IsNullOrWhiteSpace(profile) || !string.IsNullOrWhiteSpace(personal))
+            {
+                return; // Cannot force the null-home branch on this OS; skip without failing.
+            }
+
+            var expanded = (string)method!.Invoke(null, new object[] { "~/Songs" })!;
+            Assert.Equal("~/Songs", expanded);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("HOME", savedHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", savedUserProfile);
+        }
+    }
+
+    [Fact]
     public void EnsureDirectory_ShouldCreateDirectoryAndIgnoreBlankPath()
     {
         var root = Path.Combine(Path.GetTempPath(), "dtx-app-path-tests", Guid.NewGuid().ToString("N"));

--- a/DTXMania.Test/Utilities/AppPathsTests.cs
+++ b/DTXMania.Test/Utilities/AppPathsTests.cs
@@ -6,6 +6,7 @@ using DTXMania.Game.Lib.Utilities;
 
 namespace DTXMania.Test.Utilities;
 
+[Trait("Category", "Unit")]
 public class AppPathsTests
 {
     [Fact]
@@ -240,6 +241,7 @@ public class AppPathsTests
     }
 }
 
+[Trait("Category", "Unit")]
 [Collection("AppPaths")]
 public class AppPathsEnvironmentTests
 {

--- a/DTXMania.Test/Utilities/AppPathsTests.cs
+++ b/DTXMania.Test/Utilities/AppPathsTests.cs
@@ -6,7 +6,6 @@ using DTXMania.Game.Lib.Utilities;
 
 namespace DTXMania.Test.Utilities;
 
-[Collection("AppPaths")]
 public class AppPathsTests
 {
     [Fact]
@@ -150,38 +149,6 @@ public class AppPathsTests
     }
 
     [Fact]
-    public void ExpandHomePath_WhenHomeDirectoryUnavailable_ShouldReturnOriginalPath()
-    {
-        var method = typeof(AppPaths).GetMethod("ExpandHomePath", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
-        var savedHome = Environment.GetEnvironmentVariable("HOME");
-        var savedUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
-        try
-        {
-            Environment.SetEnvironmentVariable("HOME", "");
-            Environment.SetEnvironmentVariable("USERPROFILE", "");
-
-            // When UserProfile + Personal + HOME all yield an empty string the helper
-            // bails out and returns the original tilde-prefixed path unchanged.
-            var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var personal = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-            if (!string.IsNullOrWhiteSpace(profile) || !string.IsNullOrWhiteSpace(personal))
-            {
-                return; // Cannot force the null-home branch on this OS; skip without failing.
-            }
-
-            var expanded = (string)method!.Invoke(null, new object[] { "~/Songs" })!;
-            Assert.Equal("~/Songs", expanded);
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("HOME", savedHome);
-            Environment.SetEnvironmentVariable("USERPROFILE", savedUserProfile);
-        }
-    }
-
-    [Fact]
     public void EnsureDirectory_ShouldCreateDirectoryAndIgnoreBlankPath()
     {
         var root = Path.Combine(Path.GetTempPath(), "dtx-app-path-tests", Guid.NewGuid().ToString("N"));
@@ -270,5 +237,55 @@ public class AppPathsTests
         }
 
         return home;
+    }
+}
+
+[Collection("AppPaths")]
+public class AppPathsEnvironmentTests
+{
+    /// <summary>
+    /// After clearing HOME/USERPROFILE env vars, checks whether the null-home fallback
+    /// branch can be exercised. On most CI runners, SpecialFolder.UserProfile/Personal
+    /// still resolve, so the fallback cannot be forced. The test asserts the actual
+    /// behavior observed: if SpecialFolders resolve, expansion succeeds; if they don't,
+    /// the original tilde path is returned unchanged.
+    /// </summary>
+    [Fact]
+    public void ExpandHomePath_WhenHomeDirectoryUnavailable_ShouldReturnOriginalPath()
+    {
+        var method = typeof(AppPaths).GetMethod("ExpandHomePath", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var savedHome = Environment.GetEnvironmentVariable("HOME");
+        var savedUserProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        try
+        {
+            Environment.SetEnvironmentVariable("HOME", "");
+            Environment.SetEnvironmentVariable("USERPROFILE", "");
+
+            var profile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var personal = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+
+            if (string.IsNullOrWhiteSpace(profile) && string.IsNullOrWhiteSpace(personal))
+            {
+                // Null-home branch can be exercised: expansion should return original path
+                var expanded = (string)method!.Invoke(null, new object[] { "~/Songs" })!;
+                Assert.Equal("~/Songs", expanded);
+            }
+            else
+            {
+                // SpecialFolders still resolve on this platform — the null-home fallback
+                // cannot be forced. Verify that expansion uses the resolved home instead.
+                var home = profile;
+                if (string.IsNullOrWhiteSpace(home)) home = personal;
+                var expanded = (string)method!.Invoke(null, new object[] { "~/Songs" })!;
+                Assert.Equal(Path.Combine(home, "Songs"), expanded);
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("HOME", savedHome);
+            Environment.SetEnvironmentVariable("USERPROFILE", savedUserProfile);
+        }
     }
 }

--- a/docs/superpowers/plans/2026-05-14-unit-test-coverage-90.md
+++ b/docs/superpowers/plans/2026-05-14-unit-test-coverage-90.md
@@ -1,0 +1,1128 @@
+# Unit Test Coverage to 90% — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise line coverage on `DTXMania.Game.Mac` / `DTXMania.Game` from 81.92% to ≥ 90% via a single sweeping PR.
+
+**Architecture:** Three-pillar strategy — (1) direct xUnit + Moq tests for testable logic, (2) `[ExcludeFromCodeCoverage]` on genuinely graphics-bound methods, (3) targeted extraction of testable logic out of the four worst offenders (`SongStatusPanel`, `SongBarRenderer`, `PerformanceStage`, `SongSelectionStage`). The Windows full suite is the gating coverage metric.
+
+**Tech Stack:** .NET 8, MonoGame 3.8, xUnit, Moq, Coverlet, ReportGenerator (optional, for local viewing).
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-unit-test-coverage-90-design.md`](../specs/2026-05-14-unit-test-coverage-90-design.md)
+
+---
+
+## Conventions Used Throughout This Plan
+
+- **Test files** live under `DTXMania.Test/<MirrorOfSourceDir>/<ClassName>CoverageTests.cs` (or `<ClassName>Tests.cs` when there is no existing file). Mirror the source directory layout.
+- **Test method naming:** `Scenario_ShouldExpect` (e.g., `GetAppDataRoot_OnLinux_ShouldReturnXdgConfigDir`).
+- **Tests requiring `GraphicsDevice`** must be excluded from `DTXMania.Test/DTXMania.Test.Mac.csproj` by adding the file path to the `<Compile Include>` exclusion block. See CLAUDE.md for the existing list.
+- **`[ExcludeFromCodeCoverage]`** uses `using System.Diagnostics.CodeAnalysis;` and is always applied at the **method level**, with a one-line XML comment such as `/// <summary>Pure draw method; no logic to assert.</summary>`. Never apply at the class level.
+- **Commit style:** Conventional Commits (`test:`, `refactor:`, `chore:`), subject under 72 chars, imperative mood. Frequent commits — one per task minimum.
+- **Verification command (Mac):**
+  ```bash
+  dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+    --collect:"XPlat Code Coverage" \
+    --settings coverlet.runsettings \
+    --results-directory ./TestResults
+  ```
+- **Coverage rate command (Mac):** after running tests, parse the freshest `coverage.cobertura.xml`:
+  ```bash
+  python3 -c "import xml.etree.ElementTree as ET, glob, os; \
+    f=max(glob.glob('TestResults/*/coverage.cobertura.xml'), key=os.path.getmtime); \
+    r=ET.parse(f).getroot(); \
+    print(f'{f}: line={float(r.get(\"line-rate\"))*100:.2f}% branch={float(r.get(\"branch-rate\"))*100:.2f}%')"
+  ```
+
+---
+
+## Phase 0 — Baseline & Tooling
+
+### Task 1: Capture Mac coverage baseline
+
+**Files:**
+- No file changes; this records the starting point.
+
+- [ ] **Step 1: Run the Mac test suite with coverage**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --collect:"XPlat Code Coverage" \
+  --settings coverlet.runsettings \
+  --results-directory ./TestResults
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Record the baseline**
+
+```bash
+python3 -c "import xml.etree.ElementTree as ET, glob, os; \
+  f=max(glob.glob('TestResults/*/coverage.cobertura.xml'), key=os.path.getmtime); \
+  r=ET.parse(f).getroot(); \
+  print(f'BASELINE-MAC: line={float(r.get(\"line-rate\"))*100:.2f}% branch={float(r.get(\"branch-rate\"))*100:.2f}% lines={r.get(\"lines-covered\")}/{r.get(\"lines-valid\")}')"
+```
+
+Expected output similar to: `BASELINE-MAC: line=81.92% branch=78.16% lines=18285/22320`.
+
+Save this output to a scratch note (do not commit). It is the reference point for verifying progress.
+
+- [ ] **Step 3: Identify per-file gaps**
+
+```bash
+python3 <<'EOF'
+import xml.etree.ElementTree as ET, glob, os
+f=max(glob.glob('TestResults/*/coverage.cobertura.xml'), key=os.path.getmtime)
+root=ET.parse(f).getroot()
+fd={}
+for cls in root.iter('class'):
+    fn=cls.get('filename')
+    lv=lc=0
+    for ln in cls.iter('line'):
+        lv+=1
+        if int(ln.get('hits','0'))>0: lc+=1
+    if fn not in fd: fd[fn]=[0,0]
+    fd[fn][0]+=lc; fd[fn][1]+=lv
+for fn,(lc,lv) in sorted(fd.items(), key=lambda x:-(x[1][1]-x[1][0]))[:30]:
+    if lv: print(f'{fn:<80} {lc/lv*100:6.1f}% missing={lv-lc:>5}')
+EOF
+```
+
+Save this list to a scratch note. It tells you which files to target during Phase 4.
+
+### Task 2: Capture Windows coverage baseline
+
+**Files:**
+- No file changes; this confirms the gating-metric starting point.
+
+- [ ] **Step 1: Locate the latest Windows CI coverage**
+
+Open GitHub Actions, find the most recent successful run of `.github/workflows/build-and-test.yml` on `main`. The Windows job uploads coverage to codecov; record the codecov line-rate for `DTXMania.Game` on the gating metric.
+
+- [ ] **Step 2: If codecov is unavailable, run locally on a Windows machine**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura \
+  /p:CoverletOutput=./TestResults/windows-baseline.cobertura.xml
+```
+
+- [ ] **Step 3: Decide scope adjustment**
+
+- If Windows ≥ 90% already, narrow this plan: skip exclusions/tests for files where Windows alone is sufficient, and focus on what is needed for Mac.
+- If Windows < 82%, expand the plan as needed — note any Windows-only files that need extra tests.
+- Save the Windows baseline number alongside the Mac baseline.
+
+- [ ] **Step 4: No commit**
+
+This task produces a note only; nothing is committed.
+
+---
+
+## Phase 1 — Pillar 1: Low-risk tests for testable logic
+
+Each task in this phase follows the same recipe:
+1. Inspect the target file to find uncovered behaviors (use the per-file gap list from Task 1 Step 3 + `grep -n` to locate methods).
+2. Write `Scenario_ShouldExpect` tests covering specific uncovered behaviors.
+3. Run tests; verify pass.
+4. Re-run coverage; confirm rate increased for that file.
+5. Commit.
+
+### Task 3: Cover `AppPaths` cross-platform branches
+
+**Files:**
+- Modify: `DTXMania.Test/Utilities/AppPathsTests.cs` (create if missing)
+- Source under test: `DTXMania.Game/Lib/Utilities/AppPaths.cs` (currently 74.2%, missing 50)
+
+- [ ] **Step 1: Write failing tests for OS-branch fallback paths**
+
+Create `DTXMania.Test/Utilities/AppPathsTests.cs`. Cover at least these cases. If a directory already exists, add only the missing scenarios.
+
+```csharp
+using System;
+using System.IO;
+using DTXMania.Game.Lib.Utilities;
+using Xunit;
+
+namespace DTXMania.Test.Utilities
+{
+    public class AppPathsTests
+    {
+        [Fact]
+        public void GetAppDataRoot_ShouldReturnAbsolutePath()
+        {
+            var root = AppPaths.GetAppDataRoot();
+            Assert.False(string.IsNullOrWhiteSpace(root));
+            Assert.True(Path.IsPathRooted(root));
+            Assert.Contains("DTXManiaCX", root);
+        }
+
+        [Fact]
+        public void GetAppDataRoot_OnSecondCall_ShouldReturnSameValue()
+        {
+            var a = AppPaths.GetAppDataRoot();
+            var b = AppPaths.GetAppDataRoot();
+            Assert.Equal(a, b);
+        }
+
+        [Fact]
+        public void GetAppDataRoot_ShouldEnsureDirectoryCreatable()
+        {
+            var root = AppPaths.GetAppDataRoot();
+            Assert.True(Directory.Exists(root) || Directory.CreateDirectory(root).Exists);
+        }
+    }
+}
+```
+
+Also add tests for any other public methods on `AppPaths` (e.g., subdirectory helpers, environment-variable handling). Inspect the file with `grep -n "public " DTXMania.Game/Lib/Utilities/AppPaths.cs` to enumerate the public surface.
+
+- [ ] **Step 2: Run the new tests**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~AppPathsTests"
+```
+
+Expected: all new tests pass.
+
+- [ ] **Step 3: Re-run coverage**
+
+Use the verification + rate commands from "Conventions Used Throughout This Plan". `AppPaths.cs` should be at ≥ 90%.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Test/Utilities/AppPathsTests.cs
+git commit -m "test: cover AppPaths cross-platform branches"
+```
+
+### Task 4: Cover `ResourceManager` edge cases
+
+**Files:**
+- Modify: `DTXMania.Test/Resources/ResourceManagerCoverageTests.cs` (create if missing)
+- Source under test: `DTXMania.Game/Lib/Resources/ResourceManager.cs` (currently 86.8%, missing 132)
+
+- [ ] **Step 1: Identify uncovered branches**
+
+Inspect `ResourceManager.cs` for these behaviors that are commonly under-tested: cache-eviction, AddReference/RemoveReference symmetry, dispose on shutdown, missing-resource error paths, statistics counter updates, skin-fallback chain miss. Use `git blame` and `grep -n` to find them.
+
+- [ ] **Step 2: Add tests**
+
+Write tests targeting each uncovered behavior. Use Moq to inject `IGraphicsDevice` and skin discovery stubs where needed. Example pattern (adapt to actual constructor signature):
+
+```csharp
+[Fact]
+public void RemoveReference_WhenCountReachesZero_ShouldDisposeUnderlyingResource()
+{
+    var mockDevice = new Mock<IGraphicsDevice>();
+    var mgr = new ResourceManager(mockDevice.Object, /* skinManager */ ...);
+    var key = "test.png";
+    var first = mgr.LoadTexture(key);
+    mgr.RemoveReference(key);
+    Assert.False(mgr.TryGetTexture(key, out _));
+}
+
+[Fact]
+public void LoadTexture_WhenFileMissing_ShouldReturnFallbackOrThrow()
+{
+    var mgr = MakeResourceManager();
+    Action act = () => mgr.LoadTexture("does_not_exist.png");
+    Assert.Throws<FileNotFoundException>(act);  // or assert fallback texture, depending on actual behavior
+}
+```
+
+The exact assertions follow the file's existing behavior. Read the source first; do **not** invent behavior. If a test seems to encode a new behavior, stop and re-check the source.
+
+- [ ] **Step 3: Run & verify**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResourceManagerCoverageTests"
+```
+
+- [ ] **Step 4: Re-run coverage; `ResourceManager.cs` should be ≥ 94%.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Test/Resources/ResourceManagerCoverageTests.cs
+git commit -m "test: cover ResourceManager reference-count and miss paths"
+```
+
+### Task 5: Cover `JsonRpcServer` error paths
+
+**Files:**
+- Modify: `DTXMania.Test/JsonRpc/JsonRpcServerCoverageTests.cs` (create if missing)
+- Source under test: `DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs` (currently 91.9%, missing 84)
+
+- [ ] **Step 1: Inspect the file for uncovered branches**
+
+Run `grep -n "catch\|throw\|if (" DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs` and cross-reference with the cobertura per-line data to find the gaps. Typical untested paths: malformed JSON, missing `method` field, unknown method, request without `id` (notifications), oversized payloads, server-shutdown mid-request.
+
+- [ ] **Step 2: Add tests using `JsonRpcServer` in-process**
+
+```csharp
+[Fact]
+public async Task HandleRequest_WhenJsonMalformed_ShouldReturnParseError()
+{
+    var server = new JsonRpcServer(/* args */);
+    var response = await server.HandleRequestAsync("{not valid json");
+    var doc = JsonDocument.Parse(response);
+    Assert.Equal(-32700, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+}
+
+[Fact]
+public async Task HandleRequest_WhenMethodMissing_ShouldReturnInvalidRequest()
+{
+    var server = new JsonRpcServer(/* args */);
+    var response = await server.HandleRequestAsync("""{"jsonrpc":"2.0","id":1}""");
+    var doc = JsonDocument.Parse(response);
+    Assert.Equal(-32600, doc.RootElement.GetProperty("error").GetProperty("code").GetInt32());
+}
+```
+
+Adjust to actual public API. If the parse path is internal, expose via `InternalsVisibleTo` or test through `HandleRequestAsync` exclusively.
+
+- [ ] **Step 3: Run & verify**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerCoverageTests"
+```
+
+- [ ] **Step 4: Re-run coverage; `JsonRpcServer.cs` should be ≥ 96%.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Test/JsonRpc/JsonRpcServerCoverageTests.cs
+git commit -m "test: cover JsonRpcServer error and edge paths"
+```
+
+### Task 6: Cover `ConfigStage` non-Draw logic
+
+**Files:**
+- Modify: `DTXMania.Test/Stage/ConfigStageCoverageTests.cs` (already exists)
+- Source under test: `DTXMania.Game/Lib/Stage/ConfigStage.cs` (currently 86.1%, missing 132)
+
+- [ ] **Step 1: Identify uncovered branches**
+
+`ConfigStage` already has 4 `[ExcludeFromCodeCoverage]` attributes. Find the remaining gaps in **non-Draw** methods: menu navigation (`Update` branch on key inputs), config save/load handlers, validation logic.
+
+- [ ] **Step 2: Add tests using existing test patterns**
+
+Reuse the patterns already in `ConfigStageCoverageTests.cs`. Add new test methods covering the gaps; do not refactor existing tests.
+
+- [ ] **Step 3: Run & verify**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigStageCoverageTests"
+```
+
+- [ ] **Step 4: Re-run coverage; `ConfigStage.cs` should be ≥ 92%.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Test/Stage/ConfigStageCoverageTests.cs
+git commit -m "test: cover ConfigStage navigation and validation"
+```
+
+### Task 7: Cover `SkinManager` fallback chain
+
+**Files:**
+- Modify: `DTXMania.Test/Resources/SkinManagerCoverageTests.cs` (create if missing)
+- Source under test: `DTXMania.Game/Lib/Resources/SkinManager.cs` (currently 78.6%, missing 60)
+
+- [ ] **Step 1: Add tests for fallback resolution**
+
+```csharp
+[Fact]
+public void ResolveTexturePath_WhenInCurrentSkin_ShouldReturnCurrentSkinPath()
+{
+    var fs = MakeFakeFs(new[] { "/skins/MySkin/Graphics/foo.png" });
+    var mgr = new SkinManager(fs, currentSkin: "MySkin");
+    var resolved = mgr.ResolveTexturePath("Graphics/foo.png");
+    Assert.EndsWith("/skins/MySkin/Graphics/foo.png", resolved);
+}
+
+[Fact]
+public void ResolveTexturePath_WhenMissingFromCurrent_ShouldFallBackToSystem()
+{
+    var fs = MakeFakeFs(new[] { "/System/Graphics/foo.png" });
+    var mgr = new SkinManager(fs, currentSkin: "MySkin");
+    var resolved = mgr.ResolveTexturePath("Graphics/foo.png");
+    Assert.EndsWith("/System/Graphics/foo.png", resolved);
+}
+
+[Fact]
+public void ResolveTexturePath_WhenMissingEverywhere_ShouldReturnNullOrEmpty()
+{
+    var fs = MakeFakeFs(System.Array.Empty<string>());
+    var mgr = new SkinManager(fs, currentSkin: "MySkin");
+    var resolved = mgr.ResolveTexturePath("Graphics/nope.png");
+    Assert.True(string.IsNullOrEmpty(resolved));
+}
+```
+
+`MakeFakeFs` is a local helper using `Moq<IFileSystem>` (or whatever filesystem abstraction `SkinManager` accepts). If it accepts no abstraction, use `Path.GetTempPath()` + directory setup/teardown.
+
+- [ ] **Step 2: Run & verify**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SkinManagerCoverageTests"
+```
+
+- [ ] **Step 3: Re-run coverage; `SkinManager.cs` should be ≥ 92%.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Test/Resources/SkinManagerCoverageTests.cs
+git commit -m "test: cover SkinManager fallback chain"
+```
+
+---
+
+## Phase 2 — Pillar 3: Extract testable logic from worst offenders
+
+Each extraction follows this strict process:
+
+1. **Write characterization tests against the new class** — encoding the existing behavior. The new class doesn't exist yet; tests fail to compile. That's the failing-test state.
+2. **Create the new class** — moving the relevant methods/state out of the original file. Match signatures exactly so the original site can call into it.
+3. **Re-point the original site** — the original methods become thin shims that delegate, or are deleted entirely and call sites updated.
+4. **Run the full test suite** — every existing test must still pass. If anything fails, the extraction is not pure — fix and re-verify.
+5. **Commit refactor + tests together.**
+
+Pure-extraction rule: no behavior changes. If a method has a bug, leave it. The extracted class should produce identical output to the original code for identical inputs.
+
+### Task 8: Extract `SongStatusPanelLogic`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Components/SongStatusPanelLogic.cs`
+- Create: `DTXMania.Test/Song/Components/SongStatusPanelLogicTests.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs`
+
+**What moves** (read `SongStatusPanel.cs` to confirm before moving):
+
+- Per-difficulty selection state (`_currentDifficulty`, `UpdateSongInfo`, `GetCurrentScore`, `GetInstrumentFromDifficulty`).
+- Layout math (computed positions inside `DrawDifficultyGrid`, `DrawDifficultyCell` for cell coords).
+- Score-display formatting (computed strings inside `DrawSongInfo`, `DrawDTXManiaNXLayout`, `DrawSimplifiedInfo`, `DrawSongTypeInfo`, `DrawNotesCounter`).
+- BPM origin calculation (`GetBpmBackgroundOrigin`).
+- Decisions inside `DrawNoteDistributionBars`, `DrawProgressBar` (the arithmetic that produces bar widths/positions).
+
+**What stays in `SongStatusPanel.cs`:**
+
+- The actual `SpriteBatch.Draw` / `_renderer.Draw` calls.
+- `OnDraw`, all `DrawXxx` methods reduced to: call `SongStatusPanelLogic.ComputeXxx()`, then draw using the result.
+
+- [ ] **Step 1: Sketch the new class API**
+
+In the new file, define the public surface based on what the original code computes. Approximate shape:
+
+```csharp
+using DTXMania.Game.Lib.Song.Entities;
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    /// <summary>
+    /// Pure logic for SongStatusPanel — layout calculations, score formatting,
+    /// difficulty selection, and value derivation. No graphics device required.
+    /// </summary>
+    public class SongStatusPanelLogic
+    {
+        public int CurrentDifficulty { get; private set; }
+        public SongListNode CurrentSong { get; private set; }
+
+        public void UpdateSongInfo(SongListNode song, int difficulty) { /* ... */ }
+        public SongScore GetCurrentScore(SongListNode song, int difficulty) { /* ... */ }
+        public string GetInstrumentFromDifficulty(int difficulty) { /* ... */ }
+        public Vector2 GetBpmBackgroundOrigin(bool useStandalone) { /* ... */ }
+        public Rectangle GetDifficultyCellRect(Rectangle bounds, int gridRow, int instrumentColumn) { /* ... */ }
+        public string FormatBpm(double bpm) { /* ... */ }
+        public string FormatNotesCount(SongChart chart) { /* ... */ }
+        // ... add others as you identify them in the source
+    }
+}
+```
+
+- [ ] **Step 2: Write failing characterization tests**
+
+```csharp
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song.Components
+{
+    public class SongStatusPanelLogicTests
+    {
+        [Fact]
+        public void UpdateSongInfo_WithValidInputs_ShouldSetCurrentSongAndDifficulty()
+        {
+            var logic = new SongStatusPanelLogic();
+            var song = new SongListNode { Title = "Test" };
+            logic.UpdateSongInfo(song, 2);
+            Assert.Same(song, logic.CurrentSong);
+            Assert.Equal(2, logic.CurrentDifficulty);
+        }
+
+        [Fact]
+        public void GetInstrumentFromDifficulty_ShouldMapDifficultyToInstrumentName()
+        {
+            var logic = new SongStatusPanelLogic();
+            // Encode actual behavior from current implementation in SongStatusPanel.cs:1268
+            Assert.Equal(/* expected */, logic.GetInstrumentFromDifficulty(0));
+            // ... one test per difficulty value handled by the switch/branch
+        }
+
+        // Add at least one test for each public method on SongStatusPanelLogic.
+        // Each test must encode behavior already present in SongStatusPanel.cs.
+    }
+}
+```
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongStatusPanelLogicTests"`. Expected: build fails (class doesn't exist yet).
+
+- [ ] **Step 3: Implement `SongStatusPanelLogic`**
+
+Move the logic from `SongStatusPanel.cs` into the new file. For each method:
+- Open the original method in `SongStatusPanel.cs`.
+- Extract the pure-logic portion (e.g., the math that computes a `Rectangle`, the formatting that produces a `string`).
+- Place it in `SongStatusPanelLogic` with the same input types.
+- The original drawing code calls the new method, then passes the result to `SpriteBatch.Draw`.
+
+- [ ] **Step 4: Re-point `SongStatusPanel.cs`**
+
+Each affected method shrinks. Example shape for `DrawDifficultyCell`:
+
+```csharp
+private void DrawDifficultyCell(SpriteBatch spriteBatch, int x, int y, int gridRow, int instrument, ChartLevelInfo chartInfo)
+{
+    var bounds = GetCachedBounds();
+    var cellRect = _logic.GetDifficultyCellRect(bounds, gridRow, instrument);
+    spriteBatch.Draw(_difficultyFrameTexture.Texture, cellRect, Color.White);
+    DrawDifficultyCellContent(spriteBatch, cellRect.X, cellRect.Y, cellRect.Width, cellRect.Height, gridRow, instrument, chartInfo);
+}
+```
+
+Add a `private readonly SongStatusPanelLogic _logic = new();` field on `SongStatusPanel`. Where the panel used to read its own `_currentDifficulty`, it now reads `_logic.CurrentDifficulty`.
+
+- [ ] **Step 5: Run the full Mac suite**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: ALL existing tests pass + new `SongStatusPanelLogicTests` pass. If any existing test fails, the extraction is not pure. Diff what changed and fix.
+
+- [ ] **Step 6: Re-run coverage**
+
+`SongStatusPanel.cs` should drop in absolute line count (logic moved out). `SongStatusPanelLogic.cs` is added with ≥ 95% coverage. Overall coverage rate should rise by 2–4 percentage points.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongStatusPanelLogic.cs \
+        DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs \
+        DTXMania.Test/Song/Components/SongStatusPanelLogicTests.cs
+git commit -m "refactor: extract SongStatusPanelLogic for testability"
+```
+
+### Task 9: Extract `SongBarRenderLogic`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Components/SongBarRenderLogic.cs`
+- Create: `DTXMania.Test/Song/Components/SongBarRenderLogicTests.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/SongBarRenderer.cs`
+
+**What moves:** bar layout (Y coordinate per index, fade-in/scroll math), label truncation (string length given a max-pixel width), color selection (per song type / difficulty / state), and any decision logic embedded in current rendering methods.
+
+**What stays:** the `SpriteBatch.Draw` calls and font draws themselves.
+
+- [ ] **Step 1: Sketch the new class API**
+
+```csharp
+namespace DTXMania.Game.Lib.Song.Components
+{
+    public class SongBarRenderLogic
+    {
+        public int GetBarY(int barIndex, int selectedIndex, int barHeight, float scrollOffset) { /* ... */ }
+        public string TruncateLabel(string label, int maxPixelWidth, int charWidthEstimate) { /* ... */ }
+        public Color GetBarColor(SongListNode node, bool isSelected) { /* ... */ }
+        // Add methods to mirror each logic block in SongBarRenderer.cs
+    }
+}
+```
+
+- [ ] **Step 2: Write failing characterization tests**
+
+```csharp
+public class SongBarRenderLogicTests
+{
+    [Fact]
+    public void GetBarY_AtSelectedIndex_ShouldReturnSelectedRowCoordinate()
+    {
+        var logic = new SongBarRenderLogic();
+        var y = logic.GetBarY(barIndex: 5, selectedIndex: 5, barHeight: 40, scrollOffset: 0f);
+        Assert.Equal(/* expected from current code */, y);
+    }
+
+    [Fact]
+    public void TruncateLabel_WhenFitsInWidth_ShouldReturnInputUnchanged()
+    {
+        var logic = new SongBarRenderLogic();
+        Assert.Equal("hello", logic.TruncateLabel("hello", maxPixelWidth: 200, charWidthEstimate: 10));
+    }
+
+    [Fact]
+    public void TruncateLabel_WhenExceedsWidth_ShouldAppendEllipsisOrTruncate()
+    {
+        var logic = new SongBarRenderLogic();
+        var result = logic.TruncateLabel("hello world", maxPixelWidth: 30, charWidthEstimate: 10);
+        Assert.True(result.Length <= "hello".Length);
+    }
+
+    // Add one test per behavior identified in the source.
+}
+```
+
+Run; expect compile failure.
+
+- [ ] **Step 3: Implement `SongBarRenderLogic`**
+
+Move logic out of `SongBarRenderer.cs`. The renderer keeps its field for the logic instance and calls into it before drawing.
+
+- [ ] **Step 4: Re-point `SongBarRenderer.cs`**
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Re-run coverage; rate should rise 1–2 percentage points.**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongBarRenderLogic.cs \
+        DTXMania.Game/Lib/Song/Components/SongBarRenderer.cs \
+        DTXMania.Test/Song/Components/SongBarRenderLogicTests.cs
+git commit -m "refactor: extract SongBarRenderLogic for testability"
+```
+
+### Task 10: Extract `PerformanceStageLoader`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Performance/PerformanceStageLoader.cs`
+- Create: `DTXMania.Test/Stage/Performance/PerformanceStageLoaderTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+
+**What moves:** the song-load pipeline — chart parsing kickoff, BGM file resolution (path lookup, fallback rules), audio-pre-load scheduling. This is the discrete chunk of `PerformanceStage` that runs on activation and produces a `LoadedSong` result.
+
+**What stays:** `OnActivate` itself still orchestrates, but delegates to `PerformanceStageLoader.LoadAsync(...)`.
+
+- [ ] **Step 1: Identify the load pipeline in `PerformanceStage.cs`**
+
+Run `grep -n "OnActivate\|LoadChart\|LoadBgm\|LoadAudio" DTXMania.Game/Lib/Stage/PerformanceStage.cs`. The contiguous block(s) of code that perform loading are what moves. If loading is mixed with state assignment on `PerformanceStage` fields, the loader returns a `LoadResult` record and the stage applies the result.
+
+- [ ] **Step 2: Sketch the API**
+
+```csharp
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    public class PerformanceStageLoader
+    {
+        private readonly IResourceManager _resources;
+        private readonly DTXChartParser _parser;
+
+        public PerformanceStageLoader(IResourceManager resources, DTXChartParser parser)
+        { _resources = resources; _parser = parser; }
+
+        public LoadResult Load(string chartPath) { /* ... */ }
+    }
+
+    public record LoadResult(ParsedChart Chart, string BgmPath, /* ... */);
+}
+```
+
+Exact types depend on the source; do not invent fields.
+
+- [ ] **Step 3: Write failing characterization tests using mocks**
+
+```csharp
+public class PerformanceStageLoaderTests
+{
+    [Fact]
+    public void Load_WithValidChartPath_ShouldReturnParsedChartAndResolvedBgmPath()
+    {
+        var resources = new Mock<IResourceManager>();
+        var parser = new DTXChartParser(/* args */);
+        var loader = new PerformanceStageLoader(resources.Object, parser);
+
+        var result = loader.Load("TestData/sample.dtx");
+
+        Assert.NotNull(result.Chart);
+        Assert.False(string.IsNullOrEmpty(result.BgmPath));
+    }
+
+    [Fact]
+    public void Load_WhenBgmMissing_ShouldFallBackOrReturnEmptyBgmPath()
+    {
+        // Encode actual behavior from PerformanceStage.cs current code.
+    }
+}
+```
+
+- [ ] **Step 4: Implement the loader**
+
+- [ ] **Step 5: Re-point `PerformanceStage.OnActivate`** to call `_loader.Load(chartPath)` and consume `LoadResult`.
+
+- [ ] **Step 6: Run full suite**
+
+Expected: all pass.
+
+- [ ] **Step 7: Re-run coverage; `PerformanceStage.cs` shrinks; `PerformanceStageLoader.cs` covered.**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/PerformanceStageLoader.cs \
+        DTXMania.Game/Lib/Stage/PerformanceStage.cs \
+        DTXMania.Test/Stage/Performance/PerformanceStageLoaderTests.cs
+git commit -m "refactor: extract PerformanceStageLoader for testability"
+```
+
+If the loader turns out to be too entangled to extract cleanly, **stop after one good-faith attempt**, revert, and document the obstacle in the commit message of a `chore:` commit. Then skip to Task 11 (end flow) which is more decoupled. The plan's risk-mitigation budget permits this.
+
+### Task 11: Extract `PerformanceStageEndFlow`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Performance/PerformanceStageEndFlow.cs`
+- Create: `DTXMania.Test/Stage/Performance/PerformanceStageEndFlowTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+
+**What moves:** the end-of-song flow — deciding when the song is over (final note + tail time + audio finished), assembling the `ResultStage`'s input, and the transition trigger logic. State-machine logic, no graphics.
+
+- [ ] **Step 1: Identify the end-flow code in `PerformanceStage.cs`**
+
+`grep -n "Result\|EndOfSong\|FinalNote\|TransitionTo" DTXMania.Game/Lib/Stage/PerformanceStage.cs`. Contiguous logic is what moves.
+
+- [ ] **Step 2: Sketch the API**
+
+```csharp
+public class PerformanceStageEndFlow
+{
+    public EndState Step(double currentSongTimeMs, bool audioStillPlaying, int notesRemaining) { /* ... */ }
+    public ResultStageInput BuildResult(ScoreSnapshot score, ComboSnapshot combo, /* ... */) { /* ... */ }
+}
+
+public enum EndState { Playing, Tailing, ReadyForResult }
+```
+
+- [ ] **Step 3: Write failing tests for state transitions**
+
+```csharp
+[Fact]
+public void Step_WhenNotesRemainAndAudioPlaying_ShouldReturnPlaying()
+[Fact]
+public void Step_WhenAllNotesDoneButAudioPlaying_ShouldReturnTailing()
+[Fact]
+public void Step_WhenAllNotesDoneAndAudioFinished_ShouldReturnReadyForResult()
+[Fact]
+public void BuildResult_ShouldPopulateResultStageInputFromSnapshots()
+```
+
+- [ ] **Step 4: Implement `PerformanceStageEndFlow`**
+
+- [ ] **Step 5: Re-point `PerformanceStage.Update`** to consult the new state machine.
+
+- [ ] **Step 6: Run full suite; verify pass.**
+
+- [ ] **Step 7: Re-run coverage.**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/PerformanceStageEndFlow.cs \
+        DTXMania.Game/Lib/Stage/PerformanceStage.cs \
+        DTXMania.Test/Stage/Performance/PerformanceStageEndFlowTests.cs
+git commit -m "refactor: extract PerformanceStageEndFlow state machine"
+```
+
+---
+
+## Phase 3 — Pillar 1 continued: remaining test gaps
+
+### Task 12: Cover `SongManager` edge cases
+
+**Files:**
+- Modify: `DTXMania.Test/Song/SongManagerCoverageTests.cs` (already exists)
+- Source under test: `DTXMania.Game/Lib/Song/SongManager.cs` (currently 94.8%, missing 152)
+
+- [ ] **Step 1: Inspect uncovered branches**
+
+Use the per-file gap data from Task 1 Step 3. Common gaps in singletons: locking paths under contention, re-initialization, edge cases in collection mutation, error paths in DB load.
+
+- [ ] **Step 2: Add tests**
+
+Add tests targeting each uncovered behavior. Use the existing `SongManagerCollectionDefinition` xUnit collection if singleton isolation matters.
+
+- [ ] **Step 3: Run, verify, commit**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongManager"
+git add DTXMania.Test/Song/SongManagerCoverageTests.cs
+git commit -m "test: cover SongManager edge cases"
+```
+
+`SongManager.cs` target: ≥ 98%.
+
+### Task 13: Cover `ModularInputManager` paths
+
+**Files:**
+- Modify: `DTXMania.Test/Input/ModularInputManagerTests.cs` (create if missing)
+- Source under test: `DTXMania.Game/Lib/Input/ModularInputManager.cs` (currently 86.1%, missing 68)
+
+- [ ] **Step 1: Identify uncovered branches**
+
+Likely candidates: source-priority switching, source-disable handling, duplicate-event suppression, repeat-key timing.
+
+- [ ] **Step 2: Add tests using `Mock<IInputSource>`**
+
+```csharp
+[Fact]
+public void Update_WithMultipleSources_ShouldMergeStatesInDeclaredOrder()
+{
+    var src1 = new Mock<IInputSource>();
+    var src2 = new Mock<IInputSource>();
+    src1.Setup(x => x.IsKeyPressed(Keys.A)).Returns(false);
+    src2.Setup(x => x.IsKeyPressed(Keys.A)).Returns(true);
+    var mgr = new ModularInputManager(new[] { src1.Object, src2.Object });
+    mgr.Update();
+    Assert.True(mgr.IsKeyPressed(Keys.A));
+}
+```
+
+- [ ] **Step 3: Run, verify, commit**
+
+```bash
+git add DTXMania.Test/Input/ModularInputManagerTests.cs
+git commit -m "test: cover ModularInputManager source merging and edge cases"
+```
+
+`ModularInputManager.cs` target: ≥ 94%.
+
+### Task 14: Cover `DTXChartParser` and supporting code
+
+**Files:**
+- Modify: `DTXMania.Test/Song/DTXChartParserAdditionalTests.cs` (already exists)
+- Source under test: `DTXMania.Game/Lib/Song/DTXChartParser.cs` (currently 90.0%, missing 128)
+
+- [ ] **Step 1: Identify uncovered branches**
+
+The 128 missing lines likely live in: rare channel handlers, malformed-line tolerance paths, encoding-detection branches, BPM-change handling at unusual positions. Cross-reference cobertura per-line data.
+
+- [ ] **Step 2: Add tests with crafted `.dtx` snippets**
+
+Place fixtures under `DTXMania.Test/TestData/` (existing pattern). One fixture per behavior.
+
+```csharp
+[Fact]
+public void Parse_WithMalformedHeader_ShouldSkipLineAndContinue()
+{
+    var raw = "#TITLE Test\n#BPMnot-a-number\n#WAV01 hi.wav\n#00111: 01";
+    var chart = DTXChartParser.Parse(raw);
+    Assert.Equal("Test", chart.Title);
+    Assert.Single(chart.Notes);
+}
+
+[Fact]
+public void Parse_WithBpmChangeMidSong_ShouldRecordBpmChange()
+{
+    // Encode actual current behavior using a fixture
+}
+```
+
+- [ ] **Step 3: Run, verify, commit**
+
+```bash
+git add DTXMania.Test/Song/DTXChartParserAdditionalTests.cs DTXMania.Test/TestData/*
+git commit -m "test: cover DTXChartParser tolerance and BPM change paths"
+```
+
+`DTXChartParser.cs` target: ≥ 95%.
+
+### Task 15: Cover remaining Pillar-1 stragglers
+
+**Files:**
+- Modify or create:
+  - `DTXMania.Test/Song/SongDatabaseServiceCoverageTests.cs` (already exists)
+  - `DTXMania.Test/UI/DefaultGraphicsGeneratorTests.cs` (create if missing)
+  - `DTXMania.Test/Song/Components/PreviewImagePanelTests.cs` (create if missing)
+
+Source targets:
+- `Lib/Song/Entities/SongDatabaseService.cs` (84.1%, missing 150) — DB upsert paths, error handling, schema migration edges.
+- `Lib/UI/DefaultGraphicsGenerator.cs` (88.8%, missing 72) — non-graphics methods only; the `GraphicsDevice` paths are Pillar 2 territory.
+- `Lib/Song/Components/PreviewImagePanel.cs` (90.5%, missing 74) — state transitions, fade math, file-missing fallbacks.
+
+- [ ] **Step 1: For each file, identify gaps and add `Scenario_ShouldExpect` tests**
+
+Use the patterns established in Tasks 3–7.
+
+- [ ] **Step 2: Run, verify, commit one file at a time**
+
+```bash
+git add DTXMania.Test/Song/SongDatabaseServiceCoverageTests.cs
+git commit -m "test: cover SongDatabaseService upsert and migration paths"
+
+git add DTXMania.Test/UI/DefaultGraphicsGeneratorTests.cs
+git commit -m "test: cover DefaultGraphicsGenerator non-graphics methods"
+
+git add DTXMania.Test/Song/Components/PreviewImagePanelTests.cs
+git commit -m "test: cover PreviewImagePanel state and fade math"
+```
+
+---
+
+## Phase 4 — Pillar 2: apply exclusions
+
+Each task in this phase modifies one source file (or a small group). For each method targeted:
+1. Confirm the method is **pure graphics** (only `SpriteBatch.Draw` / `_renderer.Draw` / `font.DrawText` calls; no conditionals, loops, or state mutation beyond looping over a collection to draw each element).
+2. Add `[ExcludeFromCodeCoverage]` with a one-line XML summary.
+3. Run the test suite to confirm nothing broke (it shouldn't — attribute-only change).
+4. Re-run coverage to confirm rate rises.
+5. Commit.
+
+If a method has conditionals or state mutation, **do not exclude it**. Either leave it (it must be covered by a test) or extract its logic (would be a back-port of Pillar 3 — note it as a follow-up, do not do it in this PR).
+
+### Task 16: Exclude Draw methods on stages
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+- Modify: `DTXMania.Game/Lib/Stage/TitleStage.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongTransitionStage.cs`
+- Modify: `DTXMania.Game/Lib/Stage/ResultStage.cs`
+
+**Target methods** (verified to be pure draw paths by inspection; double-check each before applying):
+
+| File | Method (line) |
+|---|---|
+| `PerformanceStage.cs` | `OnDraw` (236), `DrawNotes` (725), `DrawNoteOverlays` (745), `DrawCenteredText` (937), `DrawBackground` (1427), `DrawLaneBackgrounds` (1444), `DrawJudgementLine` (1486), `DrawPads` (1502), `DrawHitEffects` (1510), `DrawJudgementTexts` (1516), `DrawUIElements` (1522), `DrawShutters` (1551), `DrawGaugeElements` (1567) |
+| `TitleStage.cs` | `OnDraw` (141), `DrawVersionInfo` (570), `DrawMenu` (582), `DrawMenuWithTexture` (595), `DrawMenuItemFromTexture` (625), `DrawMenuCursor` (638), `DrawMenuWithRectangles` (670), `DrawTextRect` (720) |
+| `SongTransitionStage.cs` | `OnDraw` (582), `DrawBackground` (613), `DrawText` (643), `DrawDifficultyBackground` (678), `DrawDifficultySprite` (699), `DrawDifficultyLevelNumber` (719), `DrawPreviewImage` (747) |
+| `ResultStage.cs` | `OnDraw` (102), `DrawBackground` (226), `DrawResults` (263), `DrawResultLine` (300) |
+
+`DrawGameplayState` in `PerformanceStage.cs` (line 767) is **probably not pure** (likely contains state branching). Inspect before deciding; default to NOT excluding unless verified pure.
+
+- [ ] **Step 1: For each file in the list, open and verify each method is pure draw**
+
+A method is pure draw iff its body consists only of: variable declarations, calls to `spriteBatch.Draw`, `_renderer.Draw`, `font.DrawText`, simple `for`/`foreach` loops over collections where each iteration only draws, and trivial null-checks against draw dependencies (texture, font). Anything else → **do not exclude**.
+
+- [ ] **Step 2: Apply attributes**
+
+Add `using System.Diagnostics.CodeAnalysis;` if missing. Above each verified method:
+
+```csharp
+/// <summary>Pure draw method; no logic to assert.</summary>
+[ExcludeFromCodeCoverage]
+private void DrawBackground()
+{
+    // ... existing body unchanged
+}
+```
+
+- [ ] **Step 3: Run the full suite**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all pass (attribute-only change).
+
+- [ ] **Step 4: Re-run coverage**
+
+Expected: rate jumps by 2–4 percentage points; valid-line count drops.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/PerformanceStage.cs \
+        DTXMania.Game/Lib/Stage/TitleStage.cs \
+        DTXMania.Game/Lib/Stage/SongTransitionStage.cs \
+        DTXMania.Game/Lib/Stage/ResultStage.cs
+git commit -m "test: exclude pure draw methods on stages from coverage"
+```
+
+### Task 17: Exclude Draw methods on Performance components
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs`
+- Modify: `DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs`
+- Modify: `DTXMania.Game/Lib/Stage/Performance/GaugeDisplay.cs`
+- Modify: `DTXMania.Game/Lib/Stage/Performance/ComboDisplay.cs`
+- Modify: `DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs`
+
+**Target methods** (verify each before applying):
+
+| File | Method (line) |
+|---|---|
+| `NoteRenderer.cs` | `DrawNotes` (199), `DrawNote` (226), `DrawNoteOverlays` (330), `DrawNoteOverlay` (347), `DrawOverlayEffect` (487), `DrawLaneFlashEffects` (530) |
+| `PadRenderer.cs` | `Draw` (163), `DrawPadSpriteCore` (178), `DrawFallbackTextureCore` (198), `DrawPadForLane` (277), `TryDrawSpriteSheetPad` (330), `DrawFallbackPad` (361) |
+| `GaugeDisplay.cs` | `Draw` (126), `DrawFrame` (199) |
+| `ComboDisplay.cs` | `Draw` (146) |
+| `EffectsManager.cs` | `Draw` (125) |
+
+- [ ] **Step 1: Verify each method is pure draw** (same rule as Task 16 Step 1).
+- [ ] **Step 2: Apply `[ExcludeFromCodeCoverage]` with summary comments.**
+- [ ] **Step 3: Run full suite; expect pass.**
+- [ ] **Step 4: Re-run coverage.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs \
+        DTXMania.Game/Lib/Stage/Performance/PadRenderer.cs \
+        DTXMania.Game/Lib/Stage/Performance/GaugeDisplay.cs \
+        DTXMania.Game/Lib/Stage/Performance/ComboDisplay.cs \
+        DTXMania.Game/Lib/Stage/Performance/EffectsManager.cs
+git commit -m "test: exclude pure draw methods on Performance components"
+```
+
+### Task 18: Exclude graphics-bound resource methods
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Resources/ManagedFont.cs`
+- Modify: `DTXMania.Game/Lib/Resources/BitmapFont.cs`
+- Modify: `DTXMania.Game/Lib/Resources/ManagedSpriteTexture.cs`
+
+**Target methods** (verify each):
+
+| File | Method (line) |
+|---|---|
+| `ManagedFont.cs` | `DrawString` (341, 369), `DrawStringWithOutline` (388), `DrawStringWithGradient` (410), `DrawStringWithShadow` (432), `DrawStringWrapped` (445), `DrawStringCustom` (921) |
+| `BitmapFont.cs` | `DrawText` (99), `DrawCharacter` (269) |
+| `ManagedSpriteTexture.cs` | `DrawSprite` (108, 121, 137, 154, 167, 180) |
+
+`TryDrawCharacter` in `ManagedFont.cs` (line 752) is **probably not pure** (returns bool, may have decision logic). Inspect before applying.
+
+- [ ] **Step 1: Verify each method is pure draw.**
+- [ ] **Step 2: Apply `[ExcludeFromCodeCoverage]`.**
+- [ ] **Step 3: Run full suite; expect pass.**
+- [ ] **Step 4: Re-run coverage.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Resources/ManagedFont.cs \
+        DTXMania.Game/Lib/Resources/BitmapFont.cs \
+        DTXMania.Game/Lib/Resources/ManagedSpriteTexture.cs
+git commit -m "test: exclude pure draw methods in resource wrappers"
+```
+
+### Task 19: Exclude any remaining pure-draw helpers in `SongStatusPanel` / `SongBarRenderer` / `SongListDisplay`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/SongBarRenderer.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
+
+After Tasks 8 and 9, the renderers in `SongStatusPanel.cs` and `SongBarRenderer.cs` are now thin shims around `SongStatusPanelLogic` / `SongBarRenderLogic`. They should qualify as pure draw.
+
+**Target methods in `SongStatusPanel.cs`** (post-extraction):
+
+`OnDraw` (496), `DrawBackground` (540), `DrawSongInfo` (575), `DrawDTXManiaNXLayout` (604), `DrawSimplifiedInfo` (619), `DrawSongTypeInfo` (629), `DrawBPMSection` (654), `DrawBPMBackground` (693), `DrawSimpleBPMBackground` (746), `DrawGraphPanelBackground` (771), `DrawFallbackGraphPanelBackground` (808), `DrawSkillPointSection` (831), `DrawDifficultyGrid` (861), `DrawDifficultyCell` (933), `DrawDifficultyFrame` (944), `DrawDifficultyCellContent` (974), `DrawRankSymbol` (993), `DrawDifficultyText` (1029), `DrawGraphPanel` (1055), `DrawNoteDistributionBars` (1094), `DrawProgressBar` (1128), `DrawNotesCounter` (1153), `DrawNoSongMessage` (1207), `DrawTextWithShadow` (1233).
+
+Note: line numbers shift after Task 8. Re-run `grep -n "private void Draw\|protected override void OnDraw" DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs` to find current locations.
+
+**Target methods in `SongBarRenderer.cs`** (post-extraction): all `Draw*` methods that remain after Task 9. Re-list with `grep -n "Draw" DTXMania.Game/Lib/Song/Components/SongBarRenderer.cs`.
+
+**Target methods in `SongListDisplay.cs`**: inspect with `grep -n "Draw" DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`, then apply the same rule: pure draws get the attribute; anything with conditional logic does not.
+
+- [ ] **Step 1: For each file, list `Draw*` methods and verify each is pure draw.**
+- [ ] **Step 2: Apply `[ExcludeFromCodeCoverage]` to verified ones.**
+- [ ] **Step 3: Run full suite; expect pass.**
+- [ ] **Step 4: Re-run coverage.**
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs \
+        DTXMania.Game/Lib/Song/Components/SongBarRenderer.cs \
+        DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+git commit -m "test: exclude pure draw methods on Song components"
+```
+
+---
+
+## Phase 5 — Final Verification
+
+### Task 20: Verify Mac coverage ≥ 90%
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Run the Mac suite with coverage**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --collect:"XPlat Code Coverage" \
+  --settings coverlet.runsettings \
+  --results-directory ./TestResults
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Print the new rate**
+
+```bash
+python3 -c "import xml.etree.ElementTree as ET, glob, os; \
+  f=max(glob.glob('TestResults/*/coverage.cobertura.xml'), key=os.path.getmtime); \
+  r=ET.parse(f).getroot(); \
+  print(f'FINAL-MAC: line={float(r.get(\"line-rate\"))*100:.2f}% branch={float(r.get(\"branch-rate\"))*100:.2f}% lines={r.get(\"lines-covered\")}/{r.get(\"lines-valid\")}')"
+```
+
+Expected: `line >= 90.00%`. If not, return to whichever phase has obvious gaps remaining (re-run Task 1 Step 3 to see which file is now the biggest contributor).
+
+- [ ] **Step 3: No commit**
+
+This task produces a verification number only.
+
+### Task 21: Push branch and verify Windows CI
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 2: Open the GitHub Actions run for the PR**
+
+Wait for both Mac and Windows jobs to complete. Confirm both pass.
+
+- [ ] **Step 3: Check codecov status on the PR**
+
+Codecov must show the Windows full suite at ≥ 90%. If Windows is below 90% despite Mac being above:
+- Inspect the Windows-only files (e.g., `SongStatusPanel.cs` tests that ran on Windows but not Mac). Apply Pillar 1 or Pillar 2 to them.
+- The most likely culprits are graphics-dependent test files that exist but didn't get attention in this PR.
+- Add additional commits to address the gap; do not merge until both metrics clear.
+
+- [ ] **Step 4: Open PR**
+
+Once codecov is green, open the PR with a description that lists the three pillars, the before/after coverage numbers (Mac and Windows), and any deviations from this plan.
+
+---
+
+## Self-Review (post-write)
+
+- **Spec coverage:**
+  - "Three-pillar strategy" → Phases 1, 2, 4 cover Pillars 1, 3, 2 respectively. ✓
+  - "Windows full suite is the gating metric" → Task 2 + Task 21. ✓
+  - "Single sweeping PR" → all tasks form a single branch; PR opens at Task 21. ✓
+  - "Pure extraction, no behavior changes" → Phase 2 mandates characterization tests + full-suite verification at each step. ✓
+  - "Estimated +3,800 lines" → verification at Task 20 confirms ≥ 90%; explicit fallback if short. ✓
+  - "Risk mitigations" → Task 10 carries the explicit "stop after good-faith attempt" fallback for `PerformanceStageLoader`. ✓
+- **Placeholder scan:** No `TBD`/`TODO` / "fill in details". Every step has either a code block or an exact command. Where a test body needs to encode existing behavior, the plan explicitly instructs the engineer to read the source first.
+- **Type consistency:** `SongStatusPanelLogic` / `SongBarRenderLogic` / `PerformanceStageLoader` / `PerformanceStageEndFlow` referenced consistently. `[ExcludeFromCodeCoverage]` always method-level. Test file naming consistent (`<Class>CoverageTests.cs` or `<Class>Tests.cs`).

--- a/docs/superpowers/specs/2026-05-14-unit-test-coverage-90-design.md
+++ b/docs/superpowers/specs/2026-05-14-unit-test-coverage-90-design.md
@@ -1,0 +1,178 @@
+# Unit Test Coverage to 90% — Design
+
+**Date:** 2026-05-14
+**Status:** Approved (pending user review of spec)
+**Target:** Raise line coverage of `DTXMania.Game.Mac` / `DTXMania.Game` from 81.92% to ≥ 90%.
+
+## Goal & Success Criteria
+
+- Raise line coverage on the unified game source to **≥ 90%** in both the Mac test suite (`DTXMania.Test.Mac.csproj`) and the Windows full suite (`DTXMania.Test.csproj`).
+- **Windows full suite is the gating metric** (it has access to graphics-dependent tests excluded on Mac). Codecov is configured server-side and already gates PRs.
+- Approximately **+3,606 net lines** need to move from "uncovered" into "covered" or "excluded".
+- Branch coverage (currently 78.16%) is not gated but should rise as a side effect.
+
+### Non-goals
+
+- **No behavior changes.** All refactors are pure extractions: move code, do not rewrite logic. New tests must encode existing behavior, not a re-imagined version of it.
+- No new coverage gates in `.csproj` or MSBuild. Codecov already enforces.
+- Not a stylistic / dead-code sweep. We touch what we need to touch and stop.
+
+## Baseline (Mac, most recent run)
+
+- Lines: **36,570 / 44,640 covered (81.92%)**
+- Branches: 6,793 / 8,691 (78.16%)
+- Top files by missing-line count:
+
+| File | Coverage | Missing | Notes |
+|---|---:|---:|---|
+| `Lib/Song/Components/SongStatusPanel.cs` | 21.9% | 1,276 | Tests excluded from Mac build |
+| `Lib/Song/Components/SongBarRenderer.cs` | 25.1% | 502 | Tests excluded from Mac build |
+| `Lib/Stage/PerformanceStage.cs` | 74.9% | 460 | Orchestration logic, lots of `Draw*` |
+| `Lib/Stage/SongSelectionStage.cs` | 82.7% | 418 | Mostly draw paths |
+| `Lib/Song/Components/SongListDisplay.cs` | 82.1% | 346 | |
+| `Lib/Resources/ManagedFont.cs` | 75.0% | 310 | Draw + font caching |
+| `Lib/Stage/SongTransitionStage.cs` | 71.9% | 284 | |
+| `Lib/Stage/TitleStage.cs` | 67.2% | 282 | |
+| `Lib/Stage/Performance/NoteRenderer.cs` | 63.7% | 278 | |
+| `Lib/Stage/Performance/PooledEffectsManager.cs` | 4.0% | 238 | Tests excluded from Mac build |
+
+A Windows coverage baseline must be obtained as the **first implementation action** to confirm starting position on the gating metric.
+
+## Strategy: Three Pillars
+
+The gap is closed by three pillars working together. Each is bounded by an explicit rule.
+
+### Pillar 1 — Direct tests for testable logic
+
+Add `Scenario_ShouldExpect` xUnit tests (with Moq) for code that is plain logic — parsers, managers, filter rules, layout math, state machines. No graphics seam needed.
+
+**Primary targets** (and estimated added covered lines):
+
+- `DTXChartParser.cs` — 90% → 95%+ (~60 lines)
+- `SongManager.cs` — 94.8% → 98% (~60 lines)
+- `ResourceManager.cs` — 86.8% → 95% (~80 lines)
+- `JsonRpcServer.cs` — 91.9% → 96% (~50 lines)
+- `ConfigStage.cs` non-Draw paths — 86.1% → 92% (~60 lines)
+- `ModularInputManager.cs` — 86.1% → 94% (~40 lines)
+- `SkinManager.cs` — 78.6% → 92% (~40 lines)
+- `AppPaths.cs`, `DefaultGraphicsGenerator.cs`, `PreviewImagePanel.cs`, `SongDatabaseService.cs` — fill obvious gaps (~260 lines combined)
+
+**Estimated total: +650 covered lines.**
+
+### Pillar 2 — `[ExcludeFromCodeCoverage]` on genuinely graphics-bound code
+
+Continue the existing convention (21 such attributes already in the codebase). Apply at the **method level only** — never at the class level.
+
+**What qualifies for exclusion:**
+
+- `Draw(...)` overrides that only call `SpriteBatch.Draw` / `_renderer.Draw` with no branching.
+- `LoadContent` / `UnloadContent` methods that only invoke MonoGame loaders.
+- Internal `DrawXxx` helpers on stages and components that purely emit graphics primitives.
+- MonoGame plumbing such as resize callbacks that contain no decision logic.
+
+**What does NOT qualify (must be tested instead, possibly after Pillar-3 extraction):**
+
+- Any method containing a non-trivial conditional, loop, or state mutation.
+- Methods that select between draw paths based on game state — extract the selector, exclude the tail.
+- Methods that compute layout / coordinates — extract math into a logic class, test that.
+
+**Each exclusion gets** `using System.Diagnostics.CodeAnalysis;` plus a one-line comment such as `/// <summary>Pure draw method; no logic to assert.</summary>`.
+
+**Primary targets:** `Draw*` methods on `PerformanceStage`, `TitleStage`, `SongTransitionStage`, `ResultStage`, `NoteRenderer`, `GaugeDisplay`, `ComboDisplay`, `PadRenderer`, `EffectsManager`, `BitmapFont`, `ManagedFont`, `ManagedSpriteTexture`, plus `LoadContent` glue across stages.
+
+**Estimated valid-line reduction: ~1,400 lines.** This effectively pushes the percentage up without writing tests for code that cannot be reasonably unit tested.
+
+### Pillar 3 — Targeted extraction for worst offenders
+
+For files where exclusion alone cannot reach 90% because real logic is intermixed with drawing, extract the logic into a sibling class that can be tested on Mac (no `GraphicsDevice` required).
+
+**Each extraction is a pure move-and-call:** the new class's public API matches the methods it replaces, and the original file's behavior is unchanged.
+
+| File | Extract to | What moves | Est. lines won |
+|---|---|---|---:|
+| `Lib/Song/Components/SongStatusPanel.cs` | `SongStatusPanelLogic` (sibling) | Layout calculation, score formatting, animation state, per-difficulty selection | ~900 |
+| `Lib/Song/Components/SongBarRenderer.cs` | `SongBarRenderLogic` (sibling) | Bar layout, label truncation, color selection, scroll math | ~350 |
+| `Lib/Stage/PerformanceStage.cs` | `PerformanceStageLoader`, `PerformanceStageEndFlow` (siblings) | Song-load pipeline, BGM scheduling, end-of-song flow | ~300 |
+| `Lib/Stage/SongSelectionStage.cs` | (mostly Pillar 1/2; small inline extractions) | — | ~200 |
+
+**Estimated total: +1,750 covered lines.**
+
+**Process per extraction:**
+
+1. Write characterization tests against the *new* class first (defining its expected API and behavior, copying behavior from the source).
+2. Move the implementation into the new class.
+3. Re-point the original site to call the new class.
+4. Run the suite. If anything fails, the extraction is not pure — fix and re-verify.
+
+## Estimated Arithmetic to 90%
+
+Starting: 36,570 / 44,640 covered (81.92%). Target: ≥ 40,176 covered (90%).
+
+| Pillar | Coverage gain (lines) |
+|---|---:|
+| P1 — direct tests | +650 |
+| P2 — exclusions (denominator shrinks ~1,400) | ≈ +1,400 effective |
+| P3 — extractions + tests | +1,750 |
+| **Net effect** | **≈ +3,800** |
+
+Math: 44,640 valid − 1,400 excluded = 43,240 valid. Need 0.9 × 43,240 = **38,916 covered**. We project ~38,970 covered, placing us at **~90.1%** with a small buffer for shortfall on any pillar.
+
+## File & Test Conventions
+
+- **Test file location:** `DTXMania.Test/<MirrorOfSourceDir>/<ClassName>Tests.cs` (existing pattern).
+- **Test method naming:** `Scenario_ShouldExpect` (existing convention; enforced in recent commits).
+- **xUnit traits:** Use `[Trait("Category", "Audio")]` etc. only where existing categories apply; do not invent new ones for this work.
+- **Moq:** Mock interfaces (`IResourceManager`, `IConfigManager`, `IGraphicsManager`, etc.). Never construct `GraphicsDevice` in Mac tests.
+- **Mac exclusion list:** Any new test that genuinely needs `GraphicsDevice` must be added to the `Compile Include` exclusion list in `DTXMania.Test/DTXMania.Test.Mac.csproj` — same pattern documented in CLAUDE.md.
+- **Extracted logic classes:** live next to their source (`Lib/Song/Components/SongStatusPanelLogic.cs`) and share the same namespace.
+- **Exclusion attribute:** `[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]` at the method level only, with a brief XML summary.
+
+## Verification
+
+1. Local Mac run before each commit:
+   ```bash
+   dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+     --collect:"XPlat Code Coverage" \
+     --settings coverlet.runsettings \
+     --results-directory ./TestResults
+   ```
+2. Generate a local report (e.g., `reportgenerator`) to confirm Mac is climbing toward 90% before push.
+3. CI runs both Mac and Windows jobs; codecov reports both.
+4. The Windows full suite is the gating metric. PR is not mergeable until Windows ≥ 90%.
+
+## Risks & Mitigations
+
+**Risk 1 — Extractions accidentally change behavior.**
+*Mitigation:* Characterization tests written against the new class **before** the move. Pure move-and-call only. Any test failure after the move means the extraction is not pure; fix or revert.
+
+**Risk 2 — Over-eager exclusion hides real testable logic.**
+*Mitigation:* Hard rule — never exclude a method with non-trivial conditional, loop, or state mutation. Every exclusion gets a one-line comment explaining why. Reviewable as a list of attribute additions.
+
+**Risk 3 — Single sweeping PR is hard to review.**
+*Mitigation:* Organize commits by pillar × subsystem (`test:`, `refactor:`, etc., per Conventional Commits). Each commit stays focused so the PR is reviewable commit-by-commit even if it is large.
+
+**Risk 4 — Windows baseline differs significantly from Mac.**
+*Mitigation:* First implementation step is to obtain a Windows coverage baseline (from the latest GitHub Actions artifact, or by running locally on a Windows machine). If Windows already exceeds 90%, scope contracts; if it is lower than Mac, scope expands. The plan adapts based on this data.
+
+**Risk 5 — `PerformanceStage` extraction is tangled with MonoGame update loop.**
+*Mitigation:* Extract only the discrete, stateful pieces (song loader pipeline, end-of-song flow). Do not attempt to lift the entire `Update` method. If `PerformanceStageLoader` is too intertwined to extract cleanly, fall back to Pillar 2 (exclude its draw paths) and accept whatever coverage gain remains.
+
+## Delivery
+
+**Single sweeping PR**, with commits grouped by pillar and subsystem. Suggested commit sequence:
+
+1. `chore: capture Windows coverage baseline` (artifact / notes)
+2. `test: cover Resources/Config/JsonRpc gaps` (Pillar 1, low risk)
+3. `refactor: extract SongStatusPanelLogic` + `test: cover SongStatusPanelLogic` (Pillar 3)
+4. `refactor: extract SongBarRenderLogic` + `test: cover SongBarRenderLogic` (Pillar 3)
+5. `refactor: extract PerformanceStage loader/end-flow` + `test: cover extracted helpers` (Pillar 3)
+6. `test: cover Song/SongManager edge cases` (Pillar 1)
+7. `test: cover Input/Modular paths` (Pillar 1)
+8. `test: exclude pure draw methods across stages` (Pillar 2)
+9. `test: exclude pure draw helpers in Performance components` (Pillar 2)
+10. `test: exclude graphics-bound resource methods` (Pillar 2)
+11. `chore: final coverage verification` (verify both suites ≥ 90%)
+
+## Open Questions
+
+- Do we want a coverage badge in the README updated as part of this work? (Not in scope unless requested.)


### PR DESCRIPTION
## Summary

Initial coverage-improvement work targeting the path to 90% line coverage.

- Fix pre-existing test isolation issue around `ManagedFont` static font factory (two contradictory tests now serialized in a `[Collection("ManagedFont")]`).
- Add direct tests for `AppPaths.GetAppDataRoot` / `GetHomeDirectory` / `ExpandHomePath` fallback paths.
- Apply `[ExcludeFromCodeCoverage]` to pure-draw methods across stages, performance components, resource wrappers, and song components (~30 methods). Strict rule applied — methods with state-driven logic were left intact for future Pillar-3 extraction.

## Coverage delta (Mac suite)

- Baseline: 81.92% (18,285 / 22,320)
- This branch: 82.50% (18,141 / 21,987)

## Open question

Pillar 2 exclusions yielded much less than the plan's +1,400-line estimate (most "draw" methods in the codebase contain genuine state-driven logic). The remaining 1,650 lines to 90% require Pillar-3 extractions — significant refactoring of `SongStatusPanel.cs`, `SongBarRenderer.cs`, and `PerformanceStage.cs`. Opening this draft to read the Windows coverage number from codecov and decide whether to pursue extractions or accept current scope.

## Test plan

- [x] Mac suite passes (4,703 / 4,703)
- [ ] Windows CI passes
- [ ] Codecov gate green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage tracking by marking pure rendering methods as excluded from coverage analysis across multiple components.
  * Enhanced test infrastructure with collection definitions for proper test isolation.

* **Tests**
  * Expanded test coverage for application path resolution, home directory handling, and idempotence validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/DTXManiaCX/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->