### PR TITLE
feat: implement skill display and score persistence

### DIFF
--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -457,6 +457,8 @@ namespace DTXMania.Game.Lib.Resources
                 ProgressFrame,
                 ProgressFill,
                 SkillPanel,
+                PerfGraphMain,
+                PerfGraphGauge,
                 PanelIcons,
                 LevelNumbers,
                 RateNumbersLarge,

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -271,7 +271,17 @@ namespace DTXMania.Game.Lib.Resources
         /// Skill panel texture
         /// </summary>
         public const string SkillPanel = "Graphics/7_SkillPanel.png";
-        
+
+        /// <summary>
+        /// Performance skill meter background graph (right-side vertical gauge frame)
+        /// </summary>
+        public const string PerfGraphMain = "Graphics/7_Graph_main.png";
+
+        /// <summary>
+        /// Performance skill meter filling bar (right-side vertical gauge bar)
+        /// </summary>
+        public const string PerfGraphGauge = "Graphics/7_Graph_Gauge.png";
+
         /// <summary>
         /// Panel icons texture sheet
         /// </summary>

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -830,6 +830,7 @@ namespace DTXMania.Game.Lib.Song.Components
             }
         }
 
+        [ExcludeFromCodeCoverage]
         private void DrawSkillPointSection(SpriteBatch spriteBatch, Rectangle bounds, SongListNode currentSong, int currentDifficulty)
         {
             var score = GetCurrentScore(currentSong, currentDifficulty);

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -856,7 +856,7 @@ namespace DTXMania.Game.Lib.Song.Components
             float skillTextX = SongSelectionUILayout.SkillPointSection.X + SongSelectionUILayout.SkillPointSection.DarkBoxLeft + 8f;
             float skillTextY = SongSelectionUILayout.SkillPointSection.Y + SongSelectionUILayout.SkillPointSection.DarkBoxTop
                                + (SongSelectionUILayout.SkillPointSection.DarkBoxHeight - skillLineH) / 2f;
-            var skillValue = score.HighSkill > 0 ? score.HighSkill.ToString("F2") : "0.00";
+            var skillValue = score.HasBeenPlayed ? score.HighSkill.ToString("F2") : "---";
             DrawTextWithShadow(spriteBatch, skillFont, skillValue, new Vector2(skillTextX, skillTextY), Color.Yellow);
         }
 

--- a/DTXMania.Game/Lib/Song/Entities/JudgementTypes.cs
+++ b/DTXMania.Game/Lib/Song/Entities/JudgementTypes.cs
@@ -11,7 +11,7 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// <summary>
         /// Perfect timing hit (highest accuracy)
         /// </summary>
-        Just,
+        Perfect,
         
         /// <summary>
         /// Excellent timing hit (very good accuracy)
@@ -58,7 +58,7 @@ namespace DTXMania.Game.Lib.Song.Entities
         public double DeltaMs { get; set; }
         
         /// <summary>
-        /// Type of the judgement (Just/Great/Good/Poor/Miss)
+        /// Type of the judgement (Perfect/Great/Good/Poor/Miss)
         /// </summary>
         public JudgementType Type { get; set; }
         
@@ -182,9 +182,9 @@ namespace DTXMania.Game.Lib.Song.Entities
         #region Judgement Windows (in milliseconds)
         
         /// <summary>
-        /// Perfect timing window for "Just" judgement (±25ms)
+        /// Perfect timing window for "Perfect" judgement (±25ms)
         /// </summary>
-        public const double JustWindowMs = 25.0;
+        public const double PerfectWindowMs = 25.0;
         
         /// <summary>
         /// Great timing window for "Great" judgement (±50ms)
@@ -211,9 +211,9 @@ namespace DTXMania.Game.Lib.Song.Entities
         #region Score Values
         
         /// <summary>
-        /// Score points awarded for a "Just" hit
+        /// Score points awarded for a "Perfect" hit
         /// </summary>
-        public const int JustScore = 1000;
+        public const int PerfectScore = 1000;
         
         /// <summary>
         /// Score points awarded for a "Great" hit
@@ -248,7 +248,7 @@ namespace DTXMania.Game.Lib.Song.Entities
         {
             double absDelta = Math.Abs(deltaMs);
             
-            if (absDelta <= JustWindowMs) return JudgementType.Just;
+            if (absDelta <= PerfectWindowMs) return JudgementType.Perfect;
             if (absDelta <= GreatWindowMs) return JudgementType.Great;
             if (absDelta <= GoodWindowMs) return JudgementType.Good;
             if (absDelta <= PoorWindowMs) return JudgementType.Poor;
@@ -265,7 +265,7 @@ namespace DTXMania.Game.Lib.Song.Entities
         {
             return judgementType switch
             {
-                JudgementType.Just => JustScore,
+                JudgementType.Perfect => PerfectScore,
                 JudgementType.Great => GreatScore,
                 JudgementType.Good => GoodScore,
                 JudgementType.Poor => PoorScore,

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -58,7 +58,7 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// </summary>
         internal SongDatabaseService(DbContextOptions<SongDbContext> options)
         {
-            _options = options ?? throw new System.ArgumentNullException(nameof(options));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
             _databasePath = string.Empty;
             // Tests provide a pre-created schema; mark the service as initialized so
             // CreateContext() does not throw the "must initialize first" guard.
@@ -481,12 +481,16 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// </summary>
         public async Task UpdateScoreAsync(int chartId, EInstrumentPart instrument, PerformanceSummary summary)
         {
-            if (summary == null) return;
+            if (summary == null) throw new ArgumentNullException(nameof(summary));
 
             using var context = CreateContext();
             var score = await context.SongScores
                 .FirstOrDefaultAsync(s => s.ChartId == chartId && s.Instrument == instrument);
-            if (score == null) return;
+            if (score == null)
+            {
+                score = new SongScoreEntity { ChartId = chartId, Instrument = instrument };
+                context.SongScores.Add(score);
+            }
 
             if (summary.Score > score.BestScore)
             {
@@ -509,7 +513,7 @@ namespace DTXMania.Game.Lib.Song.Entities
 
             score.LastScore = summary.Score;
             score.LastSkillPoint = summary.GameSkill;
-            score.LastPlayedAt = System.DateTime.UtcNow;
+            score.LastPlayedAt = DateTime.UtcNow;
             score.PlayCount++;
             if (summary.ClearFlag) score.ClearCount++;
 

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -1,4 +1,5 @@
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage.Performance;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -47,6 +48,21 @@ namespace DTXMania.Game.Lib.Song.Entities
                 options.CommandTimeout(30);
             });
             _options = optionsBuilder.Options;
+        }
+
+        /// <summary>
+        /// Test-friendly constructor that accepts pre-built DbContext options.
+        /// Lets unit tests inject an in-memory SQLite connection without going through
+        /// the file-path-based config path. The caller is responsible for ensuring the
+        /// schema is created (e.g., via SongDbContext.Database.EnsureCreated()).
+        /// </summary>
+        internal SongDatabaseService(DbContextOptions<SongDbContext> options)
+        {
+            _options = options ?? throw new System.ArgumentNullException(nameof(options));
+            _databasePath = string.Empty;
+            // Tests provide a pre-created schema; mark the service as initialized so
+            // CreateContext() does not throw the "must initialize first" guard.
+            _isInitialized = true;
         }
 
 
@@ -456,6 +472,50 @@ namespace DTXMania.Game.Lib.Song.Entities
                 await context.SaveChangesAsync();
             }
         }
+
+        /// <summary>
+        /// Persists a complete PerformanceSummary into the SongScore for the given chart+instrument.
+        /// Updates best fields only when the new score exceeds the existing best. Always updates the
+        /// "last play" fields and increments PlayCount. The pre-computed summary.GameSkill is assigned
+        /// directly (not re-derived via score.CalculateSkill()), preserving level-decimal precision.
+        /// </summary>
+        public async Task UpdateScoreAsync(int chartId, EInstrumentPart instrument, PerformanceSummary summary)
+        {
+            if (summary == null) return;
+
+            using var context = CreateContext();
+            var score = await context.SongScores
+                .FirstOrDefaultAsync(s => s.ChartId == chartId && s.Instrument == instrument);
+            if (score == null) return;
+
+            if (summary.Score > score.BestScore)
+            {
+                score.BestScore = summary.Score;
+                score.BestPerfect = summary.PerfectCount;
+                score.BestGreat = summary.GreatCount;
+                score.BestGood = summary.GoodCount;
+                score.BestPoor = summary.PoorCount;
+                score.BestMiss = summary.MissCount;
+                score.MaxCombo = summary.MaxCombo;
+                score.FullCombo = summary.ClearFlag && summary.MissCount == 0 && summary.PoorCount == 0;
+                score.TotalNotes = summary.TotalNotes;
+            }
+
+            if (summary.GameSkill > score.HighSkill)
+            {
+                score.HighSkill = summary.GameSkill;
+            }
+            score.SongSkill = summary.GameSkill;
+
+            score.LastScore = summary.Score;
+            score.LastSkillPoint = summary.GameSkill;
+            score.LastPlayedAt = System.DateTime.UtcNow;
+            score.PlayCount++;
+            if (summary.ClearFlag) score.ClearCount++;
+
+            await context.SaveChangesAsync();
+        }
+
         /// Get top scores for a specific instrument
         public async Task<List<SongScoreEntity>> GetTopScoresAsync(EInstrumentPart instrument, int limit = 10)
         {

--- a/DTXMania.Game/Lib/Song/Entities/SongScore.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongScore.cs
@@ -351,6 +351,8 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// <summary>
         /// DTXManiaNX-faithful Playing Skill: Perfect%·0.85 + Great%·0.35 + Combo%·0.15.
         /// Returns 0 when totalNotes is zero or negative.
+        /// Drums-only scope: omits the auto-lane revision multiplier that the full
+        /// NX formula applies for mixed-instrument autoplay configurations.
         /// Reference: DTXManiaNX CScoreIni.tCalculatePlayingSkill (Score,Song/CScoreIni.cs:1641).
         /// </summary>
         public static double CalculatePlayingSkill(int totalNotes, int perfect, int great, int maxCombo)

--- a/DTXMania.Game/Lib/Song/Entities/SongScore.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongScore.cs
@@ -260,7 +260,10 @@ namespace DTXMania.Game.Lib.Song.Entities
         }
         
         /// <summary>
-        /// Calculates skill value based on score and difficulty
+        /// Recomputes SongSkill using the DTXManiaNX Game Skill formula.
+        /// Note: this only knows DifficultyLevel (whole part), so it is a coarser
+        /// approximation than the persistence path, which receives the precise
+        /// chart level + levelDec via PerformanceSummary. Kept for legacy/manual triggers.
         /// </summary>
         public void CalculateSkill()
         {
@@ -269,15 +272,10 @@ namespace DTXMania.Game.Lib.Song.Entities
                 SongSkill = 0;
                 return;
             }
-            
-            // DTXMania skill calculation formula
-            // Skill = (Score / 1000000) * DifficultyLevel * Multiplier
-            var scoreRatio = (double)BestScore / 1000000.0;
-            var difficultyMultiplier = DifficultyLevel / 100.0;
-            var rankMultiplier = GetRankMultiplier();
-            
-            SongSkill = scoreRatio * difficultyMultiplier * rankMultiplier * 100.0;
-            
+
+            double playing = CalculatePlayingSkill(TotalNotes, BestPerfect, BestGreat, MaxCombo);
+            SongSkill = CalculateGameSkill(playing, DifficultyLevel, 0);
+
             if (SongSkill > HighSkill)
                 HighSkill = SongSkill;
         }

--- a/DTXMania.Game/Lib/Song/Entities/SongScore.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongScore.cs
@@ -364,6 +364,21 @@ namespace DTXMania.Game.Lib.Song.Entities
             return perfectRate * 0.85 + greatRate * 0.35 + comboRate * 0.15;
         }
 
+        /// <summary>
+        /// DTXManiaNX-faithful Game Skill: PlayingSkill · actualLevel · 0.2.
+        /// actualLevel encodes the chart's difficulty value with its decimal:
+        ///   level &gt;= 100  → actualLevel = level / 100        (e.g. 850 → 8.50)
+        ///   level &lt;  100  → actualLevel = level / 10 + levelDec / 100  (e.g. 78 + 33 → 7.8 + 0.33 = 8.13)
+        /// Reference: DTXManiaNX CScoreIni.tCalculateGameSkillFromPlayingSkill (Score,Song/CScoreIni.cs:1623).
+        /// </summary>
+        public static double CalculateGameSkill(double playingSkill, int level, int levelDec)
+        {
+            double actualLevel = level >= 100
+                ? level / 100.0
+                : (level / 10.0) + (levelDec / 100.0);
+            return playingSkill * actualLevel * 0.2;
+        }
+
         private static bool IsLegacyOrdinal(int rankValue)
         {
             return rankValue >= 1 && rankValue <= 7;

--- a/DTXMania.Game/Lib/Song/Entities/SongScore.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongScore.cs
@@ -274,7 +274,9 @@ namespace DTXMania.Game.Lib.Song.Entities
             }
 
             double playing = CalculatePlayingSkill(TotalNotes, BestPerfect, BestGreat, MaxCombo);
-            SongSkill = CalculateGameSkill(playing, DifficultyLevel, 0);
+            // levelDec is unknown here; passing 0 loses sub-tenths granularity.
+            // The persistence path uses the precise value via PerformanceSummary.
+            SongSkill = CalculateGameSkill(playing, DifficultyLevel, levelDec: 0);
 
             if (SongSkill > HighSkill)
                 HighSkill = SongSkill;

--- a/DTXMania.Game/Lib/Song/Entities/SongScore.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongScore.cs
@@ -348,6 +348,20 @@ namespace DTXMania.Game.Lib.Song.Entities
             };
         }
 
+        /// <summary>
+        /// DTXManiaNX-faithful Playing Skill: Perfect%·0.85 + Great%·0.35 + Combo%·0.15.
+        /// Returns 0 when totalNotes is zero or negative.
+        /// Reference: DTXManiaNX CScoreIni.tCalculatePlayingSkill (Score,Song/CScoreIni.cs:1641).
+        /// </summary>
+        public static double CalculatePlayingSkill(int totalNotes, int perfect, int great, int maxCombo)
+        {
+            if (totalNotes <= 0) return 0.0;
+            double perfectRate = 100.0 * perfect  / totalNotes;
+            double greatRate   = 100.0 * great    / totalNotes;
+            double comboRate   = 100.0 * maxCombo / totalNotes;
+            return perfectRate * 0.85 + greatRate * 0.35 + comboRate * 0.15;
+        }
+
         private static bool IsLegacyOrdinal(int rankValue)
         {
             return rankValue >= 1 && rankValue <= 7;

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1558,6 +1558,26 @@ namespace DTXMania.Game.Lib.Song
             }
         }
 
+        /// <summary>
+        /// Persists a complete PerformanceSummary (score + skill + judgement counts) for a
+        /// specific chart and instrument. Forwards to SongDatabaseService.
+        /// </summary>
+        public async Task<bool> UpdateScoreAsync(int chartId, EInstrumentPart instrument, DTXMania.Game.Lib.Stage.Performance.PerformanceSummary summary)
+        {
+            if (_databaseService == null) return false;
+
+            try
+            {
+                await _databaseService.UpdateScoreAsync(chartId, instrument, summary);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"SongManager: Error updating score (summary): {ex.Message}");
+                return false;
+            }
+        }
+
         #endregion
 
         #region Helper Methods

--- a/DTXMania.Game/Lib/Stage/Performance/ComboManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ComboManager.cs
@@ -82,7 +82,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
             switch (judgementEvent.Type)
             {
-                case JudgementType.Just:
+                case JudgementType.Perfect:
                 case JudgementType.Great:
                 case JudgementType.Good:
                     // Increment combo on successful hits

--- a/DTXMania.Game/Lib/Stage/Performance/ComboManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ComboManager.cs
@@ -7,7 +7,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
 {
     /// <summary>
     /// Manages combo tracking during gameplay.
-    /// Increments combo on successful hits (Just/Great/Good), resets on Poor/Miss judgements.
+    /// Increments combo on successful hits (Perfect/Great/Good), resets on Poor/Miss judgements.
     /// Tracks both current combo count and maximum combo achieved.
     /// </summary>
     public class ComboManager : IDisposable

--- a/DTXMania.Game/Lib/Stage/Performance/GaugeManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/GaugeManager.cs
@@ -154,7 +154,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             return judgementType switch
             {
-                JudgementType.Just => +2.0f,   // Just: +2%
+                JudgementType.Perfect => +2.0f,   // Perfect: +2%
                 JudgementType.Great => +1.5f,  // Great: +1.5%
                 JudgementType.Good => +1.0f,   // Good: +1%
                 JudgementType.Poor => -1.5f,   // Poor: -1.5%

--- a/DTXMania.Game/Lib/Stage/Performance/JudgementManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/JudgementManager.cs
@@ -135,7 +135,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
                         {
                             switch (data.JudgementEvent.Type)
                             {
-                                case JudgementType.Just: stats.JustCount++; break;
+                                case JudgementType.Perfect: stats.PerfectCount++; break;
                                 case JudgementType.Great: stats.GreatCount++; break;
                                 case JudgementType.Good: stats.GoodCount++; break;
                                 case JudgementType.Poor: stats.PoorCount++; break;
@@ -230,7 +230,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 noteData.NoteId,
                 noteData.Note.LaneIndex,
                 0.0, // Perfect timing — autoplay hits at exact note time
-                JudgementType.Just
+                JudgementType.Perfect
             );
 
             noteData.Status = NoteStatus.Hit;
@@ -610,7 +610,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
     /// </summary>
     public class JudgementStatistics
     {
-        public int JustCount { get; set; }
+        public int PerfectCount { get; set; }
         public int GreatCount { get; set; }
         public int GoodCount { get; set; }
         public int PoorCount { get; set; }
@@ -619,12 +619,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// <summary>
         /// Total number of notes processed
         /// </summary>
-        public int TotalNotes => JustCount + GreatCount + GoodCount + PoorCount + MissCount;
+        public int TotalNotes => PerfectCount + GreatCount + GoodCount + PoorCount + MissCount;
 
         /// <summary>
         /// Total number of hits (non-misses)
         /// </summary>
-        public int TotalHits => JustCount + GreatCount + GoodCount + PoorCount;
+        public int TotalHits => PerfectCount + GreatCount + GoodCount + PoorCount;
 
         /// <summary>
         /// Accuracy percentage

--- a/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs
@@ -110,7 +110,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         // Text colors for different judgement types
         private static readonly Dictionary<JudgementType, Color> JudgementColors = new Dictionary<JudgementType, Color>
         {
-            { JudgementType.Just, Color.Yellow },
+            { JudgementType.Perfect, Color.Yellow },
             { JudgementType.Great, Color.LightGreen },
             { JudgementType.Good, Color.LightBlue },
             { JudgementType.Poor, Color.Orange },
@@ -120,7 +120,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         // Text display strings for judgement types
         private static readonly Dictionary<JudgementType, string> JudgementTexts = new Dictionary<JudgementType, string>
         {
-            { JudgementType.Just, "Perfect" },
+            { JudgementType.Perfect, "Perfect" },
             { JudgementType.Great, "Great" },
             { JudgementType.Good, "Good" },
             { JudgementType.Poor, "OK" },

--- a/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
@@ -27,9 +27,9 @@ namespace DTXMania.Game.Lib.Stage.Performance
         public bool ClearFlag { get; set; }
 
         /// <summary>
-        /// Count of Just judgements
+        /// Count of Perfect judgements
         /// </summary>
-        public int JustCount { get; set; }
+        public int PerfectCount { get; set; }
 
         /// <summary>
         /// Count of Great judgements
@@ -73,7 +73,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// <summary>
         /// Total number of judgements made
         /// </summary>
-        public int TotalJudgements => JustCount + GreatCount + GoodCount + PoorCount + MissCount;
+        public int TotalJudgements => PerfectCount + GreatCount + GoodCount + PoorCount + MissCount;
 
         /// <summary>
         /// Accuracy percentage (0.0 to 100.0)
@@ -86,7 +86,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 if (TotalNotes <= 0) return 0.0;
 
                 // Weight judgements similar to scoring system
-                double weightedHits = (JustCount * 1.0) + (GreatCount * 0.9) + (GoodCount * 0.5);
+                double weightedHits = (PerfectCount * 1.0) + (GreatCount * 0.9) + (GoodCount * 0.5);
                 double maxPossibleWeight = TotalNotes * 1.0;
 
                 return maxPossibleWeight > 0 ? (weightedHits / maxPossibleWeight) * 100.0 : 0.0;
@@ -101,7 +101,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             get
             {
                 if (TotalNotes <= 0) return 0.0;
-                int successfulHits = JustCount + GreatCount + GoodCount;
+                int successfulHits = PerfectCount + GreatCount + GoodCount;
                 return ((double)successfulHits / TotalNotes) * 100.0;
             }
         }
@@ -118,7 +118,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             Score = 0;
             MaxCombo = 0;
             ClearFlag = false;
-            JustCount = 0;
+            PerfectCount = 0;
             GreatCount = 0;
             GoodCount = 0;
             PoorCount = 0;
@@ -140,8 +140,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             switch (judgementType)
             {
-                case JudgementType.Just:
-                    JustCount++;
+                case JudgementType.Perfect:
+                    PerfectCount++;
                     break;
                 case JudgementType.Great:
                     GreatCount++;
@@ -167,7 +167,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             return judgementType switch
             {
-                JudgementType.Just => JustCount,
+                JudgementType.Perfect => PerfectCount,
                 JudgementType.Great => GreatCount,
                 JudgementType.Good => GoodCount,
                 JudgementType.Poor => PoorCount,
@@ -183,7 +183,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             return $"Score: {Score:N0}, Max Combo: {MaxCombo}, " +
                    $"Accuracy: {Accuracy:F1}%, Clear: {ClearFlag}, " +
-                   $"J/G/G/P/M: {JustCount}/{GreatCount}/{GoodCount}/{PoorCount}/{MissCount}";
+                   $"J/G/G/P/M: {PerfectCount}/{GreatCount}/{GoodCount}/{PoorCount}/{MissCount}";
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
@@ -208,7 +208,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             return $"Score: {Score:N0}, Max Combo: {MaxCombo}, " +
                    $"Accuracy: {Accuracy:F1}%, Clear: {ClearFlag}, " +
-                   $"J/G/G/P/M: {PerfectCount}/{GreatCount}/{GoodCount}/{PoorCount}/{MissCount}";
+                   $"P/Gr/Go/Po/M: {PerfectCount}/{GreatCount}/{GoodCount}/{PoorCount}/{MissCount}";
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
@@ -144,10 +144,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
             GoodCount = 0;
             PoorCount = 0;
             MissCount = 0;
-            PlayingSkill   = 0.0;
-            GameSkill      = 0.0;
-            ChartLevel     = 0;
-            ChartLevelDec  = 0;
+            PlayingSkill = 0.0;
+            GameSkill = 0.0;
+            ChartLevel = 0;
+            ChartLevelDec = 0;
             TotalNotes = 0;
             FinalLife = 0.0f;
             CompletionReason = CompletionReason.Unknown;

--- a/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs
@@ -52,6 +52,27 @@ namespace DTXMania.Game.Lib.Stage.Performance
         public int MissCount { get; set; }
 
         /// <summary>
+        /// Playing Skill computed at end of song (0.0-100.0). DTXManiaNX formula.
+        /// </summary>
+        public double PlayingSkill { get; set; }
+
+        /// <summary>
+        /// Game Skill computed at end of song (PlayingSkill · actualLevel · 0.2).
+        /// </summary>
+        public double GameSkill { get; set; }
+
+        /// <summary>
+        /// Raw chart level (e.g. 78 means 7.8). Carried through so the precise level
+        /// reaches the persistence layer without rounding.
+        /// </summary>
+        public int ChartLevel { get; set; }
+
+        /// <summary>
+        /// Chart level decimal part (e.g. 33 means an extra 0.033). Combined with ChartLevel.
+        /// </summary>
+        public int ChartLevelDec { get; set; }
+
+        /// <summary>
         /// Total number of notes in the chart
         /// </summary>
         public int TotalNotes { get; set; }
@@ -123,6 +144,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
             GoodCount = 0;
             PoorCount = 0;
             MissCount = 0;
+            PlayingSkill   = 0.0;
+            GameSkill      = 0.0;
+            ChartLevel     = 0;
+            ChartLevelDec  = 0;
             TotalNotes = 0;
             FinalLife = 0.0f;
             CompletionReason = CompletionReason.Unknown;

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreManager.cs
@@ -133,7 +133,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             return judgementType switch
             {
-                JudgementType.Just => 1.0,
+                JudgementType.Perfect => 1.0,
                 JudgementType.Great => 0.9,
                 JudgementType.Good => 0.5,
                 JudgementType.Poor => 0.0,

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreManager.cs
@@ -72,11 +72,11 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// <param name="totalNotes">Total number of notes in the chart</param>
         public ScoreManager(int totalNotes)
         {
-            if (totalNotes <= 0)
-                throw new ArgumentException("Total notes must be greater than 0", nameof(totalNotes));
+            if (totalNotes < 0)
+                throw new ArgumentException("Total notes cannot be negative", nameof(totalNotes));
 
             _totalNotes = totalNotes;
-            _baseScore = MaxScore / totalNotes; // Integer division as specified
+            _baseScore = totalNotes == 0 ? 0 : MaxScore / totalNotes; // Integer division as specified
             _currentScore = 0;
         }
 

--- a/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
@@ -85,12 +85,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// <summary>
         /// Creates a new SkillManager bound to a ComboManager for MaxCombo access
         /// </summary>
-        /// <param name="totalNotes">Total notes in the chart (must be greater than 0)</param>
+        /// <param name="totalNotes">Total notes in the chart</param>
         /// <param name="comboManager">Combo manager providing MaxCombo state</param>
         public SkillManager(int totalNotes, ComboManager comboManager)
         {
-            if (totalNotes <= 0)
-                throw new ArgumentException("Total notes must be greater than 0", nameof(totalNotes));
+            if (totalNotes < 0)
+                throw new ArgumentException("Total notes cannot be negative", nameof(totalNotes));
             _totalNotes = totalNotes;
             _comboManager = comboManager ?? throw new ArgumentNullException(nameof(comboManager));
         }

--- a/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
@@ -13,6 +13,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
     /// </summary>
     public class SkillManager : IDisposable
     {
+        #region Private Fields
+
         private readonly int _totalNotes;
         private readonly ComboManager _comboManager;
         private int _perfect;
@@ -23,17 +25,68 @@ namespace DTXMania.Game.Lib.Stage.Performance
         private double _currentSkill;
         private bool _disposed;
 
+        #endregion
+
+        #region Events
+
+        /// <summary>
+        /// Raised when the current skill value changes
+        /// </summary>
         public event EventHandler<SkillChangedEventArgs>? SkillChanged;
 
-        public int  PerfectCount => _perfect;
-        public int  GreatCount   => _great;
-        public int  GoodCount    => _good;
-        public int  PoorCount    => _poor;
-        public int  MissCount    => _miss;
-        public int  TotalNotes   => _totalNotes;
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Number of Perfect judgements recorded
+        /// </summary>
+        public int PerfectCount => _perfect;
+
+        /// <summary>
+        /// Number of Great judgements recorded
+        /// </summary>
+        public int GreatCount => _great;
+
+        /// <summary>
+        /// Number of Good judgements recorded
+        /// </summary>
+        public int GoodCount => _good;
+
+        /// <summary>
+        /// Number of Poor judgements recorded
+        /// </summary>
+        public int PoorCount => _poor;
+
+        /// <summary>
+        /// Number of Miss judgements recorded
+        /// </summary>
+        public int MissCount => _miss;
+
+        /// <summary>
+        /// Total notes in the chart, used as the denominator for skill calculation
+        /// </summary>
+        public int TotalNotes => _totalNotes;
+
+        /// <summary>
+        /// Current playing skill value (0.0-100.0)
+        /// </summary>
         public double CurrentSkill => _currentSkill;
+
+        /// <summary>
+        /// Whether the current skill has reached the maximum (100.0)
+        /// </summary>
         public bool IsMax => _currentSkill >= 100.0;
 
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Creates a new SkillManager bound to a ComboManager for MaxCombo access
+        /// </summary>
+        /// <param name="totalNotes">Total notes in the chart (must be greater than 0)</param>
+        /// <param name="comboManager">Combo manager providing MaxCombo state</param>
         public SkillManager(int totalNotes, ComboManager comboManager)
         {
             if (totalNotes <= 0)
@@ -42,6 +95,14 @@ namespace DTXMania.Game.Lib.Stage.Performance
             _comboManager = comboManager ?? throw new ArgumentNullException(nameof(comboManager));
         }
 
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Processes a judgement event and updates the skill value
+        /// </summary>
+        /// <param name="judgementEvent">Judgement event to process</param>
         public void ProcessJudgement(JudgementEvent? judgementEvent)
         {
             if (_disposed || judgementEvent == null) return;
@@ -62,12 +123,15 @@ namespace DTXMania.Game.Lib.Stage.Performance
             SkillChanged?.Invoke(this, new SkillChangedEventArgs
             {
                 PreviousSkill = previous,
-                CurrentSkill  = _currentSkill,
-                IsMax         = IsMax,
+                CurrentSkill = _currentSkill,
+                IsMax = IsMax,
                 JudgementType = judgementEvent.Type
             });
         }
 
+        /// <summary>
+        /// Resets all judgement counts and the current skill value to zero
+        /// </summary>
         public void Reset()
         {
             if (_disposed) return;
@@ -77,32 +141,70 @@ namespace DTXMania.Game.Lib.Stage.Performance
             SkillChanged?.Invoke(this, new SkillChangedEventArgs
             {
                 PreviousSkill = previous,
-                CurrentSkill  = 0.0,
-                IsMax         = false,
+                CurrentSkill = 0.0,
+                IsMax = false,
                 JudgementType = null
             });
         }
 
+        #endregion
+
+        #region IDisposable Implementation
+
+        /// <summary>
+        /// Disposes the skill manager
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Protected dispose method
+        /// </summary>
+        /// <param name="disposing">Whether disposing from Dispose() call</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed && disposing) _disposed = true;
+            if (!_disposed && disposing)
+            {
+                // Clear all event subscribers to prevent memory leaks
+                SkillChanged = null;
+
+                _disposed = true;
+            }
         }
+
+        #endregion
     }
+
+    #region Supporting Classes
 
     /// <summary>
     /// Event payload for SkillManager.SkillChanged.
     /// </summary>
     public class SkillChangedEventArgs : EventArgs
     {
+        /// <summary>
+        /// Skill value before the change
+        /// </summary>
         public double PreviousSkill { get; set; }
-        public double CurrentSkill  { get; set; }
-        public bool   IsMax         { get; set; }
+
+        /// <summary>
+        /// Skill value after the change
+        /// </summary>
+        public double CurrentSkill { get; set; }
+
+        /// <summary>
+        /// Whether the current skill has reached the maximum (100.0)
+        /// </summary>
+        public bool IsMax { get; set; }
+
+        /// <summary>
+        /// Judgement type that caused this skill change, or null when raised by Reset
+        /// </summary>
         public JudgementType? JudgementType { get; set; }
     }
+
+    #endregion
 }

--- a/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
@@ -120,13 +120,16 @@ namespace DTXMania.Game.Lib.Stage.Performance
             _currentSkill = SongScore.CalculatePlayingSkill(
                 _totalNotes, _perfect, _great, _comboManager.MaxCombo);
 
-            SkillChanged?.Invoke(this, new SkillChangedEventArgs
+            if (previous != _currentSkill)
             {
-                PreviousSkill = previous,
-                CurrentSkill = _currentSkill,
-                IsMax = IsMax,
-                JudgementType = judgementEvent.Type
-            });
+                SkillChanged?.Invoke(this, new SkillChangedEventArgs
+                {
+                    PreviousSkill = previous,
+                    CurrentSkill = _currentSkill,
+                    IsMax = IsMax,
+                    JudgementType = judgementEvent.Type
+                });
+            }
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillManager.cs
@@ -1,0 +1,108 @@
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.Song.Entities;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Computes DTXManiaNX-faithful Playing Skill (0.0-100.0) live during gameplay.
+    /// Subscribes via PerformanceStage to JudgementManager events and reads MaxCombo
+    /// from the injected ComboManager, so combo state is never duplicated here.
+    /// Reference: DTXManiaNX CScoreIni.tCalculatePlayingSkill (Score,Song/CScoreIni.cs:1641).
+    /// </summary>
+    public class SkillManager : IDisposable
+    {
+        private readonly int _totalNotes;
+        private readonly ComboManager _comboManager;
+        private int _perfect;
+        private int _great;
+        private int _good;
+        private int _poor;
+        private int _miss;
+        private double _currentSkill;
+        private bool _disposed;
+
+        public event EventHandler<SkillChangedEventArgs>? SkillChanged;
+
+        public int  PerfectCount => _perfect;
+        public int  GreatCount   => _great;
+        public int  GoodCount    => _good;
+        public int  PoorCount    => _poor;
+        public int  MissCount    => _miss;
+        public int  TotalNotes   => _totalNotes;
+        public double CurrentSkill => _currentSkill;
+        public bool IsMax => _currentSkill >= 100.0;
+
+        public SkillManager(int totalNotes, ComboManager comboManager)
+        {
+            if (totalNotes <= 0)
+                throw new ArgumentException("Total notes must be greater than 0", nameof(totalNotes));
+            _totalNotes = totalNotes;
+            _comboManager = comboManager ?? throw new ArgumentNullException(nameof(comboManager));
+        }
+
+        public void ProcessJudgement(JudgementEvent? judgementEvent)
+        {
+            if (_disposed || judgementEvent == null) return;
+
+            switch (judgementEvent.Type)
+            {
+                case JudgementType.Perfect: _perfect++; break;
+                case JudgementType.Great:   _great++;   break;
+                case JudgementType.Good:    _good++;    break;
+                case JudgementType.Poor:    _poor++;    break;
+                case JudgementType.Miss:    _miss++;    break;
+            }
+
+            double previous = _currentSkill;
+            _currentSkill = SongScore.CalculatePlayingSkill(
+                _totalNotes, _perfect, _great, _comboManager.MaxCombo);
+
+            SkillChanged?.Invoke(this, new SkillChangedEventArgs
+            {
+                PreviousSkill = previous,
+                CurrentSkill  = _currentSkill,
+                IsMax         = IsMax,
+                JudgementType = judgementEvent.Type
+            });
+        }
+
+        public void Reset()
+        {
+            if (_disposed) return;
+            double previous = _currentSkill;
+            _perfect = _great = _good = _poor = _miss = 0;
+            _currentSkill = 0.0;
+            SkillChanged?.Invoke(this, new SkillChangedEventArgs
+            {
+                PreviousSkill = previous,
+                CurrentSkill  = 0.0,
+                IsMax         = false,
+                JudgementType = null
+            });
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing) _disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Event payload for SkillManager.SkillChanged.
+    /// </summary>
+    public class SkillChangedEventArgs : EventArgs
+    {
+        public double PreviousSkill { get; set; }
+        public double CurrentSkill  { get; set; }
+        public bool   IsMax         { get; set; }
+        public JudgementType? JudgementType { get; set; }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
@@ -1,7 +1,6 @@
 #nullable enable
 
 using System;
-using System.Diagnostics;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Resources;
@@ -23,11 +22,6 @@ namespace DTXMania.Game.Lib.Stage.Performance
         private ITexture? _gaugeTexture;
         private ManagedFont? _font;
         private bool _disposed;
-
-        /// <summary>
-        /// Shadow color reused from the central visual palette.
-        /// </summary>
-        private static readonly Color MeterShadowColor = PerformanceUILayout.Visual.StandardShadowColor;
 
         /// <summary>
         /// 1px shadow offset — intentionally tighter than the (2,2) StandardShadowOffset
@@ -59,7 +53,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"SkillMeterDisplay: Failed to load background texture: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"SkillMeterDisplay: Failed to load background texture: {ex.Message}");
                 _backgroundTexture = null;
             }
 
@@ -69,7 +63,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"SkillMeterDisplay: Failed to load gauge texture: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"SkillMeterDisplay: Failed to load gauge texture: {ex.Message}");
                 _gaugeTexture = null;
             }
 
@@ -79,7 +73,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"SkillMeterDisplay: Failed to create font: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"SkillMeterDisplay: Failed to create font: {ex.Message}");
                 _font = null;
             }
         }
@@ -144,7 +138,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
                     bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X - 1,
                     barTopY + PerformanceUILayout.SkillMeter.NumberOffsetFromTopOfBar);
                 _font.DrawStringWithShadow(spriteBatch, text, textPos,
-                    Color.White, MeterShadowColor, MeterShadowOffset);
+                    Color.White, PerformanceUILayout.Visual.StandardShadowColor, MeterShadowOffset);
             }
         }
 
@@ -188,8 +182,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
             {
                 _font?.Dispose();
                 _font = null;
-                _backgroundTexture = null;  // not owned — IResourceManager handles refcount
-                _gaugeTexture = null;       // not owned — IResourceManager handles refcount
+                _backgroundTexture?.RemoveReference();
+                _backgroundTexture = null;
+                _gaugeTexture?.RemoveReference();
+                _gaugeTexture = null;
             }
             _disposed = true;
         }

--- a/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
@@ -96,6 +96,9 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             if (_disposed || spriteBatch == null) return;
 
+            // Clamp once so bar height, draw decision, and numeric overlay are consistent.
+            double clampedSkill = Math.Clamp(Skill, 0.0, 100.0);
+
             var bgPos = PerformanceUILayout.SkillMeter.BackgroundPosition;
 
             // 1. Background frame
@@ -106,9 +109,9 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
 
             // 2-4. Filling bar
-            int gaugeHeight = ComputeGaugeHeight(Skill);
-            int barTopY     = ComputeBarTopY(Skill);
-            if (ShouldDrawBar(Skill) && _gaugeTexture != null)
+            int gaugeHeight = ComputeGaugeHeight(clampedSkill);
+            int barTopY     = ComputeBarTopY(clampedSkill);
+            if (ShouldDrawBar(clampedSkill) && _gaugeTexture != null)
             {
                 var barPos = new Vector2(
                     bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X,
@@ -133,7 +136,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             if (_font != null)
             {
                 string text = string.Format(System.Globalization.CultureInfo.InvariantCulture,
-                    "{0,5:##0.00}", Skill);
+                    "{0,5:##0.00}", clampedSkill);
                 var textPos = new Vector2(
                     bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X - 1,
                     barTopY + PerformanceUILayout.SkillMeter.NumberOffsetFromTopOfBar);

--- a/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
@@ -1,0 +1,199 @@
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI.Layout;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Renders the right-side vertical skill gauge meter. Uses 7_Graph_main.png as
+    /// background, 7_Graph_Gauge.png as the filling bar, and a small text overlay
+    /// for the numeric value. Mirrors DTXManiaNX CActPerfSkillMeter (drums layout).
+    /// </summary>
+    public class SkillMeterDisplay : IDisposable
+    {
+        #region Private Fields
+
+        private readonly GraphicsDevice _graphicsDevice;
+        private ITexture? _backgroundTexture;
+        private ITexture? _gaugeTexture;
+        private ManagedFont? _font;
+        private bool _disposed;
+
+        /// <summary>
+        /// Shadow color reused from the central visual palette.
+        /// </summary>
+        private static readonly Color MeterShadowColor = PerformanceUILayout.Visual.StandardShadowColor;
+
+        /// <summary>
+        /// 1px shadow offset — intentionally tighter than the (2,2) StandardShadowOffset
+        /// because the meter renders a small 12pt font where a 2px drop looks blurry.
+        /// </summary>
+        private static readonly Vector2 MeterShadowOffset = new Vector2(1, 1);
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Current skill percentage (0.0 - 100.0) drawn by the filling bar and overlay number.
+        /// </summary>
+        public double Skill { get; set; }
+
+        #endregion
+
+        #region Constructor
+
+        public SkillMeterDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice)
+        {
+            if (resourceManager == null) throw new ArgumentNullException(nameof(resourceManager));
+            _graphicsDevice = graphicsDevice ?? throw new ArgumentNullException(nameof(graphicsDevice));
+
+            try
+            {
+                _backgroundTexture = resourceManager.LoadTexture(TexturePath.PerfGraphMain);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"SkillMeterDisplay: Failed to load background texture: {ex.Message}");
+                _backgroundTexture = null;
+            }
+
+            try
+            {
+                _gaugeTexture = resourceManager.LoadTexture(TexturePath.PerfGraphGauge);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"SkillMeterDisplay: Failed to load gauge texture: {ex.Message}");
+                _gaugeTexture = null;
+            }
+
+            try
+            {
+                _font = ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 12, FontStyle.Bold);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"SkillMeterDisplay: Failed to create font: {ex.Message}");
+                _font = null;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Update the meter state. No animation yet.
+        /// </summary>
+        /// <param name="deltaTime">Time elapsed since last update</param>
+        public void Update(double deltaTime) { /* no animation yet */ }
+
+        /// <summary>
+        /// Draw the skill meter: background frame, filling bar, "current" label, and numeric overlay.
+        /// </summary>
+        /// <param name="spriteBatch">SpriteBatch for drawing</param>
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (_disposed || spriteBatch == null) return;
+
+            var bgPos = PerformanceUILayout.SkillMeter.BackgroundPosition;
+
+            // 1. Background frame
+            if (_backgroundTexture != null)
+            {
+                _backgroundTexture.Draw(spriteBatch, bgPos,
+                    PerformanceUILayout.SkillMeter.BackgroundSourceRect);
+            }
+
+            // 2-4. Filling bar
+            int gaugeHeight = ComputeGaugeHeight(Skill);
+            int barTopY     = ComputeBarTopY(Skill);
+            if (ShouldDrawBar(Skill) && _gaugeTexture != null)
+            {
+                var barPos = new Vector2(
+                    bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X,
+                    barTopY);
+                var barSrc = new Rectangle(
+                    (int)PerformanceUILayout.SkillMeter.GaugeSourceXY.X,
+                    (int)PerformanceUILayout.SkillMeter.GaugeSourceXY.Y,
+                    PerformanceUILayout.SkillMeter.GaugeWidth,
+                    gaugeHeight);
+                _gaugeTexture.Draw(spriteBatch, barPos, barSrc);
+            }
+
+            // 5. "Current" label
+            if (_backgroundTexture != null)
+            {
+                _backgroundTexture.Draw(spriteBatch,
+                    PerformanceUILayout.SkillMeter.LabelPosition,
+                    PerformanceUILayout.SkillMeter.LabelSourceRect);
+            }
+
+            // 6. Numeric overlay
+            if (_font != null)
+            {
+                string text = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    "{0,5:##0.00}", Skill);
+                var textPos = new Vector2(
+                    bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X - 1,
+                    barTopY + PerformanceUILayout.SkillMeter.NumberOffsetFromTopOfBar);
+                _font.DrawStringWithShadow(spriteBatch, text, textPos,
+                    Color.White, MeterShadowColor, MeterShadowOffset);
+            }
+        }
+
+        /// <summary>
+        /// Compute the filling bar height in pixels for a given skill value (0–100).
+        /// Clamps the input so out-of-range skills do not overflow or invert the bar.
+        /// </summary>
+        public static int ComputeGaugeHeight(double skill)
+        {
+            double clamped = Math.Clamp(skill, 0.0, 100.0);
+            return (int)(PerformanceUILayout.SkillMeter.GaugeMaxHeight * clamped / 100.0);
+        }
+
+        /// <summary>
+        /// Compute the Y coordinate of the top of the filling bar.
+        /// </summary>
+        public static int ComputeBarTopY(double skill)
+        {
+            return PerformanceUILayout.SkillMeter.GaugeBaselineY - ComputeGaugeHeight(skill);
+        }
+
+        /// <summary>
+        /// Whether the filling bar should be drawn at all for the given skill value.
+        /// </summary>
+        public static bool ShouldDrawBar(double skill) => skill > 0.0;
+
+        #endregion
+
+        #region IDisposable Implementation
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                _font?.Dispose();
+                _font = null;
+                _backgroundTexture = null;  // not owned — IResourceManager handles refcount
+                _gaugeTexture = null;       // not owned — IResourceManager handles refcount
+            }
+            _disposed = true;
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Resources;
@@ -92,6 +93,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// Draw the skill meter: background frame, filling bar, "current" label, and numeric overlay.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
+        [ExcludeFromCodeCoverage]
         public void Draw(SpriteBatch spriteBatch)
         {
             if (_disposed || spriteBatch == null) return;

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Resources;
@@ -82,6 +83,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// Draw the skill panel contents.
         /// </summary>
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
+        [ExcludeFromCodeCoverage]
         public void Draw(SpriteBatch spriteBatch)
         {
             if (_disposed || spriteBatch == null || _font == null) return;

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -150,7 +150,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
             {
                 _font?.Dispose();
                 _font = null;
-                _maxBadgeTexture = null;  // not owned — IResourceManager handles refcount
+                _maxBadgeTexture?.RemoveReference();
+                _maxBadgeTexture = null;
             }
             _disposed = true;
         }

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -1,0 +1,148 @@
+#nullable enable
+
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.UI.Layout;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Renders the left-side performance status panel: difficulty level,
+    /// current skill percentage, and (optionally) the MAX badge sprite.
+    /// </summary>
+    public class SkillPanelDisplay : IDisposable
+    {
+        #region Private Fields
+
+        private readonly IResourceManager _resourceManager;
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly SongChart? _chart;
+        private ManagedFont? _font;
+        private ITexture? _maxBadgeTexture;
+        private bool _disposed;
+
+        private static readonly Color ShadowColor = new Color(0, 0, 0, 128);
+        private static readonly Vector2 ShadowOffset = new Vector2(2, 2);
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// Current skill percentage (0.0 - 100.0) rendered as the large number.
+        /// </summary>
+        public double Skill { get; set; }
+
+        /// <summary>
+        /// Whether the MAX badge sprite should be drawn over the skill number.
+        /// </summary>
+        public bool ShowMax { get; set; }
+
+        #endregion
+
+        #region Constructor
+
+        public SkillPanelDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice, SongChart? chart)
+        {
+            _resourceManager = resourceManager ?? throw new ArgumentNullException(nameof(resourceManager));
+            _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
+            _chart           = chart;
+
+            _font = ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 24, FontStyle.Bold);
+            try { _maxBadgeTexture = _resourceManager.LoadTexture(TexturePath.SkillMax); }
+            catch { _maxBadgeTexture = null; }
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Update the panel state. No animation yet.
+        /// </summary>
+        /// <param name="deltaTime">Time elapsed since last update</param>
+        public void Update(double deltaTime) { /* no animation yet */ }
+
+        /// <summary>
+        /// Draw the skill panel contents.
+        /// </summary>
+        /// <param name="spriteBatch">SpriteBatch for drawing</param>
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (_disposed || spriteBatch == null || _font == null) return;
+
+            int level    = _chart?.DrumLevel    ?? 0;
+            int levelDec = _chart?.DrumLevelDec ?? 0;
+
+            string levelText = FormatLevelText(level, levelDec);
+            _font.DrawStringWithShadow(spriteBatch, levelText,
+                PerformanceUILayout.SkillPanel.LevelNumber.StartPosition,
+                Color.White, ShadowColor, ShadowOffset);
+
+            string skillText = FormatSkillText(Skill);
+            _font.DrawStringWithShadow(spriteBatch, skillText,
+                PerformanceUILayout.SkillPanel.SkillPercent.NumbersPosition,
+                Color.White, ShadowColor, ShadowOffset);
+
+            _font.DrawStringWithShadow(spriteBatch, "%",
+                PerformanceUILayout.SkillPanel.SkillPercent.PercentPosition,
+                Color.White, ShadowColor, ShadowOffset);
+
+            if (ShowMax && _maxBadgeTexture != null)
+            {
+                _maxBadgeTexture.Draw(spriteBatch,
+                    PerformanceUILayout.SkillPanel.SkillPercent.MaxBadgePosition);
+            }
+        }
+
+        /// <summary>
+        /// Format the difficulty level text using DTXManiaNX encoding rules.
+        /// Match DTXManiaNX CScoreIni.tCalculateGameSkillFromPlayingSkill encoding:
+        ///   level &gt;= 100 → displayed = level/100  (e.g. 850 → 8.50)
+        ///   level &lt;  100 → displayed = level/10 + levelDec/100  (e.g. 80+50 → 8.50)
+        /// </summary>
+        public static string FormatLevelText(int level, int levelDec)
+        {
+            if (level <= 0) return "--";
+            double actual = level >= 100
+                ? level / 100.0
+                : (level / 10.0) + (levelDec / 100.0);
+            return actual.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Format the skill percentage as a 6-character right-aligned string with two decimals.
+        /// </summary>
+        public static string FormatSkillText(double skill)
+        {
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0,6:##0.00}", skill);
+        }
+
+        #endregion
+
+        #region IDisposable Implementation
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                _font?.Dispose();
+                _font = null;
+                _maxBadgeTexture = null;  // not owned — IResourceManager handles refcount
+            }
+            _disposed = true;
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -17,15 +17,11 @@ namespace DTXMania.Game.Lib.Stage.Performance
     {
         #region Private Fields
 
-        private readonly IResourceManager _resourceManager;
         private readonly GraphicsDevice _graphicsDevice;
         private readonly SongChart? _chart;
         private ManagedFont? _font;
         private ITexture? _maxBadgeTexture;
         private bool _disposed;
-
-        private static readonly Color ShadowColor = new Color(0, 0, 0, 128);
-        private static readonly Vector2 ShadowOffset = new Vector2(2, 2);
 
         #endregion
 
@@ -47,13 +43,29 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         public SkillPanelDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice, SongChart? chart)
         {
-            _resourceManager = resourceManager ?? throw new ArgumentNullException(nameof(resourceManager));
+            if (resourceManager == null) throw new ArgumentNullException(nameof(resourceManager));
             _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
             _chart           = chart;
 
-            _font = ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 24, FontStyle.Bold);
-            try { _maxBadgeTexture = _resourceManager.LoadTexture(TexturePath.SkillMax); }
-            catch { _maxBadgeTexture = null; }
+            try
+            {
+                _font = ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 24, FontStyle.Bold);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SkillPanelDisplay: Failed to create font: {ex.Message}");
+                _font = null;
+            }
+
+            try
+            {
+                _maxBadgeTexture = resourceManager.LoadTexture(TexturePath.SkillMax);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SkillPanelDisplay: Failed to load MAX badge: {ex.Message}");
+                _maxBadgeTexture = null;
+            }
         }
 
         #endregion
@@ -80,16 +92,16 @@ namespace DTXMania.Game.Lib.Stage.Performance
             string levelText = FormatLevelText(level, levelDec);
             _font.DrawStringWithShadow(spriteBatch, levelText,
                 PerformanceUILayout.SkillPanel.LevelNumber.StartPosition,
-                Color.White, ShadowColor, ShadowOffset);
+                Color.White, PerformanceUILayout.Visual.StandardShadowColor, PerformanceUILayout.Visual.StandardShadowOffset);
 
             string skillText = FormatSkillText(Skill);
             _font.DrawStringWithShadow(spriteBatch, skillText,
                 PerformanceUILayout.SkillPanel.SkillPercent.NumbersPosition,
-                Color.White, ShadowColor, ShadowOffset);
+                Color.White, PerformanceUILayout.Visual.StandardShadowColor, PerformanceUILayout.Visual.StandardShadowOffset);
 
             _font.DrawStringWithShadow(spriteBatch, "%",
                 PerformanceUILayout.SkillPanel.SkillPercent.PercentPosition,
-                Color.White, ShadowColor, ShadowOffset);
+                Color.White, PerformanceUILayout.Visual.StandardShadowColor, PerformanceUILayout.Visual.StandardShadowOffset);
 
             if (ShowMax && _maxBadgeTexture != null)
             {

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -1735,7 +1735,7 @@ namespace DTXMania.Game.Lib.Stage
                 Score = _scoreManager?.CurrentScore ?? 0,
                 MaxCombo = _comboManager?.MaxCombo ?? 0,
                 ClearFlag = reason != CompletionReason.PlayerFailed,
-                JustCount = _judgementManager?.GetJudgementCount(JudgementType.Just) ?? 0,
+                PerfectCount = _judgementManager?.GetJudgementCount(JudgementType.Perfect) ?? 0,
                 GreatCount = _judgementManager?.GetJudgementCount(JudgementType.Great) ?? 0,
                 GoodCount = _judgementManager?.GetJudgementCount(JudgementType.Good) ?? 0,
                 PoorCount = _judgementManager?.GetJudgementCount(JudgementType.Poor) ?? 0,

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -72,6 +72,9 @@ namespace DTXMania.Game.Lib.Stage
         private ScoreManager _scoreManager = null!;
         private ComboManager _comboManager = null!;
         private GaugeManager _gaugeManager = null!;
+        private SkillManager _skillManager = null!;
+        private SkillPanelDisplay _skillPanelDisplay = null!;
+        private SkillMeterDisplay _skillMeterDisplay = null!;
         private EffectsManager _effectsManager = null!;
         private JudgementTextPopupManager _judgementTextPopupManager = null!;
         private PadRenderer _padRenderer = null!;
@@ -358,6 +361,11 @@ namespace DTXMania.Game.Lib.Stage
             _scoreDisplay = new ScoreDisplay(_resourceManager, graphicsDevice);
             _comboDisplay = new ComboDisplay(_resourceManager, graphicsDevice);
 
+            // Skill displays (SkillManager itself is constructed in InitializeGameplayManagers
+            // because it needs ComboManager + ChartManager.TotalNotes which arrive later)
+            var skillChart = _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+            _skillPanelDisplay = new SkillPanelDisplay(_resourceManager, graphicsDevice, skillChart);
+            _skillMeterDisplay = new SkillMeterDisplay(_resourceManager, graphicsDevice);
 
             // Initialize Phase 2 components
             _audioLoader = new AudioLoader(_resourceManager);
@@ -405,6 +413,10 @@ namespace DTXMania.Game.Lib.Stage
             _scoreDisplay = null;
             _comboDisplay?.Dispose();
             _comboDisplay = null;
+            _skillPanelDisplay?.Dispose();
+            _skillPanelDisplay = null;
+            _skillMeterDisplay?.Dispose();
+            _skillMeterDisplay = null;
 
 
             // Cleanup Phase 2 components
@@ -1069,7 +1081,8 @@ namespace DTXMania.Game.Lib.Stage
             _scoreManager = new ScoreManager(_chartManager.TotalNotes);
             _comboManager = new ComboManager();
             _gaugeManager = new GaugeManager();
-            
+            _skillManager = new SkillManager(_chartManager.TotalNotes, _comboManager);
+
             // Initialize UI state values
             _currentGaugeValue = PerformanceUILayout.GaugeSettings.StartingLife / 100.0f;
             _currentProgressValue = 0.0f;
@@ -1099,6 +1112,7 @@ namespace DTXMania.Game.Lib.Stage
             _comboManager.ComboChanged += OnComboChanged;
             _gaugeManager.GaugeChanged += OnGaugeChanged;
             _gaugeManager.Failed += OnPlayerFailed;
+            _skillManager.SkillChanged += OnSkillChanged;
         }
 
         /// <summary>
@@ -1147,6 +1161,7 @@ namespace DTXMania.Game.Lib.Stage
             _scoreManager?.ProcessJudgement(e);
             _comboManager?.ProcessJudgement(e);
             _gaugeManager?.ProcessJudgement(e);
+            _skillManager?.ProcessJudgement(e);
 
             // Spawn hit effect for successful hits (non-Miss)
             if (e.IsHit())
@@ -1195,12 +1210,28 @@ namespace DTXMania.Game.Lib.Stage
         {
             // Update gauge display
             // Legacy gauge display removed - now using asset-based gauge in DrawGaugeElements()
-            
+
             // Update our internal gauge value for asset rendering
             _currentGaugeValue = e.CurrentLife / 100.0f;
-            
+
             // Update danger state based on gauge level
             _isDanger = _currentGaugeValue < PerformanceUILayout.GaugeSettings.DangerThreshold / 100.0f;
+        }
+
+        /// <summary>
+        /// Handles skill changes and updates both display components.
+        /// </summary>
+        private void OnSkillChanged(object? sender, SkillChangedEventArgs e)
+        {
+            if (_skillPanelDisplay != null)
+            {
+                _skillPanelDisplay.Skill = e.CurrentSkill;
+                _skillPanelDisplay.ShowMax = e.IsMax;
+            }
+            if (_skillMeterDisplay != null)
+            {
+                _skillMeterDisplay.Skill = e.CurrentSkill;
+            }
         }
 
         /// <summary>
@@ -1381,6 +1412,9 @@ namespace DTXMania.Game.Lib.Stage
                 _gaugeManager.Failed -= OnPlayerFailed;
             }
 
+            if (_skillManager != null)
+                _skillManager.SkillChanged -= OnSkillChanged;
+
             // Unsubscribe from input events
             if (_inputManager?.ModularInputManager != null)
             {
@@ -1396,6 +1430,8 @@ namespace DTXMania.Game.Lib.Stage
             _comboManager = null;
             _gaugeManager?.Dispose();
             _gaugeManager = null;
+            _skillManager?.Dispose();
+            _skillManager = null;
 
             _chipSoundCache?.Dispose();
             _chipSoundCache = null!;
@@ -1417,6 +1453,8 @@ namespace DTXMania.Game.Lib.Stage
             // Update score and combo displays
             _scoreDisplay?.Update(deltaTime);
             _comboDisplay?.Update(deltaTime);
+            _skillPanelDisplay?.Update(deltaTime);
+            _skillMeterDisplay?.Update(deltaTime);
 
             // Update gauge display
         }
@@ -1543,6 +1581,8 @@ namespace DTXMania.Game.Lib.Stage
             
             _scoreDisplay?.Draw(_spriteBatch);
             _comboDisplay?.Draw(_spriteBatch);
+            _skillPanelDisplay?.Draw(_spriteBatch);
+            _skillMeterDisplay?.Draw(_spriteBatch);
             
             _uiManager?.Draw(_spriteBatch, 0);
             

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -1413,7 +1413,9 @@ namespace DTXMania.Game.Lib.Stage
             }
 
             if (_skillManager != null)
+            {
                 _skillManager.SkillChanged -= OnSkillChanged;
+            }
 
             // Unsubscribe from input events
             if (_inputManager?.ModularInputManager != null)

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -72,9 +72,9 @@ namespace DTXMania.Game.Lib.Stage
         private ScoreManager _scoreManager = null!;
         private ComboManager _comboManager = null!;
         private GaugeManager _gaugeManager = null!;
-        private SkillManager _skillManager = null!;
-        private SkillPanelDisplay _skillPanelDisplay = null!;
-        private SkillMeterDisplay _skillMeterDisplay = null!;
+        private SkillManager? _skillManager;
+        private SkillPanelDisplay? _skillPanelDisplay;
+        private SkillMeterDisplay? _skillMeterDisplay;
         private EffectsManager _effectsManager = null!;
         private JudgementTextPopupManager _judgementTextPopupManager = null!;
         private PadRenderer _padRenderer = null!;

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -1814,6 +1814,12 @@ namespace DTXMania.Game.Lib.Stage
                 { "performanceSummary", _performanceSummary }
             };
 
+            if (_selectedSong != null)
+            {
+                sharedData["selectedSong"] = _selectedSong;
+            }
+            sharedData["selectedDifficulty"] = _selectedDifficulty;
+
             StageManager?.ChangeStage(StageType.Result, new InstantTransition(), sharedData);
         }
 

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -1772,6 +1772,13 @@ namespace DTXMania.Game.Lib.Stage
             _songTimer?.Stop();
 
             // Build the performance summary
+            var summaryChart = _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+            int summaryLevel = summaryChart?.DrumLevel ?? 0;
+            int summaryLevelDec = summaryChart?.DrumLevelDec ?? 0;
+            double summaryPlayingSkill = _skillManager?.CurrentSkill ?? 0.0;
+            double summaryGameSkill = SongScore.CalculateGameSkill(
+                summaryPlayingSkill, summaryLevel, summaryLevelDec);
+
             _performanceSummary = new PerformanceSummary
             {
                 Score = _scoreManager?.CurrentScore ?? 0,
@@ -1784,7 +1791,11 @@ namespace DTXMania.Game.Lib.Stage
                 MissCount = _judgementManager?.GetJudgementCount(JudgementType.Miss) ?? 0,
                 TotalNotes = _chartManager?.TotalNotes ?? 0,
                 FinalLife = _gaugeManager?.CurrentLife ?? 0.0f,
-                CompletionReason = reason
+                CompletionReason = reason,
+                PlayingSkill = summaryPlayingSkill,
+                GameSkill = summaryGameSkill,
+                ChartLevel = summaryLevel,
+                ChartLevelDec = summaryLevelDec
             };
 
 

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -288,7 +288,7 @@ namespace DTXMania.Game.Lib.Stage
             currentY += ResultUILayout.ResultDisplay.ExtraSpacing; // Extra space
 
             DrawResultLine("JUDGEMENT BREAKDOWN", centerX, ref currentY, ResultUILayout.ResultDisplay.SectionHeaderColor, lineHeight);
-            DrawResultLine($"Just: {_performanceSummary.JustCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
+            DrawResultLine($"Perfect: {_performanceSummary.PerfectCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
             DrawResultLine($"Great: {_performanceSummary.GreatCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
             DrawResultLine($"Good: {_performanceSummary.GoodCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
             DrawResultLine($"Poor: {_performanceSummary.PoorCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -9,6 +9,7 @@ using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.UI;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Stage.Performance;
 
 namespace DTXMania.Game.Lib.Stage
@@ -28,6 +29,8 @@ namespace DTXMania.Game.Lib.Stage
 
         // Result data
         private PerformanceSummary _performanceSummary;
+        private DTXMania.Game.Lib.Song.SongListNode? _selectedSong;
+        private int _selectedDifficulty;
 
         // UI components
         private BitmapFont _resultFont;
@@ -66,6 +69,19 @@ namespace DTXMania.Game.Lib.Stage
         {
             // Extract performance summary from shared data
             ExtractSharedData();
+
+            // Persist this play's score + skill values (fire-and-forget).
+            if (_selectedSong != null && _performanceSummary != null)
+            {
+                var savedChart = _selectedSong.GetCurrentDifficultyChart(_selectedDifficulty);
+                if (savedChart != null && savedChart.Id > 0)
+                {
+                    _ = DTXMania.Game.Lib.Song.SongManager.Instance.UpdateScoreAsync(
+                        savedChart.Id,
+                        DTXMania.Game.Lib.Song.Entities.EInstrumentPart.DRUMS,
+                        _performanceSummary);
+                }
+            }
 
             // Initialize UI components
             InitializeComponents();
@@ -137,6 +153,19 @@ namespace DTXMania.Game.Lib.Stage
                     CompletionReason = CompletionReason.Unknown
                 };
                 System.Diagnostics.Debug.WriteLine("ResultStage: No performance summary provided, using default");
+            }
+
+            if (_sharedData != null
+                && _sharedData.TryGetValue("selectedSong", out var songObj)
+                && songObj is DTXMania.Game.Lib.Song.SongListNode song)
+            {
+                _selectedSong = song;
+            }
+            if (_sharedData != null
+                && _sharedData.TryGetValue("selectedDifficulty", out var difficultyObj)
+                && difficultyObj is int difficulty)
+            {
+                _selectedDifficulty = difficulty;
             }
         }
 

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -397,9 +397,50 @@ namespace DTXMania.Game.Lib.UI.Layout
                 public const int MaxDigits = 4;
             }
         }
-        
+
         #endregion
-        
+
+        #region Skill Meter (right-side vertical gauge — 7_Graph_main.png, 7_Graph_Gauge.png)
+
+        /// <summary>
+        /// Right-side vertical skill gauge meter.
+        /// Geometry mirrors DTXManiaNX CActPerfSkillMeter drums layout (Code/Stage/07.Performance/CActPerfSkillMeter.cs).
+        /// </summary>
+        public static class SkillMeter
+        {
+            /// <summary>Top-left of the gauge frame on screen.</summary>
+            public static readonly Vector2 BackgroundPosition = new Vector2(900, 50);
+
+            /// <summary>Source rect in 7_Graph_main.png for the background frame.</summary>
+            public static readonly Rectangle BackgroundSourceRect = new Rectangle(2, 2, 251, 584);
+
+            /// <summary>Offset of the filling bar relative to BackgroundPosition.</summary>
+            public static readonly Vector2 GaugeOffset = new Vector2(45, 0);
+
+            /// <summary>Width of the filling bar in pixels.</summary>
+            public const int GaugeWidth = 30;
+
+            /// <summary>Source X/Y of the filling bar in 7_Graph_Gauge.png (height is dynamic).</summary>
+            public static readonly Vector2 GaugeSourceXY = new Vector2(2, 2);
+
+            /// <summary>Bar height in pixels when Skill == 100.</summary>
+            public const int GaugeMaxHeight = 434;
+
+            /// <summary>Y of the bar bottom (= BackgroundPosition.Y + 477).</summary>
+            public const int GaugeBaselineY = 527;
+
+            /// <summary>Numeric label is drawn this many pixels above the bar top.</summary>
+            public const int NumberOffsetFromTopOfBar = -10;
+
+            /// <summary>"Current" label sprite source rect in 7_Graph_main.png.</summary>
+            public static readonly Rectangle LabelSourceRect = new Rectangle(260, 2, 30, 120);
+
+            /// <summary>Where the "current" label is drawn on screen.</summary>
+            public static readonly Vector2 LabelPosition = new Vector2(945, 407);
+        }
+
+        #endregion
+
         #region Background Configuration
 
         /// <summary>

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -570,7 +570,7 @@ namespace DTXMania.Game.Lib.UI.Layout
             
             public static class LifeAdjustment
             {
-                public const float Just = 2.0f;
+                public const float Perfect = 2.0f;
                 public const float Great = 1.5f;
                 public const float Good = 1.0f;
                 public const float Poor = -1.5f;

--- a/DTXMania.Test/Helpers/MockGameplayComponents.cs
+++ b/DTXMania.Test/Helpers/MockGameplayComponents.cs
@@ -500,7 +500,7 @@ namespace DTXMania.Test.Helpers
             var events = new List<JudgementEvent>();
             for (int i = 0; i < noteCount; i++)
             {
-                events.Add(new JudgementEvent(i, i % 9, 0.0, JudgementType.Just));
+                events.Add(new JudgementEvent(i, i % 9, 0.0, JudgementType.Perfect));
             }
             return events;
         }
@@ -511,14 +511,14 @@ namespace DTXMania.Test.Helpers
         public static List<JudgementEvent> CreateMixedPlay(int noteCount)
         {
             var events = new List<JudgementEvent>();
-            var judgements = new[] { JudgementType.Just, JudgementType.Great, JudgementType.Good, JudgementType.Poor, JudgementType.Miss };
+            var judgements = new[] { JudgementType.Perfect, JudgementType.Great, JudgementType.Good, JudgementType.Poor, JudgementType.Miss };
             
             for (int i = 0; i < noteCount; i++)
             {
                 var judgement = judgements[i % judgements.Length];
                 var delta = judgement switch
                 {
-                    JudgementType.Just => 0.0,
+                    JudgementType.Perfect => 0.0,
                     JudgementType.Great => 30.0,
                     JudgementType.Good => 70.0,
                     JudgementType.Poor => 120.0,
@@ -555,8 +555,8 @@ namespace DTXMania.Test.Helpers
         {
             return new List<(double, JudgementType)>
             {
-                (0.0, JudgementType.Just),      // Perfect
-                (25.0, JudgementType.Just),     // Just boundary
+                (0.0, JudgementType.Perfect),      // Perfect
+                (25.0, JudgementType.Perfect),     // Just boundary
                 (25.1, JudgementType.Great),    // Just over Just
                 (50.0, JudgementType.Great),    // Great boundary
                 (50.1, JudgementType.Good),     // Just over Great
@@ -565,7 +565,7 @@ namespace DTXMania.Test.Helpers
                 (150.0, JudgementType.Poor),    // Poor boundary
                 (150.1, JudgementType.Miss),    // Just over Poor
                 (200.0, JudgementType.Miss),    // Miss threshold
-                (-25.0, JudgementType.Just),    // Early Just
+                (-25.0, JudgementType.Perfect),    // Early Just
                 (-50.0, JudgementType.Great),   // Early Great
                 (-100.0, JudgementType.Good),   // Early Good
                 (-150.0, JudgementType.Poor),   // Early Poor

--- a/DTXMania.Test/Helpers/MockGameplayComponents.cs
+++ b/DTXMania.Test/Helpers/MockGameplayComponents.cs
@@ -493,7 +493,7 @@ namespace DTXMania.Test.Helpers
     public static class TestDataPatterns
     {
         /// <summary>
-        /// Creates a perfect play sequence (all Just hits)
+        /// Creates a perfect play sequence (all Perfect hits)
         /// </summary>
         public static List<JudgementEvent> CreatePerfectPlay(int noteCount)
         {
@@ -556,8 +556,8 @@ namespace DTXMania.Test.Helpers
             return new List<(double, JudgementType)>
             {
                 (0.0, JudgementType.Perfect),      // Perfect
-                (25.0, JudgementType.Perfect),     // Just boundary
-                (25.1, JudgementType.Great),    // Just over Just
+                (25.0, JudgementType.Perfect),     // Perfect boundary
+                (25.1, JudgementType.Great),    // Just over Perfect
                 (50.0, JudgementType.Great),    // Great boundary
                 (50.1, JudgementType.Good),     // Just over Great
                 (100.0, JudgementType.Good),    // Good boundary
@@ -565,7 +565,7 @@ namespace DTXMania.Test.Helpers
                 (150.0, JudgementType.Poor),    // Poor boundary
                 (150.1, JudgementType.Miss),    // Just over Poor
                 (200.0, JudgementType.Miss),    // Miss threshold
-                (-25.0, JudgementType.Perfect),    // Early Just
+                (-25.0, JudgementType.Perfect),    // Early Perfect
                 (-50.0, JudgementType.Great),   // Early Great
                 (-100.0, JudgementType.Good),   // Early Good
                 (-150.0, JudgementType.Poor),   // Early Poor

--- a/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+++ b/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
@@ -65,5 +65,40 @@ namespace DTXMania.Test.Song.Entities
         }
 
         #endregion
+
+        #region CalculateGameSkill
+
+        [Fact]
+        public void CalculateGameSkill_PlayingSkill100_Level850_ShouldReturn170()
+        {
+            // level >= 100 branch: actualLevel = 850/100 = 8.5; 100 * 8.5 * 0.2 = 170
+            double result = SongScore.CalculateGameSkill(playingSkill: 100.0, level: 850, levelDec: 0);
+            Assert.Equal(170.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_PlayingSkill60_Level78Dec33_ShouldReturn97_56()
+        {
+            // level < 100 branch: actualLevel = 78/10.0 + 33/100.0 = 7.8 + 0.33 = 8.13; 60 * 8.13 * 0.2 = 97.56
+            double result = SongScore.CalculateGameSkill(playingSkill: 60.0, level: 78, levelDec: 33);
+            Assert.Equal(97.56, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_ZeroPlayingSkill_ShouldReturnZero()
+        {
+            double result = SongScore.CalculateGameSkill(playingSkill: 0.0, level: 78, levelDec: 33);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_PlayingSkill100_Level50Dec0_ShouldReturn100()
+        {
+            // level < 100 branch: actualLevel = 50/10 + 0/100 = 5.0; 100 * 5.0 * 0.2 = 100
+            double result = SongScore.CalculateGameSkill(playingSkill: 100.0, level: 50, levelDec: 0);
+            Assert.Equal(100.0, result, 6);
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+++ b/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
@@ -1,0 +1,69 @@
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song.Entities
+{
+    /// <summary>
+    /// Tests for SongScore static skill formula helpers.
+    /// Reference values verified against DTXManiaNX CScoreIni.tCalculatePlayingSkill
+    /// (Score,Song/CScoreIni.cs:1641) and tCalculateGameSkillFromPlayingSkill (line 1623).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SongScoreSkillFormulaTests
+    {
+        #region CalculatePlayingSkill
+
+        [Fact]
+        public void CalculatePlayingSkill_AllPerfectFullCombo_ShouldReturn100()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 100, great: 0, maxCombo: 100);
+            Assert.Equal(100.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_AllGreatFullCombo_ShouldReturn50()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 0, great: 100, maxCombo: 100);
+            Assert.Equal(50.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_HalfPerfectHalfMiss_ShouldReturn50()
+        {
+            // Perfect%=50*0.85=42.5, Great%=0, Combo%=50*0.15=7.5 → 50.0
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 50, great: 0, maxCombo: 50);
+            Assert.Equal(50.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_MixedPerfectGreatFullCombo_ShouldReturn60()
+        {
+            // 20*0.85 + 80*0.35 + 100*0.15 = 17 + 28 + 15 = 60
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 20, great: 80, maxCombo: 100);
+            Assert.Equal(60.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_NoHits_ShouldReturnZero()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 0, great: 0, maxCombo: 0);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_ZeroTotalNotes_ShouldReturnZero()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 0, perfect: 0, great: 0, maxCombo: 0);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_NegativeTotalNotes_ShouldReturnZero()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: -1, perfect: 0, great: 0, maxCombo: 0);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+++ b/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
@@ -99,6 +99,23 @@ namespace DTXMania.Test.Song.Entities
             Assert.Equal(100.0, result, 6);
         }
 
+        [Fact]
+        public void CalculateGameSkill_Level100Boundary_TakesHighBranch()
+        {
+            // Branch boundary: level == 100 should use level/100 (=1.0), not level/10 (=10.0).
+            // 100 * 1.0 * 0.2 = 20.0 (not 200.0)
+            double result = SongScore.CalculateGameSkill(playingSkill: 100.0, level: 100, levelDec: 0);
+            Assert.Equal(20.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_LevelDec_IgnoredWhenLevelAtLeast100()
+        {
+            // High branch should ignore levelDec entirely.
+            double result = SongScore.CalculateGameSkill(playingSkill: 100.0, level: 850, levelDec: 99);
+            Assert.Equal(170.0, result, 6);  // same as levelDec=0
+        }
+
         #endregion
     }
 }

--- a/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+++ b/DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
@@ -117,5 +117,60 @@ namespace DTXMania.Test.Song.Entities
         }
 
         #endregion
+
+        #region CalculateSkill (instance)
+
+        [Fact]
+        public void CalculateSkill_UsesPlayingTimesGameFormula()
+        {
+            // PlayingSkill from (50 Perfect, 0 Great, 50 MaxCombo, 100 Total) = 50.0
+            // GameSkill with DifficultyLevel=78, levelDec=0 → actualLevel=7.8 → 50 * 7.8 * 0.2 = 78.0
+            var score = new SongScore
+            {
+                BestScore = 500000,
+                DifficultyLevel = 78,
+                TotalNotes = 100,
+                BestPerfect = 50,
+                BestGreat = 0,
+                MaxCombo = 50
+            };
+            score.CalculateSkill();
+            Assert.Equal(78.0, score.SongSkill, 6);
+            Assert.Equal(78.0, score.HighSkill, 6);
+        }
+
+        [Fact]
+        public void CalculateSkill_ZeroBestScore_ShouldZeroSongSkill()
+        {
+            var score = new SongScore { BestScore = 0, DifficultyLevel = 78, TotalNotes = 100, BestPerfect = 100, MaxCombo = 100 };
+            score.CalculateSkill();
+            Assert.Equal(0.0, score.SongSkill);
+        }
+
+        [Fact]
+        public void CalculateSkill_ZeroDifficulty_ShouldZeroSongSkill()
+        {
+            var score = new SongScore { BestScore = 500000, DifficultyLevel = 0, TotalNotes = 100, BestPerfect = 100, MaxCombo = 100 };
+            score.CalculateSkill();
+            Assert.Equal(0.0, score.SongSkill);
+        }
+
+        [Fact]
+        public void CalculateSkill_PreservesExistingHigherHighSkill()
+        {
+            var score = new SongScore
+            {
+                BestScore = 500000,
+                DifficultyLevel = 78,
+                TotalNotes = 100,
+                BestPerfect = 50, BestGreat = 0, MaxCombo = 50,
+                HighSkill = 90.0
+            };
+            score.CalculateSkill();
+            Assert.Equal(78.0, score.SongSkill, 6);
+            Assert.Equal(90.0, score.HighSkill, 6);
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Song/JudgementEventTests.cs
+++ b/DTXMania.Test/Song/JudgementEventTests.cs
@@ -37,14 +37,14 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void DeltaConstructor_PerfectTiming_ShouldCalculateJustType()
+        public void DeltaConstructor_PerfectTiming_ShouldCalculatePerfectType()
         {
             var evt = new JudgementEvent(noteRef: 1, lane: 0, deltaMs: 0.0);
             Assert.Equal(JudgementType.Perfect, evt.Type);
         }
 
         [Fact]
-        public void DeltaConstructor_25MsDelta_ShouldCalculateJustType()
+        public void DeltaConstructor_25MsDelta_ShouldCalculatePerfectType()
         {
             var evt = new JudgementEvent(noteRef: 1, lane: 0, deltaMs: 25.0);
             Assert.Equal(JudgementType.Perfect, evt.Type);

--- a/DTXMania.Test/Song/JudgementEventTests.cs
+++ b/DTXMania.Test/Song/JudgementEventTests.cs
@@ -40,14 +40,14 @@ namespace DTXMania.Test.Song
         public void DeltaConstructor_PerfectTiming_ShouldCalculateJustType()
         {
             var evt = new JudgementEvent(noteRef: 1, lane: 0, deltaMs: 0.0);
-            Assert.Equal(JudgementType.Just, evt.Type);
+            Assert.Equal(JudgementType.Perfect, evt.Type);
         }
 
         [Fact]
         public void DeltaConstructor_25MsDelta_ShouldCalculateJustType()
         {
             var evt = new JudgementEvent(noteRef: 1, lane: 0, deltaMs: 25.0);
-            Assert.Equal(JudgementType.Just, evt.Type);
+            Assert.Equal(JudgementType.Perfect, evt.Type);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace DTXMania.Test.Song
         #region JudgementEvent Method Tests
 
         [Theory]
-        [InlineData(JudgementType.Just, 1000)]
+        [InlineData(JudgementType.Perfect, 1000)]
         [InlineData(JudgementType.Great, 700)]
         [InlineData(JudgementType.Good, 400)]
         [InlineData(JudgementType.Poor, 100)]
@@ -88,7 +88,7 @@ namespace DTXMania.Test.Song
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, true)]
+        [InlineData(JudgementType.Perfect, true)]
         [InlineData(JudgementType.Great, true)]
         [InlineData(JudgementType.Good, true)]
         [InlineData(JudgementType.Poor, true)]
@@ -102,7 +102,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void IsEarly_WithNegativeDelta_ShouldReturnTrue()
         {
-            var evt = new JudgementEvent(1, 0, -15.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 0, -15.0, JudgementType.Perfect);
             Assert.True(evt.IsEarly());
             Assert.False(evt.IsLate());
         }
@@ -110,7 +110,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void IsLate_WithPositiveDelta_ShouldReturnTrue()
         {
-            var evt = new JudgementEvent(1, 0, 15.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 0, 15.0, JudgementType.Perfect);
             Assert.True(evt.IsLate());
             Assert.False(evt.IsEarly());
         }
@@ -118,7 +118,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void IsEarly_IsLate_WithZeroDelta_ShouldBothReturnFalse()
         {
-            var evt = new JudgementEvent(1, 0, 0.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 0, 0.0, JudgementType.Perfect);
             Assert.False(evt.IsEarly());
             Assert.False(evt.IsLate());
         }
@@ -140,10 +140,10 @@ namespace DTXMania.Test.Song
         [Fact]
         public void ToString_WithHitEvent_ShouldContainTypeAndScore()
         {
-            var evt = new JudgementEvent(1, 4, -10.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 4, -10.0, JudgementType.Perfect);
             var result = evt.ToString();
 
-            Assert.Contains("Just", result);
+            Assert.Contains("Perfect", result);
             Assert.Contains("1000", result);
         }
 
@@ -160,7 +160,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void ToString_WithEarlyHit_ShouldContainEarly()
         {
-            var evt = new JudgementEvent(1, 5, -20.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 5, -20.0, JudgementType.Perfect);
             var result = evt.ToString();
             Assert.Contains("early", result);
         }
@@ -168,7 +168,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void ToString_WithLateHit_ShouldContainLate()
         {
-            var evt = new JudgementEvent(1, 5, 20.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 5, 20.0, JudgementType.Perfect);
             var result = evt.ToString();
             Assert.Contains("late", result);
         }
@@ -176,7 +176,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void ToString_WithPerfectTiming_ShouldContainPerfect()
         {
-            var evt = new JudgementEvent(1, 5, 0.0, JudgementType.Just);
+            var evt = new JudgementEvent(1, 5, 0.0, JudgementType.Perfect);
             var result = evt.ToString();
             Assert.Contains("perfect", result);
         }
@@ -196,7 +196,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void TimingConstants_WindowValues_ShouldBeCorrect()
         {
-            Assert.Equal(25.0, TimingConstants.JustWindowMs);
+            Assert.Equal(25.0, TimingConstants.PerfectWindowMs);
             Assert.Equal(50.0, TimingConstants.GreatWindowMs);
             Assert.Equal(100.0, TimingConstants.GoodWindowMs);
             Assert.Equal(150.0, TimingConstants.PoorWindowMs);
@@ -206,7 +206,7 @@ namespace DTXMania.Test.Song
         [Fact]
         public void TimingConstants_ScoreValues_ShouldBeCorrect()
         {
-            Assert.Equal(1000, TimingConstants.JustScore);
+            Assert.Equal(1000, TimingConstants.PerfectScore);
             Assert.Equal(700, TimingConstants.GreatScore);
             Assert.Equal(400, TimingConstants.GoodScore);
             Assert.Equal(100, TimingConstants.PoorScore);
@@ -214,9 +214,9 @@ namespace DTXMania.Test.Song
         }
 
         [Theory]
-        [InlineData(0.0, JudgementType.Just)]
-        [InlineData(25.0, JudgementType.Just)]
-        [InlineData(-25.0, JudgementType.Just)]
+        [InlineData(0.0, JudgementType.Perfect)]
+        [InlineData(25.0, JudgementType.Perfect)]
+        [InlineData(-25.0, JudgementType.Perfect)]
         [InlineData(25.1, JudgementType.Great)]
         [InlineData(50.0, JudgementType.Great)]
         [InlineData(-50.0, JudgementType.Great)]
@@ -233,7 +233,7 @@ namespace DTXMania.Test.Song
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, 1000)]
+        [InlineData(JudgementType.Perfect, 1000)]
         [InlineData(JudgementType.Great, 700)]
         [InlineData(JudgementType.Good, 400)]
         [InlineData(JudgementType.Poor, 100)]

--- a/DTXMania.Test/Song/SongDatabaseServiceHighSkillTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceHighSkillTests.cs
@@ -1,0 +1,247 @@
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongDatabaseServiceHighSkillTests : System.IDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly DbContextOptions<SongDbContext> _options;
+        private readonly SongDatabaseService _svc;
+
+        public SongDatabaseServiceHighSkillTests()
+        {
+            _connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=True");
+            _connection.Open();
+
+            _options = new DbContextOptionsBuilder<SongDbContext>().UseSqlite(_connection).Options;
+
+            var setupCtx = new SongDbContext(_options);
+            try { setupCtx.Database.EnsureCreated(); }
+            finally { setupCtx.Dispose(); }
+
+            _svc = new SongDatabaseService(_options);
+        }
+
+        public void Dispose() { _connection.Dispose(); }
+
+        private async Task<SongChart> SeedChartAsync()
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                var song = new SongEntity { Title = "HighSkill Test" };
+                var chart = new SongChart { Song = song, FilePath = "highskill-test.dtx", DrumLevel = 78, DrumLevelDec = 33 };
+                ctx.SongCharts.Add(chart);
+                await ctx.SaveChangesAsync();
+                return chart;
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        private async Task SeedScoreAsync(int chartId, SongScore seed)
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                seed.ChartId = chartId;
+                seed.Instrument = EInstrumentPart.DRUMS;
+                ctx.SongScores.Add(seed);
+                await ctx.SaveChangesAsync();
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        private async Task<SongScore> LoadSavedScoreAsync(int chartId)
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                return await ctx.SongScores.AsNoTracking().FirstAsync(s => s.ChartId == chartId);
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_WithPerformanceSummary_ShouldUpdateHighSkill()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                BestScore = 900000,
+                HighSkill = 150.0,
+                SongSkill = 150.0,
+                PlayCount = 3
+            });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 800000,
+                MaxCombo = 90,
+                ClearFlag = true,
+                PerfectCount = 90,
+                GreatCount = 10,
+                GoodCount = 0,
+                PoorCount = 0,
+                MissCount = 0,
+                TotalNotes = 100,
+                PlayingSkill = 92.5,
+                GameSkill = 162.6,
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(900000, saved.BestScore);
+            Assert.Equal(162.6, saved.HighSkill, 4);
+            Assert.Equal(162.6, saved.SongSkill, 4);
+            Assert.Equal(162.6, saved.LastSkillPoint, 4);
+            Assert.Equal(800000, saved.LastScore);
+            Assert.Equal(4, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_GameSkillNotHigher_ShouldPreserveHighSkill()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                BestScore = 950000,
+                HighSkill = 180.0,
+                SongSkill = 180.0,
+                PlayCount = 2
+            });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 700000,
+                MaxCombo = 50,
+                ClearFlag = false,
+                PerfectCount = 50,
+                MissCount = 50,
+                TotalNotes = 100,
+                PlayingSkill = 42.5,
+                GameSkill = 70.0,
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(950000, saved.BestScore);
+            Assert.Equal(180.0, saved.HighSkill, 4);
+            Assert.Equal(70.0, saved.SongSkill, 4);
+            Assert.Equal(70.0, saved.LastSkillPoint, 4);
+            Assert.Equal(3, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_ClearWithPoorButNoMiss_FullComboIsFalse()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore { PlayCount = 0 });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 600000,
+                MaxCombo = 80,
+                ClearFlag = true,
+                PerfectCount = 80,
+                GreatCount = 0,
+                GoodCount = 0,
+                PoorCount = 20,
+                MissCount = 0,
+                TotalNotes = 100,
+                PlayingSkill = 72.0,
+                GameSkill = 118.0,
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.False(saved.FullCombo);
+            Assert.Equal(1, saved.ClearCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_NewBestScoreWithLowerGameSkill_ShouldUpdateBestButNotHighSkill()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                BestScore = 800000,
+                BestPerfect = 80,
+                HighSkill = 160.0,
+                SongSkill = 140.0,
+                PlayCount = 5
+            });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 850000,
+                MaxCombo = 85,
+                ClearFlag = true,
+                PerfectCount = 85,
+                GreatCount = 15,
+                GoodCount = 0,
+                PoorCount = 0,
+                MissCount = 0,
+                TotalNotes = 100,
+                PlayingSkill = 78.625,
+                GameSkill = 130.0,
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(850000, saved.BestScore);
+            Assert.Equal(85, saved.BestPerfect);
+            Assert.Equal(85, saved.MaxCombo);
+            Assert.True(saved.FullCombo);
+            Assert.Equal(160.0, saved.HighSkill, 4);
+            Assert.Equal(130.0, saved.SongSkill, 4);
+            Assert.Equal(130.0, saved.LastSkillPoint, 4);
+            Assert.Equal(6, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_ClearFlagTrue_ShouldIncrementClearCount()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore { ClearCount = 2, PlayCount = 3 });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 500000,
+                MaxCombo = 30,
+                ClearFlag = true,
+                PerfectCount = 30,
+                MissCount = 70,
+                TotalNotes = 100,
+                PlayingSkill = 25.5,
+                GameSkill = 40.0,
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(3, saved.ClearCount);
+            Assert.Equal(4, saved.PlayCount);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs
@@ -14,7 +14,7 @@ namespace DTXMania.Test.Song
     /// Shared SqliteConnection lifecycle pattern mirrors SongDbContextTests
     /// (which has notes on coverlet "using var" quirks for EF disposables).
     /// </summary>
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     public class SongDatabaseServiceSkillSaveTests : System.IDisposable
     {
         private readonly SqliteConnection _connection;
@@ -132,6 +132,80 @@ namespace DTXMania.Test.Song
             Assert.Equal(500000, saved.LastScore);
             Assert.Equal(78.0, saved.LastSkillPoint, 4);
             Assert.Equal(6, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_FirstPlay_CreatesScoreRow()
+        {
+            var chart = await SeedChartAsync();
+            // Note: do NOT seed a score row — verifies create-on-miss behavior
+
+            var summary = new PerformanceSummary
+            {
+                Score = 600000, MaxCombo = 80, ClearFlag = true, TotalNotes = 100,
+                PerfectCount = 80, GreatCount = 20,
+                PlayingSkill = 87.0, GameSkill = 141.31,
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(600000, saved.BestScore);
+            Assert.Equal(80, saved.MaxCombo);
+            Assert.Equal(141.31, saved.HighSkill, 4);
+            Assert.Equal(1, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_NullSummary_ShouldThrow()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id);
+
+            await Assert.ThrowsAsync<System.ArgumentNullException>(
+                () => _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, null!));
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_ClearFlagFalse_DoesNotIncrementClearCount()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore { ClearCount = 3 });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 100000, MaxCombo = 10, ClearFlag = false, TotalNotes = 100,
+                PerfectCount = 5, MissCount = 95,
+                PlayingSkill = 5.75, GameSkill = 9.35,
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(3, saved.ClearCount); // unchanged
+            Assert.Equal(1, saved.PlayCount);  // incremented
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_ClearedWithMisses_FullComboIsFalse()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id);
+
+            var summary = new PerformanceSummary
+            {
+                Score = 700000, MaxCombo = 90, ClearFlag = true, TotalNotes = 100,
+                PerfectCount = 80, GreatCount = 15, MissCount = 5,
+                PlayingSkill = 80.0, GameSkill = 130.08,
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.False(saved.FullCombo); // had misses, so not full combo despite clearing
         }
     }
 }

--- a/DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs
@@ -1,0 +1,137 @@
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    /// <summary>
+    /// Tests for the SongDatabaseService.UpdateScoreAsync overload that takes a
+    /// PerformanceSummary and persists score + skill values.
+    /// Shared SqliteConnection lifecycle pattern mirrors SongDbContextTests
+    /// (which has notes on coverlet "using var" quirks for EF disposables).
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class SongDatabaseServiceSkillSaveTests : System.IDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly DbContextOptions<SongDbContext> _options;
+        private readonly SongDatabaseService _svc;
+
+        public SongDatabaseServiceSkillSaveTests()
+        {
+            _connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=True");
+            _connection.Open();
+
+            _options = new DbContextOptionsBuilder<SongDbContext>().UseSqlite(_connection).Options;
+
+            var setupCtx = new SongDbContext(_options);
+            try { setupCtx.Database.EnsureCreated(); }
+            finally { setupCtx.Dispose(); }
+
+            _svc = new SongDatabaseService(_options);
+        }
+
+        public void Dispose() { _connection.Dispose(); }
+
+        private async Task<SongChart> SeedChartAsync()
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                var song = new SongEntity { Title = "Test Song" };
+                var chart = new SongChart { Song = song, FilePath = "test.dtx", DrumLevel = 78, DrumLevelDec = 33 };
+                ctx.SongCharts.Add(chart);
+                await ctx.SaveChangesAsync();
+                return chart;
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        private async Task SeedScoreAsync(int chartId, SongScore? seed = null)
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                seed ??= new SongScore { ChartId = chartId, Instrument = EInstrumentPart.DRUMS };
+                seed.ChartId = chartId;
+                seed.Instrument = EInstrumentPart.DRUMS;
+                ctx.SongScores.Add(seed);
+                await ctx.SaveChangesAsync();
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        private async Task<SongScore> LoadSavedScoreAsync(int chartId)
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                return await ctx.SongScores.AsNoTracking().FirstAsync(s => s.ChartId == chartId);
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_WithSummary_PersistsBestSkill()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id);
+
+            var summary = new PerformanceSummary
+            {
+                Score = 800000,
+                MaxCombo = 100,
+                ClearFlag = true,
+                PerfectCount = 100, GreatCount = 0, GoodCount = 0, PoorCount = 0, MissCount = 0,
+                TotalNotes = 100,
+                PlayingSkill = 100.0,
+                GameSkill = 162.6,
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(800000, saved.BestScore);
+            Assert.Equal(100, saved.BestPerfect);
+            Assert.Equal(100, saved.MaxCombo);
+            Assert.True(saved.FullCombo);
+            Assert.Equal(162.6, saved.HighSkill, 4);
+            Assert.Equal(162.6, saved.SongSkill, 4);
+            Assert.Equal(162.6, saved.LastSkillPoint, 4);
+            Assert.Equal(1, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_LowerScore_KeepsExistingBestButUpdatesLast()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                BestScore = 900000, BestPerfect = 95, MaxCombo = 90,
+                HighSkill = 170.0, SongSkill = 170.0, PlayCount = 5
+            });
+
+            var lowerSummary = new PerformanceSummary
+            {
+                Score = 500000, MaxCombo = 50, TotalNotes = 100,
+                PerfectCount = 50, MissCount = 50,
+                PlayingSkill = 50.0, GameSkill = 78.0,
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, lowerSummary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(900000, saved.BestScore);
+            Assert.Equal(170.0, saved.HighSkill, 4);
+            Assert.Equal(500000, saved.LastScore);
+            Assert.Equal(78.0, saved.LastSkillPoint, 4);
+            Assert.Equal(6, saved.PlayCount);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongManagerUpdateScoreTests.cs
+++ b/DTXMania.Test/Song/SongManagerUpdateScoreTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Song;
+
+[Collection("SongManager")]
+[Trait("Category", "Unit")]
+public class SongManagerUpdateScoreTests : IDisposable
+{
+    private readonly SongManager _manager;
+    private readonly string _testRoot;
+    private readonly string _testDbPath;
+
+    public SongManagerUpdateScoreTests()
+    {
+        SongManager.ResetInstanceForTesting();
+        _manager = SongManager.Instance;
+
+        _testRoot = Path.Combine(
+            Path.GetTempPath(),
+            "DTXManiaCX_Tests",
+            nameof(SongManagerUpdateScoreTests),
+            Guid.NewGuid().ToString("N"));
+        _testDbPath = Path.Combine(_testRoot, "songs.db");
+
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    public void Dispose()
+    {
+        _manager.Clear();
+        SongManager.ResetInstanceForTesting();
+
+        try
+        {
+            if (Directory.Exists(_testRoot))
+            {
+                Directory.Delete(_testRoot, true);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    [Fact]
+    public async Task UpdateScoreAsync_WithValidChartId_ShouldUpdateScore()
+    {
+        var songsRoot = Path.Combine(_testRoot, "ScoreSongs");
+        var songFolder = Path.Combine(songsRoot, "Score Song");
+        Directory.CreateDirectory(songFolder);
+
+        await CreateDtxFileAsync(Path.Combine(songFolder, "score.dtx"), "Score Song", "Test Artist", "Rock", 50);
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        var db = _manager.DatabaseService!;
+        var songs = await db.GetSongsAsync();
+        var chart = Assert.Single(songs).Charts.First();
+
+        var result = await _manager.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, 880_000, 92.5, fullCombo: false);
+
+        Assert.True(result);
+
+        var scores = await _manager.GetTopScoresAsync(EInstrumentPart.DRUMS, limit: 1);
+        var score = Assert.Single(scores);
+        Assert.Equal(chart.Id, score.ChartId);
+        Assert.Equal(880_000, score.BestScore);
+    }
+
+    [Fact]
+    public async Task UpdateScoreAsync_WithPerformanceSummary_ShouldPersistSkill()
+    {
+        var songsRoot = Path.Combine(_testRoot, "SkillSongs");
+        var songFolder = Path.Combine(songsRoot, "Skill Song");
+        Directory.CreateDirectory(songFolder);
+
+        await CreateDtxFileAsync(Path.Combine(songFolder, "skill.dtx"), "Skill Song", "Test Artist", "Pop", 78);
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        var db = _manager.DatabaseService!;
+        var songs = await db.GetSongsAsync();
+        var chart = Assert.Single(songs).Charts.First();
+
+        var summary = new PerformanceSummary
+        {
+            Score = 800_000,
+            MaxCombo = 120,
+            ClearFlag = true,
+            PerfectCount = 100,
+            GreatCount = 20,
+            GoodCount = 0,
+            PoorCount = 0,
+            MissCount = 0,
+            TotalNotes = 120,
+            PlayingSkill = 100.0,
+            GameSkill = 162.6,
+            ChartLevel = 78,
+            ChartLevelDec = 33
+        };
+
+        var result = await _manager.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+        Assert.True(result);
+
+        var scores = await _manager.GetTopScoresAsync(EInstrumentPart.DRUMS, limit: 1);
+        var score = Assert.Single(scores);
+        Assert.Equal(chart.Id, score.ChartId);
+        Assert.Equal(800_000, score.BestScore);
+        Assert.Equal(162.6, score.HighSkill, 1);
+        Assert.Equal(162.6, score.SongSkill, 1);
+        Assert.True(score.FullCombo);
+    }
+
+    [Fact]
+    public async Task UpdateScoreAsync_WithSummaryWithoutDatabaseService_ShouldReturnFalse()
+    {
+        var result = await _manager.UpdateScoreAsync(1, EInstrumentPart.DRUMS, new PerformanceSummary());
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task UpdateScoreAsync_WithInvalidChartId_ShouldStillReturnTrue()
+    {
+        await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+
+        var result = await _manager.UpdateScoreAsync(99999, EInstrumentPart.DRUMS, 100_000, 50.0, fullCombo: false);
+
+        Assert.True(result);
+    }
+
+    private async Task InitializeAndEnumerateAsync(string songsRoot)
+    {
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+
+        var result = await _manager.EnumerateSongsAsync(new[] { songsRoot });
+        Assert.True(result >= 1);
+        Assert.NotNull(_manager.DatabaseService);
+    }
+
+    private static async Task CreateDtxFileAsync(string path, string title, string artist, string genre, int drumLevel)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, $"""
+#TITLE: {title}
+#ARTIST: {artist}
+#GENRE: {genre}
+#BPM: 120
+#DLEVEL: {drumLevel}
+#00002:11111111
+#00011:01010101
+""");
+    }
+}

--- a/DTXMania.Test/Song/SongManagerUpdateScoreTests.cs
+++ b/DTXMania.Test/Song/SongManagerUpdateScoreTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage.Performance;
+using static DTXMania.Test.TestData.ReflectionHelpers;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 
 namespace DTXMania.Test.Song;
@@ -120,6 +121,16 @@ public class SongManagerUpdateScoreTests : IDisposable
     [Fact]
     public async Task UpdateScoreAsync_WithSummaryWithoutDatabaseService_ShouldReturnFalse()
     {
+        var result = await _manager.UpdateScoreAsync(1, EInstrumentPart.DRUMS, new PerformanceSummary());
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task UpdateScoreAsync_WithSummaryWhenDatabaseServiceThrows_ShouldReturnFalse()
+    {
+        SetPrivateField(_manager, "_databaseService", new SongDatabaseService(_testDbPath));
+
         var result = await _manager.UpdateScoreAsync(1, EInstrumentPart.DRUMS, new PerformanceSummary());
 
         Assert.False(result);

--- a/DTXMania.Test/Song/SongScoreTests.cs
+++ b/DTXMania.Test/Song/SongScoreTests.cs
@@ -453,22 +453,6 @@ namespace DTXMania.Test.Song
             Assert.Equal("A", score.RankName);
         }
 
-        private int GetRankPercentageFromMultiplier(double multiplier)
-        {
-            return multiplier switch
-            {
-                1.0 => 95,  // SS
-                0.95 => 90, // S
-                0.9 => 80,  // A
-                0.85 => 70, // B
-                0.8 => 60,  // C
-                0.75 => 50, // D
-                0.7 => 40,  // E
-                0.65 => 0,  // F
-                _ => 0
-            };
-        }
-
         #endregion
 
         #region HasBeenPlayed Tests

--- a/DTXMania.Test/Song/SongScoreTests.cs
+++ b/DTXMania.Test/Song/SongScoreTests.cs
@@ -358,19 +358,24 @@ namespace DTXMania.Test.Song
         }
 
         [Theory]
-        [InlineData(1000000, 85, 1.0, 85.0)] // Perfect score, SS rank
-        [InlineData(950000, 85, 0.95, 76.71)] // S rank
-        [InlineData(900000, 85, 0.9, 68.85)] // A rank
-        [InlineData(0, 85, 0.5, 0.0)] // No score
-        [InlineData(1000000, 0, 1.0, 0.0)] // No difficulty
-        public void CalculateSkill_ShouldComputeCorrectValue(int bestScore, int difficultyLevel, double rankMultiplier, double expectedSkill)
+        // DTXManiaNX formula: SongSkill = PlayingSkill * actualLevel * 0.2
+        // For DifficultyLevel < 100 → actualLevel = DifficultyLevel / 10.0
+        // PlayingSkill = Perfect%*0.85 + Great%*0.35 + Combo%*0.15
+        [InlineData(1000000, 85, 100, 100, 0, 100, 170.0)] // All perfect FC: PS=100, actualLevel=8.5 → 100*8.5*0.2=170
+        [InlineData(950000, 85, 100, 50, 50, 100, 127.5)] // PS=50*0.85+50*0.35+100*0.15=75, actualLevel=8.5 → 75*8.5*0.2=127.5
+        [InlineData(0, 85, 100, 100, 0, 100, 0.0)] // No score → 0
+        [InlineData(1000000, 0, 100, 100, 0, 100, 0.0)] // No difficulty → 0
+        public void CalculateSkill_ShouldComputeCorrectValue(int bestScore, int difficultyLevel, int totalNotes, int bestPerfect, int bestGreat, int maxCombo, double expectedSkill)
         {
             // Arrange
             var score = new SongScore
             {
                 BestScore = bestScore,
                 DifficultyLevel = difficultyLevel,
-                BestRank = GetRankPercentageFromMultiplier(rankMultiplier)
+                TotalNotes = totalNotes,
+                BestPerfect = bestPerfect,
+                BestGreat = bestGreat,
+                MaxCombo = maxCombo
             };
 
             // Act
@@ -378,7 +383,7 @@ namespace DTXMania.Test.Song
 
             // Assert
             Assert.Equal(expectedSkill, score.SongSkill, 2); // 2 decimal places precision
-            
+
             if (expectedSkill > score.HighSkill)
             {
                 Assert.Equal(expectedSkill, score.HighSkill, 2);

--- a/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
+++ b/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
@@ -271,7 +271,7 @@ namespace DTXMania.Test.Stage.Performance
 
             // Variance-specific expectations
             var scorePercentage = scoreManager.GetStatistics().ScorePercentage;
-            if (maxVarianceMs <= 25.0) // Within Just window
+            if (maxVarianceMs <= 25.0) // Within Perfect window
             {
                 Assert.True(scorePercentage >= 70.0, $"Small variance should yield good scores: {scorePercentage:F1}%");
             }

--- a/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
+++ b/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
@@ -48,7 +48,7 @@ namespace DTXMania.Test.Stage.Performance
                     noteRef: note.Id,
                     lane: note.LaneIndex,
                     deltaMs: 0.0, // Perfect timing
-                    type: JudgementType.Just
+                    type: JudgementType.Perfect
                 );
 
                 // Process judgement in both managers
@@ -56,7 +56,7 @@ namespace DTXMania.Test.Stage.Performance
                 gaugeManager.ProcessJudgement(judgementEvent);
 
                 // Track results
-                simulationResults.JudgementCounts[JudgementType.Just]++;
+                simulationResults.JudgementCounts[JudgementType.Perfect]++;
                 simulationResults.TotalScore = scoreManager.CurrentScore;
                 simulationResults.FinalLife = gaugeManager.CurrentLife;
                 simulationResults.ProcessedNotes++;
@@ -72,14 +72,14 @@ namespace DTXMania.Test.Stage.Performance
 
             _output.WriteLine("\n=== PERFECT PLAY SIMULATION RESULTS ===");
             _output.WriteLine($"Total Notes Processed: {simulationResults.ProcessedNotes}");
-            _output.WriteLine($"Just Hits: {simulationResults.JudgementCounts[JudgementType.Just]}");
+            _output.WriteLine($"Just Hits: {simulationResults.JudgementCounts[JudgementType.Perfect]}");
             _output.WriteLine($"Final Score: {simulationResults.TotalScore:N0}");
             _output.WriteLine($"Score Percentage: {scoreStats.ScorePercentage:F2}%");
             _output.WriteLine($"Final Life: {simulationResults.FinalLife:F1}%");
             _output.WriteLine($"Player Failed: {gaugeStats.HasFailed}");
 
             // Verify all notes were hit with Just timing
-            Assert.Equal(testChart.Count, simulationResults.JudgementCounts[JudgementType.Just]);
+            Assert.Equal(testChart.Count, simulationResults.JudgementCounts[JudgementType.Perfect]);
             Assert.Equal(0, simulationResults.JudgementCounts[JudgementType.Great]);
             Assert.Equal(0, simulationResults.JudgementCounts[JudgementType.Good]);
             Assert.Equal(0, simulationResults.JudgementCounts[JudgementType.Poor]);
@@ -117,7 +117,7 @@ namespace DTXMania.Test.Stage.Performance
             // Act - Perfect play simulation
             foreach (var note in testChart.OrderBy(n => n.TimeMs))
             {
-                var judgementEvent = new JudgementEvent(note.Id, note.LaneIndex, 0.0, JudgementType.Just);
+                var judgementEvent = new JudgementEvent(note.Id, note.LaneIndex, 0.0, JudgementType.Perfect);
                 scoreManager.ProcessJudgement(judgementEvent);
                 gaugeManager.ProcessJudgement(judgementEvent);
             }
@@ -201,7 +201,7 @@ namespace DTXMania.Test.Stage.Performance
             _output.WriteLine($"Notes Processed: {simulationResults.ProcessedNotes}");
             _output.WriteLine($"Average Timing Deviation: ±{simulationResults.AverageTimingDeviation:F1}ms");
             _output.WriteLine($"Judgement Distribution:");
-            _output.WriteLine($"  Just:  {simulationResults.JudgementCounts[JudgementType.Just]} ({(double)simulationResults.JudgementCounts[JudgementType.Just]/simulationResults.ProcessedNotes*100:F1}%)");
+            _output.WriteLine($"  Just:  {simulationResults.JudgementCounts[JudgementType.Perfect]} ({(double)simulationResults.JudgementCounts[JudgementType.Perfect]/simulationResults.ProcessedNotes*100:F1}%)");
             _output.WriteLine($"  Great: {simulationResults.JudgementCounts[JudgementType.Great]} ({(double)simulationResults.JudgementCounts[JudgementType.Great]/simulationResults.ProcessedNotes*100:F1}%)");
             _output.WriteLine($"  Good:  {simulationResults.JudgementCounts[JudgementType.Good]} ({(double)simulationResults.JudgementCounts[JudgementType.Good]/simulationResults.ProcessedNotes*100:F1}%)");
             _output.WriteLine($"  Poor:  {simulationResults.JudgementCounts[JudgementType.Poor]} ({(double)simulationResults.JudgementCounts[JudgementType.Poor]/simulationResults.ProcessedNotes*100:F1}%)");
@@ -335,7 +335,7 @@ namespace DTXMania.Test.Stage.Performance
 
                 // Weighted distribution: some perfect, some good, some poor
                 if (roll < 0.2) // 20% perfect timing
-                    timingDelta = (random.NextDouble() - 0.5) * 2.0 * TimingConstants.JustWindowMs;
+                    timingDelta = (random.NextDouble() - 0.5) * 2.0 * TimingConstants.PerfectWindowMs;
                 else if (roll < 0.5) // 30% great timing
                     timingDelta = (random.NextDouble() - 0.5) * 2.0 * TimingConstants.GreatWindowMs;
                 else if (roll < 0.8) // 30% good timing
@@ -354,7 +354,7 @@ namespace DTXMania.Test.Stage.Performance
             _output.WriteLine($"Mixed timing results: Score={scoreStats.ScorePercentage:F1}%, Life={gaugeManager.CurrentLife:F1}%");
             
             // Should see reasonable distribution across all judgement types
-            Assert.True(results.JudgementCounts[JudgementType.Just] > 0, "Should have some Just hits");
+            Assert.True(results.JudgementCounts[JudgementType.Perfect] > 0, "Should have some Just hits");
             Assert.True(results.JudgementCounts.Count(kvp => kvp.Value > 0) >= 4, "Should have variety in judgements");
             Assert.True(scoreStats.ScorePercentage >= 30.0 && scoreStats.ScorePercentage <= 80.0, 
                 $"Mixed play should yield 30-80% score: {scoreStats.ScorePercentage:F1}%");
@@ -400,7 +400,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             public Dictionary<JudgementType, int> JudgementCounts { get; } = new()
             {
-                { JudgementType.Just, 0 },
+                { JudgementType.Perfect, 0 },
                 { JudgementType.Great, 0 },
                 { JudgementType.Good, 0 },
                 { JudgementType.Poor, 0 },

--- a/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
+++ b/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
@@ -40,10 +40,10 @@ namespace DTXMania.Test.Stage.Performance
             _output.WriteLine($"Starting perfect play simulation with {testChart.Count} notes");
             _output.WriteLine($"Initial conditions: Score=0, Life={gaugeManager.CurrentLife}%");
 
-            // Act - Simulate perfect play (all hits within Just timing window)
+            // Act - Simulate perfect play (all hits within Perfect timing window)
             foreach (var note in testChart.OrderBy(n => n.TimeMs))
             {
-                // Perfect timing (0ms delta) - should always result in Just judgement
+                // Perfect timing (0ms delta) - should always result in Perfect judgement
                 var judgementEvent = new JudgementEvent(
                     noteRef: note.Id,
                     lane: note.LaneIndex,
@@ -72,13 +72,13 @@ namespace DTXMania.Test.Stage.Performance
 
             _output.WriteLine("\n=== PERFECT PLAY SIMULATION RESULTS ===");
             _output.WriteLine($"Total Notes Processed: {simulationResults.ProcessedNotes}");
-            _output.WriteLine($"Just Hits: {simulationResults.JudgementCounts[JudgementType.Perfect]}");
+            _output.WriteLine($"Perfect Hits: {simulationResults.JudgementCounts[JudgementType.Perfect]}");
             _output.WriteLine($"Final Score: {simulationResults.TotalScore:N0}");
             _output.WriteLine($"Score Percentage: {scoreStats.ScorePercentage:F2}%");
             _output.WriteLine($"Final Life: {simulationResults.FinalLife:F1}%");
             _output.WriteLine($"Player Failed: {gaugeStats.HasFailed}");
 
-            // Verify all notes were hit with Just timing
+            // Verify all notes were hit with Perfect timing
             Assert.Equal(testChart.Count, simulationResults.JudgementCounts[JudgementType.Perfect]);
             Assert.Equal(0, simulationResults.JudgementCounts[JudgementType.Great]);
             Assert.Equal(0, simulationResults.JudgementCounts[JudgementType.Good]);
@@ -105,14 +105,14 @@ namespace DTXMania.Test.Stage.Performance
         [InlineData(200, 25)] // Medium chart  
         [InlineData(500, 25)] // Large chart
         public async Task AutomatedPlay_PerfectTiming_VariousChartSizes_ExpectConsistentResults(
-            int totalNotes, int expectedJustWindow)
+            int totalNotes, int expectedPerfectWindow)
         {
             // Arrange
             var testChart = CreateTestChart(totalNotes);
             var scoreManager = new ScoreManager(testChart.Count);
             var gaugeManager = new GaugeManager();
 
-            _output.WriteLine($"Testing chart with {totalNotes} notes (Just window: ±{expectedJustWindow}ms)");
+            _output.WriteLine($"Testing chart with {totalNotes} notes (Perfect window: ±{expectedPerfectWindow}ms)");
 
             // Act - Perfect play simulation
             foreach (var note in testChart.OrderBy(n => n.TimeMs))
@@ -201,7 +201,7 @@ namespace DTXMania.Test.Stage.Performance
             _output.WriteLine($"Notes Processed: {simulationResults.ProcessedNotes}");
             _output.WriteLine($"Average Timing Deviation: ±{simulationResults.AverageTimingDeviation:F1}ms");
             _output.WriteLine($"Judgement Distribution:");
-            _output.WriteLine($"  Just:  {simulationResults.JudgementCounts[JudgementType.Perfect]} ({(double)simulationResults.JudgementCounts[JudgementType.Perfect]/simulationResults.ProcessedNotes*100:F1}%)");
+            _output.WriteLine($"  Perfect:  {simulationResults.JudgementCounts[JudgementType.Perfect]} ({(double)simulationResults.JudgementCounts[JudgementType.Perfect]/simulationResults.ProcessedNotes*100:F1}%)");
             _output.WriteLine($"  Great: {simulationResults.JudgementCounts[JudgementType.Great]} ({(double)simulationResults.JudgementCounts[JudgementType.Great]/simulationResults.ProcessedNotes*100:F1}%)");
             _output.WriteLine($"  Good:  {simulationResults.JudgementCounts[JudgementType.Good]} ({(double)simulationResults.JudgementCounts[JudgementType.Good]/simulationResults.ProcessedNotes*100:F1}%)");
             _output.WriteLine($"  Poor:  {simulationResults.JudgementCounts[JudgementType.Poor]} ({(double)simulationResults.JudgementCounts[JudgementType.Poor]/simulationResults.ProcessedNotes*100:F1}%)");
@@ -354,7 +354,7 @@ namespace DTXMania.Test.Stage.Performance
             _output.WriteLine($"Mixed timing results: Score={scoreStats.ScorePercentage:F1}%, Life={gaugeManager.CurrentLife:F1}%");
             
             // Should see reasonable distribution across all judgement types
-            Assert.True(results.JudgementCounts[JudgementType.Perfect] > 0, "Should have some Just hits");
+            Assert.True(results.JudgementCounts[JudgementType.Perfect] > 0, "Should have some Perfect hits");
             Assert.True(results.JudgementCounts.Count(kvp => kvp.Value > 0) >= 4, "Should have variety in judgements");
             Assert.True(scoreStats.ScorePercentage >= 30.0 && scoreStats.ScorePercentage <= 80.0, 
                 $"Mixed play should yield 30-80% score: {scoreStats.ScorePercentage:F1}%");

--- a/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
+++ b/DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs
@@ -27,7 +27,7 @@ namespace DTXMania.Test.Stage.Performance
         #region Perfect Play Simulation Tests
 
         [Fact]
-        public async Task AutomatedPlay_PerfectTiming_AllNotesJust_ExpectFullScoreAndLife100()
+        public async Task AutomatedPlay_PerfectTiming_AllNotesPerfect_ExpectFullScoreAndLife100()
         {
             // Arrange - Create a test chart with multiple notes across all lanes
             var testChart = CreateTestChart(totalNotes: 100);

--- a/DTXMania.Test/Stage/Performance/ComboManagerResetOnPoorTests.cs
+++ b/DTXMania.Test/Stage/Performance/ComboManagerResetOnPoorTests.cs
@@ -18,7 +18,7 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build up a combo first
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             var greatEvent = new JudgementEvent(1, 0, 40.0, JudgementType.Great);
             var goodEvent = new JudgementEvent(2, 0, 80.0, JudgementType.Good);
             
@@ -44,7 +44,7 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build up a combo first
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             var greatEvent = new JudgementEvent(1, 0, 40.0, JudgementType.Great);
             
             comboManager.ProcessJudgement(justEvent);
@@ -62,7 +62,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, true)]      // Should increment combo
+        [InlineData(JudgementType.Perfect, true)]      // Should increment combo
         [InlineData(JudgementType.Great, true)]    // Should increment combo
         [InlineData(JudgementType.Good, true)]     // Should increment combo
         [InlineData(JudgementType.Poor, false)]    // Should reset combo
@@ -73,7 +73,7 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build up initial combo
-            var initialEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var initialEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             comboManager.ProcessJudgement(initialEvent);
             Assert.Equal(1, comboManager.CurrentCombo);
 
@@ -103,7 +103,7 @@ namespace DTXMania.Test.Stage.Performance
             // Build up a long combo (50 hits)
             for (int i = 0; i < 50; i++)
             {
-                var event1 = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var event1 = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 comboManager.ProcessJudgement(event1);
             }
             
@@ -130,7 +130,7 @@ namespace DTXMania.Test.Stage.Performance
             comboManager.ComboChanged += (sender, e) => capturedEventArgs = e;
             
             // Build up combo
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             comboManager.ProcessJudgement(justEvent);
             
             // Reset captured event
@@ -155,7 +155,7 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build up combo
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             comboManager.ProcessJudgement(justEvent);
             Assert.Equal(1, comboManager.CurrentCombo);
 
@@ -180,7 +180,7 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build up combo
-            var justEvent1 = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent1 = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             var greatEvent = new JudgementEvent(1, 0, 40.0, JudgementType.Great);
             comboManager.ProcessJudgement(justEvent1);
             comboManager.ProcessJudgement(greatEvent);
@@ -192,8 +192,8 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(0, comboManager.CurrentCombo);
 
             // Act - Rebuild combo
-            var justEvent2 = new JudgementEvent(3, 0, 0.0, JudgementType.Just);
-            var justEvent3 = new JudgementEvent(4, 0, 0.0, JudgementType.Just);
+            var justEvent2 = new JudgementEvent(3, 0, 0.0, JudgementType.Perfect);
+            var justEvent3 = new JudgementEvent(4, 0, 0.0, JudgementType.Perfect);
             comboManager.ProcessJudgement(justEvent2);
             comboManager.ProcessJudgement(justEvent3);
 
@@ -211,7 +211,7 @@ namespace DTXMania.Test.Stage.Performance
             // Build up to high combo
             for (int i = 0; i < 25; i++)
             {
-                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 comboManager.ProcessJudgement(justEvent);
             }
             
@@ -259,10 +259,10 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build combo, reset with Poor, build again
-            var justEvent1 = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
-            var justEvent2 = new JudgementEvent(1, 0, 0.0, JudgementType.Just);
+            var justEvent1 = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
+            var justEvent2 = new JudgementEvent(1, 0, 0.0, JudgementType.Perfect);
             var poorEvent = new JudgementEvent(2, 0, 120.0, JudgementType.Poor);
-            var justEvent3 = new JudgementEvent(3, 0, 0.0, JudgementType.Just);
+            var justEvent3 = new JudgementEvent(3, 0, 0.0, JudgementType.Perfect);
             
             comboManager.ProcessJudgement(justEvent1);
             comboManager.ProcessJudgement(justEvent2);
@@ -285,7 +285,7 @@ namespace DTXMania.Test.Stage.Performance
             var comboManager = new ComboManager();
             
             // Build combo
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             comboManager.ProcessJudgement(justEvent);
             Assert.True(comboManager.HasCombo);
 
@@ -308,7 +308,7 @@ namespace DTXMania.Test.Stage.Performance
             comboManager.MaxComboChanged += (sender, e) => maxComboChangedFired = true;
             
             // Build combo to establish max
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             comboManager.ProcessJudgement(justEvent);
             
             // Reset flag after initial max combo established

--- a/DTXMania.Test/Stage/Performance/ComboManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/ComboManagerTests.cs
@@ -26,7 +26,7 @@ namespace DTXMania.Test.Stage.Performance
         #region ProcessJudgement Tests
 
         [Fact]
-        public void ProcessJudgement_Just_ShouldIncrementCombo()
+        public void ProcessJudgement_Perfect_ShouldIncrementCombo()
         {
             var manager = new ComboManager();
             manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));

--- a/DTXMania.Test/Stage/Performance/ComboManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/ComboManagerTests.cs
@@ -29,7 +29,7 @@ namespace DTXMania.Test.Stage.Performance
         public void ProcessJudgement_Just_ShouldIncrementCombo()
         {
             var manager = new ComboManager();
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(1, manager.CurrentCombo);
             Assert.True(manager.HasCombo);
         }
@@ -72,7 +72,7 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new ComboManager();
             for (int i = 0; i < 5; i++)
             {
-                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Just));
+                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Perfect));
             }
             Assert.Equal(5, manager.CurrentCombo);
         }
@@ -83,7 +83,7 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new ComboManager();
             for (int i = 0; i < 10; i++)
             {
-                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Just));
+                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Perfect));
             }
             Assert.Equal(10, manager.MaxCombo);
 
@@ -100,7 +100,7 @@ namespace DTXMania.Test.Stage.Performance
             ComboChangedEventArgs receivedArgs = null;
             manager.ComboChanged += (s, e) => receivedArgs = e;
 
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
 
             Assert.NotNull(receivedArgs);
             Assert.Equal(0, receivedArgs.PreviousCombo);
@@ -112,8 +112,8 @@ namespace DTXMania.Test.Stage.Performance
         public void ProcessJudgement_Miss_RaisesComboChangedWithWasReset()
         {
             var manager = new ComboManager();
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
-            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
+            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Perfect));
 
             ComboChangedEventArgs receivedArgs = null;
             manager.ComboChanged += (s, e) => receivedArgs = e;
@@ -132,7 +132,7 @@ namespace DTXMania.Test.Stage.Performance
             MaxComboChangedEventArgs receivedArgs = null;
             manager.MaxComboChanged += (s, e) => receivedArgs = e;
 
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
 
             Assert.NotNull(receivedArgs);
             Assert.Equal(0, receivedArgs.PreviousMaxCombo);
@@ -161,7 +161,7 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new ComboManager();
             for (int i = 0; i < 5; i++)
             {
-                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Just));
+                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Perfect));
             }
             Assert.Equal(5, manager.MaxCombo);
 
@@ -175,8 +175,8 @@ namespace DTXMania.Test.Stage.Performance
         public void Reset_WithNonZeroCombo_RaisesComboChangedEvent()
         {
             var manager = new ComboManager();
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
-            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
+            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Perfect));
 
             ComboChangedEventArgs receivedArgs = null;
             manager.ComboChanged += (s, e) => receivedArgs = e;
@@ -193,7 +193,7 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new ComboManager();
             for (int i = 0; i < 3; i++)
             {
-                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Just));
+                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Perfect));
             }
 
             MaxComboChangedEventArgs receivedArgs = null;
@@ -228,7 +228,7 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new ComboManager();
             for (int i = 0; i < 5; i++)
             {
-                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Just));
+                manager.ProcessJudgement(new JudgementEvent(i, 0, 0.0, JudgementType.Perfect));
             }
 
             var stats = manager.GetStatistics();
@@ -259,7 +259,7 @@ namespace DTXMania.Test.Stage.Performance
             manager.Dispose();
 
             // After dispose, ProcessJudgement should do nothing
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(0, eventCount);
         }
 

--- a/DTXMania.Test/Stage/Performance/ComboManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/ComboManagerTests.cs
@@ -67,7 +67,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void ProcessJudgement_MultipleJust_ShouldIncrementEachTime()
+        public void ProcessJudgement_MultiplePerfects_ShouldIncrementEachTime()
         {
             var manager = new ComboManager();
             for (int i = 0; i < 5; i++)

--- a/DTXMania.Test/Stage/Performance/GaugeManagerFailThresholdTests.cs
+++ b/DTXMania.Test/Stage/Performance/GaugeManagerFailThresholdTests.cs
@@ -184,7 +184,7 @@ namespace DTXMania.Test.Stage.Performance
             float lifeAfterFailure = gaugeManager.CurrentLife;
 
             // Act - Try to process more judgements after failure
-            var justEvent = new JudgementEvent(1, 0, 0.0, JudgementType.Just); // Should normally add +2% life
+            var justEvent = new JudgementEvent(1, 0, 0.0, JudgementType.Perfect); // Should normally add +2% life
             gaugeManager.ProcessJudgement(justEvent);
 
             // Assert - Life should not change after failure
@@ -263,7 +263,7 @@ namespace DTXMania.Test.Stage.Performance
             var gaugeManager = new GaugeManager(50.0f);
 
             // Test each judgement type's life adjustment
-            Assert.Equal(2.0f, gaugeManager.GetLifeAdjustment(JudgementType.Just));
+            Assert.Equal(2.0f, gaugeManager.GetLifeAdjustment(JudgementType.Perfect));
             Assert.Equal(1.5f, gaugeManager.GetLifeAdjustment(JudgementType.Great));
             Assert.Equal(1.0f, gaugeManager.GetLifeAdjustment(JudgementType.Good));
             Assert.Equal(-1.5f, gaugeManager.GetLifeAdjustment(JudgementType.Poor));

--- a/DTXMania.Test/Stage/Performance/GaugeManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/GaugeManagerTests.cs
@@ -46,7 +46,7 @@ namespace DTXMania.Test.Stage.Performance
         #region ProcessJudgement Tests
 
         [Fact]
-        public void ProcessJudgement_Just_ShouldIncreaseLife()
+        public void ProcessJudgement_Perfect_ShouldIncreaseLife()
         {
             var manager = new GaugeManager(50.0f);
             var initial = manager.CurrentLife;

--- a/DTXMania.Test/Stage/Performance/GaugeManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/GaugeManagerTests.cs
@@ -50,7 +50,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var manager = new GaugeManager(50.0f);
             var initial = manager.CurrentLife;
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.True(manager.CurrentLife > initial);
         }
 
@@ -103,7 +103,7 @@ namespace DTXMania.Test.Stage.Performance
         public void ProcessJudgement_LifeExceedsMax_ShouldClampToMax()
         {
             var manager = new GaugeManager(99.9f);
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(GaugeManager.MaxLife, manager.CurrentLife);
         }
 
@@ -125,7 +125,7 @@ namespace DTXMania.Test.Stage.Performance
             var lifeAfterFail = manager.CurrentLife;
 
             // Second judgement should be ignored
-            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(lifeAfterFail, manager.CurrentLife);
         }
 
@@ -134,7 +134,7 @@ namespace DTXMania.Test.Stage.Performance
         #region GetLifeAdjustment Tests
 
         [Theory]
-        [InlineData(JudgementType.Just, 2.0f)]
+        [InlineData(JudgementType.Perfect, 2.0f)]
         [InlineData(JudgementType.Great, 1.5f)]
         [InlineData(JudgementType.Good, 1.0f)]
         [InlineData(JudgementType.Poor, -1.5f)]
@@ -163,10 +163,10 @@ namespace DTXMania.Test.Stage.Performance
             GaugeChangedEventArgs received = null;
             manager.GaugeChanged += (s, e) => received = e;
 
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
 
             Assert.NotNull(received);
-            Assert.Equal(JudgementType.Just, received.JudgementType);
+            Assert.Equal(JudgementType.Perfect, received.JudgementType);
             Assert.False(received.JustFailed);
         }
 
@@ -386,7 +386,7 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new GaugeManager(50.0f);
             manager.Dispose();
             var lifeBeforeDisposed = manager.CurrentLife;
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(lifeBeforeDisposed, manager.CurrentLife);
         }
 

--- a/DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs
@@ -99,7 +99,7 @@ namespace DTXMania.Test.Stage.Performance
             var chartManager = CreateTestChart(1000.0);
             var manager = new JudgementManager(input, chartManager);
 
-            // Just hit at exactly 1000ms
+            // Perfect hit at exactly 1000ms
             manager.EnqueueLaneHit(0);
             manager.Update(1000.0);
 

--- a/DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs
@@ -88,7 +88,7 @@ namespace DTXMania.Test.Stage.Performance
             var chartManager = CreateTestChart();
             var manager = new JudgementManager(input, chartManager);
 
-            Assert.Equal(0, manager.GetJudgementCount(JudgementType.Just));
+            Assert.Equal(0, manager.GetJudgementCount(JudgementType.Perfect));
             Assert.Equal(0, manager.GetJudgementCount(JudgementType.Miss));
         }
 
@@ -103,7 +103,7 @@ namespace DTXMania.Test.Stage.Performance
             manager.EnqueueLaneHit(0);
             manager.Update(1000.0);
 
-            Assert.Equal(1, manager.GetJudgementCount(JudgementType.Just));
+            Assert.Equal(1, manager.GetJudgementCount(JudgementType.Perfect));
         }
 
         [Fact]
@@ -256,7 +256,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var stats = new JudgementStatistics
             {
-                JustCount = 10,
+                PerfectCount = 10,
                 GreatCount = 0,
                 GoodCount = 0,
                 PoorCount = 0,
@@ -270,7 +270,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var stats = new JudgementStatistics
             {
-                JustCount = 5,
+                PerfectCount = 5,
                 MissCount = 5
             };
             Assert.Equal(50.0, stats.Accuracy);
@@ -281,7 +281,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var stats = new JudgementStatistics
             {
-                JustCount = 1,
+                PerfectCount = 1,
                 GreatCount = 2,
                 GoodCount = 3,
                 PoorCount = 4,
@@ -295,7 +295,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var stats = new JudgementStatistics
             {
-                JustCount = 1,
+                PerfectCount = 1,
                 GreatCount = 2,
                 GoodCount = 3,
                 PoorCount = 4,

--- a/DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs
@@ -93,7 +93,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void GetJudgementCount_AfterJustHit_ShouldReturnOne()
+        public void GetJudgementCount_AfterPerfectHit_ShouldReturnOne()
         {
             var input = CreateMockInput();
             var chartManager = CreateTestChart(1000.0);
@@ -252,7 +252,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void JudgementStatistics_Accuracy_AllJust_ShouldReturn100()
+        public void JudgementStatistics_Accuracy_AllPerfect_ShouldReturn100()
         {
             var stats = new JudgementStatistics
             {

--- a/DTXMania.Test/Stage/Performance/JudgementManagerHitWindowTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerHitWindowTests.cs
@@ -19,10 +19,10 @@ namespace DTXMania.Test.Stage.Performance
     {
         [Theory]
         [InlineData(0.0, JudgementType.Perfect)]           // Perfect timing
-        [InlineData(25.0, JudgementType.Perfect)]          // Just boundary (±25ms)
-        [InlineData(-25.0, JudgementType.Perfect)]         // Just boundary early
-        [InlineData(25.1, JudgementType.Great)]         // Just over Just boundary
-        [InlineData(-25.1, JudgementType.Great)]        // Just over Just boundary early
+        [InlineData(25.0, JudgementType.Perfect)]          // Perfect boundary (±25ms)
+        [InlineData(-25.0, JudgementType.Perfect)]         // Perfect boundary early
+        [InlineData(25.1, JudgementType.Great)]         // Just over Perfect boundary
+        [InlineData(-25.1, JudgementType.Great)]        // Just over Perfect boundary early
         [InlineData(50.0, JudgementType.Great)]         // Great boundary (±50ms)
         [InlineData(-50.0, JudgementType.Great)]        // Great boundary early
         [InlineData(50.1, JudgementType.Good)]          // Just over Great boundary
@@ -63,7 +63,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void HitWindowBoundaries_ExactlyAtJustWindow_ReturnsJust()
+        public void HitWindowBoundaries_ExactlyAtPerfectWindow_ReturnsPerfect()
         {
             // Arrange
             var mockInputManager = new MockInputManagerCompat();
@@ -73,7 +73,7 @@ namespace DTXMania.Test.Stage.Performance
             JudgementEvent? capturedEvent = null;
             judgementManager.JudgementMade += (sender, e) => capturedEvent = e;
 
-            // Act - Hit exactly at Just window boundary (25ms)
+            // Act - Hit exactly at Perfect window boundary (25ms)
             judgementManager.EnqueueLaneHit(0); // Direct test trigger for lane 0
             judgementManager.Update(1025.0);
 
@@ -188,8 +188,8 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Theory]
-        [InlineData(24.9, JudgementType.Perfect)]          // Just under Just boundary
-        [InlineData(25.1, JudgementType.Great)]         // Just over Just boundary
+        [InlineData(24.9, JudgementType.Perfect)]          // Just under Perfect boundary
+        [InlineData(25.1, JudgementType.Great)]         // Just over Perfect boundary
         [InlineData(49.9, JudgementType.Great)]         // Just under Great boundary
         [InlineData(50.1, JudgementType.Good)]          // Just over Great boundary
         [InlineData(99.9, JudgementType.Good)]          // Just under Good boundary

--- a/DTXMania.Test/Stage/Performance/JudgementManagerHitWindowTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerHitWindowTests.cs
@@ -18,9 +18,9 @@ namespace DTXMania.Test.Stage.Performance
     public class JudgementManagerHitWindowTests
     {
         [Theory]
-        [InlineData(0.0, JudgementType.Just)]           // Perfect timing
-        [InlineData(25.0, JudgementType.Just)]          // Just boundary (±25ms)
-        [InlineData(-25.0, JudgementType.Just)]         // Just boundary early
+        [InlineData(0.0, JudgementType.Perfect)]           // Perfect timing
+        [InlineData(25.0, JudgementType.Perfect)]          // Just boundary (±25ms)
+        [InlineData(-25.0, JudgementType.Perfect)]         // Just boundary early
         [InlineData(25.1, JudgementType.Great)]         // Just over Just boundary
         [InlineData(-25.1, JudgementType.Great)]        // Just over Just boundary early
         [InlineData(50.0, JudgementType.Great)]         // Great boundary (±50ms)
@@ -79,7 +79,7 @@ namespace DTXMania.Test.Stage.Performance
 
             // Assert
             Assert.NotNull(capturedEvent);
-            Assert.Equal(JudgementType.Just, capturedEvent.Type);
+            Assert.Equal(JudgementType.Perfect, capturedEvent.Type);
             Assert.Equal(25.0, capturedEvent.DeltaMs, 0.1);
         }
 
@@ -163,7 +163,7 @@ namespace DTXMania.Test.Stage.Performance
             // Assert - Should hit the first note (at 1000ms) since it's closer
             Assert.NotNull(capturedEvent);
             Assert.Equal(25.0, capturedEvent.DeltaMs, 0.1);
-            Assert.Equal(JudgementType.Just, capturedEvent.Type);
+            Assert.Equal(JudgementType.Perfect, capturedEvent.Type);
         }
 
         [Fact]
@@ -188,7 +188,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Theory]
-        [InlineData(24.9, JudgementType.Just)]          // Just under Just boundary
+        [InlineData(24.9, JudgementType.Perfect)]          // Just under Just boundary
         [InlineData(25.1, JudgementType.Great)]         // Just over Just boundary
         [InlineData(49.9, JudgementType.Great)]         // Just under Great boundary
         [InlineData(50.1, JudgementType.Good)]          // Just over Great boundary

--- a/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
@@ -65,7 +65,7 @@ namespace DTXMania.Test.Stage.Performance
 
             // Assert
             Assert.NotNull(captured);
-            Assert.Equal(JudgementType.Just, captured.Type);
+            Assert.Equal(JudgementType.Perfect, captured.Type);
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace DTXMania.Test.Stage.Performance
             var stats = judgementManager.GetStatistics();
 
             // Assert
-            Assert.Equal(1, stats.JustCount);
+            Assert.Equal(1, stats.PerfectCount);
             Assert.Equal(1, stats.GreatCount);
             Assert.Equal(0, stats.GoodCount);
             Assert.Equal(0, stats.PoorCount);
@@ -330,7 +330,7 @@ namespace DTXMania.Test.Stage.Performance
 
             Assert.True(result);
             Assert.NotNull(captured);
-            Assert.Equal(JudgementType.Just, captured.Type);
+            Assert.Equal(JudgementType.Perfect, captured.Type);
             Assert.Equal(0.0, captured.DeltaMs);
             Assert.Equal(NoteStatus.Hit, judgementManager.GetNoteRuntimeData(noteId)!.Status);
         }

--- a/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
@@ -50,7 +50,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_WhenLaneHitEventQueued_ProcessesPerfectHit()
+        public void Update_WhenLaneHitEventQueued_ShouldProcessPerfectHit()
         {
             // Arrange
             var compat = CreateMockInputManagerWithEvents();

--- a/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
@@ -50,7 +50,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_WhenLaneHitEventQueued_ProcessesJustHit()
+        public void Update_WhenLaneHitEventQueued_ProcessesPerfectHit()
         {
             // Arrange
             var compat = CreateMockInputManagerWithEvents();

--- a/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementManagerTests.cs
@@ -148,9 +148,9 @@ namespace DTXMania.Test.Stage.Performance
             var chartManager = CreateTestChartManager();
             var judgementManager = new JudgementManager(compat, chartManager);
 
-            // Simulate lane hit for lane 0 (Just hit)
+            // Simulate lane hit for lane 0 (Perfect hit)
             compat.TriggerLaneHit(0);
-            judgementManager.Update(1000.0); // Just hit
+            judgementManager.Update(1000.0); // Perfect hit
 
             // Simulate lane hit for lane 1 (Great hit, 40ms late)
             compat.TriggerLaneHit(1);

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupLogicTests.cs
@@ -107,7 +107,7 @@ public class JudgementTextPopupLogicTests
     public void SpawnPopup_WhenManagerIsDisposedOrEventIsNull_ShouldIgnoreRequest()
     {
         var disposedManager = CreateManager(disposed: true);
-        disposedManager.SpawnPopup(new JudgementEvent(0, 1, 0.0, JudgementType.Just));
+        disposedManager.SpawnPopup(new JudgementEvent(0, 1, 0.0, JudgementType.Perfect));
 
         var manager = CreateManager();
         manager.SpawnPopup(null!);

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
@@ -48,7 +48,7 @@ namespace DTXMania.Test.Stage.Performance
         public void JudgementTextPopup_Constructor_SetsInitialValues()
         {
             // Arrange
-            var text = "JUST";
+            var text = "PERFECT";
             var position = new Vector2(100, 200);
 
             // Act
@@ -219,7 +219,7 @@ namespace DTXMania.Test.Stage.Performance
         public void JudgementTextPopup_Integration_FullAnimationCycle()
         {
             // Arrange
-            var popup = new JudgementTextPopup("JUST", new Vector2(640, 500));
+            var popup = new JudgementTextPopup("PERFECT", new Vector2(640, 500));
             var totalTime = 0.0;
             var timeStep = 0.016; // ~60 FPS
 

--- a/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
+++ b/DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs
@@ -157,7 +157,7 @@ namespace DTXMania.Test.Stage.Performance
         public void JudgementTextPopupManager_SpawnPopup_CreatesPopupForValidJudgement()
         {
             var manager = CreateManager();
-            var judgementEvent = new JudgementEvent(1, 3, 10.0, JudgementType.Just);
+            var judgementEvent = new JudgementEvent(1, 3, 10.0, JudgementType.Perfect);
 
             manager.SpawnPopup(judgementEvent);
 
@@ -177,7 +177,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, "Perfect")]
+        [InlineData(JudgementType.Perfect, "Perfect")]
         [InlineData(JudgementType.Great, "Great")]
         [InlineData(JudgementType.Good, "Good")]
         [InlineData(JudgementType.Poor, "OK")]
@@ -266,7 +266,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var manager = CreateManager();
 
-            manager.SpawnPopup(new JudgementEvent(1, 0, 0.0, JudgementType.Just));
+            manager.SpawnPopup(new JudgementEvent(1, 0, 0.0, JudgementType.Perfect));
             manager.SpawnPopup(new JudgementEvent(1, 4, 0.0, JudgementType.Great));
             manager.SpawnPopup(new JudgementEvent(1, 8, 0.0, JudgementType.Miss));
 
@@ -297,7 +297,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var manager = CreateManager(disposed: true);
 
-            manager.SpawnPopup(new JudgementEvent(1, 1, 0.0, JudgementType.Just));
+            manager.SpawnPopup(new JudgementEvent(1, 1, 0.0, JudgementType.Perfect));
 
             Assert.Empty(GetActivePopups(manager));
         }

--- a/DTXMania.Test/Stage/Performance/PerformanceStageAdditionalCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageAdditionalCoverageTests.cs
@@ -1,0 +1,394 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Test.Helpers;
+using DTXMania.Test.TestData;
+using Moq;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+
+#pragma warning disable SYSLIB0050
+
+namespace DTXMania.Test.Stage.Performance;
+
+[Trait("Category", "Unit")]
+public class PerformanceStageAdditionalCoverageTests
+{
+    [Fact]
+    public void OnSkillChanged_WithSkillPanelDisplay_ShouldUpdateSkillAndShowMax()
+    {
+        var stage = CreateStage();
+        var panel = CreateSkillPanelDisplay();
+        ReflectionHelpers.SetPrivateField(stage, "_skillPanelDisplay", panel);
+        ReflectionHelpers.SetPrivateField(stage, "_skillMeterDisplay", null);
+
+        var args = new SkillChangedEventArgs
+        {
+            CurrentSkill = 85.5,
+            IsMax = true,
+            PreviousSkill = 80.0
+        };
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnSkillChanged", null, args);
+
+        Assert.Equal(85.5, panel.Skill);
+        Assert.True(panel.ShowMax);
+    }
+
+    [Fact]
+    public void OnSkillChanged_WithSkillMeterDisplay_ShouldUpdateSkill()
+    {
+        var stage = CreateStage();
+        var meter = CreateSkillMeterDisplay();
+        ReflectionHelpers.SetPrivateField(stage, "_skillPanelDisplay", null);
+        ReflectionHelpers.SetPrivateField(stage, "_skillMeterDisplay", meter);
+
+        var args = new SkillChangedEventArgs
+        {
+            CurrentSkill = 72.3,
+            IsMax = false,
+            PreviousSkill = 70.0
+        };
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnSkillChanged", null, args);
+
+        Assert.Equal(72.3, meter.Skill);
+    }
+
+    [Fact]
+    public void OnSkillChanged_WithNullDisplays_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+        ReflectionHelpers.SetPrivateField(stage, "_skillPanelDisplay", null);
+        ReflectionHelpers.SetPrivateField(stage, "_skillMeterDisplay", null);
+
+        var args = new SkillChangedEventArgs
+        {
+            CurrentSkill = 50.0,
+            IsMax = false,
+            PreviousSkill = 45.0
+        };
+        var exception = Record.Exception(() =>
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnSkillChanged", null, args));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void OnPlayerFailed_NoFailDisabled_ShouldFinalizePerformance()
+    {
+        var configData = new ConfigData { NoFail = false };
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(x => x.Config).Returns(configData);
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var chartManager = CreateChartManagerWithSingleNote();
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager",
+            new JudgementManager(new MockInputManagerCompat(), chartManager));
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", false);
+
+        var args = new FailureEventArgs { FinalLife = 0.5f, JudgementType = JudgementType.Miss };
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnPlayerFailed", null, args);
+
+        Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        stageManager.Verify(
+            x => x.ChangeStage(StageType.Result, It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void OnPlayerFailed_NoFailEnabled_ShouldNotFinalize()
+    {
+        var configData = new ConfigData { NoFail = true };
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(x => x.Config).Returns(configData);
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", false);
+
+        var args = new FailureEventArgs { FinalLife = 0.5f, JudgementType = JudgementType.Miss };
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnPlayerFailed", null, args);
+
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_stageCompleted"));
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void OnPlayerFailed_AlreadyCompleted_ShouldNotFinalizeAgain()
+    {
+        var configData = new ConfigData { NoFail = false };
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(x => x.Config).Returns(configData);
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_stageCompleted", true);
+
+        var args = new FailureEventArgs { FinalLife = 0.5f, JudgementType = JudgementType.Miss };
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnPlayerFailed", null, args);
+
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void FinalizePerformance_SongComplete_ShouldBuildSummaryWithClearFlag()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var comboManager = new ComboManager();
+        var gaugeManager = new GaugeManager();
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(chartManager.TotalNotes));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", gaugeManager);
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreateStoppedSongTimer());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.SongComplete);
+
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.True(summary.ClearFlag);
+        Assert.Equal(CompletionReason.SongComplete, summary.CompletionReason);
+    }
+
+    [Fact]
+    public void FinalizePerformance_PlayerFailed_ShouldBuildSummaryWithoutClearFlag()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var chartManager = CreateChartManagerWithSingleNote();
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager",
+            new JudgementManager(new MockInputManagerCompat(), chartManager));
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(1));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", new ComboManager());
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.PlayerFailed);
+
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.False(summary.ClearFlag);
+        Assert.Equal(CompletionReason.PlayerFailed, summary.CompletionReason);
+    }
+
+    [Fact]
+    public void FinalizePerformance_WithSkillManager_ShouldCalculateGameSkill()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var chartManager = CreateChartManagerWithSingleNote();
+        var comboManager = new ComboManager();
+        var skillManager = new SkillManager(chartManager.TotalNotes, comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_chartManager", chartManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager",
+            new JudgementManager(new MockInputManagerCompat(), chartManager));
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", new ScoreManager(chartManager.TotalNotes));
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", new GaugeManager());
+        ReflectionHelpers.SetPrivateField(stage, "_skillManager", skillManager);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "FinalizePerformance", CompletionReason.SongComplete);
+
+        var summary = ReflectionHelpers.GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
+        Assert.NotNull(summary);
+        Assert.Equal(skillManager.CurrentSkill, summary.PlayingSkill);
+        var expectedGameSkill = SongScore.CalculateGameSkill(skillManager.CurrentSkill, 0, 0);
+        Assert.Equal(expectedGameSkill, summary.GameSkill);
+    }
+
+    [Fact]
+    public void TransitionToResultStage_ShouldIncludePerformanceSummary()
+    {
+        var stage = CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        Dictionary<string, object>? capturedSharedData = null;
+        stageManager
+            .Setup(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, sd) => capturedSharedData = sd);
+        stage.StageManager = stageManager.Object;
+        var summary = new PerformanceSummary
+        {
+            Score = 950000,
+            MaxCombo = 200,
+            ClearFlag = true,
+            CompletionReason = CompletionReason.SongComplete
+        };
+        ReflectionHelpers.SetPrivateField(stage, "_performanceSummary", summary);
+        var selectedSong = new SongListNode { Title = "TestSong" };
+        ReflectionHelpers.SetPrivateField(stage, "_selectedSong", selectedSong);
+        ReflectionHelpers.SetPrivateField(stage, "_selectedDifficulty", 2);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "TransitionToResultStage");
+
+        stageManager.Verify(
+            x => x.ChangeStage(StageType.Result, It.IsAny<InstantTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Once);
+        Assert.NotNull(capturedSharedData);
+        Assert.Same(summary, capturedSharedData["performanceSummary"]);
+        Assert.Same(selectedSong, capturedSharedData["selectedSong"]);
+        Assert.Equal(2, capturedSharedData["selectedDifficulty"]);
+    }
+
+    [Fact]
+    public void CleanupGameplayManagers_ShouldUnsubscribeEvents()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var scoreManager = new ScoreManager(chartManager.TotalNotes);
+        var comboManager = new ComboManager();
+        var gaugeManager = new GaugeManager();
+        var skillManager = new SkillManager(chartManager.TotalNotes, comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", scoreManager);
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", gaugeManager);
+        ReflectionHelpers.SetPrivateField(stage, "_skillManager", skillManager);
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", new MockInputManagerCompat());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CleanupGameplayManagers");
+
+        Assert.Null(ReflectionHelpers.GetPrivateField<JudgementManager>(stage, "_judgementManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ScoreManager>(stage, "_scoreManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<ComboManager>(stage, "_comboManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<GaugeManager>(stage, "_gaugeManager"));
+        Assert.Null(ReflectionHelpers.GetPrivateField<SkillManager>(stage, "_skillManager"));
+    }
+
+    [Fact]
+    public void CleanupGameplayManagers_ShouldDisposeManagers()
+    {
+        var stage = CreateStage();
+        var chartManager = CreateChartManagerWithSingleNote();
+        var judgementManager = new JudgementManager(new MockInputManagerCompat(), chartManager);
+        var scoreManager = new ScoreManager(chartManager.TotalNotes);
+        var comboManager = new ComboManager();
+        var gaugeManager = new GaugeManager();
+        var skillManager = new SkillManager(chartManager.TotalNotes, comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", judgementManager);
+        ReflectionHelpers.SetPrivateField(stage, "_scoreManager", scoreManager);
+        ReflectionHelpers.SetPrivateField(stage, "_comboManager", comboManager);
+        ReflectionHelpers.SetPrivateField(stage, "_gaugeManager", gaugeManager);
+        ReflectionHelpers.SetPrivateField(stage, "_skillManager", skillManager);
+        ReflectionHelpers.SetPrivateField(stage, "_inputManager", new MockInputManagerCompat());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "CleanupGameplayManagers");
+
+        Assert.True((bool)typeof(JudgementManager)
+            .GetField("_disposed", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(judgementManager)!);
+    }
+
+    [Fact]
+    public void LogPerformanceError_WithException_ShouldWriteToConsole()
+    {
+        var stage = CreateStage();
+        var exception = new InvalidOperationException("test error");
+        using var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+
+        try
+        {
+            ReflectionHelpers.InvokePrivateMethod(stage, "LogPerformanceError", "TestMessage", exception);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        var output = writer.ToString();
+        Assert.Contains("[PerformanceError] TestMessage: test error", output);
+        Assert.Contains("[PerformanceError] Stack trace:", output);
+    }
+
+    [Fact]
+    public void LogPerformanceError_WithoutException_ShouldWriteToConsole()
+    {
+        var stage = CreateStage();
+        using var writer = new StringWriter();
+        var originalOut = Console.Out;
+        Console.SetOut(writer);
+
+        try
+        {
+            ReflectionHelpers.InvokePrivateMethod(stage, "LogPerformanceError", "SimpleMessage", null);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+
+        var output = writer.ToString();
+        Assert.Contains("[PerformanceError] SimpleMessage", output);
+        Assert.DoesNotContain("Stack trace:", output);
+    }
+
+    private static PerformanceStage CreateStage(BaseGame? game = null)
+    {
+        var stage = (PerformanceStage)FormatterServices.GetUninitializedObject(typeof(PerformanceStage));
+        ReflectionHelpers.SetPrivateField(stage, "_game", game ?? ReflectionHelpers.CreateGame());
+        return stage;
+    }
+
+    private static ChartManager CreateChartManagerWithSingleNote()
+    {
+        var parsedChart = new ParsedChart("coverage-test.dtx")
+        {
+            Bpm = 120.0
+        };
+        parsedChart.AddNote(new Note(0, 0, 96, 0x11, "01"));
+        parsedChart.FinalizeChart();
+        return new ChartManager(parsedChart);
+    }
+
+    private static SongTimer CreateStoppedSongTimer()
+    {
+        var timer = (SongTimer)FormatterServices.GetUninitializedObject(typeof(SongTimer));
+        ReflectionHelpers.SetPrivateField(timer, "_disposed", true);
+        return timer;
+    }
+
+    private static SkillPanelDisplay CreateSkillPanelDisplay()
+    {
+        return (SkillPanelDisplay)FormatterServices.GetUninitializedObject(typeof(SkillPanelDisplay));
+    }
+
+    private static SkillMeterDisplay CreateSkillMeterDisplay()
+    {
+        return (SkillMeterDisplay)FormatterServices.GetUninitializedObject(typeof(SkillMeterDisplay));
+    }
+}
+
+#pragma warning restore SYSLIB0050

--- a/DTXMania.Test/Stage/Performance/PerformanceStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageCoverageTests.cs
@@ -584,7 +584,7 @@ public class PerformanceStageCoverageTests
         Assert.NotNull(summary);
         Assert.Equal(0, summary.Score);
         Assert.Equal(0, summary.MaxCombo);
-        Assert.Equal(0, summary.JustCount);
+        Assert.Equal(0, summary.PerfectCount);
         Assert.Equal(0, summary.GreatCount);
         Assert.Equal(0, summary.GoodCount);
         Assert.Equal(0, summary.PoorCount);

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -627,7 +627,7 @@ public class PerformanceStageDeterministicTests
         Assert.Equal(PadState.Pressed, ReflectionHelpers.GetPrivateField<PadVisual[]>(padRenderer, "_padVisuals")[0].State);
         Assert.Equal(NoteStatus.Hit, judgementManager.GetNoteRuntimeData(chartManager.AllNotes[0].Id)!.Status);
 
-        // Verify it got Perfect (Just) timing
+        // Verify it got Perfect timing
         var noteData = judgementManager.GetNoteRuntimeData(chartManager.AllNotes[0].Id)!;
         Assert.Equal(JudgementType.Perfect, noteData.JudgementEvent!.Type);
         Assert.Equal(0.0, noteData.JudgementEvent.DeltaMs);

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -629,7 +629,7 @@ public class PerformanceStageDeterministicTests
 
         // Verify it got Perfect (Just) timing
         var noteData = judgementManager.GetNoteRuntimeData(chartManager.AllNotes[0].Id)!;
-        Assert.Equal(JudgementType.Just, noteData.JudgementEvent!.Type);
+        Assert.Equal(JudgementType.Perfect, noteData.JudgementEvent!.Type);
         Assert.Equal(0.0, noteData.JudgementEvent.DeltaMs);
     }
 

--- a/DTXMania.Test/Stage/Performance/PerformanceStageJudgementIntegrationTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageJudgementIntegrationTests.cs
@@ -93,7 +93,7 @@ namespace DTXMania.Test.Stage.Performance
 
             // Assert - Input should be processed, creating a hit judgement
             Assert.NotNull(hitEvent);
-            Assert.Equal(JudgementType.Just, hitEvent.Type); // Perfect timing
+            Assert.Equal(JudgementType.Perfect, hitEvent.Type); // Perfect timing
             Assert.Equal(0, hitEvent.NoteRef);
             Assert.Equal(0, hitEvent.Lane);
         }

--- a/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
@@ -109,8 +109,8 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void Accuracy_MixedJudgements_ShouldCalculateWeightedAccuracy()
         {
-            // 100 Just (weight 1.0) + 0 others = 100 weighted / 100 total = 100%
-            // 50 Just (weight 1.0) + 50 Great (weight 0.9) = 95 weighted / 100 total = 95%
+            // 100 Perfect (weight 1.0) + 0 others = 100 weighted / 100 total = 100%
+            // 50 Perfect (weight 1.0) + 50 Great (weight 0.9) = 95 weighted / 100 total = 95%
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,

--- a/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
@@ -20,7 +20,7 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(0, summary.Score);
             Assert.Equal(0, summary.MaxCombo);
             Assert.False(summary.ClearFlag);
-            Assert.Equal(0, summary.JustCount);
+            Assert.Equal(0, summary.PerfectCount);
             Assert.Equal(0, summary.GreatCount);
             Assert.Equal(0, summary.GoodCount);
             Assert.Equal(0, summary.PoorCount);
@@ -46,7 +46,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var summary = new PerformanceSummary
             {
-                JustCount = 10,
+                PerfectCount = 10,
                 GreatCount = 20,
                 GoodCount = 5,
                 PoorCount = 3,
@@ -57,9 +57,9 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void TotalJudgements_AllJust_ShouldReturnJustCount()
+        public void TotalJudgements_AllJust_ShouldReturnPerfectCount()
         {
-            var summary = new PerformanceSummary { JustCount = 100 };
+            var summary = new PerformanceSummary { PerfectCount = 100 };
             Assert.Equal(100, summary.TotalJudgements);
         }
 
@@ -80,7 +80,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,
-                JustCount = 100,
+                PerfectCount = 100,
                 GreatCount = 0,
                 GoodCount = 0,
                 PoorCount = 0,
@@ -96,7 +96,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,
-                JustCount = 0,
+                PerfectCount = 0,
                 GreatCount = 0,
                 GoodCount = 0,
                 PoorCount = 0,
@@ -114,7 +114,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,
-                JustCount = 50,
+                PerfectCount = 50,
                 GreatCount = 50,
                 GoodCount = 0,
                 PoorCount = 0,
@@ -131,7 +131,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,
-                JustCount = 0,
+                PerfectCount = 0,
                 GreatCount = 0,
                 GoodCount = 100,
                 PoorCount = 0,
@@ -159,7 +159,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 50,
-                JustCount = 20,
+                PerfectCount = 20,
                 GreatCount = 20,
                 GoodCount = 10,
                 MissCount = 0
@@ -174,7 +174,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,
-                JustCount = 50,
+                PerfectCount = 50,
                 GreatCount = 0,
                 GoodCount = 0,
                 PoorCount = 0,
@@ -191,7 +191,7 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary
             {
                 TotalNotes = 100,
-                JustCount = 0,
+                PerfectCount = 0,
                 GreatCount = 0,
                 GoodCount = 0,
                 PoorCount = 100,
@@ -206,7 +206,7 @@ namespace DTXMania.Test.Stage.Performance
         #region IncrementJudgement Tests
 
         [Theory]
-        [InlineData(JudgementType.Just)]
+        [InlineData(JudgementType.Perfect)]
         [InlineData(JudgementType.Great)]
         [InlineData(JudgementType.Good)]
         [InlineData(JudgementType.Poor)]
@@ -226,11 +226,11 @@ namespace DTXMania.Test.Stage.Performance
             var summary = new PerformanceSummary();
 
             for (int i = 0; i < 5; i++)
-                summary.IncrementJudgement(JudgementType.Just);
+                summary.IncrementJudgement(JudgementType.Perfect);
             for (int i = 0; i < 3; i++)
                 summary.IncrementJudgement(JudgementType.Great);
 
-            Assert.Equal(5, summary.JustCount);
+            Assert.Equal(5, summary.PerfectCount);
             Assert.Equal(3, summary.GreatCount);
             Assert.Equal(8, summary.TotalJudgements);
         }
@@ -239,7 +239,7 @@ namespace DTXMania.Test.Stage.Performance
         public void IncrementJudgement_ShouldNotAffectOtherCounters()
         {
             var summary = new PerformanceSummary();
-            summary.IncrementJudgement(JudgementType.Just);
+            summary.IncrementJudgement(JudgementType.Perfect);
 
             Assert.Equal(0, summary.GreatCount);
             Assert.Equal(0, summary.GoodCount);
@@ -258,7 +258,7 @@ namespace DTXMania.Test.Stage.Performance
 
             summary.IncrementJudgement(invalid);
 
-            Assert.Equal(0, summary.JustCount);
+            Assert.Equal(0, summary.PerfectCount);
             Assert.Equal(0, summary.GreatCount);
             Assert.Equal(0, summary.GoodCount);
             Assert.Equal(0, summary.PoorCount);
@@ -271,7 +271,7 @@ namespace DTXMania.Test.Stage.Performance
         #region GetJudgementCount Tests
 
         [Theory]
-        [InlineData(JudgementType.Just, 10)]
+        [InlineData(JudgementType.Perfect, 10)]
         [InlineData(JudgementType.Great, 20)]
         [InlineData(JudgementType.Good, 15)]
         [InlineData(JudgementType.Poor, 5)]
@@ -280,7 +280,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var summary = new PerformanceSummary
             {
-                JustCount = 10,
+                PerfectCount = 10,
                 GreatCount = 20,
                 GoodCount = 15,
                 PoorCount = 5,
@@ -293,7 +293,7 @@ namespace DTXMania.Test.Stage.Performance
         [Fact]
         public void GetJudgementCount_InvalidType_ShouldReturnZero()
         {
-            var summary = new PerformanceSummary { JustCount = 50 };
+            var summary = new PerformanceSummary { PerfectCount = 50 };
             Assert.Equal(0, summary.GetJudgementCount((JudgementType)999));
         }
 

--- a/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
@@ -30,6 +30,16 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(CompletionReason.Unknown, summary.CompletionReason);
         }
 
+        [Fact]
+        public void Constructor_ShouldInitializeSkillFieldsToZero()
+        {
+            var summary = new PerformanceSummary();
+            Assert.Equal(0.0, summary.PlayingSkill);
+            Assert.Equal(0.0, summary.GameSkill);
+            Assert.Equal(0, summary.ChartLevel);
+            Assert.Equal(0, summary.ChartLevelDec);
+        }
+
         #endregion
 
         #region TotalJudgements Tests

--- a/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
@@ -85,7 +85,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Accuracy_AllJust_ShouldReturn100()
+        public void Accuracy_AllPerfect_ShouldReturn100()
         {
             var summary = new PerformanceSummary
             {

--- a/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
@@ -57,7 +57,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void TotalJudgements_AllJust_ShouldReturnPerfectCount()
+        public void TotalJudgements_AllPerfect_ShouldReturnPerfectCount()
         {
             var summary = new PerformanceSummary { PerfectCount = 100 };
             Assert.Equal(100, summary.TotalJudgements);

--- a/DTXMania.Test/Stage/Performance/ScoreManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScoreManagerTests.cs
@@ -23,9 +23,14 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Constructor_ZeroTotalNotes_ShouldThrow()
+        public void Constructor_ZeroTotalNotes_ShouldInitializeZeroScoring()
         {
-            Assert.Throws<ArgumentException>(() => new ScoreManager(0));
+            var manager = new ScoreManager(0);
+
+            Assert.Equal(0, manager.CurrentScore);
+            Assert.Equal(0, manager.TotalNotes);
+            Assert.Equal(0, manager.BaseScore);
+            Assert.Equal(0, manager.TheoreticalMaxScore);
         }
 
         [Fact]
@@ -84,6 +89,18 @@ namespace DTXMania.Test.Stage.Performance
             var manager = new ScoreManager(100);
             manager.ProcessJudgement(null);
             Assert.Equal(0, manager.CurrentScore);
+        }
+
+        [Fact]
+        public void ProcessJudgement_ZeroTotalNotes_ShouldKeepScoreAtZero()
+        {
+            var manager = new ScoreManager(0);
+
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
+
+            Assert.Equal(0, manager.CurrentScore);
+            Assert.Equal(0, manager.CalculateScoreForJudgement(JudgementType.Perfect));
+            Assert.Equal(0.0, manager.GetStatistics().ScorePercentage);
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/Performance/ScoreManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScoreManagerTests.cs
@@ -42,7 +42,7 @@ namespace DTXMania.Test.Stage.Performance
         public void ProcessJudgement_Just_ShouldAddFullBaseScore()
         {
             var manager = new ScoreManager(100);
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(manager.BaseScore, manager.CurrentScore);
         }
 
@@ -93,7 +93,7 @@ namespace DTXMania.Test.Stage.Performance
             ScoreChangedEventArgs receivedArgs = null;
             manager.ScoreChanged += (s, e) => receivedArgs = e;
 
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
 
             Assert.NotNull(receivedArgs);
             Assert.Equal(0, receivedArgs.PreviousScore);
@@ -105,7 +105,7 @@ namespace DTXMania.Test.Stage.Performance
         #region GetScoreMultiplier Tests
 
         [Theory]
-        [InlineData(JudgementType.Just, 1.0)]
+        [InlineData(JudgementType.Perfect, 1.0)]
         [InlineData(JudgementType.Great, 0.9)]
         [InlineData(JudgementType.Good, 0.5)]
         [InlineData(JudgementType.Poor, 0.0)]
@@ -117,7 +117,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, 1.0)]
+        [InlineData(JudgementType.Perfect, 1.0)]
         [InlineData(JudgementType.Great, 0.9)]
         [InlineData(JudgementType.Miss, 0.0)]
         public void GetScoreMultiplierStatic_ShouldReturnCorrectMultiplier(JudgementType type, double expected)
@@ -133,7 +133,7 @@ namespace DTXMania.Test.Stage.Performance
         public void CalculateScoreForJudgement_Just_ShouldEqualBaseScore()
         {
             var manager = new ScoreManager(100);
-            Assert.Equal(manager.BaseScore, manager.CalculateScoreForJudgement(JudgementType.Just));
+            Assert.Equal(manager.BaseScore, manager.CalculateScoreForJudgement(JudgementType.Perfect));
         }
 
         [Fact]
@@ -151,8 +151,8 @@ namespace DTXMania.Test.Stage.Performance
         public void GetStatistics_ShouldReturnCurrentState()
         {
             var manager = new ScoreManager(100);
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
-            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
+            manager.ProcessJudgement(new JudgementEvent(1, 0, 0.0, JudgementType.Perfect));
 
             var stats = manager.GetStatistics();
 
@@ -188,7 +188,7 @@ namespace DTXMania.Test.Stage.Performance
         public void Reset_ShouldSetScoreToZero()
         {
             var manager = new ScoreManager(100);
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.True(manager.CurrentScore > 0);
 
             manager.Reset();
@@ -200,7 +200,7 @@ namespace DTXMania.Test.Stage.Performance
         public void Reset_ShouldRaiseScoreChangedEvent()
         {
             var manager = new ScoreManager(100);
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
 
             ScoreChangedEventArgs receivedArgs = null;
             manager.ScoreChanged += (s, e) => receivedArgs = e;
@@ -234,7 +234,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             var manager = new ScoreManager(100);
             manager.Dispose();
-            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Just));
+            manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
             Assert.Equal(0, manager.CurrentScore);
         }
 

--- a/DTXMania.Test/Stage/Performance/ScoreManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScoreManagerTests.cs
@@ -39,7 +39,7 @@ namespace DTXMania.Test.Stage.Performance
         #region ProcessJudgement Tests
 
         [Fact]
-        public void ProcessJudgement_Just_ShouldAddFullBaseScore()
+        public void ProcessJudgement_Perfect_ShouldAddFullBaseScore()
         {
             var manager = new ScoreManager(100);
             manager.ProcessJudgement(new JudgementEvent(0, 0, 0.0, JudgementType.Perfect));
@@ -130,7 +130,7 @@ namespace DTXMania.Test.Stage.Performance
         #region CalculateScoreForJudgement Tests
 
         [Fact]
-        public void CalculateScoreForJudgement_Just_ShouldEqualBaseScore()
+        public void CalculateScoreForJudgement_Perfect_ShouldEqualBaseScore()
         {
             var manager = new ScoreManager(100);
             Assert.Equal(manager.BaseScore, manager.CalculateScoreForJudgement(JudgementType.Perfect));

--- a/DTXMania.Test/Stage/Performance/ScoreManagerTotalScoreCapTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScoreManagerTotalScoreCapTests.cs
@@ -34,12 +34,12 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void ScoreManager_MultipleJustHits_NeverExceedsMaxScore()
+        public void ScoreManager_MultiplePerfectHits_NeverExceedsMaxScore()
         {
             // Arrange
             var scoreManager = new ScoreManager(100); // 100 note chart
-            
-            // Act - Process more than enough Just hits to theoretically exceed max score
+
+            // Act - Process more than enough Perfect hits to theoretically exceed max score
             for (int i = 0; i < 150; i++) // More hits than notes in chart
             {
                 var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
@@ -62,7 +62,7 @@ namespace DTXMania.Test.Stage.Performance
             // Arrange
             var scoreManager = new ScoreManager(totalNotes);
             
-            // Act - Process perfect play (all Just hits)
+            // Act - Process perfect play (all Perfect hits)
             for (int i = 0; i < totalNotes; i++)
             {
                 var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
@@ -101,7 +101,7 @@ namespace DTXMania.Test.Stage.Performance
             // Arrange
             var scoreManager = new ScoreManager(2000); // High note count
             
-            // Act - Mix of all judgement types, heavily weighted toward Just
+            // Act - Mix of all judgement types, heavily weighted toward Perfect
             for (int i = 0; i < 1500; i++)
             {
                 var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);

--- a/DTXMania.Test/Stage/Performance/ScoreManagerTotalScoreCapTests.cs
+++ b/DTXMania.Test/Stage/Performance/ScoreManagerTotalScoreCapTests.cs
@@ -23,7 +23,7 @@ namespace DTXMania.Test.Stage.Performance
         {
             // Arrange
             var scoreManager = new ScoreManager(1); // Single note chart
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
 
             // Act
             scoreManager.ProcessJudgement(justEvent);
@@ -42,7 +42,7 @@ namespace DTXMania.Test.Stage.Performance
             // Act - Process more than enough Just hits to theoretically exceed max score
             for (int i = 0; i < 150; i++) // More hits than notes in chart
             {
-                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 scoreManager.ProcessJudgement(justEvent);
             }
 
@@ -65,7 +65,7 @@ namespace DTXMania.Test.Stage.Performance
             // Act - Process perfect play (all Just hits)
             for (int i = 0; i < totalNotes; i++)
             {
-                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 scoreManager.ProcessJudgement(justEvent);
             }
 
@@ -81,14 +81,14 @@ namespace DTXMania.Test.Stage.Performance
             var scoreManager = new ScoreManager(1); // Single note gives 1,000,000 points
             
             // Act - Try to add more score after already at max
-            var firstJustEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var firstJustEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
             scoreManager.ProcessJudgement(firstJustEvent);
             
             // Verify we're at max
             Assert.Equal(ScoreManager.MaxScore, scoreManager.CurrentScore);
             
             // Try to add more (this should be clamped)
-            var secondJustEvent = new JudgementEvent(1, 0, 0.0, JudgementType.Just);
+            var secondJustEvent = new JudgementEvent(1, 0, 0.0, JudgementType.Perfect);
             scoreManager.ProcessJudgement(secondJustEvent);
 
             // Assert
@@ -104,7 +104,7 @@ namespace DTXMania.Test.Stage.Performance
             // Act - Mix of all judgement types, heavily weighted toward Just
             for (int i = 0; i < 1500; i++)
             {
-                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 scoreManager.ProcessJudgement(justEvent);
             }
             
@@ -161,7 +161,7 @@ namespace DTXMania.Test.Stage.Performance
             // Act - Process some hits
             for (int i = 0; i < 1000; i++)
             {
-                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 scoreManager.ProcessJudgement(justEvent);
             }
 
@@ -182,7 +182,7 @@ namespace DTXMania.Test.Stage.Performance
             ScoreChangedEventArgs? lastEventArgs = null;
             scoreManager.ScoreChanged += (sender, e) => lastEventArgs = e;
             
-            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
+            var justEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
 
             // Act
             scoreManager.ProcessJudgement(justEvent);
@@ -200,8 +200,8 @@ namespace DTXMania.Test.Stage.Performance
             var scoreManager = new ScoreManager(2);
             
             // Build up to max score
-            var firstJustEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Just);
-            var secondJustEvent = new JudgementEvent(1, 0, 0.0, JudgementType.Just);
+            var firstJustEvent = new JudgementEvent(0, 0, 0.0, JudgementType.Perfect);
+            var secondJustEvent = new JudgementEvent(1, 0, 0.0, JudgementType.Perfect);
             
             scoreManager.ProcessJudgement(firstJustEvent);
             scoreManager.ProcessJudgement(secondJustEvent);
@@ -220,7 +220,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Theory]
-        [InlineData(JudgementType.Just, 1.0)]
+        [InlineData(JudgementType.Perfect, 1.0)]
         [InlineData(JudgementType.Great, 0.9)]
         [InlineData(JudgementType.Good, 0.5)]
         [InlineData(JudgementType.Poor, 0.0)]
@@ -252,7 +252,7 @@ namespace DTXMania.Test.Stage.Performance
             // Process perfect play
             for (int i = 0; i < 100; i++)
             {
-                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Just);
+                var justEvent = new JudgementEvent(i, 0, 0.0, JudgementType.Perfect);
                 scoreManager.ProcessJudgement(justEvent);
             }
 

--- a/DTXMania.Test/Stage/Performance/SkillManagerCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillManagerCoverageTests.cs
@@ -1,0 +1,81 @@
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    [Trait("Category", "Unit")]
+    public class SkillManagerCoverageTests
+    {
+        private static JudgementEvent JudgEvent(JudgementType type) =>
+            new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: type);
+
+        [Fact]
+        public void Dispose_WithActiveSubscribers_ShouldClearEventAndPreventFurtherUse()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            int eventCount = 0;
+            sm.SkillChanged += (s, e) => eventCount++;
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            Assert.Equal(1, eventCount);
+
+            sm.Dispose();
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            Assert.Equal(1, eventCount);
+            Assert.Equal(1, sm.PerfectCount);
+        }
+
+        [Fact]
+        public void Dispose_CalledTwice_ShouldNotThrow()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+
+            sm.Dispose();
+            sm.Dispose();
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            Assert.Equal(0, sm.PerfectCount);
+        }
+
+        [Fact]
+        public void Reset_AfterDispose_ShouldNotFireEvent()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            sm.Dispose();
+
+            SkillChangedEventArgs? captured = null;
+            sm.SkillChanged += (s, e) => captured = e;
+            sm.Reset();
+
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Null(captured);
+        }
+
+        [Fact]
+        public void SkillChanged_AfterDisposeAndReSubscribe_ShouldNotFire()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            sm.Dispose();
+
+            int eventCount = 0;
+            sm.SkillChanged += (s, e) => eventCount++;
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            Assert.Equal(0, eventCount);
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Performance/SkillManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillManagerTests.cs
@@ -28,9 +28,13 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Constructor_ZeroTotalNotes_ShouldThrow()
+        public void Constructor_ZeroTotalNotes_ShouldInitializeZeroSkill()
         {
-            Assert.Throws<ArgumentException>(() => new SkillManager(0, new ComboManager()));
+            var sm = new SkillManager(0, new ComboManager());
+
+            Assert.Equal(0, sm.TotalNotes);
+            Assert.Equal(0.0, sm.CurrentSkill);
+            Assert.False(sm.IsMax);
         }
 
         [Fact]
@@ -149,6 +153,20 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(0.0, sm.CurrentSkill);
         }
 
+        [Fact]
+        public void CurrentSkill_ZeroTotalNotes_ShouldStayZero()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(0, combo);
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Equal(0.0, sm.CurrentSkill);
+            Assert.False(sm.IsMax);
+        }
+
         #endregion
 
         #region SkillChanged event
@@ -214,14 +232,13 @@ namespace DTXMania.Test.Stage.Performance
             var sm = new SkillManager(100, combo);
             combo.ProcessJudgement(new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: JudgementType.Perfect));
             sm.ProcessJudgement(new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: JudgementType.Perfect));
+            var skillBeforeDispose = sm.CurrentSkill;
             sm.Dispose();
 
-            SkillChangedEventArgs? captured = null;
-            sm.SkillChanged += (s, e) => captured = e;  // Note: after Dispose, SkillChanged was nulled; this re-subscribes
             sm.Reset();
-            // Counts should remain frozen (Reset returns early on _disposed)
+
             Assert.Equal(1, sm.PerfectCount);
-            Assert.Null(captured);
+            Assert.Equal(skillBeforeDispose, sm.CurrentSkill);
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/SkillManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillManagerTests.cs
@@ -78,7 +78,7 @@ namespace DTXMania.Test.Stage.Performance
         public void ProcessJudgement_NullEvent_ShouldBeIgnored()
         {
             var sm = new SkillManager(10, new ComboManager());
-            sm.ProcessJudgement(null!);
+            sm.ProcessJudgement((JudgementEvent?)null);
             Assert.Equal(0, sm.PerfectCount);
         }
 
@@ -190,6 +190,38 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(0.0, sm.CurrentSkill);
             Assert.NotNull(captured);
             Assert.Equal(0.0, captured!.CurrentSkill);
+        }
+
+        #endregion
+
+        #region Dispose
+
+        [Fact]
+        public void ProcessJudgement_AfterDispose_ShouldBeNoOp()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            sm.Dispose();
+            sm.ProcessJudgement(new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: JudgementType.Perfect));
+            Assert.Equal(0, sm.PerfectCount);
+            Assert.Equal(0.0, sm.CurrentSkill);
+        }
+
+        [Fact]
+        public void Reset_AfterDispose_ShouldBeNoOp()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            combo.ProcessJudgement(new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: JudgementType.Perfect));
+            sm.ProcessJudgement(new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: JudgementType.Perfect));
+            sm.Dispose();
+
+            SkillChangedEventArgs? captured = null;
+            sm.SkillChanged += (s, e) => captured = e;  // Note: after Dispose, SkillChanged was nulled; this re-subscribes
+            sm.Reset();
+            // Counts should remain frozen (Reset returns early on _disposed)
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Null(captured);
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/SkillManagerTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillManagerTests.cs
@@ -1,0 +1,197 @@
+using System;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    /// <summary>
+    /// Tests for SkillManager. Verifies DTXManiaNX-faithful Playing Skill computation
+    /// based on live judgement events and combo state.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SkillManagerTests
+    {
+        private static JudgementEvent JudgEvent(JudgementType type) =>
+            new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: type);
+
+        #region Constructor
+
+        [Fact]
+        public void Constructor_ValidTotalNotes_ShouldInitializeZero()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            Assert.Equal(0.0, sm.CurrentSkill);
+            Assert.False(sm.IsMax);
+            Assert.Equal(0, sm.PerfectCount);
+        }
+
+        [Fact]
+        public void Constructor_ZeroTotalNotes_ShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => new SkillManager(0, new ComboManager()));
+        }
+
+        [Fact]
+        public void Constructor_NegativeTotalNotes_ShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => new SkillManager(-5, new ComboManager()));
+        }
+
+        [Fact]
+        public void Constructor_NullComboManager_ShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SkillManager(100, null!));
+        }
+
+        #endregion
+
+        #region ProcessJudgement counts
+
+        [Fact]
+        public void ProcessJudgement_PerfectIncrementsPerfectCount()
+        {
+            var sm = new SkillManager(10, new ComboManager());
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Equal(0, sm.GreatCount);
+        }
+
+        [Fact]
+        public void ProcessJudgement_AllFiveTypesIncrementCorrectly()
+        {
+            var sm = new SkillManager(10, new ComboManager());
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Great));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Good));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Poor));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Miss));
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Equal(1, sm.GreatCount);
+            Assert.Equal(1, sm.GoodCount);
+            Assert.Equal(1, sm.PoorCount);
+            Assert.Equal(1, sm.MissCount);
+        }
+
+        [Fact]
+        public void ProcessJudgement_NullEvent_ShouldBeIgnored()
+        {
+            var sm = new SkillManager(10, new ComboManager());
+            sm.ProcessJudgement(null!);
+            Assert.Equal(0, sm.PerfectCount);
+        }
+
+        #endregion
+
+        #region CurrentSkill formula
+
+        /// <summary>
+        /// All Perfect + full combo → 100. Combo is fed via the real ComboManager.
+        /// </summary>
+        [Fact]
+        public void CurrentSkill_AllPerfectFullCombo_ShouldReach100()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            for (int i = 0; i < 100; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            }
+            Assert.Equal(100.0, sm.CurrentSkill, 6);
+            Assert.True(sm.IsMax);
+        }
+
+        [Fact]
+        public void CurrentSkill_AllGreatFullCombo_ShouldReach50()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            for (int i = 0; i < 100; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Great));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Great));
+            }
+            Assert.Equal(50.0, sm.CurrentSkill, 6);
+            Assert.False(sm.IsMax);
+        }
+
+        [Fact]
+        public void CurrentSkill_HalfPerfectHalfMiss_WithPartialCombo_ShouldReturn49_85()
+        {
+            // Sequence: 1 Perfect, 1 Miss (combo break), 49 Perfect (combo 1→49, max=49), 49 Miss.
+            // Final tally: PerfectCount=50, MissCount=50, MaxCombo=49.
+            // Skill = 50*0.85 + 0 + 49*0.15 = 42.5 + 7.35 = 49.85.
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect)); // combo=1, max=1
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            combo.ProcessJudgement(JudgEvent(JudgementType.Miss));    // combo reset
+            sm.ProcessJudgement(JudgEvent(JudgementType.Miss));
+            for (int i = 0; i < 49; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            }
+            for (int i = 0; i < 49; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Miss));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Miss));
+            }
+            Assert.Equal(49.85, sm.CurrentSkill, 4);
+        }
+
+        [Fact]
+        public void CurrentSkill_NoJudgements_ShouldBeZero()
+        {
+            var sm = new SkillManager(100, new ComboManager());
+            Assert.Equal(0.0, sm.CurrentSkill);
+        }
+
+        #endregion
+
+        #region SkillChanged event
+
+        [Fact]
+        public void ProcessJudgement_ShouldRaiseSkillChanged()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            SkillChangedEventArgs? captured = null;
+            sm.SkillChanged += (s, e) => captured = e;
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            Assert.NotNull(captured);
+            Assert.Equal(0.0, captured!.PreviousSkill);
+            Assert.True(captured.CurrentSkill > 0.0);
+            Assert.Equal(JudgementType.Perfect, captured.JudgementType);
+        }
+
+        #endregion
+
+        #region Reset
+
+        [Fact]
+        public void Reset_ShouldClearCountsAndFireEvent()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            SkillChangedEventArgs? captured = null;
+            sm.SkillChanged += (s, e) => captured = e;
+            sm.Reset();
+
+            Assert.Equal(0, sm.PerfectCount);
+            Assert.Equal(0.0, sm.CurrentSkill);
+            Assert.NotNull(captured);
+            Assert.Equal(0.0, captured!.CurrentSkill);
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/Performance/SkillMeterDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillMeterDisplayCoverageTests.cs
@@ -105,10 +105,12 @@ namespace DTXMania.Test.Stage.Performance
             var rm = new Mock<IResourceManager>();
             rm.Setup(x => x.LoadTexture(It.IsAny<string>())).Throws(new Exception("load failed"));
 
-            var display = CreateUninitializedDisplay();
+            var display = WithManagedFontUnavailable(() =>
+                new SkillMeterDisplay(rm.Object, CreateUninitialized<GraphicsDevice>()));
 
             Assert.Null(GetPrivateField<ITexture>(display, "_backgroundTexture"));
             Assert.Null(GetPrivateField<ITexture>(display, "_gaugeTexture"));
+            display.Dispose();
         }
 
         [Fact]
@@ -126,9 +128,11 @@ namespace DTXMania.Test.Stage.Performance
                   return gaugeTexture;
               });
 
-            var display = CreateUninitializedDisplay();
+            var display = WithManagedFontUnavailable(() =>
+                new SkillMeterDisplay(rm.Object, CreateUninitialized<GraphicsDevice>()));
 
             Assert.Null(GetPrivateField<ITexture>(display, "_backgroundTexture"));
+            display.Dispose();
         }
 
         #endregion
@@ -373,16 +377,17 @@ namespace DTXMania.Test.Stage.Performance
             var factoryLock = managedFontType
                 .GetField("_fontFactoryLock", BindingFlags.Static | BindingFlags.NonPublic)!
                 .GetValue(null)!;
-            var contentManagerField = managedFontType.GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var originalContentManager = contentManagerField.GetValue(null);
-
-            var loadedFontsField = managedFontType.GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var loadedFonts = (System.Collections.IDictionary)loadedFontsField.GetValue(null)!;
-            var originalEntries = new System.Collections.DictionaryEntry[loadedFonts.Count];
-            loadedFonts.CopyTo(originalEntries, 0);
 
             lock (factoryLock)
             {
+                var contentManagerField = managedFontType.GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic)!;
+                var originalContentManager = contentManagerField.GetValue(null);
+
+                var loadedFontsField = managedFontType.GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic)!;
+                var loadedFonts = (System.Collections.IDictionary)loadedFontsField.GetValue(null)!;
+                var originalEntries = new System.Collections.DictionaryEntry[loadedFonts.Count];
+                loadedFonts.CopyTo(originalEntries, 0);
+
                 try
                 {
                     contentManagerField.SetValue(null, null);

--- a/DTXMania.Test/Stage/Performance/SkillMeterDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillMeterDisplayCoverageTests.cs
@@ -50,6 +50,56 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
+        public void Constructor_WithTexturesAvailable_ShouldStoreTexturesAndIgnoreUnavailableFont()
+        {
+            var rm = new Mock<IResourceManager>();
+            var backgroundTexture = new Mock<ITexture>().Object;
+            var gaugeTexture = new Mock<ITexture>().Object;
+            rm.Setup(x => x.LoadTexture(TexturePath.PerfGraphMain)).Returns(backgroundTexture);
+            rm.Setup(x => x.LoadTexture(TexturePath.PerfGraphGauge)).Returns(gaugeTexture);
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillMeterDisplay(rm.Object, CreateUninitialized<GraphicsDevice>()));
+
+            Assert.Same(backgroundTexture, GetPrivateField<ITexture?>(display, "_backgroundTexture"));
+            Assert.Same(gaugeTexture, GetPrivateField<ITexture?>(display, "_gaugeTexture"));
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_font"));
+            display.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WhenBackgroundLoadFails_ShouldStillLoadGaugeTexture()
+        {
+            var rm = new Mock<IResourceManager>();
+            var gaugeTexture = new Mock<ITexture>().Object;
+            rm.Setup(x => x.LoadTexture(TexturePath.PerfGraphMain)).Throws(new Exception("background failed"));
+            rm.Setup(x => x.LoadTexture(TexturePath.PerfGraphGauge)).Returns(gaugeTexture);
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillMeterDisplay(rm.Object, CreateUninitialized<GraphicsDevice>()));
+
+            Assert.Null(GetPrivateField<ITexture?>(display, "_backgroundTexture"));
+            Assert.Same(gaugeTexture, GetPrivateField<ITexture?>(display, "_gaugeTexture"));
+            display.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WhenGaugeLoadFails_ShouldKeepGaugeTextureNull()
+        {
+            var rm = new Mock<IResourceManager>();
+            var backgroundTexture = new Mock<ITexture>().Object;
+            rm.Setup(x => x.LoadTexture(TexturePath.PerfGraphMain)).Returns(backgroundTexture);
+            rm.Setup(x => x.LoadTexture(TexturePath.PerfGraphGauge)).Throws(new Exception("gauge failed"));
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillMeterDisplay(rm.Object, CreateUninitialized<GraphicsDevice>()));
+
+            Assert.Same(backgroundTexture, GetPrivateField<ITexture?>(display, "_backgroundTexture"));
+            Assert.Null(GetPrivateField<ITexture?>(display, "_gaugeTexture"));
+            display.Dispose();
+        }
+
+        [Fact]
         public void Constructor_TextureLoadFails_ShouldSetBackgroundTextureNull()
         {
             var rm = new Mock<IResourceManager>();
@@ -316,5 +366,39 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         #endregion
+
+        private static T WithManagedFontUnavailable<T>(Func<T> action)
+        {
+            var managedFontType = typeof(ManagedFont);
+            var factoryLock = managedFontType
+                .GetField("_fontFactoryLock", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetValue(null)!;
+            var contentManagerField = managedFontType.GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var originalContentManager = contentManagerField.GetValue(null);
+
+            var loadedFontsField = managedFontType.GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var loadedFonts = (System.Collections.IDictionary)loadedFontsField.GetValue(null)!;
+            var originalEntries = new System.Collections.DictionaryEntry[loadedFonts.Count];
+            loadedFonts.CopyTo(originalEntries, 0);
+
+            lock (factoryLock)
+            {
+                try
+                {
+                    contentManagerField.SetValue(null, null);
+                    loadedFonts.Clear();
+                    return action();
+                }
+                finally
+                {
+                    loadedFonts.Clear();
+                    foreach (System.Collections.DictionaryEntry entry in originalEntries)
+                    {
+                        loadedFonts[entry.Key] = entry.Value;
+                    }
+                    contentManagerField.SetValue(null, originalContentManager);
+                }
+            }
+        }
     }
 }

--- a/DTXMania.Test/Stage/Performance/SkillMeterDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillMeterDisplayCoverageTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    [Trait("Category", "Unit")]
+    public class SkillMeterDisplayCoverageTests
+    {
+        private static SkillMeterDisplay CreateUninitializedDisplay()
+        {
+#pragma warning disable SYSLIB0050
+            return (SkillMeterDisplay)FormatterServices.GetUninitializedObject(typeof(SkillMeterDisplay));
+#pragma warning restore SYSLIB0050
+        }
+
+        private static void InvokeDisposeBool(object target, bool disposing)
+        {
+            var method = typeof(SkillMeterDisplay).GetMethod(
+                "Dispose",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(bool) },
+                null);
+            Assert.NotNull(method);
+            method!.Invoke(target, new object[] { disposing });
+        }
+
+        #region Constructor Tests
+
+        [Fact]
+        public void Constructor_NullResourceManager_ShouldThrowArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SkillMeterDisplay(null!, null!));
+        }
+
+        [Fact]
+        public void Constructor_NullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var rm = new Mock<IResourceManager>().Object;
+            Assert.Throws<ArgumentNullException>(() => new SkillMeterDisplay(rm, null!));
+        }
+
+        [Fact]
+        public void Constructor_TextureLoadFails_ShouldSetBackgroundTextureNull()
+        {
+            var rm = new Mock<IResourceManager>();
+            rm.Setup(x => x.LoadTexture(It.IsAny<string>())).Throws(new Exception("load failed"));
+
+            var display = CreateUninitializedDisplay();
+
+            Assert.Null(GetPrivateField<ITexture>(display, "_backgroundTexture"));
+            Assert.Null(GetPrivateField<ITexture>(display, "_gaugeTexture"));
+        }
+
+        [Fact]
+        public void Constructor_BackgroundTextureLoadFails_ShouldSetBackgroundTextureNullOnly()
+        {
+            var rm = new Mock<IResourceManager>();
+            var gaugeTexture = new Mock<ITexture>().Object;
+            int callCount = 0;
+            rm.Setup(x => x.LoadTexture(It.IsAny<string>()))
+              .Returns<string>(path =>
+              {
+                  callCount++;
+                  if (callCount == 1)
+                      throw new Exception("bg failed");
+                  return gaugeTexture;
+              });
+
+            var display = CreateUninitializedDisplay();
+
+            Assert.Null(GetPrivateField<ITexture>(display, "_backgroundTexture"));
+        }
+
+        #endregion
+
+        #region Update Tests
+
+        [Fact]
+        public void Update_ShouldNotThrow()
+        {
+            var display = CreateUninitializedDisplay();
+            var exception = Record.Exception(() => display.Update(1.0));
+            Assert.Null(exception);
+        }
+
+        #endregion
+
+        #region Draw Tests
+
+        [Fact]
+        public void Draw_WhenDisposed_ShouldReturnImmediately()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", true);
+            SetPrivateField(display, "_backgroundTexture", null);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+
+            display.Draw(null!);
+        }
+
+        [Fact]
+        public void Draw_WhenSpriteBatchNull_ShouldReturnImmediately()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", null);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+
+            display.Draw(null!);
+        }
+
+        [Fact]
+        public void Draw_WithNoTextures_ShouldNotThrow()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", null);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+            display.Skill = 50.0;
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Draw_WithBackgroundTextureAndNoGauge_ShouldNotThrow()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+            display.Skill = 0.0;
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Draw_WithGaugeTextureAndPositiveSkill_ShouldNotThrow()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_gaugeTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_font", null);
+            display.Skill = 75.0;
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Draw_WithFontAndPositiveSkill_ShouldNotThrow()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_gaugeTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_font", null);
+            display.Skill = 42.5;
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Draw_WithZeroSkill_ShouldNotDrawGaugeBar()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_gaugeTexture", new Mock<ITexture>().Object);
+            SetPrivateField(display, "_font", null);
+            display.Skill = 0.0;
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        #endregion
+
+        #region Skill Property Tests
+
+        [Fact]
+        public void Skill_GetterSetter_ShouldWork()
+        {
+            var display = CreateUninitializedDisplay();
+            display.Skill = 88.5;
+            Assert.Equal(88.5, display.Skill);
+        }
+
+        #endregion
+
+        #region Dispose Tests
+
+        [Fact]
+        public void Dispose_ShouldSetDisposed()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", null);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+
+            display.Dispose();
+
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+        }
+
+        [Fact]
+        public void Dispose_CalledTwice_ShouldNotThrow()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", null);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+
+            display.Dispose();
+            var exception = Record.Exception(() => display.Dispose());
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Dispose_ShouldReleaseTextures()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            var bgTex = new Mock<ITexture>();
+            var gaugeTex = new Mock<ITexture>();
+            bgTex.Setup(t => t.RemoveReference());
+            gaugeTex.Setup(t => t.RemoveReference());
+            SetPrivateField(display, "_backgroundTexture", bgTex.Object);
+            SetPrivateField(display, "_gaugeTexture", gaugeTex.Object);
+            SetPrivateField(display, "_font", null);
+
+            display.Dispose();
+
+            bgTex.Verify(t => t.RemoveReference(), Times.Once);
+            gaugeTex.Verify(t => t.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<ITexture>(display, "_backgroundTexture"));
+            Assert.Null(GetPrivateField<ITexture>(display, "_gaugeTexture"));
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+        }
+
+        [Fact]
+        public void Dispose_ShouldHandleNullFontAndTextures()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_backgroundTexture", null);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+
+            var exception = Record.Exception(() => display.Dispose());
+            Assert.Null(exception);
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+        }
+
+        #endregion
+
+        #region Dispose(bool) Tests
+
+        [Fact]
+        public void Dispose_BoolDisposingFalse_ShouldStillSetDisposed()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            var bgTex = new Mock<ITexture>();
+            bgTex.Setup(t => t.RemoveReference());
+            SetPrivateField(display, "_backgroundTexture", bgTex.Object);
+            SetPrivateField(display, "_gaugeTexture", null);
+            SetPrivateField(display, "_font", null);
+
+            InvokeDisposeBool(display, false);
+
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+            Assert.NotNull(GetPrivateField<ITexture>(display, "_backgroundTexture"));
+            bgTex.Verify(t => t.RemoveReference(), Times.Never);
+        }
+
+        [Fact]
+        public void Dispose_BoolDisposingTrue_ShouldReleaseResources()
+        {
+            var display = CreateUninitializedDisplay();
+            SetPrivateField(display, "_disposed", false);
+            var bgTex = new Mock<ITexture>();
+            var gaugeTex = new Mock<ITexture>();
+            bgTex.Setup(t => t.RemoveReference());
+            gaugeTex.Setup(t => t.RemoveReference());
+            SetPrivateField(display, "_backgroundTexture", bgTex.Object);
+            SetPrivateField(display, "_gaugeTexture", gaugeTex.Object);
+            SetPrivateField(display, "_font", null);
+
+            InvokeDisposeBool(display, true);
+
+            bgTex.Verify(t => t.RemoveReference(), Times.Once);
+            gaugeTex.Verify(t => t.RemoveReference(), Times.Once);
+            Assert.Null(GetPrivateField<ITexture>(display, "_backgroundTexture"));
+            Assert.Null(GetPrivateField<ITexture>(display, "_gaugeTexture"));
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
@@ -1,0 +1,49 @@
+using DTXMania.Game.Lib.Stage.Performance;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    /// <summary>
+    /// Pure logic tests for SkillMeterDisplay math helpers — runs on all platforms.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SkillMeterDisplayLogicTests
+    {
+        [Theory]
+        [InlineData(  0.0,   0)]
+        [InlineData( 50.0, 217)]
+        [InlineData(100.0, 434)]
+        [InlineData(150.0, 434)]   // clamped
+        [InlineData( -5.0,   0)]   // clamped low
+        public void ComputeGaugeHeight_ReturnsExpected(double skill, int expected)
+        {
+            Assert.Equal(expected, SkillMeterDisplay.ComputeGaugeHeight(skill));
+        }
+
+        [Fact]
+        public void ComputeBarTopY_FullGauge_ShouldEqualBackgroundTop()
+        {
+            // GaugeBaselineY (527) - GaugeMaxHeight (434) = 93
+            Assert.Equal(93, SkillMeterDisplay.ComputeBarTopY(100.0));
+        }
+
+        [Fact]
+        public void ComputeBarTopY_EmptyGauge_ShouldEqualBaseline()
+        {
+            Assert.Equal(527, SkillMeterDisplay.ComputeBarTopY(0.0));
+        }
+
+        [Fact]
+        public void ShouldDrawBar_ZeroSkill_ShouldBeFalse()
+        {
+            Assert.False(SkillMeterDisplay.ShouldDrawBar(0.0));
+        }
+
+        [Fact]
+        public void ShouldDrawBar_AnyPositiveSkill_ShouldBeTrue()
+        {
+            Assert.True(SkillMeterDisplay.ShouldDrawBar(0.01));
+            Assert.True(SkillMeterDisplay.ShouldDrawBar(100.0));
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
@@ -15,6 +15,7 @@ namespace DTXMania.Test.Stage.Performance
         [InlineData(100.0, 434)]
         [InlineData(150.0, 434)]   // clamped
         [InlineData( -5.0,   0)]   // clamped low
+        [InlineData( 33.33, 144)]  // 434 * 33.33 / 100 = 144.6522 -> truncates to 144
         public void ComputeGaugeHeight_ReturnsExpected(double skill, int expected)
         {
             Assert.Equal(expected, SkillMeterDisplay.ComputeGaugeHeight(skill));

--- a/DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
@@ -1,3 +1,4 @@
+using System;
 using DTXMania.Game.Lib.Stage.Performance;
 using Xunit;
 
@@ -45,6 +46,41 @@ namespace DTXMania.Test.Stage.Performance
         {
             Assert.True(SkillMeterDisplay.ShouldDrawBar(0.01));
             Assert.True(SkillMeterDisplay.ShouldDrawBar(100.0));
+        }
+
+        /// <summary>
+        /// Verifies that Draw() clamps Skill before passing to helpers, so bar and
+        /// numeric overlay never disagree. We test the clamping pattern indirectly:
+        /// an over-range Skill fed through the same clamp+helper pipeline that Draw()
+        /// uses must produce the same results as a max-valid Skill.
+        /// </summary>
+        [Fact]
+        public void ClampedSkill_OverflowValue_ShouldMatchMaxValue()
+        {
+            double overflow = 150.0;
+            double clamped = Math.Clamp(overflow, 0.0, 100.0);
+
+            Assert.Equal(100.0, clamped);
+            Assert.Equal(
+                SkillMeterDisplay.ComputeGaugeHeight(100.0),
+                SkillMeterDisplay.ComputeGaugeHeight(clamped));
+            Assert.Equal(
+                SkillMeterDisplay.ComputeBarTopY(100.0),
+                SkillMeterDisplay.ComputeBarTopY(clamped));
+            Assert.True(SkillMeterDisplay.ShouldDrawBar(clamped));
+        }
+
+        [Fact]
+        public void ClampedSkill_NegativeValue_ShouldMatchZero()
+        {
+            double negative = -10.0;
+            double clamped = Math.Clamp(negative, 0.0, 100.0);
+
+            Assert.Equal(0.0, clamped);
+            Assert.Equal(
+                SkillMeterDisplay.ComputeGaugeHeight(0.0),
+                SkillMeterDisplay.ComputeGaugeHeight(clamped));
+            Assert.False(SkillMeterDisplay.ShouldDrawBar(clamped));
         }
     }
 }

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
@@ -55,6 +55,22 @@ namespace DTXMania.Test.Stage.Performance
             display.Dispose();
         }
 
+        [Fact]
+        public void Constructor_TextureLoadSucceeds_ShouldStoreMaxBadgeTexture()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var maxBadgeTexture = new Mock<ITexture>().Object;
+            resourceManager
+                .Setup(rm => rm.LoadTexture(TexturePath.SkillMax))
+                .Returns(maxBadgeTexture);
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), null));
+
+            Assert.Same(maxBadgeTexture, GetPrivateField<ITexture?>(display, "_maxBadgeTexture"));
+            display.Dispose();
+        }
+
         #endregion
 
         #region Update Tests

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
@@ -1,0 +1,210 @@
+#pragma warning disable SYSLIB0050
+
+using System;
+using System.Reflection;
+using System.Runtime.Serialization;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    [Trait("Category", "Unit")]
+    public class SkillPanelDisplayCoverageTests
+    {
+        #region Constructor Guard Tests
+
+        [Fact]
+        public void Constructor_NullResourceManager_ShouldThrowArgumentNullException()
+        {
+            var graphicsDevice = CreateUninitialized<GraphicsDevice>();
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new SkillPanelDisplay(null!, graphicsDevice, null));
+
+            Assert.Equal("resourceManager", ex.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_NullGraphicsDevice_ShouldThrowArgumentNullException()
+        {
+            var resourceManager = new Mock<IResourceManager>().Object;
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new SkillPanelDisplay(resourceManager, null!, null));
+
+            Assert.Equal("graphicsDevice", ex.ParamName);
+        }
+
+        [Fact]
+        public void Constructor_TextureLoadFails_ShouldSetMaxBadgeTextureNull()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(rm => rm.LoadTexture(It.IsAny<string>()))
+                .Throws(new Exception("texture load failure"));
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), null));
+
+            Assert.Null(GetPrivateField<ITexture?>(display, "_maxBadgeTexture"));
+            display.Dispose();
+        }
+
+        #endregion
+
+        #region Update Tests
+
+        [Fact]
+        public void Update_ShouldNotThrow()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+
+            var exception = Record.Exception(() => display.Update(1.0));
+            Assert.Null(exception);
+        }
+
+        #endregion
+
+        #region Draw Guard Tests
+
+        [Fact]
+        public void Draw_WhenDisposed_ShouldReturnImmediately()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+            SetPrivateField(display, "_disposed", true);
+            SetPrivateField(display, "_font", CreateUninitialized<ManagedFont>());
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Draw_WhenSpriteBatchNull_ShouldReturnImmediately()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_font", CreateUninitialized<ManagedFont>());
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void Draw_WhenFontNull_ShouldReturnImmediately()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+            SetPrivateField(display, "_disposed", false);
+            SetPrivateField(display, "_font", null);
+
+            var exception = Record.Exception(() => display.Draw(null!));
+            Assert.Null(exception);
+        }
+
+        #endregion
+
+        #region Property Tests
+
+        [Fact]
+        public void Skill_Property_ShouldGetAndSet()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+
+            display.Skill = 87.5;
+            Assert.Equal(87.5, display.Skill);
+
+            display.Skill = 0.0;
+            Assert.Equal(0.0, display.Skill);
+        }
+
+        [Fact]
+        public void ShowMax_Property_ShouldGetAndSet()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+
+            display.ShowMax = true;
+            Assert.True(display.ShowMax);
+
+            display.ShowMax = false;
+            Assert.False(display.ShowMax);
+        }
+
+        #endregion
+
+        #region Dispose Tests
+
+        [Fact]
+        public void Dispose_ShouldReleaseFontAndTextures()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+            var mockTexture = new Mock<ITexture>();
+            SetPrivateField(display, "_font", null);
+            SetPrivateField(display, "_maxBadgeTexture", mockTexture.Object);
+            SetPrivateField(display, "_disposed", false);
+
+            display.Dispose();
+
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_font"));
+            Assert.Null(GetPrivateField<ITexture?>(display, "_maxBadgeTexture"));
+            Assert.True(GetPrivateField<bool>(display, "_disposed"));
+            mockTexture.Verify(t => t.RemoveReference(), Times.Once);
+        }
+
+        [Fact]
+        public void Dispose_CalledTwice_ShouldNotThrow()
+        {
+            var display = CreateUninitialized<SkillPanelDisplay>();
+            SetPrivateField(display, "_font", null);
+            SetPrivateField(display, "_maxBadgeTexture", null);
+            SetPrivateField(display, "_disposed", false);
+
+            display.Dispose();
+            var exception = Record.Exception(() => display.Dispose());
+            Assert.Null(exception);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private static T WithManagedFontUnavailable<T>(Func<T> action)
+        {
+            var managedFontType = typeof(ManagedFont);
+            var factoryLock = managedFontType
+                .GetField("_fontFactoryLock", BindingFlags.Static | BindingFlags.NonPublic)!
+                .GetValue(null)!;
+            var contentManagerField = managedFontType.GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var originalContentManager = contentManagerField.GetValue(null);
+
+            var loadedFontsField = managedFontType.GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic)!;
+            var loadedFonts = (System.Collections.IDictionary)loadedFontsField.GetValue(null)!;
+            var originalEntries = new System.Collections.DictionaryEntry[loadedFonts.Count];
+            loadedFonts.CopyTo(originalEntries, 0);
+
+            lock (factoryLock)
+            {
+                try
+                {
+                    contentManagerField.SetValue(null, null);
+                    loadedFonts.Clear();
+                    return action();
+                }
+                finally
+                {
+                    loadedFonts.Clear();
+                    foreach (System.Collections.DictionaryEntry entry in originalEntries)
+                    {
+                        loadedFonts[entry.Key] = entry.Value;
+                    }
+                    contentManagerField.SetValue(null, originalContentManager);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
@@ -193,16 +193,17 @@ namespace DTXMania.Test.Stage.Performance
             var factoryLock = managedFontType
                 .GetField("_fontFactoryLock", BindingFlags.Static | BindingFlags.NonPublic)!
                 .GetValue(null)!;
-            var contentManagerField = managedFontType.GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var originalContentManager = contentManagerField.GetValue(null);
-
-            var loadedFontsField = managedFontType.GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic)!;
-            var loadedFonts = (System.Collections.IDictionary)loadedFontsField.GetValue(null)!;
-            var originalEntries = new System.Collections.DictionaryEntry[loadedFonts.Count];
-            loadedFonts.CopyTo(originalEntries, 0);
 
             lock (factoryLock)
             {
+                var contentManagerField = managedFontType.GetField("_contentManager", BindingFlags.Static | BindingFlags.NonPublic)!;
+                var originalContentManager = contentManagerField.GetValue(null);
+
+                var loadedFontsField = managedFontType.GetField("_loadedFonts", BindingFlags.Static | BindingFlags.NonPublic)!;
+                var loadedFonts = (System.Collections.IDictionary)loadedFontsField.GetValue(null)!;
+                var originalEntries = new System.Collections.DictionaryEntry[loadedFonts.Count];
+                loadedFonts.CopyTo(originalEntries, 0);
+
                 try
                 {
                     contentManagerField.SetValue(null, null);

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
@@ -1,0 +1,38 @@
+using DTXMania.Game.Lib.Stage.Performance;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    /// <summary>
+    /// Logic tests for SkillPanelDisplay formatting helpers.
+    /// Mac-excluded because the type lives alongside graphics resources.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SkillPanelDisplayLogicTests
+    {
+        // Level encoding (DTXManiaNX-faithful):
+        //   level <  100 → displayed = level/10 + levelDec/100  (e.g. 80+50 → 8.50)
+        //   level >= 100 → displayed = level/100                (e.g. 850 → 8.50)
+        [Theory]
+        [InlineData(78,  0, "7.80")]
+        [InlineData(80, 50, "8.50")]
+        [InlineData(78, 33, "8.13")]
+        [InlineData(50,  0, "5.00")]
+        [InlineData(850, 0, "8.50")]
+        [InlineData( 0,  0, "--")]
+        public void FormatLevelText_ReturnsExpected(int level, int levelDec, string expected)
+        {
+            Assert.Equal(expected, SkillPanelDisplay.FormatLevelText(level, levelDec));
+        }
+
+        [Theory]
+        [InlineData(  0.0,  "  0.00")]
+        [InlineData( 87.42, " 87.42")]
+        [InlineData(100.0, "100.00")]
+        [InlineData( 50.5,  " 50.50")]
+        public void FormatSkillText_ReturnsExpected(double skill, string expected)
+        {
+            Assert.Equal(expected, SkillPanelDisplay.FormatSkillText(skill));
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
@@ -20,7 +20,7 @@ namespace DTXMania.Test.Stage.Performance
         [InlineData(850, 0, "8.50")]
         [InlineData( 0,  0, "--")]
         [InlineData(-1,  0, "--")]
-        public void FormatLevelText_ReturnsExpected(int level, int levelDec, string expected)
+        public void FormatLevelText_WithVariousInputs_ShouldReturnExpected(int level, int levelDec, string expected)
         {
             Assert.Equal(expected, SkillPanelDisplay.FormatLevelText(level, levelDec));
         }
@@ -30,7 +30,7 @@ namespace DTXMania.Test.Stage.Performance
         [InlineData( 87.42, " 87.42")]
         [InlineData(100.0, "100.00")]
         [InlineData( 50.5,  " 50.50")]
-        public void FormatSkillText_ReturnsExpected(double skill, string expected)
+        public void FormatSkillText_WithVariousInputs_ShouldReturnExpected(double skill, string expected)
         {
             Assert.Equal(expected, SkillPanelDisplay.FormatSkillText(skill));
         }

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
@@ -4,8 +4,7 @@ using Xunit;
 namespace DTXMania.Test.Stage.Performance
 {
     /// <summary>
-    /// Logic tests for SkillPanelDisplay formatting helpers.
-    /// Mac-excluded because the type lives alongside graphics resources.
+    /// Pure logic tests for SkillPanelDisplay formatting helpers — runs on all platforms.
     /// </summary>
     [Trait("Category", "Unit")]
     public class SkillPanelDisplayLogicTests
@@ -20,6 +19,7 @@ namespace DTXMania.Test.Stage.Performance
         [InlineData(50,  0, "5.00")]
         [InlineData(850, 0, "8.50")]
         [InlineData( 0,  0, "--")]
+        [InlineData(-1,  0, "--")]
         public void FormatLevelText_ReturnsExpected(int level, int levelDec, string expected)
         {
             Assert.Equal(expected, SkillPanelDisplay.FormatLevelText(level, levelDec));

--- a/DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
+++ b/DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
@@ -13,7 +13,7 @@ namespace DTXMania.Test.Stage
     public class PerformanceStageSkillIntegrationTests
     {
         [Fact]
-        public void SkillFields_AllPerfectInputs_MatchExpectedFormula()
+        public void SkillFields_AllPerfectInputs_ShouldMatchExpectedFormula()
         {
             int totalNotes = 100;
             int perfect = 100;

--- a/DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
+++ b/DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
@@ -1,0 +1,65 @@
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    /// <summary>
+    /// Verifies PerformanceSummary skill fields are populated correctly when
+    /// PerformanceStage builds it at completion. Done as a unit-level check by
+    /// constructing the summary the same way PerformanceStage does, rather than
+    /// running the full stage (which needs a graphics device).
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class PerformanceStageSkillIntegrationTests
+    {
+        [Fact]
+        public void BuildSummary_AllPerfect_ShouldPopulateMaxPlayingSkill()
+        {
+            int totalNotes = 100;
+            int perfect    = 100;
+            int great      = 0;
+            int maxCombo   = 100;
+            int level      = 78;
+            int levelDec   = 33;
+
+            double playing = SongScore.CalculatePlayingSkill(totalNotes, perfect, great, maxCombo);
+            double game    = SongScore.CalculateGameSkill(playing, level, levelDec);
+
+            var summary = new PerformanceSummary
+            {
+                TotalNotes    = totalNotes,
+                PerfectCount  = perfect,
+                MaxCombo      = maxCombo,
+                PlayingSkill  = playing,
+                GameSkill     = game,
+                ChartLevel    = level,
+                ChartLevelDec = levelDec
+            };
+
+            Assert.Equal(100.0, summary.PlayingSkill, 6);
+            // actualLevel = 78/10 + 33/100 = 8.13; 100 * 8.13 * 0.2 = 162.6
+            Assert.Equal(162.6, summary.GameSkill, 4);
+            Assert.Equal(78, summary.ChartLevel);
+            Assert.Equal(33, summary.ChartLevelDec);
+        }
+
+        [Fact]
+        public void BuildSummary_NoHits_ShouldZeroSkill()
+        {
+            var summary = new PerformanceSummary
+            {
+                TotalNotes    = 100,
+                PerfectCount  = 0,
+                MaxCombo      = 0,
+                PlayingSkill  = SongScore.CalculatePlayingSkill(100, 0, 0, 0),
+                GameSkill     = SongScore.CalculateGameSkill(0.0, 78, 33),
+                ChartLevel    = 78,
+                ChartLevelDec = 33
+            };
+
+            Assert.Equal(0.0, summary.PlayingSkill);
+            Assert.Equal(0.0, summary.GameSkill);
+        }
+    }
+}

--- a/DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
+++ b/DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
@@ -5,35 +5,34 @@ using Xunit;
 namespace DTXMania.Test.Stage
 {
     /// <summary>
-    /// Verifies PerformanceSummary skill fields are populated correctly when
-    /// PerformanceStage builds it at completion. Done as a unit-level check by
-    /// constructing the summary the same way PerformanceStage does, rather than
-    /// running the full stage (which needs a graphics device).
+    /// Verifies the contract that PerformanceStage.FinalizePerformance must honor when
+    /// populating skill fields on PerformanceSummary: the formula compositions of
+    /// CalculatePlayingSkill + CalculateGameSkill, given the same chart and judgement inputs.
     /// </summary>
-    [Trait("Category", "Integration")]
+    [Trait("Category", "Unit")]
     public class PerformanceStageSkillIntegrationTests
     {
         [Fact]
-        public void BuildSummary_AllPerfect_ShouldPopulateMaxPlayingSkill()
+        public void SkillFields_AllPerfectInputs_MatchExpectedFormula()
         {
             int totalNotes = 100;
-            int perfect    = 100;
-            int great      = 0;
-            int maxCombo   = 100;
-            int level      = 78;
-            int levelDec   = 33;
+            int perfect = 100;
+            int great = 0;
+            int maxCombo = 100;
+            int level = 78;
+            int levelDec = 33;
 
             double playing = SongScore.CalculatePlayingSkill(totalNotes, perfect, great, maxCombo);
-            double game    = SongScore.CalculateGameSkill(playing, level, levelDec);
+            double game = SongScore.CalculateGameSkill(playing, level, levelDec);
 
             var summary = new PerformanceSummary
             {
-                TotalNotes    = totalNotes,
-                PerfectCount  = perfect,
-                MaxCombo      = maxCombo,
-                PlayingSkill  = playing,
-                GameSkill     = game,
-                ChartLevel    = level,
+                TotalNotes = totalNotes,
+                PerfectCount = perfect,
+                MaxCombo = maxCombo,
+                PlayingSkill = playing,
+                GameSkill = game,
+                ChartLevel = level,
                 ChartLevelDec = levelDec
             };
 
@@ -45,16 +44,16 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void BuildSummary_NoHits_ShouldZeroSkill()
+        public void SkillFields_NoHits_ShouldBeZero()
         {
             var summary = new PerformanceSummary
             {
-                TotalNotes    = 100,
-                PerfectCount  = 0,
-                MaxCombo      = 0,
-                PlayingSkill  = SongScore.CalculatePlayingSkill(100, 0, 0, 0),
-                GameSkill     = SongScore.CalculateGameSkill(0.0, 78, 33),
-                ChartLevel    = 78,
+                TotalNotes = 100,
+                PerfectCount = 0,
+                MaxCombo = 0,
+                PlayingSkill = SongScore.CalculatePlayingSkill(100, 0, 0, 0),
+                GameSkill = SongScore.CalculateGameSkill(0.0, 78, 33),
+                ChartLevel = 78,
                 ChartLevelDec = 33
             };
 

--- a/DTXMania.Test/Stage/ResultStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageCoverageTests.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Runtime.Serialization;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.UI.Layout;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    [Trait("Category", "Unit")]
+    public class ResultStageCoverageTests
+    {
+        [Fact]
+        public void DrawFallbackBackground_WithWhitePixel_ShouldDrawTexture()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
+            var whitePixel = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(stage, "_whitePixel", whitePixel);
+
+            var rect = new Rectangle(0, 0, 800, 600);
+            var color = Color.DarkBlue;
+
+            stage.DrawFallbackBackground(rect, color);
+
+            Assert.Same(whitePixel, stage.DrawTextureArgument);
+            Assert.Equal(rect, stage.DrawTextureRectangle);
+            Assert.Equal(color, stage.DrawTextureColor);
+        }
+
+        [Fact]
+        public void DrawFallbackBackground_WithoutWhitePixel_ShouldNotDraw()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(stage, "_whitePixel", null);
+
+            var rect = new Rectangle(0, 0, 800, 600);
+            var color = Color.DarkBlue;
+
+            stage.DrawFallbackBackground(rect, color);
+
+            Assert.Null(stage.DrawTextureArgument);
+            Assert.Null(stage.DrawTextureRectangle);
+            Assert.Null(stage.DrawTextureColor);
+        }
+
+        [Fact]
+        public void DrawResultLine_WithNoFont_ShouldDrawFallbackRectangle()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(stage, "_spriteBatch", CreateFakeSpriteBatch(800, 600));
+            SetPrivateField(stage, "_resultFont", null);
+            SetPrivateField(stage, "_whitePixel", null);
+
+            object[] args = ["CLEARED", 400, 100, Color.Green, 40];
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResultLine", args));
+
+            Assert.Null(exception);
+            Assert.Equal(140, args[2]);
+        }
+
+        [Fact]
+        public void DrawResults_WithNullSummary_ShouldReturnImmediately()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(stage, "_performanceSummary", null);
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResults"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DrawResults_WithClearedPerformance_ShouldShowCleared()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(stage, "_spriteBatch", CreateFakeSpriteBatch(800, 600));
+            SetPrivateField(stage, "_resultFont", null);
+            SetPrivateField(stage, "_whitePixel", null);
+            SetPrivateField(stage, "_performanceSummary", new PerformanceSummary
+            {
+                Score = 950000,
+                MaxCombo = 200,
+                ClearFlag = true,
+                PerfectCount = 100,
+                GreatCount = 50,
+                GoodCount = 20,
+                PoorCount = 5,
+                MissCount = 2,
+                TotalNotes = 177,
+                CompletionReason = CompletionReason.SongComplete
+            });
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResults"));
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DrawResults_WithFailedPerformance_ShouldShowFailed()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(stage, "_spriteBatch", CreateFakeSpriteBatch(800, 600));
+            SetPrivateField(stage, "_resultFont", null);
+            SetPrivateField(stage, "_whitePixel", null);
+            SetPrivateField(stage, "_performanceSummary", new PerformanceSummary
+            {
+                Score = 200000,
+                MaxCombo = 50,
+                ClearFlag = false,
+                PerfectCount = 30,
+                GreatCount = 10,
+                GoodCount = 5,
+                PoorCount = 3,
+                MissCount = 40,
+                TotalNotes = 88,
+                CompletionReason = CompletionReason.PlayerFailed
+            });
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResults"));
+
+            Assert.Null(exception);
+        }
+
+        #region Helpers
+
+        private static SpriteBatch CreateFakeSpriteBatch(int width, int height)
+        {
+#pragma warning disable SYSLIB0050
+            var spriteBatch = (SpriteBatch)FormatterServices.GetUninitializedObject(typeof(SpriteBatch));
+            var graphicsDevice = (GraphicsDevice)FormatterServices.GetUninitializedObject(typeof(GraphicsDevice));
+#pragma warning restore SYSLIB0050
+            SetPrivateField(spriteBatch, "graphicsDevice", graphicsDevice);
+            SetPrivateField(graphicsDevice, "_viewport", new Viewport(0, 0, width, height));
+            return spriteBatch;
+        }
+
+        private sealed class InspectableResultStage : ResultStage
+        {
+            public InspectableResultStage(BaseGame game) : base(game) { }
+
+            public Texture2D DrawTextureArgument { get; private set; }
+            public Rectangle? DrawTextureRectangle { get; private set; }
+            public Color? DrawTextureColor { get; private set; }
+
+            internal override void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Color color)
+            {
+                DrawTextureArgument = texture;
+                DrawTextureRectangle = destinationRectangle;
+                DrawTextureColor = color;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/ResultStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageCoverageTests.cs
@@ -21,6 +21,7 @@ namespace DTXMania.Test.Stage
             var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
             var whitePixel = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
 #pragma warning restore SYSLIB0050
+            GC.SuppressFinalize(whitePixel);
             SetPrivateField(stage, "_whitePixel", whitePixel);
 
             var rect = new Rectangle(0, 0, 800, 600);
@@ -145,6 +146,10 @@ namespace DTXMania.Test.Stage
             var spriteBatch = (SpriteBatch)FormatterServices.GetUninitializedObject(typeof(SpriteBatch));
             var graphicsDevice = (GraphicsDevice)FormatterServices.GetUninitializedObject(typeof(GraphicsDevice));
 #pragma warning restore SYSLIB0050
+            // Suppress finalization — these objects were never properly constructed and their
+            // GraphicsResource finalizer would crash trying to access uninitialized state.
+            GC.SuppressFinalize(spriteBatch);
+            GC.SuppressFinalize(graphicsDevice);
             SetPrivateField(spriteBatch, "graphicsDevice", graphicsDevice);
             SetPrivateField(graphicsDevice, "_viewport", new Viewport(0, 0, width, height));
             return spriteBatch;

--- a/DTXMania.Test/Stage/ResultStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageCoverageTests.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using DTXMania.Game;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Game.Lib.UI.Layout;
@@ -8,6 +12,7 @@ using static DTXMania.Test.TestData.ReflectionHelpers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Xunit;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 
 namespace DTXMania.Test.Stage
 {
@@ -138,6 +143,53 @@ namespace DTXMania.Test.Stage
             Assert.Null(exception);
         }
 
+        [Fact]
+        public void OnActivate_WithSelectedSongAndDifficulty_ShouldExtractSharedDataAndRequestScorePersist()
+        {
+            SongManager.ResetInstanceForTesting();
+#pragma warning disable SYSLIB0050
+            var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
+#pragma warning restore SYSLIB0050
+
+            var summary = new PerformanceSummary
+            {
+                Score = 750000,
+                MaxCombo = 120,
+                ClearFlag = true,
+                GameSkill = 124.5
+            };
+            var chart = new SongChart
+            {
+                Id = 42,
+                HasDrumChart = true,
+                DrumLevel = 75
+            };
+            var song = new SongListNode
+            {
+                DatabaseSong = new SongEntity
+                {
+                    Charts = new List<SongChart> { chart }
+                }
+            };
+            SetPrivateField(stage, "_inputManager", null);
+            SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+            {
+                ["performanceSummary"] = summary,
+                ["selectedSong"] = song,
+                ["selectedDifficulty"] = 0
+            });
+
+            var exception = Record.Exception(() => InvokePrivateMethod(stage, "OnActivate"));
+
+            Assert.Null(exception);
+            Assert.Same(summary, GetPrivateField<PerformanceSummary>(stage, "_performanceSummary"));
+            Assert.Same(song, GetPrivateField<SongListNode?>(stage, "_selectedSong"));
+            Assert.Equal(0, GetPrivateField<int>(stage, "_selectedDifficulty"));
+            Assert.True(stage.WhitePixelRequested);
+            Assert.True(stage.ResultFontRequested);
+            SongManager.ResetInstanceForTesting();
+        }
+
         #region Helpers
 
         private static SpriteBatch CreateFakeSpriteBatch(int width, int height)
@@ -162,6 +214,20 @@ namespace DTXMania.Test.Stage
             public Texture2D DrawTextureArgument { get; private set; }
             public Rectangle? DrawTextureRectangle { get; private set; }
             public Color? DrawTextureColor { get; private set; }
+            public bool WhitePixelRequested { get; private set; }
+            public bool ResultFontRequested { get; private set; }
+
+            internal override Texture2D CreateWhitePixel()
+            {
+                WhitePixelRequested = true;
+                return null!;
+            }
+
+            internal override BitmapFont CreateResultFont()
+            {
+                ResultFontRequested = true;
+                return null!;
+            }
 
             internal override void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Color color)
             {

--- a/DTXMania.Test/Stage/ResultStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageCoverageTests.cs
@@ -147,47 +147,53 @@ namespace DTXMania.Test.Stage
         public void OnActivate_WithSelectedSongAndDifficulty_ShouldExtractSharedDataAndRequestScorePersist()
         {
             SongManager.ResetInstanceForTesting();
+            try
+            {
 #pragma warning disable SYSLIB0050
-            var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
+                var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
 #pragma warning restore SYSLIB0050
 
-            var summary = new PerformanceSummary
-            {
-                Score = 750000,
-                MaxCombo = 120,
-                ClearFlag = true,
-                GameSkill = 124.5
-            };
-            var chart = new SongChart
-            {
-                Id = 42,
-                HasDrumChart = true,
-                DrumLevel = 75
-            };
-            var song = new SongListNode
-            {
-                DatabaseSong = new SongEntity
+                var summary = new PerformanceSummary
                 {
-                    Charts = new List<SongChart> { chart }
-                }
-            };
-            SetPrivateField(stage, "_inputManager", null);
-            SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+                    Score = 750000,
+                    MaxCombo = 120,
+                    ClearFlag = true,
+                    GameSkill = 124.5
+                };
+                var chart = new SongChart
+                {
+                    Id = 42,
+                    HasDrumChart = true,
+                    DrumLevel = 75
+                };
+                var song = new SongListNode
+                {
+                    DatabaseSong = new SongEntity
+                    {
+                        Charts = new List<SongChart> { chart }
+                    }
+                };
+                SetPrivateField(stage, "_inputManager", null);
+                SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+                {
+                    ["performanceSummary"] = summary,
+                    ["selectedSong"] = song,
+                    ["selectedDifficulty"] = 0
+                });
+
+                var exception = Record.Exception(() => InvokePrivateMethod(stage, "OnActivate"));
+
+                Assert.Null(exception);
+                Assert.Same(summary, GetPrivateField<PerformanceSummary>(stage, "_performanceSummary"));
+                Assert.Same(song, GetPrivateField<SongListNode?>(stage, "_selectedSong"));
+                Assert.Equal(0, GetPrivateField<int>(stage, "_selectedDifficulty"));
+                Assert.True(stage.WhitePixelRequested);
+                Assert.True(stage.ResultFontRequested);
+            }
+            finally
             {
-                ["performanceSummary"] = summary,
-                ["selectedSong"] = song,
-                ["selectedDifficulty"] = 0
-            });
-
-            var exception = Record.Exception(() => InvokePrivateMethod(stage, "OnActivate"));
-
-            Assert.Null(exception);
-            Assert.Same(summary, GetPrivateField<PerformanceSummary>(stage, "_performanceSummary"));
-            Assert.Same(song, GetPrivateField<SongListNode?>(stage, "_selectedSong"));
-            Assert.Equal(0, GetPrivateField<int>(stage, "_selectedDifficulty"));
-            Assert.True(stage.WhitePixelRequested);
-            Assert.True(stage.ResultFontRequested);
-            SongManager.ResetInstanceForTesting();
+                SongManager.ResetInstanceForTesting();
+            }
         }
 
         #region Helpers

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -165,7 +165,7 @@ namespace DTXMania.Test.Stage
 
             var summary = GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
             Assert.NotNull(summary);
-            Assert.Equal(0, summary!.JustCount);
+            Assert.Equal(0, summary!.PerfectCount);
             Assert.Equal(0, summary.GreatCount);
             Assert.Equal(0, summary.GoodCount);
             Assert.Equal(0, summary.PoorCount);
@@ -182,7 +182,7 @@ namespace DTXMania.Test.Stage
             var expectedSummary = new PerformanceSummary
             {
                 Score = 500000,
-                JustCount = 100,
+                PerfectCount = 100,
                 GreatCount = 50,
                 GoodCount = 20,
                 PoorCount = 5,
@@ -201,7 +201,7 @@ namespace DTXMania.Test.Stage
 
             var summary = GetPrivateField<PerformanceSummary>(stage, "_performanceSummary");
             Assert.NotNull(summary);
-            Assert.Equal(100, summary!.JustCount);
+            Assert.Equal(100, summary!.PerfectCount);
             Assert.Equal(50, summary.GreatCount);
             Assert.Equal(20, summary.GoodCount);
             Assert.Equal(5, summary.PoorCount);

--- a/DTXMania.Test/UI/LayoutExtendedTests.cs
+++ b/DTXMania.Test/UI/LayoutExtendedTests.cs
@@ -127,7 +127,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void GaugeSettings_LifeAdjustment_JustShouldBePositive()
+        public void GaugeSettings_LifeAdjustment_PerfectShouldBePositive()
         {
             Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Perfect > 0f);
         }
@@ -139,7 +139,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void GaugeSettings_LifeAdjustment_JustGreaterThanGreat()
+        public void GaugeSettings_LifeAdjustment_PerfectGreaterThanGreat()
         {
             Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Perfect > PerformanceUILayout.GaugeSettings.LifeAdjustment.Great);
         }

--- a/DTXMania.Test/UI/LayoutExtendedTests.cs
+++ b/DTXMania.Test/UI/LayoutExtendedTests.cs
@@ -129,7 +129,7 @@ namespace DTXMania.Test.UI
         [Fact]
         public void GaugeSettings_LifeAdjustment_JustShouldBePositive()
         {
-            Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Just > 0f);
+            Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Perfect > 0f);
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace DTXMania.Test.UI
         [Fact]
         public void GaugeSettings_LifeAdjustment_JustGreaterThanGreat()
         {
-            Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Just > PerformanceUILayout.GaugeSettings.LifeAdjustment.Great);
+            Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Perfect > PerformanceUILayout.GaugeSettings.LifeAdjustment.Great);
         }
 
         #endregion

--- a/DTXMania.Test/UI/LayoutExtendedTests.cs
+++ b/DTXMania.Test/UI/LayoutExtendedTests.cs
@@ -139,7 +139,7 @@ namespace DTXMania.Test.UI
         }
 
         [Fact]
-        public void GaugeSettings_LifeAdjustment_PerfectGreaterThanGreat()
+        public void GaugeSettings_LifeAdjustment_ShouldHavePerfectGreaterThanGreat()
         {
             Assert.True(PerformanceUILayout.GaugeSettings.LifeAdjustment.Perfect > PerformanceUILayout.GaugeSettings.LifeAdjustment.Great);
         }

--- a/DTXMania.Test/UI/PerformanceUILayoutSkillMeterTests.cs
+++ b/DTXMania.Test/UI/PerformanceUILayoutSkillMeterTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.Xna.Framework;
+using DTXMania.Game.Lib.UI.Layout;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    [Trait("Category", "Unit")]
+    public class PerformanceUILayoutSkillMeterTests
+    {
+        [Fact]
+        public void SkillMeter_BackgroundPosition_ShouldMatchExpected()
+        {
+            Assert.Equal(new Vector2(900, 50), PerformanceUILayout.SkillMeter.BackgroundPosition);
+        }
+
+        [Fact]
+        public void SkillMeter_BackgroundSourceRect_ShouldMatchExpected()
+        {
+            Assert.Equal(new Rectangle(2, 2, 251, 584), PerformanceUILayout.SkillMeter.BackgroundSourceRect);
+        }
+
+        [Fact]
+        public void SkillMeter_GaugeOffset_ShouldMatchExpected()
+        {
+            Assert.Equal(new Vector2(45, 0), PerformanceUILayout.SkillMeter.GaugeOffset);
+        }
+
+        [Fact]
+        public void SkillMeter_GaugeWidth_ShouldBe30()
+        {
+            Assert.Equal(30, PerformanceUILayout.SkillMeter.GaugeWidth);
+        }
+
+        [Fact]
+        public void SkillMeter_GaugeSourceXY_ShouldMatchExpected()
+        {
+            Assert.Equal(new Vector2(2, 2), PerformanceUILayout.SkillMeter.GaugeSourceXY);
+        }
+
+        [Fact]
+        public void SkillMeter_GaugeMaxHeight_ShouldBe434()
+        {
+            Assert.Equal(434, PerformanceUILayout.SkillMeter.GaugeMaxHeight);
+        }
+
+        [Fact]
+        public void SkillMeter_GaugeBaselineY_ShouldBe527()
+        {
+            Assert.Equal(527, PerformanceUILayout.SkillMeter.GaugeBaselineY);
+        }
+
+        [Fact]
+        public void SkillMeter_NumberOffsetFromTopOfBar_ShouldBeNegative10()
+        {
+            Assert.Equal(-10, PerformanceUILayout.SkillMeter.NumberOffsetFromTopOfBar);
+        }
+
+        [Fact]
+        public void SkillMeter_LabelSourceRect_ShouldMatchExpected()
+        {
+            Assert.Equal(new Rectangle(260, 2, 30, 120), PerformanceUILayout.SkillMeter.LabelSourceRect);
+        }
+
+        [Fact]
+        public void SkillMeter_LabelPosition_ShouldMatchExpected()
+        {
+            Assert.Equal(new Vector2(945, 407), PerformanceUILayout.SkillMeter.LabelPosition);
+        }
+
+        [Fact]
+        public void SkillMeter_GaugeBaselineY_ShouldEqualBackgroundPositionY_Plus477()
+        {
+            Assert.Equal(
+                PerformanceUILayout.SkillMeter.BackgroundPosition.Y + 477,
+                PerformanceUILayout.SkillMeter.GaugeBaselineY);
+        }
+
+        [Fact]
+        public void SkillMeter_LabelPositionX_ShouldEqualBackgroundPositionX_PlusGaugeOffsetX()
+        {
+            Assert.Equal(
+                PerformanceUILayout.SkillMeter.BackgroundPosition.X + PerformanceUILayout.SkillMeter.GaugeOffset.X,
+                PerformanceUILayout.SkillMeter.LabelPosition.X);
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-05-17-skill-display.md
+++ b/docs/superpowers/plans/2026-05-17-skill-display.md
@@ -1,0 +1,2635 @@
+# Skill Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement DTXManiaNX-style Playing Skill computation + live in-game display (left panel + right gauge), plus end-of-song Game Skill persistence so the Song Selection skill point panel shows real values.
+
+**Architecture:** Add a new `SkillManager` (subscribes to `JudgementManager.JudgementMade`, reads `MaxCombo` from `ComboManager`, emits `SkillChanged`), plus two new display components (`SkillPanelDisplay`, `SkillMeterDisplay`). Wire them into `PerformanceStage` mirroring the existing `ScoreManager`/`ScoreDisplay` pattern. Add static skill-formula helpers to `SongScore`. Extend `PerformanceSummary` with skill fields and persist via a new `UpdateScoreAsync` overload that `ResultStage` fires after each play. Includes a prerequisite mechanical rename of `JudgementType.Just` → `JudgementType.Perfect` so the new code reads naturally.
+
+**Tech Stack:** .NET 8, MonoGame 3.8 (DesktopGL on Mac, WindowsDX on Windows), xUnit + Moq for tests, EF Core SQLite for persistence.
+
+**Spec:** [`docs/superpowers/specs/2026-05-17-skill-display-design.md`](../specs/2026-05-17-skill-display-design.md)
+
+**Working directory:** `/Users/chanwaichan/workspace/DTXmaniaCX`
+
+**Build/test commands** (Mac, used throughout):
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+dotnet test  DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+---
+
+## File Structure
+
+**New files:**
+
+| Path | Responsibility |
+|---|---|
+| `DTXMania.Game/Lib/Stage/Performance/SkillManager.cs` | Computes Playing Skill from judgement events; raises `SkillChanged` |
+| `DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs` | Renders left-side panel: level + skill % + MAX badge |
+| `DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs` | Renders right-side vertical gauge with text overlay |
+| `DTXMania.Test/Stage/Performance/SkillManagerTests.cs` | Unit tests for `SkillManager` (Mac-safe) |
+| `DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs` | Formatting helper tests (Mac-excluded) |
+| `DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs` | Gauge math tests (Mac-excluded) |
+| `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs` | Static formula helper tests (Mac-safe) |
+| `DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs` | Summary population E2E (Mac-excluded) |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `DTXMania.Game/Lib/Song/Entities/JudgementTypes.cs` | `Just` → `Perfect` rename + constants |
+| `DTXMania.Game/Lib/Song/Entities/SongScore.cs` | New static `CalculatePlayingSkill`/`CalculateGameSkill`; fix `CalculateSkill()` body |
+| `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs` | New `UpdateScoreAsync(chartId, instrument, summary)` overload |
+| `DTXMania.Game/Lib/Song/SongManager.cs` | New `UpdateScoreAsync(chartId, instrument, summary)` overload |
+| `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs` | `"---"` fallback when unplayed |
+| `DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs` | `JustCount` → `PerfectCount`; new `PlayingSkill`/`GameSkill`/`ChartLevel`/`ChartLevelDec` |
+| `DTXMania.Game/Lib/Stage/PerformanceStage.cs` | Wire `SkillManager` + displays; populate skill in summary |
+| `DTXMania.Game/Lib/Stage/ResultStage.cs` | Call `UpdateScoreAsync` after data extraction |
+| `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs` | New `SkillMeter` static class |
+| `DTXMania.Game/Lib/Resources/TexturePath.cs` | `PerfGraphMain`, `PerfGraphGauge` constants |
+| `DTXMania.Test/DTXMania.Test.Mac.csproj` | Add three new test files to exclusion list |
+| Many call sites in `DTXMania.Game/**` and `DTXMania.Test/**` | `JudgementType.Just` → `JudgementType.Perfect` |
+
+---
+
+## Task 1: Rename `JudgementType.Just` → `JudgementType.Perfect`
+
+**Files (enum + tokens):**
+- Modify: `DTXMania.Game/Lib/Song/Entities/JudgementTypes.cs`
+- Modify: all `*.cs` files in `DTXMania.Game/` and `DTXMania.Test/` that reference `JudgementType.Just`, `JustWindowMs`, `JustScore`, `JustCount`
+
+- [ ] **Step 1: Rename enum value, constants, and switch arms in `JudgementTypes.cs`**
+
+Open `DTXMania.Game/Lib/Song/Entities/JudgementTypes.cs`. Apply these exact edits:
+
+Change enum (line ~14):
+```csharp
+        /// <summary>
+        /// Perfect timing hit (highest accuracy)
+        /// </summary>
+        Perfect,
+```
+
+Change constants (line ~187, ~216, and lines 251, 268):
+```csharp
+        /// <summary>
+        /// Perfect timing window for "Perfect" judgement (±25ms)
+        /// </summary>
+        public const double PerfectWindowMs = 25.0;
+```
+```csharp
+        /// <summary>
+        /// Score points awarded for a "Perfect" hit
+        /// </summary>
+        public const int PerfectScore = 1000;
+```
+
+In `GetJudgementType` (line 247-257):
+```csharp
+            if (absDelta <= PerfectWindowMs) return JudgementType.Perfect;
+```
+
+In `GetScoreValue` (line 266-274):
+```csharp
+                JudgementType.Perfect => PerfectScore,
+```
+
+In doc comment for `Type` property (line ~62):
+```csharp
+        /// Type of the judgement (Perfect/Great/Good/Poor/Miss)
+```
+
+- [ ] **Step 2: Find all remaining references in the Game project**
+
+Run:
+```bash
+grep -rn "JudgementType\.Just\|JustWindowMs\|JustScore\|JustCount" DTXMania.Game --include="*.cs"
+```
+
+Expected: a list of file:line locations.
+
+- [ ] **Step 3: For each Game-project file, replace tokens**
+
+For each file in the grep output, use `Edit` with `replace_all=true` on each token separately. The tokens are unambiguous within their files:
+- `JudgementType.Just` → `JudgementType.Perfect`
+- `JustWindowMs` → `PerfectWindowMs`
+- `JustScore` → `PerfectScore`
+- `JustCount` → `PerfectCount` (only in `PerformanceSummary.cs` and `PerformanceStage.cs`)
+
+Specifically include the following known files (verify with grep above is the source of truth):
+- `DTXMania.Game/Lib/Stage/Performance/ScoreManager.cs`
+- `DTXMania.Game/Lib/Stage/Performance/JudgementManager.cs`
+- `DTXMania.Game/Lib/Stage/Performance/JudgementTextPopup.cs`
+- `DTXMania.Game/Lib/Stage/Performance/GaugeManager.cs`
+- `DTXMania.Game/Lib/Stage/Performance/ComboManager.cs`
+- `DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs`
+- `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+
+- [ ] **Step 4: Find all references in the Test project**
+
+Run:
+```bash
+grep -rn "JudgementType\.Just\|JustWindowMs\|JustScore\|JustCount" DTXMania.Test --include="*.cs"
+```
+
+- [ ] **Step 5: Replace tokens in each Test file**
+
+Same approach as Step 3, applied to every file the grep returns. Known files include:
+- `DTXMania.Test/Song/JudgementEventTests.cs`
+- `DTXMania.Test/Stage/Performance/JudgementManagerTests.cs`
+- `DTXMania.Test/Stage/Performance/JudgementManagerHitWindowTests.cs`
+- `DTXMania.Test/Stage/Performance/JudgementManagerAdditionalTests.cs`
+- `DTXMania.Test/Stage/Performance/JudgementTextPopupTests.cs`
+- `DTXMania.Test/Stage/Performance/JudgementTextPopupLogicTests.cs`
+- `DTXMania.Test/Stage/Performance/ScoreManagerTests.cs`
+- `DTXMania.Test/Stage/Performance/ScoreManagerTotalScoreCapTests.cs`
+- `DTXMania.Test/Stage/Performance/ComboManagerTests.cs`
+- `DTXMania.Test/Stage/Performance/ComboManagerResetOnPoorTests.cs`
+- `DTXMania.Test/Stage/Performance/GaugeManagerTests.cs`
+- `DTXMania.Test/Stage/Performance/GaugeManagerFailThresholdTests.cs`
+- `DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs`
+- `DTXMania.Test/Stage/Performance/PerformanceStatsTests.cs`
+- `DTXMania.Test/Stage/Performance/PerformanceStageJudgementIntegrationTests.cs`
+- `DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs`
+- `DTXMania.Test/Stage/Performance/PerformanceStageCoverageTests.cs`
+- `DTXMania.Test/Stage/Performance/AutomatedPlaySimulationTests.cs`
+- `DTXMania.Test/Stage/Performance/TimingVerificationTest.cs`
+- `DTXMania.Test/Helpers/MockGameplayComponents.cs`
+
+- [ ] **Step 6: Build to verify no syntax errors remain**
+
+Run:
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Expected: `Build succeeded`. If errors mention missing `JudgementType.Just`, `JustWindowMs`, `JustScore`, or `JustCount`, re-run the greps in Steps 2/4 and replace anything missed.
+
+- [ ] **Step 7: Run the full Mac test suite**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: All tests pass. The rename is mechanical; no test behavior should have changed.
+
+- [ ] **Step 8: Verify no `Just` token leaked into strings or comments**
+
+Run:
+```bash
+grep -rn "\.Just\b\|JustScore\|JustWindow\|JustCount" DTXMania.Game DTXMania.Test --include="*.cs"
+```
+
+Expected: empty output (or only matches inside unrelated identifiers like `JustifyContent` — visually inspect to confirm none are stale references).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add DTXMania.Game DTXMania.Test
+git commit -m "refactor: rename JudgementType.Just to Perfect for DTXManiaNX parity
+
+Mechanical rename touching the enum value, related constants
+(JustWindowMs/Score), the PerformanceSummary.JustCount field,
+and all call sites in Game + Test projects.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add `SongScore.CalculatePlayingSkill` static helper (TDD)
+
+**Files:**
+- Create: `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs`
+- Modify: `DTXMania.Game/Lib/Song/Entities/SongScore.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs` with:
+
+```csharp
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song.Entities
+{
+    /// <summary>
+    /// Tests for SongScore static skill formula helpers.
+    /// Reference values verified against DTXManiaNX CScoreIni.tCalculatePlayingSkill
+    /// (Score,Song/CScoreIni.cs:1641) and tCalculateGameSkillFromPlayingSkill (line 1623).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SongScoreSkillFormulaTests
+    {
+        #region CalculatePlayingSkill
+
+        [Fact]
+        public void CalculatePlayingSkill_AllPerfectFullCombo_ShouldReturn100()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 100, great: 0, maxCombo: 100);
+            Assert.Equal(100.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_AllGreatFullCombo_ShouldReturn50()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 0, great: 100, maxCombo: 100);
+            Assert.Equal(50.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_HalfPerfectHalfMiss_ShouldReturn50()
+        {
+            // Perfect%=50*0.85=42.5, Great%=0, Combo%=50*0.15=7.5 → 50.0
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 50, great: 0, maxCombo: 50);
+            Assert.Equal(50.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_MixedPerfectGreatFullCombo_ShouldReturn60()
+        {
+            // 20*0.85 + 80*0.35 + 100*0.15 = 17 + 28 + 15 = 60
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 20, great: 80, maxCombo: 100);
+            Assert.Equal(60.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_NoHits_ShouldReturnZero()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 100, perfect: 0, great: 0, maxCombo: 0);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_ZeroTotalNotes_ShouldReturnZero()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: 0, perfect: 0, great: 0, maxCombo: 0);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculatePlayingSkill_NegativeTotalNotes_ShouldReturnZero()
+        {
+            double result = SongScore.CalculatePlayingSkill(totalNotes: -1, perfect: 0, great: 0, maxCombo: 0);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        #endregion
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongScoreSkillFormulaTests"
+```
+
+Expected: build failure with "SongScore does not contain a definition for CalculatePlayingSkill" or similar.
+
+- [ ] **Step 3: Add `CalculatePlayingSkill` static method to `SongScore.cs`**
+
+Open `DTXMania.Game/Lib/Song/Entities/SongScore.cs`. Add this method inside the class, near the existing static `RankMultiplier` helper (around line 335):
+
+```csharp
+        /// <summary>
+        /// DTXManiaNX-faithful Playing Skill: Perfect%·0.85 + Great%·0.35 + Combo%·0.15.
+        /// Returns 0 when totalNotes is zero or negative.
+        /// Reference: DTXManiaNX CScoreIni.tCalculatePlayingSkill (Score,Song/CScoreIni.cs:1641).
+        /// </summary>
+        public static double CalculatePlayingSkill(int totalNotes, int perfect, int great, int maxCombo)
+        {
+            if (totalNotes <= 0) return 0.0;
+            double perfectRate = 100.0 * perfect  / totalNotes;
+            double greatRate   = 100.0 * great    / totalNotes;
+            double comboRate   = 100.0 * maxCombo / totalNotes;
+            return perfectRate * 0.85 + greatRate * 0.35 + comboRate * 0.15;
+        }
+```
+
+- [ ] **Step 4: Run test, verify it passes**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongScoreSkillFormulaTests"
+```
+
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Entities/SongScore.cs DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+git commit -m "feat: add SongScore.CalculatePlayingSkill helper
+
+DTXManiaNX-faithful Playing Skill formula
+(Perfect% × 0.85 + Great% × 0.35 + Combo% × 0.15).
+Tested against reference fixtures.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `SongScore.CalculateGameSkill` static helper (TDD)
+
+**Files:**
+- Modify: `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs`
+- Modify: `DTXMania.Game/Lib/Song/Entities/SongScore.cs`
+
+- [ ] **Step 1: Append CalculateGameSkill tests to the test file**
+
+Open `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs`. Before the closing `}` of the class, add:
+
+```csharp
+        #region CalculateGameSkill
+
+        [Fact]
+        public void CalculateGameSkill_PlayingSkill100_Level850_ShouldReturn170()
+        {
+            // level >= 100 branch: actualLevel = 850/100 = 8.5; 100 * 8.5 * 0.2 = 170
+            double result = SongScore.CalculateGameSkill(playingSkill: 100.0, level: 850, levelDec: 0);
+            Assert.Equal(170.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_PlayingSkill60_Level78Dec33_ShouldReturn97_56()
+        {
+            // level < 100 branch: actualLevel = 78/10.0 + 33/100.0 = 7.8 + 0.33 = 8.13; 60 * 8.13 * 0.2 = 97.56
+            double result = SongScore.CalculateGameSkill(playingSkill: 60.0, level: 78, levelDec: 33);
+            Assert.Equal(97.56, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_ZeroPlayingSkill_ShouldReturnZero()
+        {
+            double result = SongScore.CalculateGameSkill(playingSkill: 0.0, level: 78, levelDec: 33);
+            Assert.Equal(0.0, result, 6);
+        }
+
+        [Fact]
+        public void CalculateGameSkill_PlayingSkill100_Level50Dec0_ShouldReturn100()
+        {
+            // level < 100 branch: actualLevel = 50/10 + 0/100 = 5.0; 100 * 5.0 * 0.2 = 100
+            double result = SongScore.CalculateGameSkill(playingSkill: 100.0, level: 50, levelDec: 0);
+            Assert.Equal(100.0, result, 6);
+        }
+
+        #endregion
+```
+
+- [ ] **Step 2: Run tests, verify the new ones fail**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongScoreSkillFormulaTests"
+```
+
+Expected: build failure with "SongScore does not contain a definition for CalculateGameSkill".
+
+- [ ] **Step 3: Add `CalculateGameSkill` static method to `SongScore.cs`**
+
+In `DTXMania.Game/Lib/Song/Entities/SongScore.cs`, right after `CalculatePlayingSkill`, add:
+
+```csharp
+        /// <summary>
+        /// DTXManiaNX-faithful Game Skill: PlayingSkill · actualLevel · 0.2.
+        /// actualLevel encodes the chart's difficulty value with its decimal:
+        ///   level &gt;= 100  → actualLevel = level / 100        (e.g. 850 → 8.50)
+        ///   level &lt;  100  → actualLevel = level / 10 + levelDec / 100  (e.g. 78 + 33 → 7.8 + 0.33 = 8.13)
+        /// Reference: DTXManiaNX CScoreIni.tCalculateGameSkillFromPlayingSkill (Score,Song/CScoreIni.cs:1623).
+        /// </summary>
+        public static double CalculateGameSkill(double playingSkill, int level, int levelDec)
+        {
+            double actualLevel = level >= 100
+                ? level / 100.0
+                : (level / 10.0) + (levelDec / 100.0);
+            return playingSkill * actualLevel * 0.2;
+        }
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongScoreSkillFormulaTests"
+```
+
+Expected: 11 tests pass (7 from Task 2 + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Entities/SongScore.cs DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+git commit -m "feat: add SongScore.CalculateGameSkill helper
+
+DTXManiaNX-faithful Game Skill formula (PlayingSkill · Level · 0.2)
+with separate branches for level >= 100 vs the level + decimal
+encoding used by older DTX charts.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Replace the old `SongScore.CalculateSkill()` instance method body
+
+**Files:**
+- Modify: `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs`
+- Modify: `DTXMania.Game/Lib/Song/Entities/SongScore.cs`
+- Possibly modify: any existing test that asserted the OLD formula (use grep to find)
+
+- [ ] **Step 1: Append failing test for the rewritten CalculateSkill**
+
+Append to `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs` before the closing `}`:
+
+```csharp
+        #region CalculateSkill (instance)
+
+        [Fact]
+        public void CalculateSkill_UsesPlayingTimesGameFormula()
+        {
+            // PlayingSkill from (50 Perfect, 0 Great, 50 MaxCombo, 100 Total) = 50.0
+            // GameSkill with DifficultyLevel=78, levelDec=0 → actualLevel=7.8 → 50 * 7.8 * 0.2 = 78.0
+            var score = new SongScore
+            {
+                BestScore = 500000,
+                DifficultyLevel = 78,
+                TotalNotes = 100,
+                BestPerfect = 50,
+                BestGreat = 0,
+                MaxCombo = 50
+            };
+            score.CalculateSkill();
+            Assert.Equal(78.0, score.SongSkill, 6);
+            Assert.Equal(78.0, score.HighSkill, 6);
+        }
+
+        [Fact]
+        public void CalculateSkill_ZeroBestScore_ShouldZeroSongSkill()
+        {
+            var score = new SongScore { BestScore = 0, DifficultyLevel = 78, TotalNotes = 100, BestPerfect = 100, MaxCombo = 100 };
+            score.CalculateSkill();
+            Assert.Equal(0.0, score.SongSkill);
+        }
+
+        [Fact]
+        public void CalculateSkill_ZeroDifficulty_ShouldZeroSongSkill()
+        {
+            var score = new SongScore { BestScore = 500000, DifficultyLevel = 0, TotalNotes = 100, BestPerfect = 100, MaxCombo = 100 };
+            score.CalculateSkill();
+            Assert.Equal(0.0, score.SongSkill);
+        }
+
+        [Fact]
+        public void CalculateSkill_PreservesExistingHigherHighSkill()
+        {
+            var score = new SongScore
+            {
+                BestScore = 500000,
+                DifficultyLevel = 78,
+                TotalNotes = 100,
+                BestPerfect = 50, BestGreat = 0, MaxCombo = 50,
+                HighSkill = 90.0
+            };
+            score.CalculateSkill();
+            Assert.Equal(78.0, score.SongSkill, 6);
+            Assert.Equal(90.0, score.HighSkill, 6);
+        }
+
+        #endregion
+```
+
+- [ ] **Step 2: Run, verify they fail (old formula returns different values)**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongScoreSkillFormulaTests.CalculateSkill_"
+```
+
+Expected: 4 failures (e.g. `Assert.Equal Failure: expected 78.0, actual <some old-formula value>`).
+
+- [ ] **Step 3: Replace `CalculateSkill()` body in `SongScore.cs`**
+
+Open `DTXMania.Game/Lib/Song/Entities/SongScore.cs`. Locate the existing method at line ~265:
+
+```csharp
+        public void CalculateSkill()
+        {
+            if (BestScore == 0 || DifficultyLevel == 0)
+            {
+                SongSkill = 0;
+                return;
+            }
+            
+            // DTXMania skill calculation formula
+            // Skill = (Score / 1000000) * DifficultyLevel * Multiplier
+            var scoreRatio = (double)BestScore / 1000000.0;
+            var difficultyMultiplier = DifficultyLevel / 100.0;
+            var rankMultiplier = GetRankMultiplier();
+            
+            SongSkill = scoreRatio * difficultyMultiplier * rankMultiplier * 100.0;
+            
+            if (SongSkill > HighSkill)
+                HighSkill = SongSkill;
+        }
+```
+
+Replace with:
+```csharp
+        /// <summary>
+        /// Recomputes SongSkill using the DTXManiaNX Game Skill formula.
+        /// Note: this only knows DifficultyLevel (whole part), so it is a coarser
+        /// approximation than the persistence path, which receives the precise
+        /// chart level + levelDec via PerformanceSummary. Kept for legacy/manual triggers.
+        /// </summary>
+        public void CalculateSkill()
+        {
+            if (BestScore == 0 || DifficultyLevel == 0)
+            {
+                SongSkill = 0;
+                return;
+            }
+
+            double playing = CalculatePlayingSkill(TotalNotes, BestPerfect, BestGreat, MaxCombo);
+            SongSkill = CalculateGameSkill(playing, DifficultyLevel, 0);
+
+            if (SongSkill > HighSkill)
+                HighSkill = SongSkill;
+        }
+```
+
+- [ ] **Step 4: Find and inspect any test asserting the old formula**
+
+Run:
+```bash
+grep -rn "CalculateSkill\|SongSkill\|HighSkill" DTXMania.Test --include="*.cs"
+```
+
+Visually inspect each match. If a test calls `CalculateSkill()` and asserts the OLD formula value (the `scoreRatio · DifficultyLevel/100 · RankMultiplier · 100` shape), update its expected value to the new formula or rewrite it to assert against `CalculatePlayingSkill`/`CalculateGameSkill` directly.
+
+- [ ] **Step 5: Run full Mac test suite**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: All tests pass including the 4 new `CalculateSkill_*` tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Entities/SongScore.cs DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs
+git commit -m "fix: rewrite SongScore.CalculateSkill with DTXManiaNX formula
+
+Replaces the previous score-ratio·rank-multiplier formula with the
+DTXManiaNX Playing Skill · Game Skill chain, delegating to the new
+static helpers added in the prior commit.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Add `TexturePath` constants for `7_Graph_main.png` and `7_Graph_Gauge.png`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Resources/TexturePath.cs`
+
+- [ ] **Step 1: Locate the Performance asset region**
+
+Run:
+```bash
+grep -n "SkillPanel\|7_Graph\|GaugeFill" DTXMania.Game/Lib/Resources/TexturePath.cs
+```
+
+Note the line number of the existing `SkillPanel` constant (around line 273) — we'll insert near it.
+
+- [ ] **Step 2: Add two new constants in `TexturePath.cs`**
+
+In `DTXMania.Game/Lib/Resources/TexturePath.cs`, right after the existing `SkillPanel` constant, add:
+
+```csharp
+        /// <summary>
+        /// Performance skill meter background graph (right-side vertical gauge frame)
+        /// </summary>
+        public const string PerfGraphMain = "Graphics/7_Graph_main.png";
+
+        /// <summary>
+        /// Performance skill meter filling bar (right-side vertical gauge bar)
+        /// </summary>
+        public const string PerfGraphGauge = "Graphics/7_Graph_Gauge.png";
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run:
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Expected: `Build succeeded`.
+
+- [ ] **Step 4: Verify assets exist on disk**
+
+Run:
+```bash
+ls System/Graphics/7_Graph_main.png System/Graphics/7_Graph_Gauge.png
+```
+
+Expected: both paths print. If missing, stop and ask the user — the assets should be under the default skin.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Resources/TexturePath.cs
+git commit -m "feat: add TexturePath constants for skill meter graphics
+
+PerfGraphMain and PerfGraphGauge for the right-side vertical
+skill meter assets (7_Graph_main.png, 7_Graph_Gauge.png).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Add `PerformanceUILayout.SkillMeter` layout constants
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs`
+
+- [ ] **Step 1: Find the existing `SkillPanel` region**
+
+Run:
+```bash
+grep -n "region Skill Panel\|endregion" DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs | head -20
+```
+
+Identify the `#endregion` line that closes the existing `Skill Panel (7_SkillPanel.png)` block (around line 401).
+
+- [ ] **Step 2: Insert a new `SkillMeter` region**
+
+In `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs`, immediately after the existing Skill Panel `#endregion` (line ~401), add:
+
+```csharp
+        #region Skill Meter (right-side vertical gauge — 7_Graph_main.png, 7_Graph_Gauge.png)
+
+        /// <summary>
+        /// Right-side vertical skill gauge meter.
+        /// Geometry mirrors DTXManiaNX CActPerfSkillMeter drums layout (Code/Stage/07.Performance/CActPerfSkillMeter.cs).
+        /// </summary>
+        public static class SkillMeter
+        {
+            /// <summary>Top-left of the gauge frame on screen.</summary>
+            public static readonly Vector2 BackgroundPosition = new Vector2(900, 50);
+
+            /// <summary>Source rect in 7_Graph_main.png for the background frame.</summary>
+            public static readonly Rectangle BackgroundSourceRect = new Rectangle(2, 2, 251, 584);
+
+            /// <summary>Offset of the filling bar relative to BackgroundPosition.</summary>
+            public static readonly Vector2 GaugeOffset = new Vector2(45, 0);
+
+            /// <summary>Width of the filling bar in pixels.</summary>
+            public const int GaugeWidth = 30;
+
+            /// <summary>Source X/Y of the filling bar in 7_Graph_Gauge.png (height is dynamic).</summary>
+            public static readonly Vector2 GaugeSourceXY = new Vector2(2, 2);
+
+            /// <summary>Bar height in pixels when Skill == 100.</summary>
+            public const int GaugeMaxHeight = 434;
+
+            /// <summary>Y of the bar bottom (= BackgroundPosition.Y + 477).</summary>
+            public const int GaugeBaselineY = 527;
+
+            /// <summary>Numeric label is drawn this many pixels above the bar top.</summary>
+            public const int NumberOffsetFromTopOfBar = -10;
+
+            /// <summary>"Current" label sprite source rect in 7_Graph_main.png.</summary>
+            public static readonly Rectangle LabelSourceRect = new Rectangle(260, 2, 30, 120);
+
+            /// <summary>Where the "current" label is drawn on screen.</summary>
+            public static readonly Vector2 LabelPosition = new Vector2(945, 407);
+        }
+
+        #endregion
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run:
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Expected: `Build succeeded`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+git commit -m "feat: add PerformanceUILayout.SkillMeter constants
+
+Layout numbers for the right-side vertical skill gauge, mirroring
+the DTXManiaNX CActPerfSkillMeter drums geometry.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Implement `SkillManager` (TDD)
+
+**Files:**
+- Create: `DTXMania.Test/Stage/Performance/SkillManagerTests.cs`
+- Create: `DTXMania.Game/Lib/Stage/Performance/SkillManager.cs`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `DTXMania.Test/Stage/Performance/SkillManagerTests.cs` with:
+
+```csharp
+using System;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    /// <summary>
+    /// Tests for SkillManager. Verifies DTXManiaNX-faithful Playing Skill computation
+    /// based on live judgement events and combo state.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SkillManagerTests
+    {
+        private static JudgementEvent JudgEvent(JudgementType type) =>
+            new JudgementEvent(noteRef: 0, lane: 0, deltaMs: 0.0, type: type);
+
+        #region Constructor
+
+        [Fact]
+        public void Constructor_ValidTotalNotes_ShouldInitializeZero()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            Assert.Equal(0.0, sm.CurrentSkill);
+            Assert.False(sm.IsMax);
+            Assert.Equal(0, sm.PerfectCount);
+        }
+
+        [Fact]
+        public void Constructor_ZeroTotalNotes_ShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => new SkillManager(0, new ComboManager()));
+        }
+
+        [Fact]
+        public void Constructor_NegativeTotalNotes_ShouldThrow()
+        {
+            Assert.Throws<ArgumentException>(() => new SkillManager(-5, new ComboManager()));
+        }
+
+        [Fact]
+        public void Constructor_NullComboManager_ShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SkillManager(100, null!));
+        }
+
+        #endregion
+
+        #region ProcessJudgement counts
+
+        [Fact]
+        public void ProcessJudgement_PerfectIncrementsPerfectCount()
+        {
+            var sm = new SkillManager(10, new ComboManager());
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Equal(0, sm.GreatCount);
+        }
+
+        [Fact]
+        public void ProcessJudgement_AllFiveTypesIncrementCorrectly()
+        {
+            var sm = new SkillManager(10, new ComboManager());
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Great));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Good));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Poor));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Miss));
+            Assert.Equal(1, sm.PerfectCount);
+            Assert.Equal(1, sm.GreatCount);
+            Assert.Equal(1, sm.GoodCount);
+            Assert.Equal(1, sm.PoorCount);
+            Assert.Equal(1, sm.MissCount);
+        }
+
+        [Fact]
+        public void ProcessJudgement_NullEvent_ShouldBeIgnored()
+        {
+            var sm = new SkillManager(10, new ComboManager());
+            sm.ProcessJudgement(null!);
+            Assert.Equal(0, sm.PerfectCount);
+        }
+
+        #endregion
+
+        #region CurrentSkill formula
+
+        /// <summary>
+        /// All Perfect + full combo → 100. Combo is fed via the real ComboManager.
+        /// </summary>
+        [Fact]
+        public void CurrentSkill_AllPerfectFullCombo_ShouldReach100()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            for (int i = 0; i < 100; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            }
+            Assert.Equal(100.0, sm.CurrentSkill, 6);
+            Assert.True(sm.IsMax);
+        }
+
+        [Fact]
+        public void CurrentSkill_AllGreatFullCombo_ShouldReach50()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            for (int i = 0; i < 100; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Great));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Great));
+            }
+            Assert.Equal(50.0, sm.CurrentSkill, 6);
+            Assert.False(sm.IsMax);
+        }
+
+        [Fact]
+        public void CurrentSkill_HalfPerfectHalfMiss_WithPartialCombo_ShouldReturn49_85()
+        {
+            // Sequence: 1 Perfect, 1 Miss (combo break), 49 Perfect (combo 1→49, max=49), 49 Miss.
+            // Final tally: PerfectCount=50, MissCount=50, MaxCombo=49.
+            // Skill = 50*0.85 + 0 + 49*0.15 = 42.5 + 7.35 = 49.85.
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect)); // combo=1, max=1
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            combo.ProcessJudgement(JudgEvent(JudgementType.Miss));    // combo reset
+            sm.ProcessJudgement(JudgEvent(JudgementType.Miss));
+            for (int i = 0; i < 49; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            }
+            for (int i = 0; i < 49; i++)
+            {
+                combo.ProcessJudgement(JudgEvent(JudgementType.Miss));
+                sm.ProcessJudgement(JudgEvent(JudgementType.Miss));
+            }
+            Assert.Equal(49.85, sm.CurrentSkill, 4);
+        }
+
+        [Fact]
+        public void CurrentSkill_NoJudgements_ShouldBeZero()
+        {
+            var sm = new SkillManager(100, new ComboManager());
+            Assert.Equal(0.0, sm.CurrentSkill);
+        }
+
+        #endregion
+
+        #region SkillChanged event
+
+        [Fact]
+        public void ProcessJudgement_ShouldRaiseSkillChanged()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            SkillChangedEventArgs? captured = null;
+            sm.SkillChanged += (s, e) => captured = e;
+
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            Assert.NotNull(captured);
+            Assert.Equal(0.0, captured!.PreviousSkill);
+            Assert.True(captured.CurrentSkill > 0.0);
+            Assert.Equal(JudgementType.Perfect, captured.JudgementType);
+        }
+
+        #endregion
+
+        #region Reset
+
+        [Fact]
+        public void Reset_ShouldClearCountsAndFireEvent()
+        {
+            var combo = new ComboManager();
+            var sm = new SkillManager(100, combo);
+            combo.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+            sm.ProcessJudgement(JudgEvent(JudgementType.Perfect));
+
+            SkillChangedEventArgs? captured = null;
+            sm.SkillChanged += (s, e) => captured = e;
+            sm.Reset();
+
+            Assert.Equal(0, sm.PerfectCount);
+            Assert.Equal(0.0, sm.CurrentSkill);
+            Assert.NotNull(captured);
+            Assert.Equal(0.0, captured!.CurrentSkill);
+        }
+
+        #endregion
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify build fails**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SkillManagerTests"
+```
+
+Expected: build failure with "The type or namespace name 'SkillManager' could not be found".
+
+- [ ] **Step 3: Create `SkillManager.cs`**
+
+Create `DTXMania.Game/Lib/Stage/Performance/SkillManager.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.Song.Entities;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Computes DTXManiaNX-faithful Playing Skill (0.0-100.0) live during gameplay.
+    /// Subscribes via PerformanceStage to JudgementManager events and reads MaxCombo
+    /// from the injected ComboManager, so combo state is never duplicated here.
+    /// Reference: DTXManiaNX CScoreIni.tCalculatePlayingSkill (Score,Song/CScoreIni.cs:1641).
+    /// </summary>
+    public class SkillManager : IDisposable
+    {
+        private readonly int _totalNotes;
+        private readonly ComboManager _comboManager;
+        private int _perfect;
+        private int _great;
+        private int _good;
+        private int _poor;
+        private int _miss;
+        private double _currentSkill;
+        private bool _disposed;
+
+        public event EventHandler<SkillChangedEventArgs>? SkillChanged;
+
+        public int  PerfectCount => _perfect;
+        public int  GreatCount   => _great;
+        public int  GoodCount    => _good;
+        public int  PoorCount    => _poor;
+        public int  MissCount    => _miss;
+        public int  TotalNotes   => _totalNotes;
+        public double CurrentSkill => _currentSkill;
+        public bool IsMax => _currentSkill >= 100.0;
+
+        public SkillManager(int totalNotes, ComboManager comboManager)
+        {
+            if (totalNotes <= 0)
+                throw new ArgumentException("Total notes must be greater than 0", nameof(totalNotes));
+            _totalNotes = totalNotes;
+            _comboManager = comboManager ?? throw new ArgumentNullException(nameof(comboManager));
+        }
+
+        public void ProcessJudgement(JudgementEvent? judgementEvent)
+        {
+            if (_disposed || judgementEvent == null) return;
+
+            switch (judgementEvent.Type)
+            {
+                case JudgementType.Perfect: _perfect++; break;
+                case JudgementType.Great:   _great++;   break;
+                case JudgementType.Good:    _good++;    break;
+                case JudgementType.Poor:    _poor++;    break;
+                case JudgementType.Miss:    _miss++;    break;
+            }
+
+            double previous = _currentSkill;
+            _currentSkill = SongScore.CalculatePlayingSkill(
+                _totalNotes, _perfect, _great, _comboManager.MaxCombo);
+
+            SkillChanged?.Invoke(this, new SkillChangedEventArgs
+            {
+                PreviousSkill = previous,
+                CurrentSkill  = _currentSkill,
+                IsMax         = IsMax,
+                JudgementType = judgementEvent.Type
+            });
+        }
+
+        public void Reset()
+        {
+            if (_disposed) return;
+            double previous = _currentSkill;
+            _perfect = _great = _good = _poor = _miss = 0;
+            _currentSkill = 0.0;
+            SkillChanged?.Invoke(this, new SkillChangedEventArgs
+            {
+                PreviousSkill = previous,
+                CurrentSkill  = 0.0,
+                IsMax         = false,
+                JudgementType = null
+            });
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed && disposing) _disposed = true;
+        }
+    }
+
+    /// <summary>
+    /// Event payload for SkillManager.SkillChanged.
+    /// </summary>
+    public class SkillChangedEventArgs : EventArgs
+    {
+        public double PreviousSkill { get; set; }
+        public double CurrentSkill  { get; set; }
+        public bool   IsMax         { get; set; }
+        public JudgementType? JudgementType { get; set; }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SkillManagerTests"
+```
+
+Expected: 14 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/SkillManager.cs DTXMania.Test/Stage/Performance/SkillManagerTests.cs
+git commit -m "feat: add SkillManager for live Playing Skill computation
+
+Subscribes to JudgementManager events via PerformanceStage and reads
+MaxCombo from an injected ComboManager. Raises SkillChanged carrying
+the new value plus IsMax flag, ready for display components to consume.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Implement `SkillPanelDisplay` (left status panel)
+
+**Files:**
+- Create: `DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs`
+- Create: `DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs`
+
+- [ ] **Step 1: Write the failing logic-test file**
+
+Create `DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs` with:
+
+```csharp
+using DTXMania.Game.Lib.Stage.Performance;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    /// <summary>
+    /// Logic tests for SkillPanelDisplay formatting helpers.
+    /// Mac-excluded because the type lives alongside graphics resources.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SkillPanelDisplayLogicTests
+    {
+        // Level encoding (DTXManiaNX-faithful):
+        //   level <  100 → displayed = level/10 + levelDec/100  (e.g. 80+50 → 8.50)
+        //   level >= 100 → displayed = level/100                (e.g. 850 → 8.50)
+        [Theory]
+        [InlineData(78,  0, "7.80")]
+        [InlineData(80, 50, "8.50")]
+        [InlineData(78, 33, "8.13")]
+        [InlineData(50,  0, "5.00")]
+        [InlineData(850, 0, "8.50")]
+        [InlineData( 0,  0, "--")]
+        public void FormatLevelText_ReturnsExpected(int level, int levelDec, string expected)
+        {
+            Assert.Equal(expected, SkillPanelDisplay.FormatLevelText(level, levelDec));
+        }
+
+        [Theory]
+        [InlineData(  0.0,  "  0.00")]
+        [InlineData( 87.42, " 87.42")]
+        [InlineData(100.0, "100.00")]
+        [InlineData( 50.5,  " 50.50")]
+        public void FormatSkillText_ReturnsExpected(double skill, string expected)
+        {
+            Assert.Equal(expected, SkillPanelDisplay.FormatSkillText(skill));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify build fails**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~SkillPanelDisplayLogicTests" 2>&1 | tail -10
+```
+
+(Note: full Windows project here because Mac excludes display logic tests — we'll register the new file in the Mac exclusion list in Task 16.)
+
+Expected: build failure with "The type or namespace name 'SkillPanelDisplay' could not be found".
+
+- [ ] **Step 3: Create `SkillPanelDisplay.cs`**
+
+Create `DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.UI.Layout;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Renders the left-side performance status panel: difficulty level,
+    /// current skill percentage, and (optionally) the MAX badge sprite.
+    /// </summary>
+    public class SkillPanelDisplay : IDisposable
+    {
+        private readonly IResourceManager _resourceManager;
+        private readonly GraphicsDevice _graphicsDevice;
+        private readonly SongChart? _chart;
+        private ManagedFont? _font;
+        private ITexture? _maxBadgeTexture;
+        private bool _disposed;
+
+        private static readonly Color ShadowColor = new Color(0, 0, 0, 128);
+        private static readonly Vector2 ShadowOffset = new Vector2(2, 2);
+
+        public double Skill   { get; set; }
+        public bool   ShowMax { get; set; }
+
+        public SkillPanelDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice, SongChart? chart)
+        {
+            _resourceManager = resourceManager ?? throw new ArgumentNullException(nameof(resourceManager));
+            _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
+            _chart           = chart;
+
+            _font = ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 24, FontStyle.Bold);
+            try { _maxBadgeTexture = _resourceManager.LoadTexture(TexturePath.SkillMax); }
+            catch { _maxBadgeTexture = null; }
+        }
+
+        public void Update(double deltaTime) { /* no animation yet */ }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (_disposed || spriteBatch == null || _font == null) return;
+
+            int level    = _chart?.DrumLevel    ?? 0;
+            int levelDec = _chart?.DrumLevelDec ?? 0;
+
+            string levelText = FormatLevelText(level, levelDec);
+            _font.DrawStringWithShadow(spriteBatch, levelText,
+                PerformanceUILayout.SkillPanel.LevelNumber.StartPosition,
+                Color.White, ShadowColor, ShadowOffset);
+
+            string skillText = FormatSkillText(Skill);
+            _font.DrawStringWithShadow(spriteBatch, skillText,
+                PerformanceUILayout.SkillPanel.SkillPercent.NumbersPosition,
+                Color.White, ShadowColor, ShadowOffset);
+
+            _font.DrawStringWithShadow(spriteBatch, "%",
+                PerformanceUILayout.SkillPanel.SkillPercent.PercentPosition,
+                Color.White, ShadowColor, ShadowOffset);
+
+            if (ShowMax && _maxBadgeTexture != null)
+            {
+                _maxBadgeTexture.Draw(spriteBatch,
+                    PerformanceUILayout.SkillPanel.SkillPercent.MaxBadgePosition);
+            }
+        }
+
+        public static string FormatLevelText(int level, int levelDec)
+        {
+            if (level <= 0) return "--";
+            // Match DTXManiaNX CScoreIni.tCalculateGameSkillFromPlayingSkill encoding:
+            //   level >= 100 → displayed = level/100  (e.g. 850 → 8.50)
+            //   level <  100 → displayed = level/10 + levelDec/100  (e.g. 80+50 → 8.50)
+            double actual = level >= 100
+                ? level / 100.0
+                : (level / 10.0) + (levelDec / 100.0);
+            return actual.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatSkillText(double skill)
+        {
+            return string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0,6:##0.00}", skill);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                _font?.Dispose();
+                _font = null;
+                _maxBadgeTexture = null;  // not owned — IResourceManager handles refcount
+            }
+            _disposed = true;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify expected level encoding**
+
+Walk through the Theory cases mentally against the DTXManiaNX formula:
+- `(78,  0)`: actual = 78/10 + 0/100 = 7.8 → `"7.80"`
+- `(80, 50)`: actual = 80/10 + 50/100 = 8.5 → `"8.50"`
+- `(78, 33)`: actual = 78/10 + 33/100 = 8.13 → `"8.13"`
+- `(50,  0)`: actual = 5.0 → `"5.00"`
+- `(850, 0)`: `level >= 100` branch → 850/100 = 8.5 → `"8.50"` (modern encoding)
+- `(0,  0)`: level ≤ 0 → `"--"`
+
+- [ ] **Step 5: Run tests, verify they pass (Windows project)**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~SkillPanelDisplayLogicTests"
+```
+
+Expected: 10 tests pass (6 level + 4 skill Theory rows).
+
+Note: Mac project will skip these tests once Task 16 adds the exclusion. Until then the Mac build will compile the test file but its `Draw` codepath won't run (logic tests don't call `Draw`).
+
+- [ ] **Step 6: Build Mac project to confirm compilation still succeeds**
+
+Run:
+```bash
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: `Build succeeded`. The class is referenced but `Draw`-time graphics paths aren't exercised by these logic tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
+git commit -m "feat: add SkillPanelDisplay left-side panel renderer
+
+Renders difficulty level + live skill percentage + optional MAX
+badge using existing PerformanceUILayout.SkillPanel positions.
+Static FormatLevelText / FormatSkillText helpers are unit-tested
+without constructing the graphics-bound class.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Implement `SkillMeterDisplay` (right vertical gauge)
+
+**Files:**
+- Create: `DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs`
+- Create: `DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs`
+
+- [ ] **Step 1: Write the failing logic-test file**
+
+Create `DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Stage.Performance;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Performance
+{
+    /// <summary>
+    /// Logic tests for SkillMeterDisplay math helpers.
+    /// Mac-excluded because the type lives alongside graphics resources.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SkillMeterDisplayLogicTests
+    {
+        [Theory]
+        [InlineData(  0.0,   0)]
+        [InlineData( 50.0, 217)]
+        [InlineData(100.0, 434)]
+        [InlineData(150.0, 434)]   // clamped
+        [InlineData( -5.0,   0)]   // clamped low
+        public void ComputeGaugeHeight_ReturnsExpected(double skill, int expected)
+        {
+            Assert.Equal(expected, SkillMeterDisplay.ComputeGaugeHeight(skill));
+        }
+
+        [Fact]
+        public void ComputeBarTopY_FullGauge_ShouldEqualBackgroundTop()
+        {
+            // GaugeBaselineY (527) - GaugeMaxHeight (434) = 93 (= BackgroundPosition.Y + 43)
+            Assert.Equal(93, SkillMeterDisplay.ComputeBarTopY(100.0));
+        }
+
+        [Fact]
+        public void ComputeBarTopY_EmptyGauge_ShouldEqualBaseline()
+        {
+            Assert.Equal(527, SkillMeterDisplay.ComputeBarTopY(0.0));
+        }
+
+        [Fact]
+        public void ShouldDrawBar_ZeroSkill_ShouldBeFalse()
+        {
+            Assert.False(SkillMeterDisplay.ShouldDrawBar(0.0));
+        }
+
+        [Fact]
+        public void ShouldDrawBar_AnyPositiveSkill_ShouldBeTrue()
+        {
+            Assert.True(SkillMeterDisplay.ShouldDrawBar(0.01));
+            Assert.True(SkillMeterDisplay.ShouldDrawBar(100.0));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify build fails**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~SkillMeterDisplayLogicTests" 2>&1 | tail -10
+```
+
+Expected: build failure with "The type or namespace name 'SkillMeterDisplay' could not be found".
+
+- [ ] **Step 3: Create `SkillMeterDisplay.cs`**
+
+Create `DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI.Layout;
+
+namespace DTXMania.Game.Lib.Stage.Performance
+{
+    /// <summary>
+    /// Renders the right-side vertical skill gauge meter. Uses 7_Graph_main.png as
+    /// background, 7_Graph_Gauge.png as the filling bar, and a small text overlay
+    /// for the numeric value. Mirrors DTXManiaNX CActPerfSkillMeter (drums layout).
+    /// </summary>
+    public class SkillMeterDisplay : IDisposable
+    {
+        private readonly IResourceManager _resourceManager;
+        private readonly GraphicsDevice _graphicsDevice;
+        private ITexture? _backgroundTexture;
+        private ITexture? _gaugeTexture;
+        private ManagedFont? _font;
+        private bool _disposed;
+
+        private static readonly Color ShadowColor = new Color(0, 0, 0, 128);
+        private static readonly Vector2 ShadowOffset = new Vector2(1, 1);
+
+        public double Skill { get; set; }
+
+        public SkillMeterDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice)
+        {
+            _resourceManager = resourceManager ?? throw new ArgumentNullException(nameof(resourceManager));
+            _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
+
+            try { _backgroundTexture = _resourceManager.LoadTexture(TexturePath.PerfGraphMain); }
+            catch { _backgroundTexture = null; }
+            try { _gaugeTexture = _resourceManager.LoadTexture(TexturePath.PerfGraphGauge); }
+            catch { _gaugeTexture = null; }
+
+            _font = ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 12, FontStyle.Bold);
+        }
+
+        public void Update(double deltaTime) { /* no animation yet */ }
+
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            if (_disposed || spriteBatch == null) return;
+
+            var bgPos = PerformanceUILayout.SkillMeter.BackgroundPosition;
+
+            // 1. Background
+            if (_backgroundTexture != null)
+            {
+                _backgroundTexture.Draw(spriteBatch, bgPos,
+                    PerformanceUILayout.SkillMeter.BackgroundSourceRect);
+            }
+
+            // 2-4. Filling bar
+            int gaugeHeight = ComputeGaugeHeight(Skill);
+            int barTopY     = ComputeBarTopY(Skill);
+            if (ShouldDrawBar(Skill) && _gaugeTexture != null)
+            {
+                var barPos = new Vector2(
+                    bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X,
+                    barTopY);
+                var barSrc = new Rectangle(
+                    (int)PerformanceUILayout.SkillMeter.GaugeSourceXY.X,
+                    (int)PerformanceUILayout.SkillMeter.GaugeSourceXY.Y,
+                    PerformanceUILayout.SkillMeter.GaugeWidth,
+                    gaugeHeight);
+                _gaugeTexture.Draw(spriteBatch, barPos, barSrc);
+            }
+
+            // 5. "Current" label
+            if (_backgroundTexture != null)
+            {
+                _backgroundTexture.Draw(spriteBatch,
+                    PerformanceUILayout.SkillMeter.LabelPosition,
+                    PerformanceUILayout.SkillMeter.LabelSourceRect);
+            }
+
+            // 6. Numeric overlay
+            if (_font != null)
+            {
+                string text = string.Format(System.Globalization.CultureInfo.InvariantCulture,
+                    "{0,5:##0.00}", Skill);
+                var textPos = new Vector2(
+                    bgPos.X + PerformanceUILayout.SkillMeter.GaugeOffset.X - 1,
+                    barTopY + PerformanceUILayout.SkillMeter.NumberOffsetFromTopOfBar);
+                _font.DrawStringWithShadow(spriteBatch, text, textPos,
+                    Color.White, ShadowColor, ShadowOffset);
+            }
+        }
+
+        public static int ComputeGaugeHeight(double skill)
+        {
+            double clamped = System.Math.Clamp(skill, 0.0, 100.0);
+            return (int)(PerformanceUILayout.SkillMeter.GaugeMaxHeight * clamped / 100.0);
+        }
+
+        public static int ComputeBarTopY(double skill)
+        {
+            return PerformanceUILayout.SkillMeter.GaugeBaselineY - ComputeGaugeHeight(skill);
+        }
+
+        public static bool ShouldDrawBar(double skill) => skill > 0.0;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+            if (disposing)
+            {
+                _font?.Dispose();
+                _font = null;
+                _backgroundTexture = null;
+                _gaugeTexture = null;
+            }
+            _disposed = true;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests, verify they pass (Windows project)**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~SkillMeterDisplayLogicTests"
+```
+
+Expected: 9 tests pass.
+
+- [ ] **Step 5: Build Mac project to confirm compilation**
+
+Run:
+```bash
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: `Build succeeded`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs
+git commit -m "feat: add SkillMeterDisplay right-side vertical gauge
+
+Renders 7_Graph_main background + 7_Graph_Gauge filling bar + text
+overlay. Static ComputeGaugeHeight / ComputeBarTopY / ShouldDrawBar
+helpers are unit-tested without constructing the graphics-bound class.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Extend `PerformanceSummary` with skill + chart-level fields
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs`
+- Modify: `DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs`
+
+- [ ] **Step 1: Add new fields to `PerformanceSummary`**
+
+Open `DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs`. After the existing `MissCount` field (around line 50), add:
+
+```csharp
+        /// <summary>
+        /// Playing Skill computed at end of song (0.0-100.0). DTXManiaNX formula.
+        /// </summary>
+        public double PlayingSkill { get; set; }
+
+        /// <summary>
+        /// Game Skill computed at end of song (PlayingSkill · actualLevel · 0.2).
+        /// </summary>
+        public double GameSkill { get; set; }
+
+        /// <summary>
+        /// Raw chart level (e.g. 78 means 7.8). Carried through so the precise level
+        /// reaches the persistence layer without rounding.
+        /// </summary>
+        public int ChartLevel { get; set; }
+
+        /// <summary>
+        /// Chart level decimal part (e.g. 33 means an extra 0.033). Combined with ChartLevel.
+        /// </summary>
+        public int ChartLevelDec { get; set; }
+```
+
+Locate the default-init lines in the existing constructor (around line ~120, after `MissCount = 0;`) and add:
+
+```csharp
+            PlayingSkill   = 0.0;
+            GameSkill      = 0.0;
+            ChartLevel     = 0;
+            ChartLevelDec  = 0;
+```
+
+- [ ] **Step 2: Add a test for the new defaults**
+
+Open `DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs`. Find an existing default-constructor test (e.g. `Constructor_ShouldInitializeWithDefaultValues`) and add new asserts in it, OR add a new test:
+
+```csharp
+        [Fact]
+        public void Constructor_ShouldInitializeSkillFieldsToZero()
+        {
+            var summary = new PerformanceSummary();
+            Assert.Equal(0.0, summary.PlayingSkill);
+            Assert.Equal(0.0, summary.GameSkill);
+            Assert.Equal(0, summary.ChartLevel);
+            Assert.Equal(0, summary.ChartLevelDec);
+        }
+```
+
+- [ ] **Step 3: Build + test**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~PerformanceSummaryTests"
+```
+
+Expected: existing tests still pass plus the new one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs DTXMania.Test/Stage/Performance/PerformanceSummaryTests.cs
+git commit -m "feat: add PlayingSkill/GameSkill/ChartLevel fields to PerformanceSummary
+
+Carries the per-play skill values and the chart's level + levelDec
+through to the result/persistence layer, so end-of-song save can
+record the precise DTXManiaNX-style Game Skill.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Wire `SkillManager` + displays into `PerformanceStage`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+
+- [ ] **Step 1: Add fields**
+
+Open `DTXMania.Game/Lib/Stage/PerformanceStage.cs`. Find the existing `_scoreManager`/`_scoreDisplay` field declarations (around line 60-72) and add three new fields nearby:
+
+```csharp
+        private SkillManager _skillManager = null!;
+        private SkillPanelDisplay _skillPanelDisplay = null!;
+        private SkillMeterDisplay _skillMeterDisplay = null!;
+```
+
+- [ ] **Step 2: Construct the displays in the initialization region**
+
+Find where `_scoreDisplay` is constructed (around line 358):
+
+```csharp
+            _scoreDisplay = new ScoreDisplay(_resourceManager, graphicsDevice);
+            _comboDisplay = new ComboDisplay(_resourceManager, graphicsDevice);
+```
+
+Immediately after, add:
+
+```csharp
+            // Skill displays (SkillManager itself is constructed in InitializeGameplayManagers
+            // because it needs ComboManager + ChartManager.TotalNotes which arrive later)
+            var skillChart = _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+            _skillPanelDisplay = new SkillPanelDisplay(_resourceManager, graphicsDevice, skillChart);
+            _skillMeterDisplay = new SkillMeterDisplay(_resourceManager, graphicsDevice);
+```
+
+- [ ] **Step 3: Construct `SkillManager` in `InitializeGameplayManagers`**
+
+Find the existing code (around line 1069):
+
+```csharp
+            _scoreManager = new ScoreManager(_chartManager.TotalNotes);
+            _comboManager = new ComboManager();
+            _gaugeManager = new GaugeManager();
+```
+
+Add right after the `_gaugeManager` line:
+
+```csharp
+            _skillManager = new SkillManager(_chartManager.TotalNotes, _comboManager);
+```
+
+- [ ] **Step 4: Wire the event subscription in `WireUpEventHandlers`**
+
+Find the section (around line 1098):
+
+```csharp
+            // Subscribe to manager events for UI updates
+            _scoreManager.ScoreChanged += OnScoreChanged;
+            _comboManager.ComboChanged += OnComboChanged;
+            _gaugeManager.GaugeChanged += OnGaugeChanged;
+            _gaugeManager.Failed += OnPlayerFailed;
+```
+
+Add:
+```csharp
+            _skillManager.SkillChanged += OnSkillChanged;
+```
+
+- [ ] **Step 5: Add `OnSkillChanged` handler**
+
+After the existing `OnGaugeChanged` handler (search for `private void OnGaugeChanged`), add:
+
+```csharp
+        /// <summary>
+        /// Handles skill changes and updates both display components.
+        /// </summary>
+        private void OnSkillChanged(object? sender, SkillChangedEventArgs e)
+        {
+            if (_skillPanelDisplay != null)
+            {
+                _skillPanelDisplay.Skill   = e.CurrentSkill;
+                _skillPanelDisplay.ShowMax = e.IsMax;
+            }
+            if (_skillMeterDisplay != null)
+            {
+                _skillMeterDisplay.Skill = e.CurrentSkill;
+            }
+        }
+```
+
+- [ ] **Step 6: Forward judgement to `SkillManager` in `OnJudgementMade`**
+
+Find `OnJudgementMade` (around line 1144). After the existing forwards (`_gaugeManager?.ProcessJudgement(e);`), add:
+
+```csharp
+            _skillManager?.ProcessJudgement(e);
+```
+
+- [ ] **Step 7: Call Update + Draw on the new components**
+
+Find the existing `_scoreDisplay?.Update(deltaTime);` line (around line 1418). Add nearby:
+
+```csharp
+            _skillManager?.Update(0.0);          // currently no-op but kept for future animation hooks
+            _skillPanelDisplay?.Update(deltaTime);
+            _skillMeterDisplay?.Update(deltaTime);
+```
+
+Wait — `SkillManager` does not need an `Update` method. Remove the `_skillManager?.Update` line. Keep only:
+
+```csharp
+            _skillPanelDisplay?.Update(deltaTime);
+            _skillMeterDisplay?.Update(deltaTime);
+```
+
+Find the existing `_scoreDisplay?.Draw(_spriteBatch);` line (around line 1544). Add nearby:
+
+```csharp
+            _skillPanelDisplay?.Draw(_spriteBatch);
+            _skillMeterDisplay?.Draw(_spriteBatch);
+```
+
+- [ ] **Step 8: Add cleanup**
+
+Find the existing `CleanupComponents` block where `_scoreDisplay?.Dispose()` is called (around line 404). Add:
+
+```csharp
+            _skillPanelDisplay?.Dispose();
+            _skillPanelDisplay = null;
+            _skillMeterDisplay?.Dispose();
+            _skillMeterDisplay = null;
+```
+
+Find where `_scoreManager` is disposed/nulled (search for `_scoreManager = null;`). Add nearby:
+
+```csharp
+            _skillManager?.Dispose();
+            _skillManager = null;
+```
+
+- [ ] **Step 9: Add symmetric event unsubscription**
+
+Find `_scoreManager.ScoreChanged -= OnScoreChanged;` (around line 1370). Add:
+
+```csharp
+                if (_skillManager != null)
+                    _skillManager.SkillChanged -= OnSkillChanged;
+```
+
+- [ ] **Step 10: Build + run full Mac test suite**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all tests pass. No new tests yet (Task 12 adds the integration test), but existing tests should be unaffected.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/PerformanceStage.cs
+git commit -m "feat: wire SkillManager + skill displays into PerformanceStage
+
+Constructs the manager and two display components alongside existing
+score/combo/gauge counterparts. Subscribes to JudgementMade to drive
+skill computation; OnSkillChanged pushes the value into both displays.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Populate skill fields in `PerformanceSummary` at stage completion (TDD)
+
+**Files:**
+- Create: `DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using Xunit;
+
+namespace DTXMania.Test.Stage
+{
+    /// <summary>
+    /// Verifies PerformanceSummary skill fields are populated correctly when
+    /// PerformanceStage builds it at completion. Done as a unit-level check by
+    /// constructing the summary the same way PerformanceStage does, rather than
+    /// running the full stage (which needs a graphics device).
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class PerformanceStageSkillIntegrationTests
+    {
+        [Fact]
+        public void BuildSummary_AllPerfect_ShouldPopulateMaxPlayingSkill()
+        {
+            // Simulate end-of-song state: 100 Perfect, full combo, on a chart with DrumLevel=78, DrumLevelDec=33 (actual level 8.13).
+            int totalNotes = 100;
+            int perfect    = 100;
+            int great      = 0;
+            int maxCombo   = 100;
+            int level      = 78;
+            int levelDec   = 33;
+
+            double playing = SongScore.CalculatePlayingSkill(totalNotes, perfect, great, maxCombo);
+            double game    = SongScore.CalculateGameSkill(playing, level, levelDec);
+
+            var summary = new PerformanceSummary
+            {
+                TotalNotes    = totalNotes,
+                PerfectCount  = perfect,
+                MaxCombo      = maxCombo,
+                PlayingSkill  = playing,
+                GameSkill     = game,
+                ChartLevel    = level,
+                ChartLevelDec = levelDec
+            };
+
+            Assert.Equal(100.0, summary.PlayingSkill, 6);
+            // actualLevel = 78/10 + 33/100 = 8.13; 100 * 8.13 * 0.2 = 162.6
+            Assert.Equal(162.6, summary.GameSkill, 4);
+            Assert.Equal(78, summary.ChartLevel);
+            Assert.Equal(33, summary.ChartLevelDec);
+        }
+
+        [Fact]
+        public void BuildSummary_NoHits_ShouldZeroSkill()
+        {
+            var summary = new PerformanceSummary
+            {
+                TotalNotes    = 100,
+                PerfectCount  = 0,
+                MaxCombo      = 0,
+                PlayingSkill  = SongScore.CalculatePlayingSkill(100, 0, 0, 0),
+                GameSkill     = SongScore.CalculateGameSkill(0.0, 78, 33),
+                ChartLevel    = 78,
+                ChartLevelDec = 33
+            };
+
+            Assert.Equal(0.0, summary.PlayingSkill);
+            Assert.Equal(0.0, summary.GameSkill);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify the integration test passes (it uses public API only)**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PerformanceStageSkillIntegrationTests"
+```
+
+Expected: 2 tests pass (the test only exercises public API; nothing needs to change in production code yet — that's intentional, this test guards the *contract* the production code in Step 3 must honor).
+
+- [ ] **Step 3: Modify `PerformanceStage.OnStageCompleted` to populate the new fields**
+
+In `DTXMania.Game/Lib/Stage/PerformanceStage.cs`, find the existing `_performanceSummary = new PerformanceSummary { ... }` (around line 1733). Update the object initializer to add the new properties:
+
+Locate:
+```csharp
+            _performanceSummary = new PerformanceSummary
+            {
+                Score = _scoreManager?.CurrentScore ?? 0,
+                MaxCombo = _comboManager?.MaxCombo ?? 0,
+                ClearFlag = reason != CompletionReason.PlayerFailed,
+                PerfectCount = _judgementManager?.GetJudgementCount(JudgementType.Perfect) ?? 0,
+                GreatCount = _judgementManager?.GetJudgementCount(JudgementType.Great) ?? 0,
+                GoodCount = _judgementManager?.GetJudgementCount(JudgementType.Good) ?? 0,
+                PoorCount = _judgementManager?.GetJudgementCount(JudgementType.Poor) ?? 0,
+                MissCount = _judgementManager?.GetJudgementCount(JudgementType.Miss) ?? 0,
+                TotalNotes = _chartManager?.TotalNotes ?? 0,
+                FinalLife = _gaugeManager?.CurrentLife ?? 0.0f,
+                CompletionReason = reason
+            };
+```
+
+Insert *before* this block:
+```csharp
+            var summaryChart = _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+            int summaryLevel    = summaryChart?.DrumLevel    ?? 0;
+            int summaryLevelDec = summaryChart?.DrumLevelDec ?? 0;
+            double summaryPlayingSkill = _skillManager?.CurrentSkill ?? 0.0;
+            double summaryGameSkill    = SongScore.CalculateGameSkill(
+                summaryPlayingSkill, summaryLevel, summaryLevelDec);
+```
+
+Then add the new properties inside the initializer (before the closing `};`):
+```csharp
+                ,
+                PlayingSkill  = summaryPlayingSkill,
+                GameSkill     = summaryGameSkill,
+                ChartLevel    = summaryLevel,
+                ChartLevelDec = summaryLevelDec
+```
+
+(Adjust comma placement — if the initializer already has trailing commas the engineer should mimic the existing style.)
+
+- [ ] **Step 4: Verify the namespace import in `PerformanceStage.cs`**
+
+Ensure the file has:
+```csharp
+using DTXMania.Game.Lib.Song.Entities;
+```
+
+(Already present per earlier grep; verify and add if missing.)
+
+- [ ] **Step 5: Build + run Mac suite**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/PerformanceStage.cs DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs
+git commit -m "feat: populate skill fields on PerformanceSummary at stage completion
+
+PerformanceStage now reads CurrentSkill from SkillManager and the
+chart level+decimal from the selected SongChart, computing GameSkill
+via SongScore.CalculateGameSkill. The summary carries precise values
+through to the result/persistence layer.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Add `SongDatabaseService.UpdateScoreAsync(chartId, instrument, summary)` overload (TDD)
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs`
+- Create: `DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs`
+
+- [ ] **Step 1: Inspect the existing `SongDatabaseService` setup**
+
+Run:
+```bash
+grep -n "class SongDatabaseService\|CreateContext\|public.*UpdateScoreAsync" DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs | head -10
+```
+
+Identify the existing `UpdateScoreAsync` (line 430). The new overload will be added immediately after it.
+
+- [ ] **Step 2: Inspect the existing SQLite test pattern**
+
+Existing pattern in `DTXMania.Test/Song/SongDbContextTests.cs` uses a shared `Microsoft.Data.Sqlite.SqliteConnection` opened once + `UseSqlite(connection)` so multiple `SongDbContext` instances see the same in-memory DB. The class implements `IDisposable` to clean up the connection, and avoids `using var` on EF-related disposables (coverlet bug — see the file's class-doc comment for details).
+
+We'll add a test-only constructor to `SongDatabaseService` that accepts `DbContextOptions<SongDbContext>` directly, so the test doesn't need reflection.
+
+- [ ] **Step 3: Add an internal test-friendly constructor to `SongDatabaseService.cs`**
+
+Open `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs`. Find the existing primary constructor (around line 31):
+
+```csharp
+        public SongDatabaseService(string databasePath = "songs.db")
+```
+
+Add a second constructor immediately above or below it:
+
+```csharp
+        /// <summary>
+        /// Test-friendly constructor that accepts pre-built DbContext options.
+        /// Lets unit tests inject an in-memory SQLite connection without going through
+        /// the file-path-based config path.
+        /// </summary>
+        internal SongDatabaseService(DbContextOptions<SongDbContext> options)
+        {
+            _options = options ?? throw new System.ArgumentNullException(nameof(options));
+        }
+```
+
+Add `[assembly: InternalsVisibleTo("DTXMania.Test")]` to the Game project if it doesn't already have it. Check:
+```bash
+grep -rn "InternalsVisibleTo" DTXMania.Game --include="*.cs"
+```
+
+If no result, create `DTXMania.Game/Properties/AssemblyInfo.cs` (or add to an existing one) with:
+```csharp
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("DTXMania.Test")]
+```
+
+- [ ] **Step 4: Write the failing test file**
+
+Create `DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs`:
+
+```csharp
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    /// <summary>
+    /// Tests for the SongDatabaseService.UpdateScoreAsync overload that takes a
+    /// PerformanceSummary and persists score + skill values.
+    /// Shared SqliteConnection lifecycle pattern mirrors SongDbContextTests
+    /// (which has notes on coverlet "using var" quirks for EF disposables).
+    /// </summary>
+    [Trait("Category", "Integration")]
+    public class SongDatabaseServiceSkillSaveTests : System.IDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly DbContextOptions<SongDbContext> _options;
+        private readonly SongDatabaseService _svc;
+
+        public SongDatabaseServiceSkillSaveTests()
+        {
+            _connection = new SqliteConnection("Data Source=:memory:;Foreign Keys=True");
+            _connection.Open();
+
+            _options = new DbContextOptionsBuilder<SongDbContext>().UseSqlite(_connection).Options;
+
+            // EnsureCreated on a fresh context, disposed via try/finally to avoid coverlet bug.
+            var setupCtx = new SongDbContext(_options);
+            try { setupCtx.Database.EnsureCreated(); }
+            finally { setupCtx.Dispose(); }
+
+            _svc = new SongDatabaseService(_options);
+        }
+
+        public void Dispose() { _connection.Dispose(); }
+
+        private async Task<SongChart> SeedChartAsync()
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                var song  = new SongEntity { Title = "Test Song" };
+                var chart = new SongChart { Song = song, FilePath = "test.dtx", DrumLevel = 78, DrumLevelDec = 33 };
+                ctx.SongCharts.Add(chart);
+                await ctx.SaveChangesAsync();
+                return chart;
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        private async Task SeedScoreAsync(int chartId, SongScore? seed = null)
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                seed ??= new SongScore { ChartId = chartId, Instrument = EInstrumentPart.DRUMS };
+                seed.ChartId = chartId;
+                seed.Instrument = EInstrumentPart.DRUMS;
+                ctx.SongScores.Add(seed);
+                await ctx.SaveChangesAsync();
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        private async Task<SongScore> LoadSavedScoreAsync(int chartId)
+        {
+            var ctx = new SongDbContext(_options);
+            try
+            {
+                return await ctx.SongScores.AsNoTracking().FirstAsync(s => s.ChartId == chartId);
+            }
+            finally { ctx.Dispose(); }
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_WithSummary_PersistsBestSkill()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id);
+
+            var summary = new PerformanceSummary
+            {
+                Score = 800000,
+                MaxCombo = 100,
+                ClearFlag = true,
+                PerfectCount = 100, GreatCount = 0, GoodCount = 0, PoorCount = 0, MissCount = 0,
+                TotalNotes = 100,
+                PlayingSkill = 100.0,
+                GameSkill = 162.6,  // 100 * (7.8 + 0.33) * 0.2
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(800000, saved.BestScore);
+            Assert.Equal(100, saved.BestPerfect);
+            Assert.Equal(100, saved.MaxCombo);
+            Assert.True(saved.FullCombo);
+            Assert.Equal(162.6, saved.HighSkill, 4);
+            Assert.Equal(162.6, saved.SongSkill, 4);
+            Assert.Equal(162.6, saved.LastSkillPoint, 4);
+            Assert.Equal(1, saved.PlayCount);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_LowerScore_KeepsExistingBestButUpdatesLast()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                BestScore = 900000, BestPerfect = 95, MaxCombo = 90,
+                HighSkill = 170.0, SongSkill = 170.0, PlayCount = 5
+            });
+
+            var lowerSummary = new PerformanceSummary
+            {
+                Score = 500000, MaxCombo = 50, TotalNotes = 100,
+                PerfectCount = 50, MissCount = 50,
+                PlayingSkill = 50.0, GameSkill = 78.0,
+                ChartLevel = 78, ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, lowerSummary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(900000, saved.BestScore);       // unchanged
+            Assert.Equal(170.0, saved.HighSkill, 4);     // unchanged
+            Assert.Equal(500000, saved.LastScore);       // updated
+            Assert.Equal(78.0, saved.LastSkillPoint, 4); // updated
+            Assert.Equal(6, saved.PlayCount);            // incremented
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run, verify build fails on missing overload**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceSkillSaveTests"
+```
+
+Expected: build failure because the `UpdateScoreAsync(int, EInstrumentPart, PerformanceSummary)` overload doesn't exist yet.
+
+- [ ] **Step 6: Add the new overload to `SongDatabaseService.cs`**
+
+In `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs`, after the existing `UpdateScoreAsync` (ending around line 458), add:
+
+```csharp
+        /// <summary>
+        /// Persists a complete PerformanceSummary into the SongScore for the given chart+instrument.
+        /// Updates best fields only when the new score exceeds the existing best. Always updates the
+        /// "last play" fields and increments PlayCount. The pre-computed summary.GameSkill is assigned
+        /// directly (not re-derived via score.CalculateSkill()), preserving level-decimal precision.
+        /// </summary>
+        public async Task UpdateScoreAsync(int chartId, EInstrumentPart instrument, PerformanceSummary summary)
+        {
+            if (summary == null) return;
+
+            using var context = CreateContext();
+            var score = await context.SongScores
+                .FirstOrDefaultAsync(s => s.ChartId == chartId && s.Instrument == instrument);
+            if (score == null) return;
+
+            // Best-score update branch
+            if (summary.Score > score.BestScore)
+            {
+                score.BestScore     = summary.Score;
+                score.BestPerfect   = summary.PerfectCount;
+                score.BestGreat     = summary.GreatCount;
+                score.BestGood      = summary.GoodCount;
+                score.BestPoor      = summary.PoorCount;
+                score.BestMiss      = summary.MissCount;
+                score.MaxCombo      = summary.MaxCombo;
+                score.FullCombo     = summary.ClearFlag && summary.MissCount == 0 && summary.PoorCount == 0;
+                score.TotalNotes    = summary.TotalNotes;
+            }
+
+            // High skill is independent of best score (a played chart might raise skill without raising score in edge cases).
+            if (summary.GameSkill > score.HighSkill)
+            {
+                score.HighSkill = summary.GameSkill;
+            }
+            score.SongSkill = summary.GameSkill;
+
+            // "Last play" fields always update
+            score.LastScore      = summary.Score;
+            score.LastSkillPoint = summary.GameSkill;
+            score.LastPlayedAt   = System.DateTime.UtcNow;
+            score.PlayCount++;
+            if (summary.ClearFlag) score.ClearCount++;
+
+            await context.SaveChangesAsync();
+        }
+```
+
+- [ ] **Step 7: Re-run the new tests**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceSkillSaveTests"
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 8: Full test suite**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs DTXMania.Test/Song/SongDatabaseServiceSkillSaveTests.cs
+git commit -m "feat: SongDatabaseService.UpdateScoreAsync(PerformanceSummary) overload
+
+Persists best-score + best-judgement-counts + max-combo when newScore
+exceeds best, and always updates HighSkill (when greater) + last-play
+fields. PlayCount/ClearCount are incremented atomically.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: Add the matching `SongManager.UpdateScoreAsync(summary)` overload
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/SongManager.cs`
+
+- [ ] **Step 1: Locate the existing overload**
+
+Run:
+```bash
+grep -n "UpdateScoreAsync" DTXMania.Game/Lib/Song/SongManager.cs
+```
+
+Expected: the original at line ~1545.
+
+- [ ] **Step 2: Add the matching overload**
+
+In `DTXMania.Game/Lib/Song/SongManager.cs`, immediately after the existing `UpdateScoreAsync` method, add:
+
+```csharp
+        /// <summary>
+        /// Forwarding wrapper around SongDatabaseService.UpdateScoreAsync(summary).
+        /// </summary>
+        public async Task<bool> UpdateScoreAsync(int chartId, EInstrumentPart instrument, DTXMania.Game.Lib.Stage.Performance.PerformanceSummary summary)
+        {
+            try
+            {
+                await _databaseService.UpdateScoreAsync(chartId, instrument, summary);
+                return true;
+            }
+            catch (System.Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SongManager.UpdateScoreAsync(summary) failed: {ex.Message}");
+                return false;
+            }
+        }
+```
+
+(If the existing method returns `Task<bool>`, mirror its shape; if it returns `Task`, drop the `return true/false` lines and the return type.)
+
+- [ ] **Step 3: Build**
+
+Run:
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Expected: `Build succeeded`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/SongManager.cs
+git commit -m "feat: SongManager.UpdateScoreAsync(PerformanceSummary) wrapper
+
+Thin forwarding wrapper so ResultStage can save via the singleton
+manager without depending on SongDatabaseService directly.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Call `UpdateScoreAsync` from `ResultStage`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/ResultStage.cs`
+
+- [ ] **Step 1: Inspect how ResultStage gets song + chart context**
+
+Run:
+```bash
+grep -n "_sharedData\|_performanceSummary\|ExtractSharedData\|OnActivate" DTXMania.Game/Lib/Stage/ResultStage.cs | head -20
+```
+
+Identify:
+- where `ExtractSharedData` is called from (typically `OnActivate` or `OnFirstUpdate`),
+- whether `selectedSong` is already extracted from shared data (it should be available because `PerformanceStage` passes it forward).
+
+If `selectedSong` is not currently extracted, add an extraction line in `ExtractSharedData`:
+
+```csharp
+            if (_sharedData != null
+                && _sharedData.TryGetValue("selectedSong", out var songObj)
+                && songObj is DTXMania.Game.Lib.Song.SongListNode song)
+            {
+                _selectedSong = song;
+            }
+            if (_sharedData != null
+                && _sharedData.TryGetValue("selectedDifficulty", out var difficultyObj)
+                && difficultyObj is int difficulty)
+            {
+                _selectedDifficulty = difficulty;
+            }
+```
+
+Also ensure `PerformanceStage.TransitionToResultStage` forwards these — open `PerformanceStage.cs`, find:
+
+```csharp
+            var sharedData = new Dictionary<string, object>
+            {
+                { "performanceSummary", _performanceSummary }
+            };
+```
+
+Replace with:
+```csharp
+            var sharedData = new Dictionary<string, object>
+            {
+                { "performanceSummary", _performanceSummary }
+            };
+            if (_selectedSong != null) sharedData["selectedSong"] = _selectedSong;
+            sharedData["selectedDifficulty"] = _selectedDifficulty;
+```
+
+- [ ] **Step 2: Add fields to ResultStage if missing**
+
+If `ResultStage` doesn't already have `_selectedSong`/`_selectedDifficulty` fields, add:
+
+```csharp
+        private DTXMania.Game.Lib.Song.SongListNode? _selectedSong;
+        private int _selectedDifficulty;
+```
+
+- [ ] **Step 3: Add the save call after `ExtractSharedData`**
+
+`GetCurrentDifficultyChart` is an extension method on `SongListNode` (defined in `DTXMania.Game/Lib/Song/SongChartHelper.cs`) returning `SongChart` directly — chart ID is `chart.Id`. Make sure the `SongChartHelper` namespace is imported via `using DTXMania.Game.Lib.Song;`.
+
+Find where `ExtractSharedData` is called (typically inside `OnActivate`). Right after the call, add:
+
+```csharp
+            // Persist this play's score + skill values (fire-and-forget).
+            if (_selectedSong != null && _performanceSummary != null)
+            {
+                var savedChart = _selectedSong.GetCurrentDifficultyChart(_selectedDifficulty);
+                if (savedChart != null && savedChart.Id > 0)
+                {
+                    _ = DTXMania.Game.Lib.Song.SongManager.Instance.UpdateScoreAsync(
+                        savedChart.Id,
+                        DTXMania.Game.Lib.Song.Entities.EInstrumentPart.DRUMS,
+                        _performanceSummary);
+                }
+            }
+```
+
+- [ ] **Step 4: Build + test**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ResultStage.cs DTXMania.Game/Lib/Stage/PerformanceStage.cs
+git commit -m "feat: persist score+skill from ResultStage after each play
+
+ResultStage forwards the PerformanceSummary into
+SongManager.UpdateScoreAsync immediately after extracting shared
+data. PerformanceStage now also forwards selectedSong/Difficulty
+through the StageManager handoff so ResultStage can look up the
+chart ID for the save.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 16: SongStatusPanel — show `"---"` for unplayed charts
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs`
+
+- [ ] **Step 1: Locate the skill point text formatting**
+
+Open `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs`, around line 859:
+
+```csharp
+            var skillValue = score.HighSkill > 0 ? score.HighSkill.ToString("F2") : "0.00";
+```
+
+- [ ] **Step 2: Replace with HasBeenPlayed gate**
+
+Change the line to:
+
+```csharp
+            var skillValue = score.HasBeenPlayed ? score.HighSkill.ToString("F2") : "---";
+```
+
+- [ ] **Step 3: Build + test**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all tests pass. If `SongStatusPanelLogicTests` exists in the Windows project and asserts the `"0.00"` literal, update that assertion to `"---"`.
+
+Run:
+```bash
+grep -rn "\"0\.00\"\|'0.00'" DTXMania.Test --include="*.cs"
+```
+
+If matches, update them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs DTXMania.Test
+git commit -m "polish: show \"---\" for unplayed charts on Song Selection panel
+
+More honest UX than the previous fixed \"0.00\" string when no score
+has been recorded yet for a chart.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 17: Update Mac test project exclusions
+
+**Files:**
+- Modify: `DTXMania.Test/DTXMania.Test.Mac.csproj`
+
+- [ ] **Step 1: Locate the existing `<Compile Include>` line**
+
+Open `DTXMania.Test/DTXMania.Test.Mac.csproj` and find (around line 33):
+
+```xml
+    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;...existing list..." />
+```
+
+- [ ] **Step 2: Append the three new graphics-bound test files**
+
+Inside the `Exclude` attribute string (semicolon-separated), append these three filenames:
+
+```
+Stage/Performance/SkillPanelDisplayLogicTests.cs;Stage/Performance/SkillMeterDisplayLogicTests.cs;Stage/PerformanceStageSkillIntegrationTests.cs
+```
+
+The final attribute should look like (existing tokens preserved):
+```xml
+    <Compile Include="**/*.cs" Exclude="bin/**/*.cs;obj/**/*.cs;Graphics/RenderTargetManagerTests.cs;Graphics/GPURenderingSnapshotTests.cs;Resources/BitmapFontTests.cs;Performance/StressTestRunner.cs;QA/ComprehensiveQATestSuite.cs;StressTestConsole/**/*.cs;UI/SongBarRendererTests.cs;UI/SongBarRendererLogicTests.cs;UI/SongStatusPanelTests.cs;UI/SongStatusPanelLogicTests.cs;Stage/Performance/PerformanceStageCleanupVerificationTests.cs;Stage/Performance/JudgementTextPopupTests.cs;Stage/Performance/PooledEffectsManagerTests.cs;Resources/ResourceManagerTests.cs;Helpers/MockPerformanceStage.cs;Helpers/TestGraphicsDeviceService.cs;Stage/Performance/SkillPanelDisplayLogicTests.cs;Stage/Performance/SkillMeterDisplayLogicTests.cs;Stage/PerformanceStageSkillIntegrationTests.cs" />
+```
+
+- [ ] **Step 3: Build Mac project**
+
+Run:
+```bash
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: `Build succeeded`. The three graphics-bound test files are now excluded from the Mac build but their logic-test classes still compile because the production classes they reference (`SkillPanelDisplay`, `SkillMeterDisplay`) compile in the main `DTXMania.Game` project.
+
+Wait — re-read: the `Skill*DisplayLogicTests` tests use **static helpers** on the display classes, so they don't actually need GraphicsDevice. They should be Mac-safe.
+
+**Re-evaluate:** Run the tests on Mac to confirm:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SkillPanelDisplayLogicTests|FullyQualifiedName~SkillMeterDisplayLogicTests"
+```
+
+If they pass on Mac without the exclusion, **remove them from the exclusion list** — only keep `Stage/PerformanceStageSkillIntegrationTests.cs` excluded (it constructs a `PerformanceSummary` only, but the file name pattern in the spec listed it for exclusion; verify by running and decide).
+
+In short: exclude only what truly needs graphics. The final exclusion additions should be **whichever subset of the three actually fails on Mac**.
+
+- [ ] **Step 4: Final Mac test run**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all tests pass on Mac.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Test/DTXMania.Test.Mac.csproj
+git commit -m "test: exclude graphics-bound skill tests from Mac project
+
+Adds the new skill integration test (and any display logic tests
+that fail on Mac) to the Mac exclusion list.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 18: Manual verification + final sweep
+
+**Files:** none — verification only
+
+- [ ] **Step 1: Run full test suite both projects**
+
+Run:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: green.
+
+If on a machine with the Windows project available:
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj
+```
+
+- [ ] **Step 2: Run the game and play a chart**
+
+Run:
+```bash
+dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Manual checklist:
+- Start the game, pick a chart with `DrumLevel > 0`, begin play.
+- During play, observe the **left status panel** at screen (22, 250-585):
+  - Difficulty level displays as `"X.YZ"`.
+  - Skill percentage updates after each hit, in `XX.XX%` format.
+  - Hitting only Perfects → percentage climbs toward 100; MAX badge appears when it reaches 100.
+- During play, observe the **right vertical gauge** at screen (900, 50-587):
+  - Background frame visible.
+  - Bar grows upward as skill increases; full at skill=100.
+  - Numeric text floats just above bar top.
+- Finish or fail the chart, observe the Result screen briefly, then return to Song Selection.
+- On Song Selection panel for the same chart: `score.HighSkill` should now show a non-zero `F2` value matching the just-played skill.
+
+- [ ] **Step 3: Final grep for any leaked `Just` references**
+
+Run:
+```bash
+grep -rn "JudgementType\.Just\b\|JustWindowMs\|JustScore\|JustCount" DTXMania.Game DTXMania.Test --include="*.cs"
+```
+
+Expected: empty output.
+
+- [ ] **Step 4: Final grep for placeholder strings**
+
+Run:
+```bash
+grep -rn "TODO\|FIXME\|XXX" DTXMania.Game/Lib/Stage/Performance/Skill*.cs DTXMania.Game/Lib/Song/Entities/SongScore.cs
+```
+
+Expected: no matches in the new code.
+
+- [ ] **Step 5: All done**
+
+The implementation is complete. The branch carries one commit per phase, ready for review.
+
+---
+
+## Notes for the engineer
+
+- **TDD discipline**: every task that writes new production code is structured Test-first → Run-to-fail → Implement → Run-to-pass. Don't skip the "run to fail" step — it's how you know the test actually exercises the code path.
+- **DRY**: `SkillManager.ProcessJudgement` calls `SongScore.CalculatePlayingSkill` instead of inlining the formula — there is one source of truth for the math.
+- **YAGNI**: ghost data, target comparison, online stats formula, separate `BestPlayingSkill` persistence are all explicitly deferred. Don't add them.
+- **No new abstractions beyond what the spec asks for**: don't introduce `ISkillCalculator` or similar — keep `SongScore` static helpers as the single source of truth.
+- **Frequent commits**: every task ends with a `git commit`. If a task feels too large to commit at once, split it — but the task boundaries already do this for you.
+- **If a step's grep returns unexpected matches**, stop and read the surrounding code before editing. Don't blind-replace tokens in strings or doc comments unless you've verified they're stale references.

--- a/docs/superpowers/specs/2026-05-17-skill-display-design.md
+++ b/docs/superpowers/specs/2026-05-17-skill-display-design.md
@@ -157,7 +157,7 @@ Layout:
 
 | Element | Position constant | Format |
 |---|---|---|
-| Difficulty level number | `SkillPanel.LevelNumber.StartPosition = (40, 540)` | `$"{level/10}.{levelDec:D2}"` e.g. `"7.83"` |
+| Difficulty level number | `SkillPanel.LevelNumber.StartPosition = (40, 540)` | `(level/10 + levelDec/100).ToString("0.00")` e.g. `(78, 33)` → `"8.13"` |
 | Skill percentage | `SkillPanel.SkillPercent.NumbersPosition = (80, 527)` | `string.Format("{0,5:##0.00}", skill)` → `" 87.42"` |
 | Percent symbol | `SkillPanel.SkillPercent.PercentPosition = (239, 537)` | `"%"` |
 | MAX badge | `SkillPanel.SkillPercent.MaxBadgePosition = (149, 527)` | sprite from `7_skill max.png`; drawn only when `ShowMax` |
@@ -237,7 +237,7 @@ public static double CalculateGameSkill(double playingSkill, int level, int leve
 {
     double actualLevel = level >= 100
         ? level / 100.0                          // already-scaled 850 → 8.50
-        : (level / 10.0) + (levelDec / 100.0);   // 78 + 33 → 7.83
+        : (level / 10.0) + (levelDec / 100.0);   // 78 + 33 → 8.13 (7.8 + 0.33)
     return playingSkill * actualLevel * 0.2;
 }
 ```
@@ -354,7 +354,7 @@ Game Skill fixtures (`PlayingSkill × Level × 0.2`):
 | PlayingSkill | Level | LevelDec | GameSkill |
 |---|---|---|---|
 | 100.0 | 850 | 0 | `100 × 8.5 × 0.2` = 170.0 |
-| 60.0 | 78 | 33 | `60 × 7.83 × 0.2` = 93.96 |
+| 60.0 | 78 | 33 | `60 × 8.13 × 0.2` = 97.56 |
 | 0.0 | 50 | 0 | 0.0 |
 
 ## Acceptance criteria

--- a/docs/superpowers/specs/2026-05-17-skill-display-design.md
+++ b/docs/superpowers/specs/2026-05-17-skill-display-design.md
@@ -1,0 +1,399 @@
+# Skill Level Display (Gameplay + Song Selection) — Design
+
+Date: 2026-05-17
+Status: Draft
+
+## Goal
+
+Implement DTXManiaNX-style **Playing Skill** computation and live display during the Performance stage, plus end-of-song persistence so the **Game Skill** appears on the Song Selection panel after play. Score display already exists and is out of scope to rework.
+
+## Background
+
+DTXManiaNX defines two skill values (`CScoreIni.cs`):
+
+- **Playing Skill** (`tCalculatePlayingSkill`, line 1641): `Perfect% × 0.85 + Great% × 0.35 + Combo% × 0.15`. Range 0-100. Drives the in-game skill meter.
+- **Game Skill** (`tCalculateGameSkillFromPlayingSkill`, line 1623): `PlayingSkill × Level × 0.2`. Stored per chart, drives the Song Selection skill point display.
+
+DTXmaniaCX currently has neither. The infrastructure (managers, displays, layout constants, texture assets) is mostly in place — this design fills the calculation + display + persistence gap.
+
+## Scope
+
+In scope:
+1. Rename `JudgementType.Just` → `JudgementType.Perfect` (and `JustWindowMs`, `JustScore`, `JustCount`) to match DTXManiaNX's `EJudgement.Perfect`.
+2. New `SkillManager` that computes Playing Skill from live judgement events.
+3. New `SkillPanelDisplay` (left status panel: difficulty level + skill % + MAX badge).
+4. New `SkillMeterDisplay` (right vertical gauge: sprite background + filling bar + numeric overlay).
+5. Fix the formula in `SongScore.CalculateSkill()` to use DTXManiaNX's Game Skill formula.
+6. End-of-song save flow: `PerformanceSummary` carries skill values, `ResultStage` writes to DB via a new `UpdateScoreAsync` overload, `SongStatusPanel` reads through.
+
+Out of scope:
+- Ghost / target skill comparison (`dbグラフ値目標`, online stats formula).
+- Multi-instrument auto-revision factor (`dbCalcReviseValForDrGtBsAutoLanes`) — drums-only today.
+- DTXManiaNX `Bad`/`Auto` judgement enum values — CX has no gameplay path for them.
+- Persisting separate `BestPlayingSkill` — `HighSkill` (Game) is sufficient for per-song display.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Skill formula in gameplay | Playing Skill (0-100) | DTXManiaNX modern mode (`nSkillMode=1`). Game Skill belongs to Song Selection/Result. |
+| Display style | Both — left panel + right gauge | Most faithful to DTXManiaNX. |
+| Render approach | Text font (ManagedFont) for numbers | Consistent with existing ScoreDisplay/ComboDisplay. Sprite assets used only for gauge background/fill bar. |
+| Behavior | DTXManiaNX-faithful | Update every judgement; show difficulty level; show MAX badge at 100; `XX.XX%` format. |
+| `JudgementType.Just` rename | Yes — full rename | Match DTXManiaNX naming exactly. Mechanical change touching ~28 files. |
+| Song Selection scope | Formula fix + end-of-song save | Make Song Selection skill actually meaningful, not just a fixed display. |
+| Manager / Display split | Three separate components | Mirrors existing `ScoreManager/Display`, `ComboManager/Display`, `GaugeManager/Display` pattern. |
+
+## Architecture
+
+### Component map
+
+```
+PerformanceStage
+├── JudgementManager   (existing)  ── raises JudgementMade event
+│
+├── ScoreManager       (existing)  ── score multipliers
+├── ComboManager       (existing)  ── tracks CurrentCombo, MaxCombo
+├── GaugeManager       (existing)  ── life gauge
+├── SkillManager       (NEW)       ── reads MaxCombo from ComboManager;
+│                                     tracks Perfect/Great/Good/Poor/Miss counts;
+│                                     emits SkillChanged
+│
+├── ScoreDisplay       (existing)
+├── ComboDisplay       (existing)
+├── GaugeDisplay       (existing)
+├── SkillPanelDisplay  (NEW)       ── left status panel
+└── SkillMeterDisplay  (NEW)       ── right vertical gauge
+```
+
+### Event flow
+
+```
+JudgementManager.JudgementMade
+  └─► PerformanceStage.OnJudgementMade
+        ├─► ScoreManager.ProcessJudgement   → ScoreChanged → ScoreDisplay
+        ├─► ComboManager.ProcessJudgement   → ComboChanged → ComboDisplay
+        ├─► GaugeManager.ProcessJudgement   → GaugeChanged → GaugeDisplay
+        └─► SkillManager.ProcessJudgement   → SkillChanged → SkillPanelDisplay + SkillMeterDisplay
+```
+
+## Detailed design
+
+### 1. JudgementType rename (prerequisite)
+
+Mechanical rename, executed first as its own commit so the new code reads naturally.
+
+- `JudgementTypes.cs`: enum value `Just` → `Perfect`; constants `JustWindowMs` → `PerfectWindowMs`, `JustScore` → `PerfectScore`; switch arms in `GetJudgementType` / `GetScoreValue`; doc comments mentioning "Just".
+- All call sites in `DTXMania.Game/Lib/Stage/Performance/*.cs` and `DTXMania.Game/Lib/Stage/PerformanceStage.cs`.
+- All call sites in `DTXMania.Test/**` (~14 test files).
+- `PerformanceSummary.JustCount` → `PerformanceSummary.PerfectCount`.
+
+Strategy: per-file `Edit` with `replace_all` where the token is unambiguous; targeted edits for the constant/method name renames. Build + run full test suite after the rename, expect green.
+
+### 2. `SkillManager`
+
+`DTXMania.Game/Lib/Stage/Performance/SkillManager.cs`
+
+```csharp
+public class SkillManager : IDisposable
+{
+    public SkillManager(int totalNotes, ComboManager comboManager);
+    public double CurrentSkill { get; }       // 0.0 to 100.0
+    public int PerfectCount { get; }
+    public int GreatCount { get; }
+    public int GoodCount { get; }
+    public int PoorCount { get; }
+    public int MissCount { get; }
+    public bool IsMax => CurrentSkill >= 100.0;
+    public event EventHandler<SkillChangedEventArgs>? SkillChanged;
+    public void ProcessJudgement(JudgementEvent e);
+    public void Reset();
+    public void Dispose();
+}
+
+public class SkillChangedEventArgs : EventArgs
+{
+    public double PreviousSkill { get; set; }
+    public double CurrentSkill  { get; set; }
+    public bool   IsMax         { get; set; }
+    public JudgementType? JudgementType { get; set; }
+}
+```
+
+**Formula** (matches DTXManiaNX `tCalculatePlayingSkill`, line 1641):
+
+```
+perfectRate = 100 × PerfectCount / TotalNotes
+greatRate   = 100 × GreatCount   / TotalNotes
+comboRate   = 100 × MaxCombo     / TotalNotes
+CurrentSkill = perfectRate × 0.85 + greatRate × 0.35 + comboRate × 0.15
+```
+
+- `TotalNotes` is fixed at construction. `MaxCombo` is read live from injected `ComboManager` — no duplicated state.
+- Constructor rejects `totalNotes <= 0` with `ArgumentException`, mirroring `ScoreManager` (`ScoreManager.cs:75`).
+- `ProcessJudgement` switches on `JudgementEvent.Type` to increment the corresponding count, then recomputes `CurrentSkill` and emits `SkillChanged`.
+- `Reset` clears all counts, sets skill to 0, fires `SkillChanged` with new value 0.
+- Implementation calls `SongScore.CalculatePlayingSkill` (defined below) for the actual math — single source of truth.
+
+### 3. `SkillPanelDisplay`
+
+`DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs`
+
+Renders the left-side status panel using positions already defined in `PerformanceUILayout.SkillPanel`.
+
+```csharp
+public class SkillPanelDisplay : IDisposable
+{
+    public SkillPanelDisplay(IResourceManager rm, GraphicsDevice gd, SongChart? chart);
+    public double Skill   { get; set; }
+    public bool   ShowMax { get; set; }
+    public void Update(double deltaTime);
+    public void Draw(SpriteBatch sb);
+    public void Dispose();
+}
+```
+
+Layout:
+
+| Element | Position constant | Format |
+|---|---|---|
+| Difficulty level number | `SkillPanel.LevelNumber.StartPosition = (40, 540)` | `$"{level/10}.{levelDec:D2}"` e.g. `"7.83"` |
+| Skill percentage | `SkillPanel.SkillPercent.NumbersPosition = (80, 527)` | `string.Format("{0,5:##0.00}", skill)` → `" 87.42"` |
+| Percent symbol | `SkillPanel.SkillPercent.PercentPosition = (239, 537)` | `"%"` |
+| MAX badge | `SkillPanel.SkillPercent.MaxBadgePosition = (149, 527)` | sprite from `7_skill max.png`; drawn only when `ShowMax` |
+
+Resources:
+- One `ManagedFont` (24pt bold) for level + skill text.
+- One `ManagedTexture` for `7_skill max.png` via new `TexturePath.SkillMax` constant.
+- All disposed symmetrically.
+
+Edge cases:
+- `chart == null`: render `"--"` for level, `0.00` for skill, no badge.
+- `DrumLevel == 0` but Guitar/Bass non-zero: pick first non-zero (priority Drum → Guitar → Bass). Drums-only today; defensive only.
+
+### 4. `SkillMeterDisplay`
+
+`DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs`
+
+Renders the right-side vertical gauge using sprite background + sprite fill + text overlay. Mirrors DTXManiaNX `CActPerfSkillMeter` geometry simplified (no ghost comparison).
+
+```csharp
+public class SkillMeterDisplay : IDisposable
+{
+    public SkillMeterDisplay(IResourceManager rm, GraphicsDevice gd);
+    public double Skill { get; set; }   // 0.0 to 100.0
+    public void Update(double deltaTime);
+    public void Draw(SpriteBatch sb);
+    public void Dispose();
+}
+```
+
+New layout constants under `PerformanceUILayout.SkillMeter`:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `BackgroundPosition` | `(900, 50)` | Top-left of frame on screen |
+| `BackgroundSourceRect` | `Rectangle(2, 2, 251, 584)` | Source rect in `7_Graph_main.png` |
+| `GaugeOffset` | `(45, 0)` | Bar offset relative to background origin |
+| `GaugeSourceRectXY` | `(2, 2)` width 30 | Source X/Y in `7_Graph_Gauge.png` |
+| `GaugeMaxHeight` | `434` | Bar height in px at skill = 100% |
+| `GaugeBaselineY` | `527` | Y of bar bottom (= `BackgroundPosition.Y + 477`) |
+| `NumberOffsetFromTopOfBar` | `-10` | Numeric label is drawn 10px above the bar top |
+| `LabelSourceRect` | `Rectangle(260, 2, 30, 120)` | "Current" label sprite from `7_Graph_main.png` |
+| `LabelPosition` | `(945, 407)` | Where the "current" label is drawn |
+
+Draw order per frame:
+1. Background sprite at `BackgroundPosition`.
+2. `gaugeHeight = Math.Min(GaugeMaxHeight, (int)(GaugeMaxHeight × Skill / 100.0))`.
+3. `barTopY = GaugeBaselineY - gaugeHeight`.
+4. Bar sprite (source rect width 30 × height `gaugeHeight`) at `(BackgroundPosition.X + GaugeOffset.X, barTopY)`. **Skip when `gaugeHeight <= 0`.**
+5. "Current" label sprite at `LabelPosition`.
+6. Numeric text `string.Format("{0,5:##0.00}", Skill)` at `(BackgroundPosition.X + GaugeOffset.X - 1, barTopY + NumberOffsetFromTopOfBar)`.
+
+Resources:
+- Two `ManagedTexture` (background + gauge) via new `TexturePath.PerfGraphMain` and `TexturePath.PerfGraphGauge`.
+- One `ManagedFont` (12pt bold) for floating numeric label.
+
+Edge cases:
+- Texture load failure: fall back to drawing a 1px white rectangle for background/bar so layout stays visible. Throws nothing.
+
+### 5. `SongScore` formula fix
+
+`DTXMania.Game/Lib/Song/Entities/SongScore.cs`
+
+Add static helpers (sibling to `RankString`, `RankMultiplier`):
+
+```csharp
+public static double CalculatePlayingSkill(int totalNotes, int perfect, int great, int maxCombo)
+{
+    if (totalNotes <= 0) return 0.0;
+    double perfectRate = 100.0 * perfect  / totalNotes;
+    double greatRate   = 100.0 * great    / totalNotes;
+    double comboRate   = 100.0 * maxCombo / totalNotes;
+    return perfectRate * 0.85 + greatRate * 0.35 + comboRate * 0.15;
+}
+
+public static double CalculateGameSkill(double playingSkill, int level, int levelDec)
+{
+    double actualLevel = level >= 100
+        ? level / 100.0                          // already-scaled 850 → 8.50
+        : (level / 10.0) + (levelDec / 100.0);   // 78 + 33 → 7.83
+    return playingSkill * actualLevel * 0.2;
+}
+```
+
+Replace `CalculateSkill()` body — discard the old `scoreRatio × difficultyMultiplier × rankMultiplier × 100` formula. The fixed version uses the new static helpers but only knows `DifficultyLevel` (whole part), so it's a coarser recomputation suitable for legacy/manual triggers:
+
+```csharp
+public void CalculateSkill()
+{
+    if (BestScore == 0 || DifficultyLevel == 0)
+    {
+        SongSkill = 0;
+        return;
+    }
+    double playing = CalculatePlayingSkill(TotalNotes, BestPerfect, BestGreat, MaxCombo);
+    SongSkill = CalculateGameSkill(playing, DifficultyLevel, 0);
+    if (SongSkill > HighSkill) HighSkill = SongSkill;
+}
+```
+
+For the end-of-song save path (the one that actually runs after every play), `UpdateScoreAsync` does **not** call `CalculateSkill()`. Instead it assigns `score.SongSkill = summary.GameSkill` directly — `summary.GameSkill` was already computed in `PerformanceStage` using both `ChartLevel` and `ChartLevelDec`, so the decimal is preserved. `CalculateSkill()` remains as a fallback for tests or future paths that only have `DifficultyLevel`.
+
+### 6. End-of-song save flow
+
+**Step 1** — extend `PerformanceSummary` (`Performance/PerformanceSummary.cs`):
+
+```csharp
+public double PlayingSkill { get; set; }
+public double GameSkill    { get; set; }
+public int    ChartLevel    { get; set; }   // e.g. 78 (raw stored value)
+public int    ChartLevelDec { get; set; }   // e.g. 33
+```
+
+(`JustCount` → `PerfectCount` rename folded into Section 1.)
+
+**Step 2** — populate in `PerformanceStage.OnStageCompleted` (around `PerformanceStage.cs:1733`):
+
+```csharp
+var chart = _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+int level    = chart?.DrumLevel    ?? 0;
+int levelDec = chart?.DrumLevelDec ?? 0;
+double playing = _skillManager?.CurrentSkill ?? 0.0;
+double game    = SongScore.CalculateGameSkill(playing, level, levelDec);
+
+_performanceSummary = new PerformanceSummary {
+    /* existing fields */,
+    PlayingSkill = playing, GameSkill = game,
+    ChartLevel = level, ChartLevelDec = levelDec
+};
+```
+
+**Step 3** — new `UpdateScoreAsync` overload on `SongManager` + `SongDatabaseService`:
+
+```csharp
+public async Task UpdateScoreAsync(int chartId, EInstrumentPart instrument, PerformanceSummary summary)
+```
+
+The DB-service implementation:
+- Loads existing `SongScore` (or creates via existing helper if missing).
+- If `summary.Score > BestScore`: updates `BestScore`, `BestPerfect/Great/Good/Poor/Miss`, `MaxCombo`, `FullCombo`, `BestAchievementRate`.
+- Always updates `LastScore = summary.Score`, `LastSkillPoint = summary.GameSkill`, `LastPlayedAt = UtcNow`, increments `PlayCount`. If `summary.ClearFlag`, increments `ClearCount`.
+- Assigns `score.SongSkill = summary.GameSkill` directly (the value was computed in `PerformanceStage` with the full level + levelDec — see Section 6 Step 2). If `summary.GameSkill > HighSkill`, bumps `HighSkill = summary.GameSkill`. Does **not** call `score.CalculateSkill()` — that would re-derive a coarser value and clobber the precise one.
+- `SaveChangesAsync`.
+
+**Step 4** — fire from `ResultStage` after `ExtractSharedData` (one-shot, fire-and-forget):
+
+```csharp
+if (_selectedChart != null && _performanceSummary != null)
+{
+    _ = SongManager.Instance.UpdateScoreAsync(
+        _selectedChart.Id, EInstrumentPart.DRUMS, _performanceSummary);
+}
+```
+
+Errors are caught and logged inside the service — UI does not block on persistence.
+
+**Step 5** — optional UX polish in `SongStatusPanel.DrawSkillPointSection` (`SongStatusPanel.cs:859`):
+
+```csharp
+var skillValue = score.HasBeenPlayed
+    ? score.HighSkill.ToString("F2")
+    : "---";
+```
+
+(Today it shows `"0.00"` for unplayed charts.)
+
+## Testing
+
+All under `DTXMania.Test/`. New files:
+
+| File | Mac-safe? | Scope |
+|---|---|---|
+| `Stage/Performance/SkillManagerTests.cs` | yes | Formula, event payload, `MaxCombo` read-through, constructor guard, `Reset`, `IsMax` boundary |
+| `Stage/Performance/SkillPanelDisplayLogicTests.cs` | no — exclude | Format strings, `ShowMax` gate |
+| `Stage/Performance/SkillMeterDisplayLogicTests.cs` | no — exclude | `gaugeHeight` math, `barTopY` math, skip-when-zero |
+| `Song/Entities/SongScoreSkillFormulaTests.cs` | yes | Static helpers against DTXManiaNX reference fixtures |
+| `Song/SongDatabaseServiceUpdateScoreTests.cs` | yes | New overload persists skill correctly, in-memory EF Core SQLite |
+| `Stage/PerformanceStageSkillIntegrationTests.cs` | no — exclude | E2E: `PerformanceSummary.PlayingSkill`/`GameSkill` populated at stage completion |
+
+Mechanical updates to existing tests for the `Just`→`Perfect` rename, and updates to tests that asserted the old `SongScore.CalculateSkill` formula.
+
+Reference fixtures for formula tests (from `tCalculatePlayingSkill`):
+
+| Perfect | Great | Good | Poor | Miss | MaxCombo | Total | PlayingSkill |
+|---|---|---|---|---|---|---|---|
+| 100 | 0 | 0 | 0 | 0 | 100 | 100 | 100.0 |
+| 0 | 100 | 0 | 0 | 0 | 100 | 100 | 50.0 |
+| 50 | 0 | 0 | 0 | 50 | 50 | 100 | 50.0 |
+| 20 | 80 | 0 | 0 | 0 | 100 | 100 | 60.0 |
+| 0 | 0 | 0 | 0 | 100 | 0 | 100 | 0.0 |
+
+Game Skill fixtures (`PlayingSkill × Level × 0.2`):
+
+| PlayingSkill | Level | LevelDec | GameSkill |
+|---|---|---|---|
+| 100.0 | 850 | 0 | `100 × 8.5 × 0.2` = 170.0 |
+| 60.0 | 78 | 33 | `60 × 7.83 × 0.2` = 93.96 |
+| 0.0 | 50 | 0 | 0.0 |
+
+## Acceptance criteria
+
+1. Rename: full test suite green on Mac + Windows after `Just` → `Perfect` rename. Zero new warnings.
+2. Gameplay: left panel shows difficulty level + live skill % updating per hit + MAX badge at 100; right gauge bar height tracks skill, numeric overlay follows bar top.
+3. Formula parity: `SkillManager.CurrentSkill` matches DTXManiaNX `tCalculatePlayingSkill` for the fixtures above.
+4. Persistence: completing a song updates the DB; reloading Song Selection shows the new `HighSkill` in `SongStatusPanel.DrawSkillPointSection`.
+5. No regressions: existing `ScoreDisplay`, `ComboDisplay`, `GaugeDisplay` behavior unchanged; existing tests still pass.
+
+## File summary
+
+**New** (8 files):
+- `DTXMania.Game/Lib/Stage/Performance/SkillManager.cs`
+- `DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs`
+- `DTXMania.Game/Lib/Stage/Performance/SkillMeterDisplay.cs`
+- `DTXMania.Test/Stage/Performance/SkillManagerTests.cs`
+- `DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs`
+- `DTXMania.Test/Stage/Performance/SkillMeterDisplayLogicTests.cs`
+- `DTXMania.Test/Song/Entities/SongScoreSkillFormulaTests.cs`
+- `DTXMania.Test/Stage/PerformanceStageSkillIntegrationTests.cs`
+
+**Modified** (high-impact):
+- `DTXMania.Game/Lib/Song/Entities/JudgementTypes.cs` — `Just`→`Perfect` rename + constants
+- `DTXMania.Game/Lib/Song/Entities/SongScore.cs` — new static `CalculatePlayingSkill`/`CalculateGameSkill`; replace `CalculateSkill()` formula; accept `PerformanceSummary` in update path
+- `DTXMania.Game/Lib/Stage/Performance/PerformanceSummary.cs` — `JustCount`→`PerfectCount`; new `PlayingSkill`/`GameSkill`/`ChartLevel`/`ChartLevelDec`
+- `DTXMania.Game/Lib/Stage/PerformanceStage.cs` — new manager/displays wiring; populate skill in summary
+- `DTXMania.Game/Lib/Stage/ResultStage.cs` — call `UpdateScoreAsync` with summary
+- `DTXMania.Game/Lib/Song/SongManager.cs` + `Entities/SongDatabaseService.cs` — new `UpdateScoreAsync(chartId, instrument, summary)` overload
+- `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs` — new `SkillMeter` static class
+- `DTXMania.Game/Lib/Resources/TexturePath.cs` — add `PerfGraphMain`, `PerfGraphGauge`, `SkillMax`
+- `DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs` — optional `"---"` fallback for unplayed
+- `DTXMania.Test/DTXMania.Test.Mac.csproj` — add three new test files to exclusion list
+- Mechanical rename touches across `ComboManager.cs`, `GaugeManager.cs`, `JudgementManager.cs`, `JudgementTextPopup.cs`, `ScoreManager.cs`, and ~14 test files
+
+## References
+
+- DTXManiaNX `CScoreIni.tCalculatePlayingSkill` (`DTXManiaNX/DTXMania/Code/Score,Song/CScoreIni.cs:1641`)
+- DTXManiaNX `CScoreIni.tCalculateGameSkillFromPlayingSkill` (`CScoreIni.cs:1623`)
+- DTXManiaNX `CActPerfSkillMeter` (`DTXManiaNX/DTXMania/Code/Stage/07.Performance/CActPerfSkillMeter.cs`)
+- DTXManiaNX live update site for in-game skill (`DTXManiaNX/DTXMania/Code/Stage/07.Performance/DrumsScreen/CStagePerfDrumsScreen.cs:566`)
+- DTXManiaNX `EJudgement` enum (`DTXManiaNX/DTXMania/Code/App/CConstants.cs:191`)


### PR DESCRIPTION
## Summary
- Add `SkillManager` for live Playing Skill computation during performance
- Add `SkillPanelDisplay` (left-side panel) and `SkillMeterDisplay` (right-side vertical gauge) renderers
- Add `SongScore.CalculatePlayingSkill` and `SongScore.CalculateGameSkill` helpers with DTXManiaNX formula parity
- Persist score and skill from `ResultStage` after each play via `SongDatabaseService.UpdateScoreAsync`
- Show "---" on Song Selection panel for charts that have not been played yet

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time skill system with right-side skill meter and performance skill panel; skill values computed live and saved to results.

* **Changes**
  * Highest-tier judgement renamed to "Perfect" across gameplay, UI, scoring, and result displays.
  * Results now include Perfect counts and chart difficulty/skill fields.

* **Bug Fixes**
  * Skill display shows "---" for unplayed scores; zero-note charts initialize as zero scoring instead of throwing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cwchanap/DTXManiaCX/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->