### PR TITLE
feat: result stage NX parity

### DIFF
--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -448,13 +448,6 @@ namespace DTXMania.Game.Lib.Resources
                 SongTransitionBackground,
                 PerformanceBackground,
                 ResultBackground,
-                ResultBackgroundRankSS,
-                ResultBackgroundRankS,
-                ResultBackgroundRankA,
-                ResultBackgroundRankB,
-                ResultBackgroundRankC,
-                ResultBackgroundRankD,
-                ResultBackgroundRankE,
                 ResultRankSS,
                 ResultRankS,
                 ResultRankA,
@@ -535,6 +528,24 @@ namespace DTXMania.Game.Lib.Resources
                 ChipWave,
                 Bonus,
                 Bonus100
+            };
+        }
+
+        /// <summary>
+        /// Gets optional result stage texture paths that may be provided by skins.
+        /// These are not required preload or validation assets.
+        /// </summary>
+        public static string[] GetOptionalResultTexturePaths()
+        {
+            return new[]
+            {
+                ResultBackgroundRankSS,
+                ResultBackgroundRankS,
+                ResultBackgroundRankA,
+                ResultBackgroundRankB,
+                ResultBackgroundRankC,
+                ResultBackgroundRankD,
+                ResultBackgroundRankE
             };
         }
         

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -38,6 +38,43 @@ namespace DTXMania.Game.Lib.Resources
         /// </summary>
         public const string ResultBackground = "Graphics/8_background.jpg";
 
+        /// <summary>
+        /// Result stage rank-specific background textures. These are optional skin assets.
+        /// </summary>
+        public const string ResultBackgroundRankSS = "Graphics/8_background rankSS.png";
+        public const string ResultBackgroundRankS = "Graphics/8_background rankS.png";
+        public const string ResultBackgroundRankA = "Graphics/8_background rankA.png";
+        public const string ResultBackgroundRankB = "Graphics/8_background rankB.png";
+        public const string ResultBackgroundRankC = "Graphics/8_background rankC.png";
+        public const string ResultBackgroundRankD = "Graphics/8_background rankD.png";
+        public const string ResultBackgroundRankE = "Graphics/8_background rankE.png";
+
+        /// <summary>
+        /// Result stage rank badge textures.
+        /// </summary>
+        public const string ResultRankSS = "Graphics/8_rankSS.png";
+        public const string ResultRankS = "Graphics/8_rankS.png";
+        public const string ResultRankA = "Graphics/8_rankA.png";
+        public const string ResultRankB = "Graphics/8_rankB.png";
+        public const string ResultRankC = "Graphics/8_rankC.png";
+        public const string ResultRankD = "Graphics/8_rankD.png";
+        public const string ResultRankE = "Graphics/8_rankE.png";
+
+        /// <summary>
+        /// Result stage clear category plate textures.
+        /// </summary>
+        public const string ResultPlateStageCleared = "Graphics/ScreenResult StageCleared.png";
+        public const string ResultPlateFullCombo = "Graphics/ScreenResult fullcombo.png";
+        public const string ResultPlateExcellent = "Graphics/ScreenResult Excellent.png";
+
+        /// <summary>
+        /// Result stage structural panel textures.
+        /// </summary>
+        public const string ResultJacketPanel = "Graphics/7_JacketPanel.png";
+        public const string ResultSkillPanel = "Graphics/7_SkillPanel.png";
+        public const string ResultNewRecord = "Graphics/8_New Record.png";
+        public const string ResultDefaultPreview = "Graphics/5_preimage default.png";
+
         #endregion
         
         #region UI Panel Textures
@@ -411,6 +448,27 @@ namespace DTXMania.Game.Lib.Resources
                 SongTransitionBackground,
                 PerformanceBackground,
                 ResultBackground,
+                ResultBackgroundRankSS,
+                ResultBackgroundRankS,
+                ResultBackgroundRankA,
+                ResultBackgroundRankB,
+                ResultBackgroundRankC,
+                ResultBackgroundRankD,
+                ResultBackgroundRankE,
+                ResultRankSS,
+                ResultRankS,
+                ResultRankA,
+                ResultRankB,
+                ResultRankC,
+                ResultRankD,
+                ResultRankE,
+                ResultPlateStageCleared,
+                ResultPlateFullCombo,
+                ResultPlateExcellent,
+                ResultJacketPanel,
+                ResultSkillPanel,
+                ResultNewRecord,
+                ResultDefaultPreview,
                 TitleMenu,
                 SongSelectionHeaderPanel,
                 SongSelectionFooterPanel,

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -459,7 +459,6 @@ namespace DTXMania.Game.Lib.Resources
                 ResultPlateFullCombo,
                 ResultPlateExcellent,
                 ResultJacketPanel,
-                ResultSkillPanel,
                 ResultNewRecord,
                 ResultDefaultPreview,
                 TitleMenu,

--- a/DTXMania.Game/Lib/Stage/Result/ResultRevealState.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultRevealState.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+using System;
+
+namespace DTXMania.Game.Lib.Stage.Result
+{
+    public sealed class ResultRevealState
+    {
+        public const double RankRevealSeconds = 0.5;
+        public const double PanelDelaySeconds = 0.15;
+        public const double PanelRevealSeconds = 0.5;
+        public const double TotalRevealSeconds = RankRevealSeconds + PanelDelaySeconds + PanelRevealSeconds;
+
+        public double ElapsedSeconds { get; private set; }
+
+        public bool IsComplete => ElapsedSeconds >= TotalRevealSeconds;
+
+        public float RankProgress => Clamp01(ElapsedSeconds / RankRevealSeconds);
+
+        public float PanelProgress => Clamp01(
+            (ElapsedSeconds - RankRevealSeconds - PanelDelaySeconds) / PanelRevealSeconds);
+
+        public void Update(double deltaSeconds)
+        {
+            if (deltaSeconds <= 0.0)
+                return;
+
+            ElapsedSeconds = Math.Min(TotalRevealSeconds, ElapsedSeconds + deltaSeconds);
+        }
+
+        public void Complete()
+        {
+            ElapsedSeconds = TotalRevealSeconds;
+        }
+
+        public void Reset()
+        {
+            ElapsedSeconds = 0.0;
+        }
+
+        private static float Clamp01(double value)
+        {
+            if (value <= 0.0)
+                return 0.0f;
+
+            if (value >= 1.0)
+                return 1.0f;
+
+            return (float)value;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
@@ -185,7 +185,7 @@ namespace DTXMania.Game.Lib.Stage.Result
         private static bool IsExcellent(PerformanceSummary summary)
         {
             return summary.TotalNotes > 0
-                && Math.Max(0, summary.PerfectCount) >= summary.TotalNotes
+                && Math.Max(0, summary.PerfectCount) == summary.TotalNotes
                 && Math.Max(0, summary.GreatCount) == 0
                 && Math.Max(0, summary.GoodCount) == 0
                 && Math.Max(0, summary.PoorCount) == 0
@@ -252,8 +252,11 @@ namespace DTXMania.Game.Lib.Stage.Result
 
         private static bool IsNewRecord(PerformanceSummary summary, SongScore? previousScore)
         {
-            if (previousScore == null || !previousScore.HasBeenPlayed)
-                return true;
+            if (previousScore == null)
+                return false;
+
+            if (!previousScore.HasBeenPlayed)
+                return summary.Score > 0 || summary.GameSkill > 0.0;
 
             return summary.Score > previousScore.BestScore
                 || summary.GameSkill > previousScore.HighSkill;

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
@@ -170,6 +170,14 @@ namespace DTXMania.Game.Lib.Stage.Result
             return Math.Max(0.0, value).ToString("0.00", CultureInfo.InvariantCulture);
         }
 
+        /// <summary>
+        /// Formats a DTX difficulty level using its two encoding schemes:
+        /// <list type="bullet">
+        ///   <item>level >= 100: hundredths encoding (e.g. 120 → 1.20)</item>
+        ///   <item>level &lt; 100: tenths from level + hundredths from levelDec (e.g. level=78, levelDec=33 → 8.13)</item>
+        /// </list>
+        /// Returns "--" when level <= 0. Uses InvariantCulture for consistent formatting.
+        /// </summary>
         public static string FormatLevel(int level, int levelDec)
         {
             if (level <= 0)

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
@@ -1,0 +1,274 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.IO;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+
+namespace DTXMania.Game.Lib.Stage.Result
+{
+    public enum ResultRank
+    {
+        SS = 0,
+        S = 1,
+        A = 2,
+        B = 3,
+        C = 4,
+        D = 5,
+        E = 6
+    }
+
+    public enum ResultPlateKind
+    {
+        Excellent,
+        FullCombo,
+        StageCleared,
+        Failed
+    }
+
+    public sealed class ResultScreenModel
+    {
+        private const string UnknownSongTitle = "Unknown Song";
+        private const string UnknownArtistName = "Unknown Artist";
+
+        private ResultScreenModel()
+        {
+        }
+
+        public PerformanceSummary Summary { get; private init; } = new();
+        public ResultRank Rank { get; private init; }
+        public string RankLabel { get; private init; } = "E";
+        public ResultPlateKind PlateKind { get; private init; }
+        public string ScoreText { get; private init; } = "0000000";
+        public string MaxComboText { get; private init; } = "0";
+        public string PerfectCountText { get; private init; } = "0";
+        public string GreatCountText { get; private init; } = "0";
+        public string GoodCountText { get; private init; } = "0";
+        public string PoorCountText { get; private init; } = "0";
+        public string MissCountText { get; private init; } = "0";
+        public string PerfectPercentText { get; private init; } = "0%";
+        public string GreatPercentText { get; private init; } = "0%";
+        public string GoodPercentText { get; private init; } = "0%";
+        public string PoorPercentText { get; private init; } = "0%";
+        public string MissPercentText { get; private init; } = "0%";
+        public string MaxComboPercentText { get; private init; } = "0%";
+        public string PlayingSkillText { get; private init; } = "0.00";
+        public string GameSkillText { get; private init; } = "0.00";
+        public string ChartLevelText { get; private init; } = "--";
+        public string Title { get; private init; } = UnknownSongTitle;
+        public string Artist { get; private init; } = UnknownArtistName;
+        public string PreviewImagePath { get; private init; } = TexturePath.ResultDefaultPreview;
+        public bool NewRecord { get; private init; }
+
+        public static ResultScreenModel Create(
+            PerformanceSummary? summary,
+            SongListNode? selectedSong,
+            int selectedDifficulty,
+            SongChart? chart,
+            SongScore? previousScore)
+        {
+            var safeSummary = summary ?? new PerformanceSummary();
+            var resolvedChart = ResolveChart(selectedSong, selectedDifficulty, chart);
+            var rank = ComputeRank(safeSummary.PlayingSkill);
+
+            return new ResultScreenModel
+            {
+                Summary = safeSummary,
+                Rank = rank,
+                RankLabel = GetRankLabel(rank),
+                PlateKind = ComputePlateKind(safeSummary),
+                ScoreText = FormatScore(safeSummary.Score),
+                MaxComboText = FormatCount(safeSummary.MaxCombo),
+                PerfectCountText = FormatCount(safeSummary.PerfectCount),
+                GreatCountText = FormatCount(safeSummary.GreatCount),
+                GoodCountText = FormatCount(safeSummary.GoodCount),
+                PoorCountText = FormatCount(safeSummary.PoorCount),
+                MissCountText = FormatCount(safeSummary.MissCount),
+                PerfectPercentText = FormatPercent(safeSummary.PerfectCount, safeSummary.TotalNotes),
+                GreatPercentText = FormatPercent(safeSummary.GreatCount, safeSummary.TotalNotes),
+                GoodPercentText = FormatPercent(safeSummary.GoodCount, safeSummary.TotalNotes),
+                PoorPercentText = FormatPercent(safeSummary.PoorCount, safeSummary.TotalNotes),
+                MissPercentText = FormatPercent(safeSummary.MissCount, safeSummary.TotalNotes),
+                MaxComboPercentText = FormatPercent(safeSummary.MaxCombo, safeSummary.TotalNotes),
+                PlayingSkillText = FormatDecimal(safeSummary.PlayingSkill),
+                GameSkillText = FormatDecimal(safeSummary.GameSkill),
+                ChartLevelText = FormatLevel(
+                    resolvedChart?.DrumLevel ?? safeSummary.ChartLevel,
+                    resolvedChart?.DrumLevelDec ?? safeSummary.ChartLevelDec),
+                Title = ResolveTitle(selectedSong),
+                Artist = ResolveArtist(selectedSong),
+                PreviewImagePath = ResolvePreviewImagePath(resolvedChart),
+                NewRecord = IsNewRecord(safeSummary, previousScore)
+            };
+        }
+
+        public static ResultRank ComputeRank(double playingSkill)
+        {
+            if (playingSkill >= 95.0) return ResultRank.SS;
+            if (playingSkill >= 80.0) return ResultRank.S;
+            if (playingSkill >= 73.0) return ResultRank.A;
+            if (playingSkill >= 63.0) return ResultRank.B;
+            if (playingSkill >= 53.0) return ResultRank.C;
+            if (playingSkill >= 45.0) return ResultRank.D;
+            return ResultRank.E;
+        }
+
+        public static ResultPlateKind ComputePlateKind(PerformanceSummary summary)
+        {
+            if (IsExcellent(summary))
+                return ResultPlateKind.Excellent;
+
+            if (summary.ClearFlag && Math.Max(0, summary.PoorCount) == 0 && Math.Max(0, summary.MissCount) == 0)
+                return ResultPlateKind.FullCombo;
+
+            if (summary.ClearFlag)
+                return ResultPlateKind.StageCleared;
+
+            return ResultPlateKind.Failed;
+        }
+
+        public static string GetRankLabel(ResultRank rank)
+        {
+            return rank switch
+            {
+                ResultRank.SS => "SS",
+                ResultRank.S => "S",
+                ResultRank.A => "A",
+                ResultRank.B => "B",
+                ResultRank.C => "C",
+                ResultRank.D => "D",
+                ResultRank.E => "E",
+                _ => "E"
+            };
+        }
+
+        public static string FormatScore(int score)
+        {
+            return Math.Clamp(score, 0, 9_999_999).ToString("0000000", CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatCount(int count)
+        {
+            return Math.Max(0, count).ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatPercent(int value, int total)
+        {
+            if (total <= 0)
+                return "0%";
+
+            var safeValue = Math.Max(0, value);
+            var percent = (int)Math.Round(safeValue * 100.0 / total, MidpointRounding.AwayFromZero);
+            return $"{Math.Clamp(percent, 0, 100)}%";
+        }
+
+        public static string FormatDecimal(double value)
+        {
+            return Math.Max(0.0, value).ToString("0.00", CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatLevel(int level, int levelDec)
+        {
+            if (level <= 0)
+                return "--";
+
+            var actualLevel = level >= 100
+                ? level / 100.0
+                : (level / 10.0) + (Math.Max(0, levelDec) / 100.0);
+
+            return actualLevel.ToString("0.00", CultureInfo.InvariantCulture);
+        }
+
+        private static bool IsExcellent(PerformanceSummary summary)
+        {
+            return summary.TotalNotes > 0
+                && Math.Max(0, summary.PerfectCount) >= summary.TotalNotes
+                && Math.Max(0, summary.GreatCount) == 0
+                && Math.Max(0, summary.GoodCount) == 0
+                && Math.Max(0, summary.PoorCount) == 0
+                && Math.Max(0, summary.MissCount) == 0;
+        }
+
+        private static SongChart? ResolveChart(SongListNode? selectedSong, int selectedDifficulty, SongChart? chart)
+        {
+            if (chart != null)
+                return chart;
+
+            if (selectedSong == null)
+                return null;
+
+            return selectedSong.GetCurrentDifficultyChart(selectedDifficulty) ?? selectedSong.DatabaseChart;
+        }
+
+        private static string ResolveTitle(SongListNode? selectedSong)
+        {
+            if (selectedSong == null)
+                return UnknownSongTitle;
+
+            var databaseSong = selectedSong.DatabaseSong;
+            if (databaseSong != null && !string.IsNullOrWhiteSpace(databaseSong.Title))
+                return databaseSong.Title;
+
+            if (HasText(selectedSong.Title))
+                return selectedSong.Title;
+
+            if (databaseSong != null && HasMeaningfulTitle(databaseSong.DisplayTitle))
+                return databaseSong.DisplayTitle;
+
+            if (HasMeaningfulTitle(selectedSong.DisplayTitle))
+                return selectedSong.DisplayTitle;
+
+            return UnknownSongTitle;
+        }
+
+        private static string ResolveArtist(SongListNode? selectedSong)
+        {
+            var artist = selectedSong?.DatabaseSong?.Artist;
+            if (!string.IsNullOrWhiteSpace(artist))
+                return artist;
+
+            return UnknownArtistName;
+        }
+
+        private static string ResolvePreviewImagePath(SongChart? chart)
+        {
+            if (chart == null || !HasText(chart.PreviewImage))
+                return TexturePath.ResultDefaultPreview;
+
+            if (Path.IsPathRooted(chart.PreviewImage))
+                return chart.PreviewImage;
+
+            var chartDirectory = HasText(chart.FilePath)
+                ? Path.GetDirectoryName(chart.FilePath)
+                : null;
+
+            return HasText(chartDirectory)
+                ? Path.Combine(chartDirectory!, chart.PreviewImage)
+                : chart.PreviewImage;
+        }
+
+        private static bool IsNewRecord(PerformanceSummary summary, SongScore? previousScore)
+        {
+            if (previousScore == null || !previousScore.HasBeenPlayed)
+                return true;
+
+            return summary.Score > previousScore.BestScore
+                || summary.GameSkill > previousScore.HighSkill;
+        }
+
+        private static bool HasMeaningfulTitle(string? value)
+        {
+            return HasText(value)
+                && !string.Equals(value, "Unknown", StringComparison.Ordinal)
+                && !string.Equals(value, UnknownSongTitle, StringComparison.Ordinal);
+        }
+
+        private static bool HasText(string? value)
+        {
+            return !string.IsNullOrWhiteSpace(value);
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs
@@ -238,16 +238,18 @@ namespace DTXMania.Game.Lib.Stage.Result
             if (chart == null || !HasText(chart.PreviewImage))
                 return TexturePath.ResultDefaultPreview;
 
-            if (Path.IsPathRooted(chart.PreviewImage))
-                return chart.PreviewImage;
+            var previewImagePath = NormalizePreviewImagePath(chart.PreviewImage);
+
+            if (IsRootedPreviewImagePath(previewImagePath))
+                return previewImagePath;
 
             var chartDirectory = HasText(chart.FilePath)
                 ? Path.GetDirectoryName(chart.FilePath)
                 : null;
 
             return HasText(chartDirectory)
-                ? Path.Combine(chartDirectory!, chart.PreviewImage)
-                : chart.PreviewImage;
+                ? Path.Combine(chartDirectory!, previewImagePath)
+                : previewImagePath;
         }
 
         private static bool IsNewRecord(PerformanceSummary summary, SongScore? previousScore)
@@ -272,6 +274,24 @@ namespace DTXMania.Game.Lib.Stage.Result
         private static bool HasText(string? value)
         {
             return !string.IsNullOrWhiteSpace(value);
+        }
+
+        private static string NormalizePreviewImagePath(string previewImagePath)
+        {
+            return previewImagePath.Replace('\\', Path.DirectorySeparatorChar);
+        }
+
+        private static bool IsRootedPreviewImagePath(string previewImagePath)
+        {
+            return Path.IsPathRooted(previewImagePath) || IsWindowsAbsolutePath(previewImagePath);
+        }
+
+        private static bool IsWindowsAbsolutePath(string previewImagePath)
+        {
+            return previewImagePath.Length >= 3
+                && char.IsLetter(previewImagePath[0])
+                && previewImagePath[1] == ':'
+                && (previewImagePath[2] == '/' || previewImagePath[2] == '\\');
         }
     }
 }

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
@@ -147,11 +147,9 @@ namespace DTXMania.Game.Lib.Stage.Result
 
         private void ReleaseLoadedTextures()
         {
-            foreach (var texture in _loadedTextures)
-            {
-                texture.RemoveReference();
-            }
-
+            // Copy and clear immediately so the list is always reset even if
+            // RemoveReference throws during iteration.
+            var textures = new List<ITexture>(_loadedTextures);
             _loadedTextures.Clear();
             _backgroundTexture = null;
             _rankBackgroundTexture = null;
@@ -161,6 +159,11 @@ namespace DTXMania.Game.Lib.Stage.Result
             _skillPanelTexture = null;
             _previewTexture = null;
             _newRecordTexture = null;
+
+            foreach (var texture in textures)
+            {
+                texture.RemoveReference();
+            }
         }
 
         [ExcludeFromCodeCoverage]

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
@@ -240,7 +240,7 @@ namespace DTXMania.Game.Lib.Stage.Result
                 visibleHeight);
             var destination = new Rectangle(
                 (int)ResultUILayout.Rank.BadgePosition.X,
-                (int)ResultUILayout.Rank.BadgePosition.Y,
+                (int)ResultUILayout.Rank.BadgePosition.Y + (_rankTexture.Height - visibleHeight),
                 _rankTexture.Width,
                 visibleHeight);
 

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
@@ -98,19 +98,24 @@ namespace DTXMania.Game.Lib.Stage.Result
 
             ApplyPanelTransparency(transparency);
 
-            DrawTexture(spriteBatch, _plateTexture, ResultUILayout.ResultPlate.Position);
-            if (model.PlateKind == ResultPlateKind.Failed)
-                DrawText(spriteBatch, _largeFont, "FAILED", ResultUILayout.ResultPlate.FailedTextPosition, Color.Red);
+            try
+            {
+                DrawTexture(spriteBatch, _plateTexture, ResultUILayout.ResultPlate.Position);
+                if (model.PlateKind == ResultPlateKind.Failed)
+                    DrawText(spriteBatch, _largeFont, "FAILED", ResultUILayout.ResultPlate.FailedTextPosition, Color.Red);
 
-            DrawTexture(spriteBatch, _jacketPanelTexture, ResultUILayout.Jacket.PanelPosition);
-            DrawPreview(spriteBatch);
-            DrawTexture(spriteBatch, _skillPanelTexture, ResultUILayout.SkillPanel.PanelPosition);
-            DrawModelText(spriteBatch, model);
+                DrawTexture(spriteBatch, _jacketPanelTexture, ResultUILayout.Jacket.PanelPosition);
+                DrawPreview(spriteBatch);
+                DrawTexture(spriteBatch, _skillPanelTexture, ResultUILayout.SkillPanel.PanelPosition);
+                DrawModelText(spriteBatch, model);
 
-            if (model.NewRecord)
-                DrawTexture(spriteBatch, _newRecordTexture, ResultUILayout.NewRecord.BadgePosition);
-
-            RestorePanelTransparency();
+                if (model.NewRecord)
+                    DrawTexture(spriteBatch, _newRecordTexture, ResultUILayout.NewRecord.BadgePosition);
+            }
+            finally
+            {
+                RestorePanelTransparency();
+            }
         }
 
         public void Dispose()
@@ -137,7 +142,7 @@ namespace DTXMania.Game.Lib.Stage.Result
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"ResultScreenRenderer: Failed to load texture '{path}': {ex.Message}");
+                Trace.WriteLine($"ResultScreenRenderer: Failed to load texture '{path}': {ex.Message}");
                 return null;
             }
         }
@@ -150,7 +155,7 @@ namespace DTXMania.Game.Lib.Stage.Result
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"ResultScreenRenderer: Failed to check texture '{path}': {ex.Message}");
+                Trace.WriteLine($"ResultScreenRenderer: Failed to check texture '{path}': {ex.Message}");
                 return false;
             }
         }

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
@@ -1,0 +1,295 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.Stage.Result
+{
+    public sealed class ResultScreenRenderer : IDisposable
+    {
+        private readonly IResourceManager _resources;
+        private readonly IFont? _smallFont;
+        private readonly IFont? _normalFont;
+        private readonly IFont? _largeFont;
+        private readonly List<ITexture> _loadedTextures = new();
+
+        private ITexture? _backgroundTexture;
+        private ITexture? _rankBackgroundTexture;
+        private ITexture? _rankTexture;
+        private ITexture? _plateTexture;
+        private ITexture? _jacketPanelTexture;
+        private ITexture? _skillPanelTexture;
+        private ITexture? _previewTexture;
+        private ITexture? _newRecordTexture;
+        private bool _disposed;
+
+        public ResultScreenRenderer(
+            IResourceManager resources,
+            IFont? smallFont,
+            IFont? normalFont,
+            IFont? largeFont)
+        {
+            _resources = resources ?? throw new ArgumentNullException(nameof(resources));
+            _smallFont = smallFont;
+            _normalFont = normalFont;
+            _largeFont = largeFont;
+        }
+
+        public static Matrix CreateViewportTransform(Viewport viewport)
+        {
+            var scaleX = viewport.Width / (float)ResultUILayout.NXViewport.Width;
+            var scaleY = viewport.Height / (float)ResultUILayout.NXViewport.Height;
+            var scale = Math.Min(scaleX, scaleY);
+            var offsetX = viewport.X + (viewport.Width - ResultUILayout.NXViewport.Width * scale) / 2.0f;
+            var offsetY = viewport.Y + (viewport.Height - ResultUILayout.NXViewport.Height * scale) / 2.0f;
+
+            return Matrix.CreateScale(scale, scale, 1.0f)
+                * Matrix.CreateTranslation(offsetX, offsetY, 0.0f);
+        }
+
+        public void Load(ResultScreenModel model)
+        {
+            if (model == null)
+                throw new ArgumentNullException(nameof(model));
+
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            ReleaseLoadedTextures();
+
+            _backgroundTexture = LoadTextureIfAvailable(TexturePath.ResultBackground);
+            _rankBackgroundTexture = LoadTextureIfAvailable(GetRankBackgroundPath(model.Rank));
+            _rankTexture = LoadTextureIfAvailable(GetRankTexturePath(model.Rank));
+            _plateTexture = model.PlateKind == ResultPlateKind.Failed
+                ? null
+                : LoadTextureIfAvailable(GetPlateTexturePath(model.PlateKind));
+            _jacketPanelTexture = LoadTextureIfAvailable(TexturePath.ResultJacketPanel);
+            _skillPanelTexture = LoadTextureIfAvailable(TexturePath.ResultSkillPanel);
+            _previewTexture = LoadTextureIfAvailable(model.PreviewImagePath)
+                ?? LoadTextureIfAvailable(TexturePath.ResultDefaultPreview);
+            _newRecordTexture = model.NewRecord
+                ? LoadTextureIfAvailable(TexturePath.ResultNewRecord)
+                : null;
+        }
+
+        [ExcludeFromCodeCoverage]
+        public void Draw(SpriteBatch spriteBatch, ResultScreenModel model, ResultRevealState reveal)
+        {
+            if (_disposed || spriteBatch == null || model == null || reveal == null)
+                return;
+
+            DrawTexture(spriteBatch, _backgroundTexture, Vector2.Zero);
+            DrawTexture(spriteBatch, _rankBackgroundTexture, Vector2.Zero);
+            DrawRank(spriteBatch, reveal);
+
+            if (reveal.PanelProgress <= 0.0f)
+                return;
+
+            DrawTexture(spriteBatch, _plateTexture, ResultUILayout.ResultPlate.Position);
+            if (model.PlateKind == ResultPlateKind.Failed)
+                DrawText(spriteBatch, _largeFont, "FAILED", ResultUILayout.ResultPlate.FailedTextPosition, Color.Red);
+
+            DrawTexture(spriteBatch, _jacketPanelTexture, ResultUILayout.Jacket.PanelPosition);
+            DrawPreview(spriteBatch);
+            DrawTexture(spriteBatch, _skillPanelTexture, ResultUILayout.SkillPanel.PanelPosition);
+            DrawModelText(spriteBatch, model);
+
+            if (model.NewRecord)
+                DrawTexture(spriteBatch, _newRecordTexture, ResultUILayout.NewRecord.BadgePosition);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            ReleaseLoadedTextures();
+            _disposed = true;
+        }
+
+        private ITexture? LoadTextureIfAvailable(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !ResourceExists(path))
+                return null;
+
+            try
+            {
+                var texture = _resources.LoadTexture(path);
+                if (texture != null)
+                    _loadedTextures.Add(texture);
+
+                return texture;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"ResultScreenRenderer: Failed to load texture '{path}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private bool ResourceExists(string path)
+        {
+            try
+            {
+                return _resources.ResourceExists(path);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"ResultScreenRenderer: Failed to check texture '{path}': {ex.Message}");
+                return false;
+            }
+        }
+
+        private void ReleaseLoadedTextures()
+        {
+            foreach (var texture in _loadedTextures)
+            {
+                texture.RemoveReference();
+            }
+
+            _loadedTextures.Clear();
+            _backgroundTexture = null;
+            _rankBackgroundTexture = null;
+            _rankTexture = null;
+            _plateTexture = null;
+            _jacketPanelTexture = null;
+            _skillPanelTexture = null;
+            _previewTexture = null;
+            _newRecordTexture = null;
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static void DrawTexture(SpriteBatch spriteBatch, ITexture? texture, Vector2 position)
+        {
+            texture?.Draw(spriteBatch, position);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void DrawRank(SpriteBatch spriteBatch, ResultRevealState reveal)
+        {
+            if (_rankTexture == null || reveal.RankProgress <= 0.0f)
+                return;
+
+            var visibleHeight = Math.Clamp(
+                (int)Math.Round(_rankTexture.Height * reveal.RankProgress),
+                0,
+                _rankTexture.Height);
+
+            if (visibleHeight <= 0)
+                return;
+
+            var source = new Rectangle(
+                0,
+                _rankTexture.Height - visibleHeight,
+                _rankTexture.Width,
+                visibleHeight);
+            var destination = new Rectangle(
+                (int)ResultUILayout.Rank.BadgePosition.X,
+                (int)ResultUILayout.Rank.BadgePosition.Y + _rankTexture.Height - visibleHeight,
+                _rankTexture.Width,
+                visibleHeight);
+
+            _rankTexture.Draw(
+                spriteBatch,
+                destination,
+                source,
+                Color.White,
+                0f,
+                Vector2.Zero,
+                SpriteEffects.None,
+                0f);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void DrawPreview(SpriteBatch spriteBatch)
+        {
+            _previewTexture?.Draw(
+                spriteBatch,
+                ResultUILayout.Jacket.PreviewDestination,
+                null,
+                Color.White,
+                0f,
+                Vector2.Zero,
+                SpriteEffects.None,
+                0f);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void DrawModelText(SpriteBatch spriteBatch, ResultScreenModel model)
+        {
+            DrawText(spriteBatch, _largeFont, model.ScoreText, ResultUILayout.Score.Position, Color.White);
+            DrawText(spriteBatch, _normalFont, model.Title, ResultUILayout.SongInfo.TitlePosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.Artist, ResultUILayout.SongInfo.ArtistPosition, Color.LightGray);
+            DrawText(spriteBatch, _normalFont, model.ChartLevelText, ResultUILayout.SkillPanel.LevelPosition, Color.White);
+            DrawText(spriteBatch, _normalFont, model.PlayingSkillText, ResultUILayout.SkillPanel.PlayingSkillPosition, Color.White);
+            DrawText(spriteBatch, _normalFont, model.GameSkillText, ResultUILayout.SkillPanel.GameSkillPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.PerfectCountText, ResultUILayout.SkillPanel.PerfectCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GreatCountText, ResultUILayout.SkillPanel.GreatCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GoodCountText, ResultUILayout.SkillPanel.GoodCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.PoorCountText, ResultUILayout.SkillPanel.PoorCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MissCountText, ResultUILayout.SkillPanel.MissCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MaxComboText, ResultUILayout.SkillPanel.MaxComboCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.PerfectPercentText, ResultUILayout.SkillPanel.PerfectPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GreatPercentText, ResultUILayout.SkillPanel.GreatPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GoodPercentText, ResultUILayout.SkillPanel.GoodPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.PoorPercentText, ResultUILayout.SkillPanel.PoorPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MissPercentText, ResultUILayout.SkillPanel.MissPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MaxComboPercentText, ResultUILayout.SkillPanel.MaxComboPercentPosition, Color.White);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static void DrawText(SpriteBatch spriteBatch, IFont? font, string text, Vector2 position, Color color)
+        {
+            if (font == null || string.IsNullOrEmpty(text))
+                return;
+
+            font.DrawString(spriteBatch, text, position, color);
+        }
+
+        private static string GetRankTexturePath(ResultRank rank)
+        {
+            return rank switch
+            {
+                ResultRank.SS => TexturePath.ResultRankSS,
+                ResultRank.S => TexturePath.ResultRankS,
+                ResultRank.A => TexturePath.ResultRankA,
+                ResultRank.B => TexturePath.ResultRankB,
+                ResultRank.C => TexturePath.ResultRankC,
+                ResultRank.D => TexturePath.ResultRankD,
+                ResultRank.E => TexturePath.ResultRankE,
+                _ => TexturePath.ResultRankE
+            };
+        }
+
+        private static string GetRankBackgroundPath(ResultRank rank)
+        {
+            return rank switch
+            {
+                ResultRank.SS => TexturePath.ResultBackgroundRankSS,
+                ResultRank.S => TexturePath.ResultBackgroundRankS,
+                ResultRank.A => TexturePath.ResultBackgroundRankA,
+                ResultRank.B => TexturePath.ResultBackgroundRankB,
+                ResultRank.C => TexturePath.ResultBackgroundRankC,
+                ResultRank.D => TexturePath.ResultBackgroundRankD,
+                ResultRank.E => TexturePath.ResultBackgroundRankE,
+                _ => TexturePath.ResultBackgroundRankE
+            };
+        }
+
+        private static string GetPlateTexturePath(ResultPlateKind plateKind)
+        {
+            return plateKind switch
+            {
+                ResultPlateKind.Excellent => TexturePath.ResultPlateExcellent,
+                ResultPlateKind.FullCombo => TexturePath.ResultPlateFullCombo,
+                ResultPlateKind.StageCleared => TexturePath.ResultPlateStageCleared,
+                _ => TexturePath.ResultPlateStageCleared
+            };
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs
@@ -28,6 +28,7 @@ namespace DTXMania.Game.Lib.Stage.Result
         private ITexture? _previewTexture;
         private ITexture? _newRecordTexture;
         private bool _disposed;
+        private List<(ITexture texture, int original)>? _panelOriginalTransparency;
 
         public ResultScreenRenderer(
             IResourceManager resources,
@@ -90,6 +91,13 @@ namespace DTXMania.Game.Lib.Stage.Result
             if (reveal.PanelProgress <= 0.0f)
                 return;
 
+            // Apply panel reveal alpha so visuals match the animation progress.
+            // ITexture.Transparency (0-255) is multiplied into every draw call.
+            var panelAlpha = Math.Clamp(reveal.PanelProgress, 0.0f, 1.0f);
+            var transparency = (int)Math.Round(panelAlpha * 255);
+
+            ApplyPanelTransparency(transparency);
+
             DrawTexture(spriteBatch, _plateTexture, ResultUILayout.ResultPlate.Position);
             if (model.PlateKind == ResultPlateKind.Failed)
                 DrawText(spriteBatch, _largeFont, "FAILED", ResultUILayout.ResultPlate.FailedTextPosition, Color.Red);
@@ -101,6 +109,8 @@ namespace DTXMania.Game.Lib.Stage.Result
 
             if (model.NewRecord)
                 DrawTexture(spriteBatch, _newRecordTexture, ResultUILayout.NewRecord.BadgePosition);
+
+            RestorePanelTransparency();
         }
 
         public void Dispose()
@@ -172,6 +182,38 @@ namespace DTXMania.Game.Lib.Stage.Result
             texture?.Draw(spriteBatch, position);
         }
 
+        /// <summary>
+        /// Applies panel reveal transparency to all panel textures.
+        /// Stored original values are kept for restoration via <see cref="RestorePanelTransparency"/>.
+        /// </summary>
+        private void ApplyPanelTransparency(int transparency)
+        {
+            _panelOriginalTransparency = new List<(ITexture texture, int original)>();
+
+            foreach (var texture in new[] { _plateTexture, _jacketPanelTexture, _previewTexture, _skillPanelTexture, _newRecordTexture })
+            {
+                if (texture != null)
+                {
+                    _panelOriginalTransparency.Add((texture, texture.Transparency));
+                    texture.Transparency = (int)Math.Round(texture.Transparency * (transparency / 255.0));
+                }
+            }
+        }
+
+        private void RestorePanelTransparency()
+        {
+            if (_panelOriginalTransparency == null)
+                return;
+
+            foreach (var (texture, original) in _panelOriginalTransparency)
+            {
+                if (!texture.IsDisposed)
+                    texture.Transparency = original;
+            }
+
+            _panelOriginalTransparency.Clear();
+        }
+
         [ExcludeFromCodeCoverage]
         private void DrawRank(SpriteBatch spriteBatch, ResultRevealState reveal)
         {
@@ -188,12 +230,12 @@ namespace DTXMania.Game.Lib.Stage.Result
 
             var source = new Rectangle(
                 0,
-                _rankTexture.Height - visibleHeight,
+                0,
                 _rankTexture.Width,
                 visibleHeight);
             var destination = new Rectangle(
                 (int)ResultUILayout.Rank.BadgePosition.X,
-                (int)ResultUILayout.Rank.BadgePosition.Y + _rankTexture.Height - visibleHeight,
+                (int)ResultUILayout.Rank.BadgePosition.Y,
                 _rankTexture.Width,
                 visibleHeight);
 

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -108,7 +108,7 @@ namespace DTXMania.Game.Lib.Stage
                 _inputManager.ResetKeyRepeatStates();
             }
 
-            System.Diagnostics.Debug.WriteLine($"ResultStage activated with performance summary: {_performanceSummary}");
+            System.Diagnostics.Trace.WriteLine($"ResultStage activated with performance summary: {_performanceSummary}");
         }
 
         protected override void OnDeactivate()
@@ -201,7 +201,7 @@ namespace DTXMania.Game.Lib.Stage
             // Create white pixel texture for backgrounds
             _whitePixel = CreateWhitePixel();
 
-            // Initialize font for text display
+            // Initialize fonts and renderer (core visual components)
             try
             {
                 _resultFont = CreateResultFont();
@@ -209,12 +209,10 @@ namespace DTXMania.Game.Lib.Stage
                 _largeResultFont = CreateLargeResultFont();
                 _resultRenderer = CreateResultRenderer();
                 _resultRenderer?.Load(_resultModel);
-                _resultSound = LoadSoundForPlate(_resultModel?.PlateKind ?? ResultPlateKind.StageCleared);
-                _newRecordSound = _resultModel?.NewRecord == true ? TryLoadSound(NewRecordSoundPath) : null;
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to initialize result components: {ex.Message}");
+                System.Diagnostics.Trace.WriteLine($"ResultStage: Failed to initialize result renderer: {ex.Message}");
                 _resultFont?.RemoveReference();
                 _smallResultFont?.RemoveReference();
                 _largeResultFont?.RemoveReference();
@@ -223,6 +221,17 @@ namespace DTXMania.Game.Lib.Stage
                 _smallResultFont = null;
                 _largeResultFont = null;
                 _resultRenderer = null;
+            }
+
+            // Initialize sounds (optional — failure should not affect visuals)
+            try
+            {
+                _resultSound = LoadSoundForPlate(_resultModel?.PlateKind ?? ResultPlateKind.StageCleared);
+                _newRecordSound = _resultModel?.NewRecord == true ? TryLoadSound(NewRecordSoundPath) : null;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"ResultStage: Failed to load result sounds: {ex.Message}");
                 _resultSound = null;
                 _newRecordSound = null;
             }
@@ -317,7 +326,7 @@ namespace DTXMania.Game.Lib.Stage
                     EInstrumentPart.DRUMS,
                     _performanceSummary)
                 .ContinueWith(
-                    task => System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to persist score: {task.Exception?.GetBaseException().Message}"),
+                    task => System.Diagnostics.Trace.WriteLine($"ResultStage: Failed to persist score: {task.Exception?.GetBaseException().Message}"),
                     TaskContinuationOptions.OnlyOnFaulted);
         }
 
@@ -401,7 +410,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to load sound '{path}': {ex.Message}");
+                System.Diagnostics.Trace.WriteLine($"ResultStage: Failed to load sound '{path}': {ex.Message}");
                 return null;
             }
         }

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -383,8 +383,7 @@ namespace DTXMania.Game.Lib.Stage
             {
                 ResultPlateKind.Excellent => TryLoadSound(ExcellentSoundPath),
                 ResultPlateKind.FullCombo => TryLoadSound(FullComboSoundPath),
-                ResultPlateKind.StageCleared => TryLoadSound(StageClearSoundPath),
-                _ => null
+                _ => TryLoadSound(StageClearSoundPath)
             };
         }
 
@@ -428,15 +427,16 @@ namespace DTXMania.Game.Lib.Stage
         [ExcludeFromCodeCoverage]
         private void DrawBackground()
         {
-            var viewport = GetBackgroundViewport();
-
             // Draw DTXManiaNX authentic background graphics (8_background.jpg)
             DrawStageBackground(_spriteBatch);
 
-            // Draw fallback if no background loaded
+            // Draw fallback if no background loaded.
+            // Use NX virtual coordinates (1280x720) because the SpriteBatch
+            // has an active viewport transform that maps virtual→screen coords.
             if (!IsBackgroundReady)
             {
-                var backgroundRect = new Rectangle(0, 0, viewport.Width, viewport.Height);
+                var backgroundRect = new Rectangle(0, 0,
+                    ResultUILayout.NXViewport.Width, ResultUILayout.NXViewport.Height);
                 var backgroundColor = ResultUILayout.Background.BackgroundColor;
 
                 DrawFallbackBackground(backgroundRect, backgroundColor);

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -104,7 +104,8 @@ namespace DTXMania.Game.Lib.Stage
             // Clear any pending input commands to prevent auto-transition
             if (_inputManager != null)
             {
-                _inputManager.GetInputCommands(); // This clears the queue
+                _inputManager.ClearPendingCommands();
+                _inputManager.ResetKeyRepeatStates();
             }
 
             System.Diagnostics.Debug.WriteLine($"ResultStage activated with performance summary: {_performanceSummary}");
@@ -161,6 +162,9 @@ namespace DTXMania.Game.Lib.Stage
 
         private void ExtractSharedData()
         {
+            _selectedSong = null;
+            _selectedDifficulty = 0;
+
             if (_sharedData != null && _sharedData.TryGetValue("performanceSummary", out var summaryObj) && summaryObj is PerformanceSummary summary)
             {
                 _performanceSummary = summary;
@@ -330,11 +334,15 @@ namespace DTXMania.Game.Lib.Stage
             InputCommand? command;
             while ((command = _inputManager.GetNextCommand()) != null)
             {
-                ExecuteInputCommand(command.Value);
+                if (ExecuteInputCommand(command.Value))
+                {
+                    _inputManager.ClearPendingCommands();
+                    break;
+                }
             }
         }
 
-        private void ExecuteInputCommand(InputCommand command)
+        private bool ExecuteInputCommand(InputCommand command)
         {
             switch (command.Type)
             {
@@ -344,7 +352,7 @@ namespace DTXMania.Game.Lib.Stage
                     {
                         _revealState.Complete();
                         PlayNewRecordSoundIfReady();
-                        break;
+                        return true;
                     }
 
                     if (_game is BaseGame baseGame && baseGame.CanPerformStageTransition())
@@ -354,6 +362,8 @@ namespace DTXMania.Game.Lib.Stage
                     }
                     break;
             }
+
+            return false;
         }
 
         private void ReturnToSongSelect()

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
@@ -10,7 +11,9 @@ using DTXMania.Game.Lib.UI;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
 
 namespace DTXMania.Game.Lib.Stage
 {
@@ -34,13 +37,26 @@ namespace DTXMania.Game.Lib.Stage
 
         // UI components
         private IFont _resultFont;
+        private IFont _smallResultFont;
+        private IFont _largeResultFont;
+        private ResultScreenModel _resultModel;
+        private ResultRevealState _revealState;
+        private ResultScreenRenderer _resultRenderer;
+        private ISound _resultSound;
+        private ISound _newRecordSound;
         private Texture2D _whitePixel;
+        private bool _newRecordSoundPlayed;
 
 
         // State
         private double _elapsedTime = 0.0;
         
         // Note: Using global stage transition debouncing from BaseGame
+
+        private const string StageClearSoundPath = "Sounds/Stage Clear.ogg";
+        private const string FullComboSoundPath = "Sounds/Full Combo.ogg";
+        private const string ExcellentSoundPath = "Sounds/Excellent.ogg";
+        private const string NewRecordSoundPath = "Sounds/New Record.ogg";
 
         #endregion
 
@@ -67,24 +83,23 @@ namespace DTXMania.Game.Lib.Stage
 
         protected override void OnActivate()
         {
-            // Extract performance summary from shared data
             ExtractSharedData();
 
-            // Persist this play's score + skill values (fire-and-forget).
-            if (_selectedSong != null && _performanceSummary != null)
-            {
-                var savedChart = _selectedSong.GetCurrentDifficultyChart(_selectedDifficulty);
-                if (savedChart != null && savedChart.Id > 0)
-                {
-                    _ = DTXMania.Game.Lib.Song.SongManager.Instance.UpdateScoreAsync(
-                        savedChart.Id,
-                        DTXMania.Game.Lib.Song.Entities.EInstrumentPart.DRUMS,
-                        _performanceSummary);
-                }
-            }
+            var selectedChart = ResolveSelectedChart();
+            var previousScore = ResolvePreviousScore(selectedChart);
+            _resultModel = CreateResultScreenModel(
+                _performanceSummary,
+                _selectedSong,
+                _selectedDifficulty,
+                selectedChart,
+                previousScore);
 
-            // Initialize UI components
+            PersistPerformanceSummary(selectedChart);
+
             InitializeComponents();
+            _revealState = new ResultRevealState();
+            _newRecordSoundPlayed = false;
+            PlayResultSound();
 
             // Clear any pending input commands to prevent auto-transition
             if (_inputManager != null)
@@ -104,6 +119,8 @@ namespace DTXMania.Game.Lib.Stage
         protected override void OnUpdate(double deltaTime)
         {
             _elapsedTime += deltaTime;
+            _revealState?.Update(deltaTime);
+            PlayNewRecordSoundIfReady();
 
             // Update input manager
             _inputManager?.Update(deltaTime);
@@ -121,13 +138,19 @@ namespace DTXMania.Game.Lib.Stage
             if (_spriteBatch == null)
                 return;
 
-            _spriteBatch.Begin();
+            var viewport = _spriteBatch.GraphicsDevice.Viewport;
+            var transform = ResultScreenRenderer.CreateViewportTransform(viewport);
 
-            // Draw background
-            DrawBackground();
+            _spriteBatch.Begin(transformMatrix: transform);
 
-            // Draw result information
-            DrawResults();
+            if (_resultRenderer != null && _resultModel != null && _revealState != null)
+            {
+                _resultRenderer.Draw(_spriteBatch, _resultModel, _revealState);
+            }
+            else
+            {
+                DrawBackground();
+            }
 
             _spriteBatch.End();
         }
@@ -178,11 +201,26 @@ namespace DTXMania.Game.Lib.Stage
             try
             {
                 _resultFont = CreateResultFont();
+                _smallResultFont = CreateSmallResultFont();
+                _largeResultFont = CreateLargeResultFont();
+                _resultRenderer = CreateResultRenderer();
+                _resultRenderer?.Load(_resultModel);
+                _resultSound = LoadSoundForPlate(_resultModel?.PlateKind ?? ResultPlateKind.StageCleared);
+                _newRecordSound = _resultModel?.NewRecord == true ? TryLoadSound(NewRecordSoundPath) : null;
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to load font: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to initialize result components: {ex.Message}");
+                _resultFont?.RemoveReference();
+                _smallResultFont?.RemoveReference();
+                _largeResultFont?.RemoveReference();
+                _resultRenderer?.Dispose();
                 _resultFont = null;
+                _smallResultFont = null;
+                _largeResultFont = null;
+                _resultRenderer = null;
+                _resultSound = null;
+                _newRecordSound = null;
             }
         }
 
@@ -197,7 +235,24 @@ namespace DTXMania.Game.Lib.Stage
         [ExcludeFromCodeCoverage]
         internal virtual IFont CreateResultFont()
         {
-            return _resourceManager.LoadFont("NotoSerifJP", 14);
+            return _resourceManager.LoadFont("NotoSerifJP", ResultUILayout.Fonts.Normal);
+        }
+
+        [ExcludeFromCodeCoverage]
+        internal virtual IFont CreateSmallResultFont()
+        {
+            return _resourceManager.LoadFont("NotoSerifJP", ResultUILayout.Fonts.Small);
+        }
+
+        [ExcludeFromCodeCoverage]
+        internal virtual IFont CreateLargeResultFont()
+        {
+            return _resourceManager.LoadFont("NotoSerifJP", ResultUILayout.Fonts.Large, FontStyle.Bold);
+        }
+
+        internal virtual ResultScreenRenderer CreateResultRenderer()
+        {
+            return new ResultScreenRenderer(_resourceManager, _smallResultFont, _resultFont, _largeResultFont);
         }
 
         private void CleanupComponents()
@@ -207,6 +262,59 @@ namespace DTXMania.Game.Lib.Stage
             _whitePixel = null;
             _resultFont?.RemoveReference();
             _resultFont = null;
+            _smallResultFont?.RemoveReference();
+            _smallResultFont = null;
+            _largeResultFont?.RemoveReference();
+            _largeResultFont = null;
+            _resultRenderer?.Dispose();
+            _resultRenderer = null;
+            _resultSound?.RemoveReference();
+            _resultSound = null;
+            _newRecordSound?.RemoveReference();
+            _newRecordSound = null;
+        }
+
+        internal virtual SongChart ResolveSelectedChart()
+        {
+            return _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+        }
+
+        internal virtual SongScore ResolvePreviousScore(SongChart selectedChart)
+        {
+            if (_selectedSong?.Scores != null && selectedChart != null)
+            {
+                foreach (var score in _selectedSong.Scores)
+                {
+                    if (score?.ChartId == selectedChart.Id && selectedChart.Id != 0)
+                        return score;
+                }
+            }
+
+            return _selectedSong?.GetScore(_selectedDifficulty);
+        }
+
+        internal virtual ResultScreenModel CreateResultScreenModel(
+            PerformanceSummary summary,
+            DTXMania.Game.Lib.Song.SongListNode selectedSong,
+            int selectedDifficulty,
+            SongChart selectedChart,
+            SongScore previousScore)
+        {
+            return ResultScreenModel.Create(summary, selectedSong, selectedDifficulty, selectedChart, previousScore);
+        }
+
+        private void PersistPerformanceSummary(SongChart selectedChart)
+        {
+            if (selectedChart == null || selectedChart.Id <= 0 || _performanceSummary == null)
+                return;
+
+            _ = SongManager.Instance.UpdateScoreAsync(
+                    selectedChart.Id,
+                    EInstrumentPart.DRUMS,
+                    _performanceSummary)
+                .ContinueWith(
+                    task => System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to persist score: {task.Exception?.GetBaseException().Message}"),
+                    TaskContinuationOptions.OnlyOnFaulted);
         }
 
         #endregion
@@ -232,6 +340,13 @@ namespace DTXMania.Game.Lib.Stage
             {
                 case InputCommandType.Activate:
                 case InputCommandType.Back:
+                    if (_revealState != null && !_revealState.IsComplete)
+                    {
+                        _revealState.Complete();
+                        PlayNewRecordSoundIfReady();
+                        break;
+                    }
+
                     if (_game is BaseGame baseGame && baseGame.CanPerformStageTransition())
                     {
                         baseGame.MarkStageTransition();
@@ -246,6 +361,54 @@ namespace DTXMania.Game.Lib.Stage
             // Return to song selection stage
             StageManager?.ChangeStage(StageType.SongSelect,
                 new DTXManiaFadeTransition(0.5), null);
+        }
+
+        #endregion
+
+        #region Sound
+
+        private ISound LoadSoundForPlate(ResultPlateKind plateKind)
+        {
+            return plateKind switch
+            {
+                ResultPlateKind.Excellent => TryLoadSound(ExcellentSoundPath),
+                ResultPlateKind.FullCombo => TryLoadSound(FullComboSoundPath),
+                ResultPlateKind.StageCleared => TryLoadSound(StageClearSoundPath),
+                _ => null
+            };
+        }
+
+        private ISound TryLoadSound(string path)
+        {
+            if (_resourceManager == null || string.IsNullOrWhiteSpace(path))
+                return null;
+
+            try
+            {
+                if (!_resourceManager.ResourceExists(path))
+                    return null;
+
+                return _resourceManager.LoadSound(path);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to load sound '{path}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private void PlayResultSound()
+        {
+            _resultSound?.Play();
+        }
+
+        private void PlayNewRecordSoundIfReady()
+        {
+            if (_newRecordSoundPlayed || _resultModel?.NewRecord != true || _revealState?.IsComplete != true)
+                return;
+
+            _newRecordSound?.Play();
+            _newRecordSoundPlayed = true;
         }
 
         #endregion
@@ -288,70 +451,6 @@ namespace DTXMania.Game.Lib.Stage
         internal virtual void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Color color)
         {
             _spriteBatch.Draw(texture, destinationRectangle, color);
-        }
-
-        private void DrawResults()
-        {
-            if (_performanceSummary == null)
-                return;
-
-            var viewport = _spriteBatch.GraphicsDevice.Viewport;
-            var centerX = viewport.Width / 2;
-            var startY = ResultUILayout.ResultDisplay.StartY;
-            var lineHeight = ResultUILayout.ResultDisplay.LineHeight;
-            var currentY = startY;
-
-            // Draw performance results
-            DrawResultLine("PERFORMANCE RESULTS", centerX, ref currentY, ResultUILayout.ResultDisplay.TitleColor, lineHeight);
-            currentY += ResultUILayout.ResultDisplay.ExtraSpacing; // Extra space
-
-            var clearText = _performanceSummary.ClearFlag ? "CLEARED" : "FAILED";
-            var clearColor = _performanceSummary.ClearFlag ? ResultUILayout.ResultDisplay.ClearedColor : ResultUILayout.ResultDisplay.FailedColor;
-            DrawResultLine(clearText, centerX, ref currentY, clearColor, lineHeight);
-
-            DrawResultLine($"Score: {_performanceSummary.Score:N0}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-            DrawResultLine($"Max Combo: {_performanceSummary.MaxCombo}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-            DrawResultLine($"Accuracy: {_performanceSummary.Accuracy:F1}%", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-
-            currentY += ResultUILayout.ResultDisplay.ExtraSpacing; // Extra space
-
-            DrawResultLine("JUDGEMENT BREAKDOWN", centerX, ref currentY, ResultUILayout.ResultDisplay.SectionHeaderColor, lineHeight);
-            DrawResultLine($"Perfect: {_performanceSummary.PerfectCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-            DrawResultLine($"Great: {_performanceSummary.GreatCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-            DrawResultLine($"Good: {_performanceSummary.GoodCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-            DrawResultLine($"Poor: {_performanceSummary.PoorCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-            DrawResultLine($"Miss: {_performanceSummary.MissCount}", centerX, ref currentY, ResultUILayout.ResultDisplay.NormalTextColor, lineHeight);
-
-            currentY += lineHeight; // Extra space
-
-            DrawResultLine("Press ESC or ENTER to continue", centerX, ref currentY, ResultUILayout.ResultDisplay.InstructionTextColor, lineHeight);
-        }
-
-        private void DrawResultLine(string text, int centerX, ref int currentY, Color color, int lineHeight)
-        {
-            if (string.IsNullOrEmpty(text))
-                return;
-
-            if (_resultFont != null)
-            {
-                var textSize = _resultFont.MeasureString(text);
-                var textPosition = new Vector2(centerX - textSize.X / 2, currentY);
-                _resultFont.DrawString(_spriteBatch, text, textPosition, color);
-            }
-            else
-            {
-                // Fallback: draw colored rectangle as placeholder
-                var rectWidth = text.Length * ResultUILayout.FallbackText.CharacterWidth;
-                var rectHeight = ResultUILayout.FallbackText.RectHeight;
-                var rectPosition = new Rectangle(centerX - rectWidth / 2, currentY, rectWidth, rectHeight);
-
-                if (_whitePixel != null)
-                {
-                    _spriteBatch.Draw(_whitePixel, rectPosition, color);
-                }
-            }
-
-            currentY += lineHeight;
         }
 
         #endregion

--- a/DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs
@@ -41,6 +41,77 @@ namespace DTXMania.Game.Lib.UI.Layout
         }
         
         #endregion
+
+        #region NX Result Layout
+
+        public static class NXViewport
+        {
+            public const int Width = 1280;
+            public const int Height = 720;
+        }
+
+        public static class Fonts
+        {
+            public const int Small = 16;
+            public const int Normal = 20;
+            public const int Large = 32;
+        }
+
+        public static class Rank
+        {
+            public static readonly Vector2 BadgePosition = new(480, 0);
+        }
+
+        public static class ResultPlate
+        {
+            public static readonly Vector2 Position = new(315, 100);
+            public static readonly Vector2 FailedTextPosition = new(420, 156);
+        }
+
+        public static class Jacket
+        {
+            public static readonly Vector2 PanelPosition = new(467, 287);
+            public static readonly Rectangle PreviewDestination = new(519, 338, 245, 245);
+        }
+
+        public static class SkillPanel
+        {
+            public static readonly Vector2 PanelPosition = new(180, 260);
+            public static readonly Vector2 LevelPosition = new(198, 550);
+            public static readonly Vector2 PlayingSkillPosition = new(238, 537);
+            public static readonly Vector2 GameSkillPosition = new(268, 623);
+            public static readonly Vector2 PerfectCountPosition = new(260, 332);
+            public static readonly Vector2 GreatCountPosition = new(260, 362);
+            public static readonly Vector2 GoodCountPosition = new(260, 392);
+            public static readonly Vector2 PoorCountPosition = new(260, 422);
+            public static readonly Vector2 MissCountPosition = new(260, 452);
+            public static readonly Vector2 MaxComboCountPosition = new(260, 482);
+            public static readonly Vector2 PerfectPercentPosition = new(347, 332);
+            public static readonly Vector2 GreatPercentPosition = new(347, 362);
+            public static readonly Vector2 GoodPercentPosition = new(347, 392);
+            public static readonly Vector2 PoorPercentPosition = new(347, 422);
+            public static readonly Vector2 MissPercentPosition = new(347, 452);
+            public static readonly Vector2 MaxComboPercentPosition = new(347, 482);
+        }
+
+        public static class Score
+        {
+            public static readonly Vector2 Position = new(30, 58);
+        }
+
+        public static class SongInfo
+        {
+            public static readonly Vector2 TitlePosition = new(500, 630);
+            public static readonly Vector2 ArtistPosition = new(500, 665);
+            public const int MaxWidth = 320;
+        }
+
+        public static class NewRecord
+        {
+            public static readonly Vector2 BadgePosition = new(298, 582);
+        }
+
+        #endregion
         
         #region Fallback Text Rendering
         

--- a/DTXMania.Test/Resources/TexturePathTests.cs
+++ b/DTXMania.Test/Resources/TexturePathTests.cs
@@ -322,7 +322,7 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
-        public void GetAllTexturePaths_ShouldOnlyDuplicateSharedResultSkillPanelAsset()
+        public void GetAllTexturePaths_ShouldNotDuplicateAnyPaths()
         {
             var paths = TexturePath.GetAllTexturePaths();
             var duplicatePaths = paths
@@ -331,8 +331,7 @@ namespace DTXMania.Test.Resources
                 .Select(group => group.Key)
                 .ToArray();
 
-            Assert.Equal(new[] { TexturePath.SkillPanel }, duplicatePaths);
-            Assert.Equal(TexturePath.SkillPanel, TexturePath.ResultSkillPanel);
+            Assert.Empty(duplicatePaths);
         }
 
         #endregion

--- a/DTXMania.Test/Resources/TexturePathTests.cs
+++ b/DTXMania.Test/Resources/TexturePathTests.cs
@@ -156,6 +156,64 @@ namespace DTXMania.Test.Resources
 
         #endregion
 
+        #region Result Stage Texture Constants
+
+        [Fact]
+        public void ResultStageAssets_ShouldUseNXPaths()
+        {
+            Assert.Equal("Graphics/8_background rankSS.png", TexturePath.ResultBackgroundRankSS);
+            Assert.Equal("Graphics/8_background rankS.png", TexturePath.ResultBackgroundRankS);
+            Assert.Equal("Graphics/8_background rankA.png", TexturePath.ResultBackgroundRankA);
+            Assert.Equal("Graphics/8_background rankB.png", TexturePath.ResultBackgroundRankB);
+            Assert.Equal("Graphics/8_background rankC.png", TexturePath.ResultBackgroundRankC);
+            Assert.Equal("Graphics/8_background rankD.png", TexturePath.ResultBackgroundRankD);
+            Assert.Equal("Graphics/8_background rankE.png", TexturePath.ResultBackgroundRankE);
+            Assert.Equal("Graphics/8_rankSS.png", TexturePath.ResultRankSS);
+            Assert.Equal("Graphics/8_rankS.png", TexturePath.ResultRankS);
+            Assert.Equal("Graphics/8_rankA.png", TexturePath.ResultRankA);
+            Assert.Equal("Graphics/8_rankB.png", TexturePath.ResultRankB);
+            Assert.Equal("Graphics/8_rankC.png", TexturePath.ResultRankC);
+            Assert.Equal("Graphics/8_rankD.png", TexturePath.ResultRankD);
+            Assert.Equal("Graphics/8_rankE.png", TexturePath.ResultRankE);
+            Assert.Equal("Graphics/ScreenResult StageCleared.png", TexturePath.ResultPlateStageCleared);
+            Assert.Equal("Graphics/ScreenResult fullcombo.png", TexturePath.ResultPlateFullCombo);
+            Assert.Equal("Graphics/ScreenResult Excellent.png", TexturePath.ResultPlateExcellent);
+            Assert.Equal("Graphics/7_JacketPanel.png", TexturePath.ResultJacketPanel);
+            Assert.Equal("Graphics/7_SkillPanel.png", TexturePath.ResultSkillPanel);
+            Assert.Equal("Graphics/8_New Record.png", TexturePath.ResultNewRecord);
+            Assert.Equal("Graphics/5_preimage default.png", TexturePath.ResultDefaultPreview);
+        }
+
+        [Fact]
+        public void ResultStageAssets_ShouldBeIncludedInAllTexturePaths()
+        {
+            var paths = TexturePath.GetAllTexturePaths();
+
+            Assert.Contains(TexturePath.ResultBackgroundRankSS, paths);
+            Assert.Contains(TexturePath.ResultBackgroundRankS, paths);
+            Assert.Contains(TexturePath.ResultBackgroundRankA, paths);
+            Assert.Contains(TexturePath.ResultBackgroundRankB, paths);
+            Assert.Contains(TexturePath.ResultBackgroundRankC, paths);
+            Assert.Contains(TexturePath.ResultBackgroundRankD, paths);
+            Assert.Contains(TexturePath.ResultBackgroundRankE, paths);
+            Assert.Contains(TexturePath.ResultRankSS, paths);
+            Assert.Contains(TexturePath.ResultRankS, paths);
+            Assert.Contains(TexturePath.ResultRankA, paths);
+            Assert.Contains(TexturePath.ResultRankB, paths);
+            Assert.Contains(TexturePath.ResultRankC, paths);
+            Assert.Contains(TexturePath.ResultRankD, paths);
+            Assert.Contains(TexturePath.ResultRankE, paths);
+            Assert.Contains(TexturePath.ResultPlateStageCleared, paths);
+            Assert.Contains(TexturePath.ResultPlateFullCombo, paths);
+            Assert.Contains(TexturePath.ResultPlateExcellent, paths);
+            Assert.Contains(TexturePath.ResultJacketPanel, paths);
+            Assert.Contains(TexturePath.ResultSkillPanel, paths);
+            Assert.Contains(TexturePath.ResultNewRecord, paths);
+            Assert.Contains(TexturePath.ResultDefaultPreview, paths);
+        }
+
+        #endregion
+
         #region Font Texture Constants
 
         [Fact]
@@ -228,6 +286,7 @@ namespace DTXMania.Test.Resources
             Assert.Contains(TexturePath.HitBar, paths);
             Assert.Contains(TexturePath.GaugeFrame, paths);
             Assert.Contains(TexturePath.JudgeStrings, paths);
+            Assert.Contains(TexturePath.SkillPanel, paths);
             Assert.Contains(TexturePath.PadCaps, paths);
         }
 
@@ -239,11 +298,17 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
-        public void GetAllTexturePaths_ShouldNotContainDuplicates()
+        public void GetAllTexturePaths_ShouldOnlyDuplicateSharedResultSkillPanelAsset()
         {
             var paths = TexturePath.GetAllTexturePaths();
-            var uniquePaths = paths.Distinct().ToArray();
-            Assert.Equal(paths.Length, uniquePaths.Length);
+            var duplicatePaths = paths
+                .GroupBy(path => path)
+                .Where(group => group.Count() > 1)
+                .Select(group => group.Key)
+                .ToArray();
+
+            Assert.Equal(new[] { TexturePath.SkillPanel }, duplicatePaths);
+            Assert.Equal(TexturePath.SkillPanel, TexturePath.ResultSkillPanel);
         }
 
         #endregion

--- a/DTXMania.Test/Resources/TexturePathTests.cs
+++ b/DTXMania.Test/Resources/TexturePathTests.cs
@@ -185,17 +185,10 @@ namespace DTXMania.Test.Resources
         }
 
         [Fact]
-        public void ResultStageAssets_ShouldBeIncludedInAllTexturePaths()
+        public void ResultStageRequiredAssets_ShouldBeIncludedInAllTexturePaths()
         {
             var paths = TexturePath.GetAllTexturePaths();
 
-            Assert.Contains(TexturePath.ResultBackgroundRankSS, paths);
-            Assert.Contains(TexturePath.ResultBackgroundRankS, paths);
-            Assert.Contains(TexturePath.ResultBackgroundRankA, paths);
-            Assert.Contains(TexturePath.ResultBackgroundRankB, paths);
-            Assert.Contains(TexturePath.ResultBackgroundRankC, paths);
-            Assert.Contains(TexturePath.ResultBackgroundRankD, paths);
-            Assert.Contains(TexturePath.ResultBackgroundRankE, paths);
             Assert.Contains(TexturePath.ResultRankSS, paths);
             Assert.Contains(TexturePath.ResultRankS, paths);
             Assert.Contains(TexturePath.ResultRankA, paths);
@@ -210,6 +203,37 @@ namespace DTXMania.Test.Resources
             Assert.Contains(TexturePath.ResultSkillPanel, paths);
             Assert.Contains(TexturePath.ResultNewRecord, paths);
             Assert.Contains(TexturePath.ResultDefaultPreview, paths);
+        }
+
+        [Fact]
+        public void ResultStageOptionalBackgrounds_ShouldBeExcludedFromAllTexturePaths()
+        {
+            var paths = TexturePath.GetAllTexturePaths();
+
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankSS, paths);
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankS, paths);
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankA, paths);
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankB, paths);
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankC, paths);
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankD, paths);
+            Assert.DoesNotContain(TexturePath.ResultBackgroundRankE, paths);
+        }
+
+        [Fact]
+        public void GetOptionalResultTexturePaths_ShouldContainOnlyOptionalRankBackgrounds()
+        {
+            var paths = TexturePath.GetOptionalResultTexturePaths();
+
+            Assert.Equal(new[]
+            {
+                TexturePath.ResultBackgroundRankSS,
+                TexturePath.ResultBackgroundRankS,
+                TexturePath.ResultBackgroundRankA,
+                TexturePath.ResultBackgroundRankB,
+                TexturePath.ResultBackgroundRankC,
+                TexturePath.ResultBackgroundRankD,
+                TexturePath.ResultBackgroundRankE
+            }, paths);
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Result/ResultRevealStateTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultRevealStateTests.cs
@@ -1,0 +1,112 @@
+#nullable enable
+
+using DTXMania.Game.Lib.Stage.Result;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Result
+{
+    [Trait("Category", "Unit")]
+    public class ResultRevealStateTests
+    {
+        [Fact]
+        public void NewState_ShouldStartAtZeroProgress()
+        {
+            var state = new ResultRevealState();
+
+            Assert.Equal(0.0, state.ElapsedSeconds);
+            Assert.Equal(0.0f, state.RankProgress);
+            Assert.Equal(0.0f, state.PanelProgress);
+            Assert.False(state.IsComplete);
+        }
+
+        [Fact]
+        public void Update_ShouldAdvanceRankBeforePanel()
+        {
+            var state = new ResultRevealState();
+
+            state.Update(ResultRevealState.RankRevealSeconds / 2.0);
+
+            Assert.InRange(state.RankProgress, 0.49f, 0.51f);
+            Assert.Equal(0.0f, state.PanelProgress);
+            Assert.False(state.IsComplete);
+        }
+
+        [Fact]
+        public void Update_AfterRankAndDelay_ShouldAdvancePanel()
+        {
+            var state = new ResultRevealState();
+
+            state.Update(
+                ResultRevealState.RankRevealSeconds
+                + ResultRevealState.PanelDelaySeconds
+                + ResultRevealState.PanelRevealSeconds / 2.0);
+
+            Assert.Equal(1.0f, state.RankProgress);
+            Assert.InRange(state.PanelProgress, 0.49f, 0.51f);
+            Assert.False(state.IsComplete);
+        }
+
+        [Fact]
+        public void Update_PastTotalDuration_ShouldClampAndComplete()
+        {
+            var state = new ResultRevealState();
+
+            state.Update(ResultRevealState.TotalRevealSeconds + 10.0);
+
+            Assert.Equal(ResultRevealState.TotalRevealSeconds, state.ElapsedSeconds);
+            Assert.Equal(1.0f, state.RankProgress);
+            Assert.Equal(1.0f, state.PanelProgress);
+            Assert.True(state.IsComplete);
+        }
+
+        [Fact]
+        public void Update_WithNegativeDelta_ShouldNotMoveBackwards()
+        {
+            var state = new ResultRevealState();
+
+            state.Update(0.25);
+            state.Update(-1.0);
+
+            Assert.Equal(0.25, state.ElapsedSeconds);
+        }
+
+        [Fact]
+        public void Update_WithZeroDelta_ShouldNotAdvance()
+        {
+            var state = new ResultRevealState();
+
+            state.Update(0.0);
+
+            Assert.Equal(0.0, state.ElapsedSeconds);
+            Assert.Equal(0.0f, state.RankProgress);
+            Assert.Equal(0.0f, state.PanelProgress);
+        }
+
+        [Fact]
+        public void Complete_ShouldJumpToEnd()
+        {
+            var state = new ResultRevealState();
+
+            state.Complete();
+
+            Assert.Equal(ResultRevealState.TotalRevealSeconds, state.ElapsedSeconds);
+            Assert.True(state.IsComplete);
+            Assert.Equal(1.0f, state.RankProgress);
+            Assert.Equal(1.0f, state.PanelProgress);
+        }
+
+        [Fact]
+        public void Reset_ShouldReturnToBeginning()
+        {
+            var state = new ResultRevealState();
+            state.Complete();
+
+            state.Reset();
+
+            Assert.Equal(0.0, state.ElapsedSeconds);
+            Assert.Equal(0.0f, state.RankProgress);
+            Assert.Equal(0.0f, state.PanelProgress);
+            Assert.False(state.IsComplete);
+        }
+    }
+}

--- a/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
@@ -213,6 +213,21 @@ public class ResultScreenModelTests
     }
 
     [Fact]
+    public void Create_WithBackslashPreviewImage_ShouldNormalizeRelativePreviewPath()
+    {
+        var chartDirectory = Path.Combine(Path.GetTempPath(), "dtx-result-test");
+        var chart = new SongChart
+        {
+            FilePath = Path.Combine(chartDirectory, "chart.dtx"),
+            PreviewImage = @"Graphics\jacket.png"
+        };
+
+        var model = ResultScreenModel.Create(Summary(), null, 0, chart, null);
+
+        Assert.Equal(Path.Combine(chartDirectory, "Graphics", "jacket.png"), model.PreviewImagePath);
+    }
+
+    [Fact]
     public void Create_WithoutPreviewImage_ShouldUseDefaultPreview()
     {
         var model = ResultScreenModel.Create(Summary(), null, 0, null, null);

--- a/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
@@ -389,6 +389,23 @@ public class ResultScreenModelTests
         Assert.False(model.NewRecord);
     }
 
+    [Theory]
+    [InlineData(0, 0, "--")]
+    [InlineData(-1, 0, "--")]
+    [InlineData(120, 0, "1.20")]
+    [InlineData(100, 0, "1.00")]
+    [InlineData(78, 33, "8.13")]
+    [InlineData(50, 0, "5.00")]
+    [InlineData(55, 50, "6.00")]
+    [InlineData(10, 99, "1.99")]
+    [InlineData(99, 99, "10.89")]
+    [InlineData(1, 0, "0.10")]
+    [InlineData(50, -1, "5.00")]
+    public void FormatLevel_ShouldHandleBothEncodingSchemes(int level, int levelDec, string expected)
+    {
+        Assert.Equal(expected, ResultScreenModel.FormatLevel(level, levelDec));
+    }
+
     private static PerformanceSummary Summary(
         int score = 0,
         int maxCombo = 0,

--- a/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
@@ -1,0 +1,374 @@
+using System.IO;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
+using Xunit;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage.Result;
+
+[Trait("Category", "Unit")]
+public class ResultScreenModelTests
+{
+    [Theory]
+    [InlineData(95.0, ResultRank.SS, "SS")]
+    [InlineData(94.99, ResultRank.S, "S")]
+    [InlineData(80.0, ResultRank.S, "S")]
+    [InlineData(79.99, ResultRank.A, "A")]
+    [InlineData(73.0, ResultRank.A, "A")]
+    [InlineData(72.99, ResultRank.B, "B")]
+    [InlineData(63.0, ResultRank.B, "B")]
+    [InlineData(62.99, ResultRank.C, "C")]
+    [InlineData(53.0, ResultRank.C, "C")]
+    [InlineData(52.99, ResultRank.D, "D")]
+    [InlineData(45.0, ResultRank.D, "D")]
+    [InlineData(44.99, ResultRank.E, "E")]
+    public void Create_ShouldComputeNXRankFromPlayingSkill(double skill, ResultRank expectedRank, string expectedLabel)
+    {
+        var model = ResultScreenModel.Create(
+            Summary(playingSkill: skill, totalNotes: 100),
+            selectedSong: null,
+            selectedDifficulty: 0,
+            chart: null,
+            previousScore: null);
+
+        Assert.Equal(expectedRank, model.Rank);
+        Assert.Equal(expectedLabel, model.RankLabel);
+    }
+
+    [Fact]
+    public void Create_AllPerfect_ShouldSelectExcellentPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 100, totalNotes: 100, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.Excellent, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_ClearNoPoorNoMiss_ShouldSelectFullComboPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 90, great: 10, totalNotes: 100, poor: 0, miss: 0, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.FullCombo, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_ClearWithMiss_ShouldSelectStageClearedPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 90, great: 9, miss: 1, totalNotes: 100, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.StageCleared, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_NotClear_ShouldSelectFailedPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 20, miss: 80, totalNotes: 100, clear: false),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.Failed, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_ShouldFormatCoreValues()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(
+                score: 123456,
+                maxCombo: 87,
+                perfect: 70,
+                great: 20,
+                good: 5,
+                poor: 3,
+                miss: 2,
+                totalNotes: 100,
+                playingSkill: 76.543,
+                gameSkill: 133.456,
+                level: 78,
+                levelDec: 33),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal("0123456", model.ScoreText);
+        Assert.Equal("87", model.MaxComboText);
+        Assert.Equal("70", model.PerfectCountText);
+        Assert.Equal("70%", model.PerfectPercentText);
+        Assert.Equal("20", model.GreatCountText);
+        Assert.Equal("20%", model.GreatPercentText);
+        Assert.Equal("5", model.GoodCountText);
+        Assert.Equal("5%", model.GoodPercentText);
+        Assert.Equal("3", model.PoorCountText);
+        Assert.Equal("3%", model.PoorPercentText);
+        Assert.Equal("2", model.MissCountText);
+        Assert.Equal("2%", model.MissPercentText);
+        Assert.Equal("87%", model.MaxComboPercentText);
+        Assert.Equal("76.54", model.PlayingSkillText);
+        Assert.Equal("133.46", model.GameSkillText);
+        Assert.Equal("8.13", model.ChartLevelText);
+    }
+
+    [Fact]
+    public void Create_NegativeValues_ShouldFormatAsZero()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(
+                score: -1,
+                maxCombo: -1,
+                perfect: -1,
+                great: -1,
+                good: -1,
+                poor: -1,
+                miss: -1,
+                totalNotes: 100,
+                playingSkill: -1.0,
+                gameSkill: -1.0),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal("0000000", model.ScoreText);
+        Assert.Equal("0", model.MaxComboText);
+        Assert.Equal("0", model.PerfectCountText);
+        Assert.Equal("0%", model.PerfectPercentText);
+        Assert.Equal("0.00", model.PlayingSkillText);
+        Assert.Equal("0.00", model.GameSkillText);
+    }
+
+    [Fact]
+    public void Create_NoTotalNotes_ShouldFormatZeroPercents()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 1, great: 1, totalNotes: 0),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal("0%", model.PerfectPercentText);
+        Assert.Equal("0%", model.GreatPercentText);
+        Assert.Equal("0%", model.MaxComboPercentText);
+    }
+
+    [Fact]
+    public void Create_WithSongAndChart_ShouldUseMetadataAndPreviewPath()
+    {
+        var chartDirectory = Path.Combine(Path.GetTempPath(), "dtx-result-test");
+        var chart = new SongChart
+        {
+            FilePath = Path.Combine(chartDirectory, "chart.dtx"),
+            PreviewImage = "jacket.png",
+            DrumLevel = 80,
+            DrumLevelDec = 50
+        };
+        var song = new SongListNode
+        {
+            Title = "Fallback Title",
+            DatabaseSong = new SongEntity { Title = "Song Title", Artist = "Song Artist" },
+            DatabaseChart = chart
+        };
+
+        var model = ResultScreenModel.Create(Summary(), song, 0, chart, null);
+
+        Assert.Equal("Song Title", model.Title);
+        Assert.Equal("Song Artist", model.Artist);
+        Assert.Equal(Path.Combine(chartDirectory, "jacket.png"), model.PreviewImagePath);
+        Assert.Equal("8.50", model.ChartLevelText);
+    }
+
+    [Fact]
+    public void Create_WithoutPreviewImage_ShouldUseDefaultPreview()
+    {
+        var model = ResultScreenModel.Create(Summary(), null, 0, null, null);
+
+        Assert.Equal(TexturePath.ResultDefaultPreview, model.PreviewImagePath);
+    }
+
+    [Fact]
+    public void Create_WithRootedPreviewImage_ShouldKeepPreviewPath()
+    {
+        var rootedPath = Path.Combine(Path.GetTempPath(), "rooted-jacket.png");
+        var chart = new SongChart
+        {
+            FilePath = Path.Combine(Path.GetTempPath(), "chart.dtx"),
+            PreviewImage = rootedPath
+        };
+
+        var model = ResultScreenModel.Create(Summary(), null, 0, chart, null);
+
+        Assert.Equal(rootedPath, model.PreviewImagePath);
+    }
+
+    [Fact]
+    public void Create_WithoutSongMetadata_ShouldUseStableFallbacks()
+    {
+        var model = ResultScreenModel.Create(Summary(), new SongListNode(), 0, null, null);
+
+        Assert.Equal("Unknown Song", model.Title);
+        Assert.Equal("Unknown Artist", model.Artist);
+        Assert.Equal("--", model.ChartLevelText);
+    }
+
+    [Fact]
+    public void Create_WithNodeTitleOnly_ShouldUseNodeTitleAndArtistFallback()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(),
+            new SongListNode { Title = "Node Title" },
+            0,
+            null,
+            null);
+
+        Assert.Equal("Node Title", model.Title);
+        Assert.Equal("Unknown Artist", model.Artist);
+    }
+
+    [Fact]
+    public void Create_WithNoPreviousScore_ShouldDetectNewRecord()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(score: 1, gameSkill: 1.0),
+            null,
+            0,
+            null,
+            previousScore: null);
+
+        Assert.True(model.NewRecord);
+    }
+
+    [Fact]
+    public void Create_WithUnplayedPreviousScore_ShouldDetectNewRecord()
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 0,
+            BestScore = 9999999,
+            HighSkill = 999.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: 0, gameSkill: 0.0),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.True(model.NewRecord);
+    }
+
+    [Fact]
+    public void Create_WithPreviousScore_ShouldDetectNewRecord()
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 4,
+            BestScore = 500000,
+            HighSkill = 90.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: 500001, gameSkill: 89.0),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.True(model.NewRecord);
+    }
+
+    [Fact]
+    public void Create_WithPreviousHighSkill_ShouldDetectNewRecord()
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 4,
+            BestScore = 500000,
+            HighSkill = 90.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: 500000, gameSkill: 90.01),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.True(model.NewRecord);
+    }
+
+    [Fact]
+    public void Create_WithPreviousBetterScoreAndSkill_ShouldNotMarkNewRecord()
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 4,
+            BestScore = 900000,
+            HighSkill = 200.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: 800000, gameSkill: 199.0),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.False(model.NewRecord);
+    }
+
+    private static PerformanceSummary Summary(
+        int score = 0,
+        int maxCombo = 0,
+        bool clear = true,
+        int perfect = 0,
+        int great = 0,
+        int good = 0,
+        int poor = 0,
+        int miss = 0,
+        int totalNotes = 0,
+        double playingSkill = 0.0,
+        double gameSkill = 0.0,
+        int level = 0,
+        int levelDec = 0)
+    {
+        return new PerformanceSummary
+        {
+            Score = score,
+            MaxCombo = maxCombo,
+            ClearFlag = clear,
+            PerfectCount = perfect,
+            GreatCount = great,
+            GoodCount = good,
+            PoorCount = poor,
+            MissCount = miss,
+            TotalNotes = totalNotes,
+            PlayingSkill = playingSkill,
+            GameSkill = gameSkill,
+            ChartLevel = level,
+            ChartLevelDec = levelDec
+        };
+    }
+}

--- a/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
@@ -65,6 +65,19 @@ public class ResultScreenModelTests
     }
 
     [Fact]
+    public void Create_PerfectCountAboveTotal_ShouldNotSelectExcellentPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 101, totalNotes: 100, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.FullCombo, model.PlateKind);
+    }
+
+    [Fact]
     public void Create_ClearWithMiss_ShouldSelectStageClearedPlate()
     {
         var model = ResultScreenModel.Create(
@@ -247,7 +260,7 @@ public class ResultScreenModelTests
     }
 
     [Fact]
-    public void Create_WithNoPreviousScore_ShouldDetectNewRecord()
+    public void Create_WithNoPreviousScore_ShouldNotDetectNewRecord()
     {
         var model = ResultScreenModel.Create(
             Summary(score: 1, gameSkill: 1.0),
@@ -256,11 +269,11 @@ public class ResultScreenModelTests
             null,
             previousScore: null);
 
-        Assert.True(model.NewRecord);
+        Assert.False(model.NewRecord);
     }
 
     [Fact]
-    public void Create_WithUnplayedPreviousScore_ShouldDetectNewRecord()
+    public void Create_WithUnplayedPreviousScoreAndZeroResult_ShouldNotDetectNewRecord()
     {
         var previous = new SongScore
         {
@@ -271,6 +284,28 @@ public class ResultScreenModelTests
 
         var model = ResultScreenModel.Create(
             Summary(score: 0, gameSkill: 0.0),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.False(model.NewRecord);
+    }
+
+    [Theory]
+    [InlineData(1, 0.0)]
+    [InlineData(0, 1.0)]
+    public void Create_WithUnplayedPreviousScoreAndPositiveResult_ShouldDetectNewRecord(int score, double gameSkill)
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 0,
+            BestScore = 9999999,
+            HighSkill = 999.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: score, gameSkill: gameSkill),
             null,
             0,
             null,

--- a/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
@@ -406,6 +406,41 @@ public class ResultScreenModelTests
         Assert.Equal(expected, ResultScreenModel.FormatLevel(level, levelDec));
     }
 
+    [Fact]
+    public void Create_WithWindowsAbsolutePathPreview_ShouldKeepPreviewPath()
+    {
+        var chart = new SongChart
+        {
+            FilePath = "/some/chart.dtx",
+            PreviewImage = @"C:\Jackets\art.png"
+        };
+
+        var model = ResultScreenModel.Create(Summary(), null, 0, chart, null);
+
+        // On any OS, a Windows-style absolute path (C:\...) should be detected as rooted
+        Assert.Equal(@"C:\Jackets\art.png".Replace('\\', Path.DirectorySeparatorChar), model.PreviewImagePath);
+    }
+
+    [Fact]
+    public void FormatPercent_MidpointValue_ShouldRoundAwayFromZero()
+    {
+        // 1/8 = 12.5% → MidpointRounding.AwayFromZero → 13%
+        Assert.Equal("13%", ResultScreenModel.FormatPercent(1, 8));
+    }
+
+    [Fact]
+    public void FormatPercent_ValueExceeds100Percent_ShouldClampTo100()
+    {
+        // 150 out of 100 notes = 150%, clamped to 100%
+        Assert.Equal("100%", ResultScreenModel.FormatPercent(150, 100));
+    }
+
+    [Fact]
+    public void FormatScore_AboveUpperClamp_ShouldClampTo9999999()
+    {
+        Assert.Equal("9999999", ResultScreenModel.FormatScore(10_000_000));
+    }
+
     private static PerformanceSummary Summary(
         int score = 0,
         int maxCombo = 0,

--- a/DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs
@@ -234,6 +234,142 @@ public class ResultScreenRendererTests
         secondTexture.Verify(t => t.RemoveReference(), Times.AtLeastOnce);
     }
 
+    [Fact]
+    public void ApplyPanelTransparency_ShouldScaleAndRestoreTransparency()
+    {
+        // Use distinct mock textures to simulate production behavior where
+        // each texture slot holds a different object.
+        var resources = new Mock<IResourceManager>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+
+        // Track per-path textures so we can verify the panel-specific ones
+        var pathToTexture = new Dictionary<string, Mock<ITexture>>();
+        resources
+            .Setup(r => r.LoadTexture(It.IsAny<string>()))
+            .Returns<string>(path =>
+            {
+                var tex = new Mock<ITexture>();
+                tex.SetupProperty(t => t.Transparency, 255);
+                pathToTexture[path] = tex;
+                return tex.Object;
+            });
+
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary
+            {
+                ClearFlag = true,
+                PerfectCount = 100,
+                TotalNotes = 100,
+                PlayingSkill = 100.0,
+                Score = 1
+            },
+            null,
+            0,
+            null,
+            new SongScore { PlayCount = 1, BestScore = 0, HighSkill = 0.0 });
+        renderer.Load(model);
+
+        var applyMethod = typeof(ResultScreenRenderer).GetMethod(
+            "ApplyPanelTransparency", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var restoreMethod = typeof(ResultScreenRenderer).GetMethod(
+            "RestorePanelTransparency", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Apply 50% alpha
+        applyMethod!.Invoke(renderer, new object[] { 128 });
+
+        // Panel textures should have transparency scaled to ~128
+        var panelPaths = new[]
+        {
+            TexturePath.ResultPlateExcellent, // SS → Excellent plate
+            TexturePath.ResultJacketPanel,
+            TexturePath.ResultDefaultPreview,
+            TexturePath.ResultSkillPanel,
+            TexturePath.ResultNewRecord,
+        };
+        foreach (var path in panelPaths)
+        {
+            if (pathToTexture.TryGetValue(path, out var tex))
+            {
+                Assert.InRange(tex.Object.Transparency, 120, 136);
+            }
+        }
+
+        restoreMethod!.Invoke(renderer, null);
+
+        // All panel textures should be restored to 255
+        foreach (var path in panelPaths)
+        {
+            if (pathToTexture.TryGetValue(path, out var tex))
+            {
+                Assert.Equal(255, tex.Object.Transparency);
+            }
+        }
+
+        renderer.Dispose();
+    }
+
+    [Fact]
+    public void ApplyPanelTransparency_ZeroAlpha_ShouldSetZeroTransparency()
+    {
+        var resources = new Mock<IResourceManager>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+
+        var pathToTexture = new Dictionary<string, Mock<ITexture>>();
+        resources
+            .Setup(r => r.LoadTexture(It.IsAny<string>()))
+            .Returns<string>(path =>
+            {
+                var tex = new Mock<ITexture>();
+                tex.SetupProperty(t => t.Transparency, 255);
+                pathToTexture[path] = tex;
+                return tex.Object;
+            });
+
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = true, TotalNotes = 10 },
+            null,
+            0,
+            null,
+            null);
+        renderer.Load(model);
+
+        var applyMethod = typeof(ResultScreenRenderer).GetMethod(
+            "ApplyPanelTransparency", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var restoreMethod = typeof(ResultScreenRenderer).GetMethod(
+            "RestorePanelTransparency", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        // Apply zero alpha
+        applyMethod!.Invoke(renderer, new object[] { 0 });
+
+        // Plate texture (FullCombo) should be at transparency 0
+        Assert.True(pathToTexture.ContainsKey(TexturePath.ResultPlateFullCombo),
+            $"Expected plate path not found. Actual paths: {string.Join(", ", pathToTexture.Keys)}");
+        Assert.Equal(0, pathToTexture[TexturePath.ResultPlateFullCombo].Object.Transparency);
+
+        restoreMethod!.Invoke(renderer, null);
+
+        // Should be restored to 255
+        Assert.Equal(255, pathToTexture[TexturePath.ResultPlateFullCombo].Object.Transparency);
+
+        renderer.Dispose();
+    }
+
+    [Fact]
+    public void RestorePanelTransparency_WithoutApply_ShouldNotThrow()
+    {
+        var resources = new Mock<IResourceManager>();
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+
+        var restoreMethod = typeof(ResultScreenRenderer).GetMethod(
+            "RestorePanelTransparency", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        var exception = CaptureException(() => restoreMethod!.Invoke(renderer, null));
+
+        Assert.Null(exception);
+    }
+
     private static Exception? CaptureException(Action action)
     {
         try

--- a/DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs
+++ b/DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs
@@ -1,0 +1,249 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Result;
+
+[Trait("Category", "Unit")]
+public class ResultScreenRendererTests
+{
+    [Fact]
+    public void CreateViewportTransform_ExactNXSize_ShouldUseIdentityScale()
+    {
+        var matrix = ResultScreenRenderer.CreateViewportTransform(new Viewport(0, 0, 1280, 720));
+
+        Assert.Equal(1.0f, matrix.M11, 3);
+        Assert.Equal(1.0f, matrix.M22, 3);
+        Assert.Equal(0.0f, matrix.M41, 3);
+        Assert.Equal(0.0f, matrix.M42, 3);
+    }
+
+    [Fact]
+    public void CreateViewportTransform_FourByThreeViewport_ShouldLetterboxVertically()
+    {
+        var matrix = ResultScreenRenderer.CreateViewportTransform(new Viewport(0, 0, 1024, 768));
+
+        Assert.Equal(0.8f, matrix.M11, 3);
+        Assert.Equal(0.8f, matrix.M22, 3);
+        Assert.Equal(0.0f, matrix.M41, 3);
+        Assert.Equal(96.0f, matrix.M42, 3);
+    }
+
+    [Fact]
+    public void CreateViewportTransform_UltrawideViewport_ShouldPillarboxHorizontally()
+    {
+        var matrix = ResultScreenRenderer.CreateViewportTransform(new Viewport(0, 0, 1920, 720));
+
+        Assert.Equal(1.0f, matrix.M11, 3);
+        Assert.Equal(1.0f, matrix.M22, 3);
+        Assert.Equal(320.0f, matrix.M41, 3);
+        Assert.Equal(0.0f, matrix.M42, 3);
+    }
+
+    [Fact]
+    public void Load_ExcellentSSModel_ShouldLoadNXStructuralPaths()
+    {
+        var resources = new Mock<IResourceManager>();
+        var loadedPaths = new List<string>();
+        var texture = new Mock<ITexture>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources
+            .Setup(r => r.LoadTexture(It.IsAny<string>()))
+            .Callback<string>(loadedPaths.Add)
+            .Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary
+            {
+                ClearFlag = true,
+                PerfectCount = 100,
+                TotalNotes = 100,
+                PlayingSkill = 100.0,
+                Score = 1
+            },
+            null,
+            0,
+            null,
+            new SongScore { PlayCount = 1, BestScore = 0, HighSkill = 0.0 });
+
+        renderer.Load(model);
+
+        Assert.Contains(TexturePath.ResultBackground, loadedPaths);
+        Assert.Contains(TexturePath.ResultBackgroundRankSS, loadedPaths);
+        Assert.Contains(TexturePath.ResultRankSS, loadedPaths);
+        Assert.Contains(TexturePath.ResultPlateExcellent, loadedPaths);
+        Assert.Contains(TexturePath.ResultJacketPanel, loadedPaths);
+        Assert.Contains(TexturePath.ResultSkillPanel, loadedPaths);
+        Assert.Contains(TexturePath.ResultDefaultPreview, loadedPaths);
+        Assert.Contains(TexturePath.ResultNewRecord, loadedPaths);
+    }
+
+    [Fact]
+    public void Load_FailedPlate_ShouldNotLoadClearPlateTextures()
+    {
+        var resources = new Mock<IResourceManager>();
+        var texture = new Mock<ITexture>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = false, MissCount = 1, TotalNotes = 1 },
+            null,
+            0,
+            null,
+            null);
+
+        renderer.Load(model);
+
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateExcellent), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateFullCombo), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateStageCleared), Times.Never);
+    }
+
+    [Fact]
+    public void Load_MissingOptionalAssets_ShouldNotThrowOrLoadMissingPaths()
+    {
+        var resources = new Mock<IResourceManager>();
+        var texture = new Mock<ITexture>();
+        resources
+            .Setup(r => r.ResourceExists(It.IsAny<string>()))
+            .Returns<string>(path => path != TexturePath.ResultBackgroundRankS
+                && path != TexturePath.ResultNewRecord);
+        resources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary
+            {
+                ClearFlag = true,
+                PerfectCount = 80,
+                GreatCount = 20,
+                TotalNotes = 100,
+                PlayingSkill = 80.0,
+                Score = 1
+            },
+            null,
+            0,
+            null,
+            new SongScore { PlayCount = 1, BestScore = 0, HighSkill = 0.0 });
+
+        var exception = CaptureException(() => renderer.Load(model));
+
+        Assert.Null(exception);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultBackgroundRankS), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultNewRecord), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultRankS), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateFullCombo), Times.Once);
+    }
+
+    [Fact]
+    public void Load_LoadTextureFailure_ShouldNotThrow()
+    {
+        var resources = new Mock<IResourceManager>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources
+            .Setup(r => r.LoadTexture(TexturePath.ResultBackgroundRankA))
+            .Throws(new InvalidOperationException("missing optional rank background"));
+        resources
+            .Setup(r => r.LoadTexture(It.Is<string>(path => path != TexturePath.ResultBackgroundRankA)))
+            .Returns(new Mock<ITexture>().Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary
+            {
+                ClearFlag = true,
+                PerfectCount = 73,
+                GreatCount = 27,
+                TotalNotes = 100,
+                PlayingSkill = 73.0
+            },
+            null,
+            0,
+            null,
+            null);
+
+        var exception = CaptureException(() => renderer.Load(model));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Load_MissingPreview_ShouldLoadDefaultPreviewFallback()
+    {
+        var chartDirectory = Path.Combine(Path.GetTempPath(), "dtx-result-renderer");
+        var previewPath = Path.Combine(chartDirectory, "custom.png");
+        var resources = new Mock<IResourceManager>();
+        var texture = new Mock<ITexture>();
+        resources
+            .Setup(r => r.ResourceExists(It.IsAny<string>()))
+            .Returns<string>(path => path != previewPath);
+        resources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = true, TotalNotes = 10 },
+            null,
+            0,
+            new SongChart
+            {
+                FilePath = Path.Combine(chartDirectory, "chart.dtx"),
+                PreviewImage = "custom.png"
+            },
+            null);
+
+        renderer.Load(model);
+
+        resources.Verify(r => r.LoadTexture(previewPath), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultDefaultPreview), Times.Once);
+    }
+
+    [Fact]
+    public void Load_ReloadAndDispose_ShouldReleaseLoadedTextures()
+    {
+        var resources = new Mock<IResourceManager>();
+        var firstTexture = new Mock<ITexture>(MockBehavior.Strict);
+        var secondTexture = new Mock<ITexture>(MockBehavior.Strict);
+        firstTexture.Setup(t => t.RemoveReference());
+        secondTexture.Setup(t => t.RemoveReference());
+        var loadCount = 0;
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources
+            .Setup(r => r.LoadTexture(It.IsAny<string>()))
+            .Returns(() => loadCount++ == 0 ? firstTexture.Object : secondTexture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = true, PerfectCount = 10, TotalNotes = 10 },
+            null,
+            0,
+            null,
+            null);
+
+        renderer.Load(model);
+        renderer.Load(model);
+        renderer.Dispose();
+
+        firstTexture.Verify(t => t.RemoveReference(), Times.Once);
+        secondTexture.Verify(t => t.RemoveReference(), Times.AtLeastOnce);
+    }
+
+    private static Exception? CaptureException(Action action)
+    {
+        try
+        {
+            action();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+}

--- a/DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs
@@ -7,6 +7,7 @@ using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Moq;
@@ -41,6 +42,7 @@ public class ResultStageAdditionalCoverageTests
         SetPrivateField(stage, "_game", game);
         var stageManager = new Mock<IStageManager>();
         stage.StageManager = stageManager.Object;
+        CompleteReveal(stage);
 
         var command = new DTXMania.Game.Lib.Input.InputCommand(
             DTXMania.Game.Lib.Input.InputCommandType.Activate, 0.0);
@@ -65,6 +67,7 @@ public class ResultStageAdditionalCoverageTests
         SetPrivateField(stage, "_game", game);
         var stageManager = new Mock<IStageManager>();
         stage.StageManager = stageManager.Object;
+        CompleteReveal(stage);
 
         var command = new DTXMania.Game.Lib.Input.InputCommand(
             DTXMania.Game.Lib.Input.InputCommandType.Back, 0.0);
@@ -89,6 +92,7 @@ public class ResultStageAdditionalCoverageTests
         SetPrivateField(stage, "_game", game);
         var stageManager = new Mock<IStageManager>();
         stage.StageManager = stageManager.Object;
+        CompleteReveal(stage);
 
         var command = new DTXMania.Game.Lib.Input.InputCommand(
             DTXMania.Game.Lib.Input.InputCommandType.Activate, 0.0);
@@ -112,15 +116,36 @@ public class ResultStageAdditionalCoverageTests
         var whitePixel = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
         GC.SuppressFinalize(whitePixel);
         var font = new Mock<IFont>();
+        var smallFont = new Mock<IFont>();
+        var largeFont = new Mock<IFont>();
+        var resultSound = new Mock<ISound>();
+        var newRecordSound = new Mock<ISound>();
+        var resourceManager = new Mock<IResourceManager>();
+        var renderer = new ResultScreenRenderer(resourceManager.Object, null, null, null);
 
         SetPrivateField(stage, "_whitePixel", whitePixel);
         SetPrivateField(stage, "_resultFont", font.Object);
+        SetPrivateField(stage, "_smallResultFont", smallFont.Object);
+        SetPrivateField(stage, "_largeResultFont", largeFont.Object);
+        SetPrivateField(stage, "_resultSound", resultSound.Object);
+        SetPrivateField(stage, "_newRecordSound", newRecordSound.Object);
+        SetPrivateField(stage, "_resultRenderer", renderer);
 
         InvokePrivateMethod(stage, "CleanupComponents");
 
         font.Verify(f => f.RemoveReference(), Times.Once);
+        smallFont.Verify(f => f.RemoveReference(), Times.Once);
+        largeFont.Verify(f => f.RemoveReference(), Times.Once);
+        resultSound.Verify(s => s.RemoveReference(), Times.Once);
+        newRecordSound.Verify(s => s.RemoveReference(), Times.Once);
+        Assert.Throws<ObjectDisposedException>(() => renderer.Load(ResultScreenModel.Create(null, null, 0, null, null)));
         Assert.Null(GetPrivateField<Texture2D>(stage, "_whitePixel"));
         Assert.Null(GetPrivateField<IFont>(stage, "_resultFont"));
+        Assert.Null(GetPrivateField<IFont>(stage, "_smallResultFont"));
+        Assert.Null(GetPrivateField<IFont>(stage, "_largeResultFont"));
+        Assert.Null(GetPrivateField<ISound>(stage, "_resultSound"));
+        Assert.Null(GetPrivateField<ISound>(stage, "_newRecordSound"));
+        Assert.Null(GetPrivateField<ResultScreenRenderer>(stage, "_resultRenderer"));
     }
 
     [Fact]
@@ -179,6 +204,66 @@ public class ResultStageAdditionalCoverageTests
         Assert.True(stage.ResultFontRequested);
     }
 
+    [Fact]
+    public void OnActivate_ShouldBuildModelBeforePersistenceAndInitializeReveal()
+    {
+#pragma warning disable SYSLIB0050
+        var stage = (InspectableNullInputResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableNullInputResultStage));
+#pragma warning restore SYSLIB0050
+        var summary = new PerformanceSummary
+        {
+            Score = 123456,
+            ClearFlag = true,
+            PerfectCount = 10,
+            TotalNotes = 10,
+            PlayingSkill = 100.0,
+            GameSkill = 100.0
+        };
+
+        SetPrivateField(stage, "_inputManager", null);
+        SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+        {
+            ["performanceSummary"] = summary
+        });
+
+        var exception = Record.Exception(() => InvokePrivateMethod(stage, "OnActivate"));
+
+        Assert.Null(exception);
+        Assert.True(stage.ResultFontRequested);
+        Assert.NotNull(GetPrivateField<object>(stage, "_resultModel"));
+        Assert.NotNull(GetPrivateField<object>(stage, "_revealState"));
+    }
+
+    [Fact]
+    public void OnActivate_WhenResultFailed_ShouldNotLoadStageClearSound()
+    {
+#pragma warning disable SYSLIB0050
+        var stage = (InspectableNullInputResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableNullInputResultStage));
+#pragma warning restore SYSLIB0050
+        var resources = new Mock<IResourceManager>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+
+        SetPrivateField(stage, "_resourceManager", resources.Object);
+        SetPrivateField(stage, "_inputManager", null);
+        SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+        {
+            ["performanceSummary"] = new PerformanceSummary
+            {
+                Score = 123456,
+                ClearFlag = false,
+                PerfectCount = 5,
+                TotalNotes = 10,
+                PlayingSkill = 40.0,
+                GameSkill = 40.0
+            }
+        });
+
+        InvokePrivateMethod(stage, "OnActivate");
+
+        resources.Verify(r => r.LoadSound("Sounds/Stage Clear.ogg"), Times.Never);
+        resources.Verify(r => r.LoadSound(It.IsAny<string>()), Times.Never);
+    }
+
     private static SpriteBatch CreateFakeSpriteBatch(int width, int height)
     {
 #pragma warning disable SYSLIB0050
@@ -190,6 +275,13 @@ public class ResultStageAdditionalCoverageTests
         SetPrivateField(spriteBatch, "graphicsDevice", graphicsDevice);
         SetPrivateField(graphicsDevice, "_viewport", new Viewport(0, 0, width, height));
         return spriteBatch;
+    }
+
+    private static void CompleteReveal(ResultStage stage)
+    {
+        var reveal = new ResultRevealState();
+        reveal.Complete();
+        SetPrivateField(stage, "_revealState", reveal);
     }
 
     private sealed class InspectableNullInputResultStage : ResultStage
@@ -208,6 +300,21 @@ public class ResultStageAdditionalCoverageTests
         internal override IFont CreateResultFont()
         {
             ResultFontRequested = true;
+            return null!;
+        }
+
+        internal override IFont CreateSmallResultFont()
+        {
+            return null!;
+        }
+
+        internal override IFont CreateLargeResultFont()
+        {
+            return null!;
+        }
+
+        internal override ResultScreenRenderer CreateResultRenderer()
+        {
             return null!;
         }
     }

--- a/DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs
@@ -235,13 +235,14 @@ public class ResultStageAdditionalCoverageTests
     }
 
     [Fact]
-    public void OnActivate_WhenResultFailed_ShouldNotLoadStageClearSound()
+    public void OnActivate_WhenResultFailed_ShouldLoadStageClearSound()
     {
 #pragma warning disable SYSLIB0050
         var stage = (InspectableNullInputResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableNullInputResultStage));
 #pragma warning restore SYSLIB0050
         var resources = new Mock<IResourceManager>();
         resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources.Setup(r => r.LoadSound(It.IsAny<string>())).Returns(new Mock<ISound>().Object);
 
         SetPrivateField(stage, "_resourceManager", resources.Object);
         SetPrivateField(stage, "_inputManager", null);
@@ -260,8 +261,8 @@ public class ResultStageAdditionalCoverageTests
 
         InvokePrivateMethod(stage, "OnActivate");
 
-        resources.Verify(r => r.LoadSound("Sounds/Stage Clear.ogg"), Times.Never);
-        resources.Verify(r => r.LoadSound(It.IsAny<string>()), Times.Never);
+        // Spec: "Otherwise cleared/failed -> stage-clear sound if available"
+        resources.Verify(r => r.LoadSound("Sounds/Stage Clear.ogg"), Times.Once);
     }
 
     private static SpriteBatch CreateFakeSpriteBatch(int width, int height)

--- a/DTXMania.Test/Stage/ResultStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageCoverageTests.cs
@@ -7,6 +7,7 @@ using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
 using DTXMania.Game.Lib.UI.Layout;
 using static DTXMania.Test.TestData.ReflectionHelpers;
 using Microsoft.Xna.Framework;
@@ -56,115 +57,6 @@ namespace DTXMania.Test.Stage
             Assert.Null(stage.DrawTextureArgument);
             Assert.Null(stage.DrawTextureRectangle);
             Assert.Null(stage.DrawTextureColor);
-        }
-
-        [Fact]
-        public void DrawResultLine_WithNoFont_ShouldDrawFallbackRectangle()
-        {
-#pragma warning disable SYSLIB0050
-            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
-#pragma warning restore SYSLIB0050
-            SetPrivateField(stage, "_spriteBatch", CreateFakeSpriteBatch(800, 600));
-            SetPrivateField(stage, "_resultFont", null);
-            SetPrivateField(stage, "_whitePixel", null);
-
-            object[] args = ["CLEARED", 400, 100, Color.Green, 40];
-            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResultLine", args));
-
-            Assert.Null(exception);
-            Assert.Equal(140, args[2]);
-        }
-
-        [Fact]
-        public void DrawResultLine_WithFont_ShouldMeasureAndDrawCenteredText()
-        {
-#pragma warning disable SYSLIB0050
-            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
-#pragma warning restore SYSLIB0050
-            var spriteBatch = CreateFakeSpriteBatch(800, 600);
-            var font = new Mock<IFont>();
-            font.Setup(f => f.MeasureString("CLEARED")).Returns(new Vector2(120, 20));
-
-            SetPrivateField(stage, "_spriteBatch", spriteBatch);
-            SetPrivateField(stage, "_resultFont", font.Object);
-
-            object[] args = ["CLEARED", 400, 100, Color.Green, 40];
-            InvokePrivateMethod(stage, "DrawResultLine", args);
-
-            font.Verify(f => f.MeasureString("CLEARED"), Times.Once);
-            font.Verify(
-                f => f.DrawString(spriteBatch, "CLEARED", new Vector2(340, 100), Color.Green),
-                Times.Once);
-            Assert.Equal(140, args[2]);
-        }
-
-        [Fact]
-        public void DrawResults_WithNullSummary_ShouldReturnImmediately()
-        {
-#pragma warning disable SYSLIB0050
-            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
-#pragma warning restore SYSLIB0050
-            SetPrivateField(stage, "_performanceSummary", null);
-
-            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResults"));
-
-            Assert.Null(exception);
-        }
-
-        [Fact]
-        public void DrawResults_WithClearedPerformance_ShouldShowCleared()
-        {
-#pragma warning disable SYSLIB0050
-            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
-#pragma warning restore SYSLIB0050
-            SetPrivateField(stage, "_spriteBatch", CreateFakeSpriteBatch(800, 600));
-            SetPrivateField(stage, "_resultFont", null);
-            SetPrivateField(stage, "_whitePixel", null);
-            SetPrivateField(stage, "_performanceSummary", new PerformanceSummary
-            {
-                Score = 950000,
-                MaxCombo = 200,
-                ClearFlag = true,
-                PerfectCount = 100,
-                GreatCount = 50,
-                GoodCount = 20,
-                PoorCount = 5,
-                MissCount = 2,
-                TotalNotes = 177,
-                CompletionReason = CompletionReason.SongComplete
-            });
-
-            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResults"));
-
-            Assert.Null(exception);
-        }
-
-        [Fact]
-        public void DrawResults_WithFailedPerformance_ShouldShowFailed()
-        {
-#pragma warning disable SYSLIB0050
-            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
-#pragma warning restore SYSLIB0050
-            SetPrivateField(stage, "_spriteBatch", CreateFakeSpriteBatch(800, 600));
-            SetPrivateField(stage, "_resultFont", null);
-            SetPrivateField(stage, "_whitePixel", null);
-            SetPrivateField(stage, "_performanceSummary", new PerformanceSummary
-            {
-                Score = 200000,
-                MaxCombo = 50,
-                ClearFlag = false,
-                PerfectCount = 30,
-                GreatCount = 10,
-                GoodCount = 5,
-                PoorCount = 3,
-                MissCount = 40,
-                TotalNotes = 88,
-                CompletionReason = CompletionReason.PlayerFailed
-            });
-
-            var exception = Record.Exception(() => InvokePrivateMethod(stage, "DrawResults"));
-
-            Assert.Null(exception);
         }
 
         [Fact]
@@ -256,6 +148,21 @@ namespace DTXMania.Test.Stage
             internal override IFont CreateResultFont()
             {
                 ResultFontRequested = true;
+                return null!;
+            }
+
+            internal override IFont CreateSmallResultFont()
+            {
+                return null!;
+            }
+
+            internal override IFont CreateLargeResultFont()
+            {
+                return null!;
+            }
+
+            internal override ResultScreenRenderer CreateResultRenderer()
+            {
                 return null!;
             }
 

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -212,6 +212,27 @@ namespace DTXMania.Test.Stage
             Assert.Equal(10, summary.MissCount);
         }
 
+        [Fact]
+        public void ExtractSharedData_WhenSongKeysAreMissing_ShouldClearPreviousSelection()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var previousSong = new SongListNode { Title = "Previous" };
+
+            SetPrivateField(stage, "_selectedSong", previousSong);
+            SetPrivateField(stage, "_selectedDifficulty", 3);
+            SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+            {
+                { PerformanceSummaryKey, new PerformanceSummary { Score = 1000 } }
+            });
+
+            InvokePrivateMethod(stage, "ExtractSharedData");
+
+            Assert.Null(GetPrivateField<SongListNode>(stage, "_selectedSong"));
+            Assert.Equal(0, GetPrivateField<int>(stage, "_selectedDifficulty"));
+        }
+
         #endregion
 
         #region Inheritance and Interface Tests
@@ -369,6 +390,24 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
 
             VerifySongSelectTransition(stage);
+        }
+
+        [Fact]
+        public void HandleInput_WhenTwoNavigationCommandsQueuedAndRevealIncomplete_ShouldCompleteRevealWithoutNavigating()
+        {
+            var stage = CreateUninitializedResultStageWithStageManager();
+            var inputManager = new TrackingInputManager();
+            var reveal = new ResultRevealState();
+
+            inputManager.Enqueue(new InputCommand(InputCommandType.Activate, 0.0));
+            inputManager.Enqueue(new InputCommand(InputCommandType.Back, 0.0));
+            SetPrivateField(stage, "_inputManager", inputManager);
+            SetPrivateField(stage, "_revealState", reveal);
+
+            InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.True(reveal.IsComplete);
+            Assert.False(GetStageManagerMock(stage).Invocations.Any());
         }
 
         [Fact]
@@ -531,6 +570,8 @@ namespace DTXMania.Test.Stage
 
             Assert.Null(exception);
             Assert.True(stage.WhitePixelRequested);
+            Assert.True(inputManager.ClearPendingCommandsCalled);
+            Assert.True(inputManager.ResetKeyRepeatStatesCalled);
             Assert.Empty(inputManager.GetInputCommands());
         }
 
@@ -738,6 +779,8 @@ namespace DTXMania.Test.Stage
         private sealed class TrackingInputManager : InputManager
         {
             public bool UpdateCalled { get; private set; }
+            public bool ClearPendingCommandsCalled { get; private set; }
+            public bool ResetKeyRepeatStatesCalled { get; private set; }
 
             public void Enqueue(InputCommand command)
             {
@@ -748,6 +791,18 @@ namespace DTXMania.Test.Stage
             {
                 UpdateCalled = true;
                 base.Update(deltaTime);
+            }
+
+            public override void ClearPendingCommands()
+            {
+                ClearPendingCommandsCalled = true;
+                base.ClearPendingCommands();
+            }
+
+            public override void ResetKeyRepeatStates()
+            {
+                ResetKeyRepeatStatesCalled = true;
+                base.ResetKeyRepeatStates();
             }
         }
 

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -9,6 +9,7 @@ using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
 using DTXMania.Game.Lib.UI;
 using DTXMania.Game.Lib.UI.Layout;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
@@ -252,6 +253,7 @@ namespace DTXMania.Test.Stage
 
             SetPrivateField(stage, "_game", game);
             stage.StageManager = stageManager.Object;
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new DTXMania.Game.Lib.Input.InputCommand(DTXMania.Game.Lib.Input.InputCommandType.Back, 0.0));
 
@@ -272,6 +274,7 @@ namespace DTXMania.Test.Stage
 
             SetPrivateField(stage, "_game", game);
             stage.StageManager = stageManager.Object;
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new DTXMania.Game.Lib.Input.InputCommand(DTXMania.Game.Lib.Input.InputCommandType.MoveDown, 0.0));
 
@@ -292,6 +295,7 @@ namespace DTXMania.Test.Stage
 
             SetPrivateField(stage, "_game", game);
             stage.StageManager = stageManager.Object;
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new DTXMania.Game.Lib.Input.InputCommand(DTXMania.Game.Lib.Input.InputCommandType.Activate, 0.0));
 
@@ -308,6 +312,7 @@ namespace DTXMania.Test.Stage
         public void ExecuteInputCommand_WhenActivateIsDebounced_ShouldNotChangeStage()
         {
             var stage = CreateUninitializedResultStageWithStageManager(totalGameTime: 0.1, lastStageTransitionTime: 0.0);
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
 
@@ -323,8 +328,45 @@ namespace DTXMania.Test.Stage
         public void ExecuteInputCommand_WhenBackAndTransitionAllowed_ShouldReturnToSongSelect()
         {
             var stage = CreateUninitializedResultStageWithStageManager();
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
+
+            VerifySongSelectTransition(stage);
+        }
+
+        [Theory]
+        [InlineData(InputCommandType.Activate)]
+        [InlineData(InputCommandType.Back)]
+        public void ExecuteInputCommand_WhenRevealIncomplete_ShouldCompleteRevealWithoutNavigating(InputCommandType commandType)
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+            var stageManager = new Mock<IStageManager>();
+            var reveal = new ResultRevealState();
+
+            SetPrivateField(stage, "_game", game);
+            stage.StageManager = stageManager.Object;
+            SetPrivateField(stage, "_revealState", reveal);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(commandType, 0.0));
+
+            Assert.True(reveal.IsComplete);
+            stageManager.Verify(
+                manager => manager.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+                Times.Never);
+            Assert.Equal(0.0, DTXMania.Test.TestData.ReflectionHelpers.GetPrivateField<double>(game, "_lastStageTransitionTime"));
+        }
+
+        [Fact]
+        public void ExecuteInputCommand_WhenRevealAlreadyComplete_ShouldNavigate()
+        {
+            var stage = CreateUninitializedResultStageWithStageManager();
+            CompleteReveal(stage);
+
+            InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
 
             VerifySongSelectTransition(stage);
         }
@@ -338,6 +380,7 @@ namespace DTXMania.Test.Stage
             var stageManager = new Mock<IStageManager>();
 
             stage.StageManager = stageManager.Object;
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Back, 0.0));
 
@@ -362,6 +405,7 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_inputManager", inputManager);
             SetPrivateField(stage, "_uiManager", new UIManager());
             SetPrivateField(stage, "_elapsedTime", 0.0);
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "OnUpdate", 0.25);
 
@@ -385,6 +429,7 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_inputManager", inputManager);
             SetPrivateField(stage, "_uiManager", null);
             SetPrivateField(stage, "_elapsedTime", 0.0);
+            CompleteReveal(stage);
 
             InvokePrivateMethod(stage, "OnUpdate", 0.25);
 
@@ -406,6 +451,35 @@ namespace DTXMania.Test.Stage
             Assert.Null(exception);
             Assert.Equal(0.25, GetPrivateField<double>(stage, "_elapsedTime"));
             Assert.False(GetStageManagerMock(stage).Invocations.Any());
+        }
+
+        [Fact]
+        public void OnUpdate_WhenRevealCompletesAndNewRecordSoundExists_ShouldPlayNewRecordSoundOnce()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var sound = new Mock<ISound>();
+            var model = ResultScreenModel.Create(
+                new PerformanceSummary { Score = 900000, GameSkill = 100.0 },
+                null,
+                0,
+                null,
+                new SongScore { PlayCount = 1, BestScore = 100, HighSkill = 1.0 });
+            var reveal = new ResultRevealState();
+
+            SetPrivateField(stage, "_inputManager", null);
+            SetPrivateField(stage, "_uiManager", new UIManager());
+            SetPrivateField(stage, "_elapsedTime", 0.0);
+            SetPrivateField(stage, "_resultModel", model);
+            SetPrivateField(stage, "_revealState", reveal);
+            SetPrivateField(stage, "_newRecordSound", sound.Object);
+            SetPrivateField(stage, "_newRecordSoundPlayed", false);
+
+            InvokePrivateMethod(stage, "OnUpdate", ResultRevealState.TotalRevealSeconds);
+            InvokePrivateMethod(stage, "OnUpdate", 0.1);
+
+            sound.Verify(s => s.Play(), Times.Once);
         }
 
         [Fact]
@@ -530,20 +604,6 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void DrawResultLine_WhenTextIsEmpty_ShouldNotAdvanceCurrentY()
-        {
-#pragma warning disable SYSLIB0050
-            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
-#pragma warning restore SYSLIB0050
-            var currentY = 120;
-            object[] args = [string.Empty, 400, currentY, Color.White, 32];
-
-            InvokePrivateMethod(stage, "DrawResultLine", args);
-
-            Assert.Equal(120, Assert.IsType<int>(args[2]));
-        }
-
-        [Fact]
         public void CleanupComponents_ShouldDisposeTrackedResourcesAndClearFields()
         {
 #pragma warning disable SYSLIB0050
@@ -551,16 +611,37 @@ namespace DTXMania.Test.Stage
             var whitePixel = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
 #pragma warning restore SYSLIB0050
             var fontMock = new Mock<IFont>();
+            var smallFontMock = new Mock<IFont>();
+            var largeFontMock = new Mock<IFont>();
+            var resultSoundMock = new Mock<ISound>();
+            var newRecordSoundMock = new Mock<ISound>();
+            var resourceManager = new Mock<IResourceManager>();
+            var renderer = new ResultScreenRenderer(resourceManager.Object, null, null, null);
 
             SetPrivateField(stage, "_whitePixel", whitePixel);
             SetPrivateField(stage, "_resultFont", fontMock.Object);
+            SetPrivateField(stage, "_smallResultFont", smallFontMock.Object);
+            SetPrivateField(stage, "_largeResultFont", largeFontMock.Object);
+            SetPrivateField(stage, "_resultSound", resultSoundMock.Object);
+            SetPrivateField(stage, "_newRecordSound", newRecordSoundMock.Object);
+            SetPrivateField(stage, "_resultRenderer", renderer);
 
             InvokePrivateMethod(stage, "CleanupComponents");
 
             Assert.True(whitePixel.WasDisposed);
             fontMock.Verify(f => f.RemoveReference(), Times.Once);
+            smallFontMock.Verify(f => f.RemoveReference(), Times.Once);
+            largeFontMock.Verify(f => f.RemoveReference(), Times.Once);
+            resultSoundMock.Verify(s => s.RemoveReference(), Times.Once);
+            newRecordSoundMock.Verify(s => s.RemoveReference(), Times.Once);
+            Assert.Throws<ObjectDisposedException>(() => renderer.Load(ResultScreenModel.Create(null, null, 0, null, null)));
             Assert.Null(GetPrivateField<Texture2D>(stage, "_whitePixel"));
             Assert.Null(GetPrivateField<IFont>(stage, "_resultFont"));
+            Assert.Null(GetPrivateField<IFont>(stage, "_smallResultFont"));
+            Assert.Null(GetPrivateField<IFont>(stage, "_largeResultFont"));
+            Assert.Null(GetPrivateField<ISound>(stage, "_resultSound"));
+            Assert.Null(GetPrivateField<ISound>(stage, "_newRecordSound"));
+            Assert.Null(GetPrivateField<ResultScreenRenderer>(stage, "_resultRenderer"));
         }
 
         [Fact]
@@ -572,12 +653,20 @@ namespace DTXMania.Test.Stage
             var whitePixel = (TrackingTexture2D)FormatterServices.GetUninitializedObject(typeof(TrackingTexture2D));
 #pragma warning restore SYSLIB0050
             var fontMock = new Mock<IFont>();
+            var smallFontMock = new Mock<IFont>();
+            var largeFontMock = new Mock<IFont>();
+            var resultSoundMock = new Mock<ISound>();
+            var newRecordSoundMock = new Mock<ISound>();
 
             SetPrivateField(stage, "_game", DTXMania.Test.TestData.ReflectionHelpers.CreateGame());
             SetPrivateField(stage, "_spriteBatch", spriteBatch);
             SetPrivateField(stage, "_uiManager", new UIManager());
             SetPrivateField(stage, "_whitePixel", whitePixel);
             SetPrivateField(stage, "_resultFont", fontMock.Object);
+            SetPrivateField(stage, "_smallResultFont", smallFontMock.Object);
+            SetPrivateField(stage, "_largeResultFont", largeFontMock.Object);
+            SetPrivateField(stage, "_resultSound", resultSoundMock.Object);
+            SetPrivateField(stage, "_newRecordSound", newRecordSoundMock.Object);
             SetPrivateField(stage, "_disposed", false);
 
             InvokeDispose(stage, true);
@@ -585,6 +674,10 @@ namespace DTXMania.Test.Stage
             Assert.True(spriteBatch.WasDisposed);
             Assert.True(whitePixel.WasDisposed);
             fontMock.Verify(f => f.RemoveReference(), Times.Once);
+            smallFontMock.Verify(f => f.RemoveReference(), Times.Once);
+            largeFontMock.Verify(f => f.RemoveReference(), Times.Once);
+            resultSoundMock.Verify(s => s.RemoveReference(), Times.Once);
+            newRecordSoundMock.Verify(s => s.RemoveReference(), Times.Once);
         }
 
         #endregion
@@ -622,6 +715,13 @@ namespace DTXMania.Test.Stage
         private static Mock<IStageManager> GetStageManagerMock(ResultStage stage)
         {
             return Mock.Get(stage.StageManager!);
+        }
+
+        private static void CompleteReveal(ResultStage stage)
+        {
+            var reveal = new ResultRevealState();
+            reveal.Complete();
+            SetPrivateField(stage, "_revealState", reveal);
         }
 
         private static void VerifySongSelectTransition(ResultStage stage, double expectedTransitionTime = 2.0)
@@ -712,6 +812,21 @@ namespace DTXMania.Test.Stage
             {
                 ResultFontRequested = true;
                 throw FontExceptionToThrow ?? new InvalidOperationException("No font exception configured.");
+            }
+
+            internal override IFont CreateSmallResultFont()
+            {
+                return null!;
+            }
+
+            internal override IFont CreateLargeResultFont()
+            {
+                return null!;
+            }
+
+            internal override ResultScreenRenderer CreateResultRenderer()
+            {
+                return null!;
             }
 
             internal override Viewport GetBackgroundViewport()

--- a/DTXMania.Test/Stage/ResultStageTests.cs
+++ b/DTXMania.Test/Stage/ResultStageTests.cs
@@ -626,7 +626,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void DrawBackground_WhenBackgroundIsNotReady_ShouldFillViewportUsingWhitePixel()
+        public void DrawBackground_WhenBackgroundIsNotReady_ShouldFillNXViewportUsingWhitePixel()
         {
 #pragma warning disable SYSLIB0050
             var stage = (InspectableResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableResultStage));
@@ -640,7 +640,9 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "DrawBackground");
 
             Assert.Same(whitePixel, stage.DrawTextureArgument);
-            Assert.Equal(new Rectangle(0, 0, 640, 480), stage.DrawTextureRectangle);
+            // Fallback uses NX virtual dimensions (1280x720), not real viewport dims,
+            // because SpriteBatch has an active 1280x720→screen viewport transform.
+            Assert.Equal(new Rectangle(0, 0, ResultUILayout.NXViewport.Width, ResultUILayout.NXViewport.Height), stage.DrawTextureRectangle);
             Assert.Equal(ResultUILayout.Background.BackgroundColor, stage.DrawTextureColor);
         }
 
@@ -719,6 +721,45 @@ namespace DTXMania.Test.Stage
             largeFontMock.Verify(f => f.RemoveReference(), Times.Once);
             resultSoundMock.Verify(s => s.RemoveReference(), Times.Once);
             newRecordSoundMock.Verify(s => s.RemoveReference(), Times.Once);
+        }
+
+        [Fact]
+        public void LoadSoundForPlate_FailedPlate_ShouldLoadStageClearSound()
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var resourceManager = new Mock<IResourceManager>();
+            var sound = new Mock<ISound>();
+            resourceManager.Setup(r => r.ResourceExists("Sounds/Stage Clear.ogg")).Returns(true);
+            resourceManager.Setup(r => r.LoadSound("Sounds/Stage Clear.ogg")).Returns(sound.Object);
+            SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+
+            var result = InvokePrivateMethod<ISound>(stage, "LoadSoundForPlate", ResultPlateKind.Failed);
+
+            Assert.NotNull(result);
+            resourceManager.Verify(r => r.LoadSound("Sounds/Stage Clear.ogg"), Times.Once);
+        }
+
+        [Theory]
+        [InlineData(ResultPlateKind.Excellent, "Sounds/Excellent.ogg")]
+        [InlineData(ResultPlateKind.FullCombo, "Sounds/Full Combo.ogg")]
+        [InlineData(ResultPlateKind.StageCleared, "Sounds/Stage Clear.ogg")]
+        [InlineData(ResultPlateKind.Failed, "Sounds/Stage Clear.ogg")]
+        public void LoadSoundForPlate_ShouldMapPlateToCorrectSoundPath(ResultPlateKind plateKind, string expectedPath)
+        {
+#pragma warning disable SYSLIB0050
+            var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+            var resourceManager = new Mock<IResourceManager>();
+            var sound = new Mock<ISound>();
+            resourceManager.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+            resourceManager.Setup(r => r.LoadSound(It.IsAny<string>())).Returns(sound.Object);
+            SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+
+            InvokePrivateMethod<ISound>(stage, "LoadSoundForPlate", plateKind);
+
+            resourceManager.Verify(r => r.LoadSound(expectedPath), Times.Once);
         }
 
         #endregion

--- a/DTXMania.Test/UI/PerformanceUILayoutTests.cs
+++ b/DTXMania.Test/UI/PerformanceUILayoutTests.cs
@@ -319,6 +319,52 @@ namespace DTXMania.Test.UI
             // Should not throw
             Assert.NotEqual(Color.Transparent, color);
         }
+
+        [Fact]
+        public void NXViewport_ShouldMatchResultAssetResolution()
+        {
+            Assert.Equal(1280, ResultUILayout.NXViewport.Width);
+            Assert.Equal(720, ResultUILayout.NXViewport.Height);
+        }
+
+        [Fact]
+        public void NXLayout_KeyPositions_ShouldMatchDrumsResultLayout()
+        {
+            Assert.Equal(new Vector2(480, 0), ResultUILayout.Rank.BadgePosition);
+            Assert.Equal(new Vector2(315, 100), ResultUILayout.ResultPlate.Position);
+            Assert.Equal(new Vector2(420, 156), ResultUILayout.ResultPlate.FailedTextPosition);
+            Assert.Equal(new Vector2(467, 287), ResultUILayout.Jacket.PanelPosition);
+            Assert.Equal(new Rectangle(519, 338, 245, 245), ResultUILayout.Jacket.PreviewDestination);
+            Assert.Equal(new Vector2(180, 260), ResultUILayout.SkillPanel.PanelPosition);
+            Assert.Equal(new Vector2(198, 550), ResultUILayout.SkillPanel.LevelPosition);
+            Assert.Equal(new Vector2(238, 537), ResultUILayout.SkillPanel.PlayingSkillPosition);
+            Assert.Equal(new Vector2(268, 623), ResultUILayout.SkillPanel.GameSkillPosition);
+            Assert.Equal(new Vector2(260, 332), ResultUILayout.SkillPanel.PerfectCountPosition);
+            Assert.Equal(new Vector2(260, 362), ResultUILayout.SkillPanel.GreatCountPosition);
+            Assert.Equal(new Vector2(260, 392), ResultUILayout.SkillPanel.GoodCountPosition);
+            Assert.Equal(new Vector2(260, 422), ResultUILayout.SkillPanel.PoorCountPosition);
+            Assert.Equal(new Vector2(260, 452), ResultUILayout.SkillPanel.MissCountPosition);
+            Assert.Equal(new Vector2(260, 482), ResultUILayout.SkillPanel.MaxComboCountPosition);
+            Assert.Equal(new Vector2(347, 332), ResultUILayout.SkillPanel.PerfectPercentPosition);
+            Assert.Equal(new Vector2(347, 362), ResultUILayout.SkillPanel.GreatPercentPosition);
+            Assert.Equal(new Vector2(347, 392), ResultUILayout.SkillPanel.GoodPercentPosition);
+            Assert.Equal(new Vector2(347, 422), ResultUILayout.SkillPanel.PoorPercentPosition);
+            Assert.Equal(new Vector2(347, 452), ResultUILayout.SkillPanel.MissPercentPosition);
+            Assert.Equal(new Vector2(347, 482), ResultUILayout.SkillPanel.MaxComboPercentPosition);
+            Assert.Equal(new Vector2(30, 58), ResultUILayout.Score.Position);
+            Assert.Equal(new Vector2(500, 630), ResultUILayout.SongInfo.TitlePosition);
+            Assert.Equal(new Vector2(500, 665), ResultUILayout.SongInfo.ArtistPosition);
+            Assert.Equal(320, ResultUILayout.SongInfo.MaxWidth);
+            Assert.Equal(new Vector2(298, 582), ResultUILayout.NewRecord.BadgePosition);
+        }
+
+        [Fact]
+        public void NXLayout_FontSizes_ShouldMatchDrumsResultLayout()
+        {
+            Assert.Equal(16, ResultUILayout.Fonts.Small);
+            Assert.Equal(20, ResultUILayout.Fonts.Normal);
+            Assert.Equal(32, ResultUILayout.Fonts.Large);
+        }
     }
 
     /// <summary>

--- a/docs/superpowers/plans/2026-05-31-result-stage-nx-parity.md
+++ b/docs/superpowers/plans/2026-05-31-result-stage-nx-parity.md
@@ -1,0 +1,1933 @@
+# Result Stage NX Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace CX's centered result text screen with an NX-style result screen using existing CX performance data, NX structural assets, sprite-font text, reveal behavior, and optional result sounds.
+
+**Architecture:** Keep `ResultStage` as the lifecycle/input/persistence owner. Add a testable `ResultScreenModel` for rank, result category, formatting, preview fallback, and new-record decisions; add `ResultRevealState` for frame-rate independent reveal timing; add `ResultScreenRenderer` for result-stage resource loading and drawing.
+
+**Tech Stack:** .NET 8, MonoGame, xUnit, Moq, CX `IResourceManager`/`ITexture`/`IFont`/`ISound`, existing `SongScore` skill helpers.
+
+---
+
+## File Structure
+
+- Modify: `DTXMania.Game/Lib/Resources/TexturePath.cs`
+  - Add structural result-stage texture constants and include them in `GetAllTexturePaths()`.
+- Modify: `DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs`
+  - Keep existing fallback constants; add NX virtual-screen dimensions and result element coordinates.
+- Create: `DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs`
+  - Pure model. Computes rank, plate category, formatted values, title/artist fallbacks, preview path, and new-record flag.
+- Create: `DTXMania.Game/Lib/Stage/Result/ResultRevealState.cs`
+  - Pure reveal timer. Tracks rank/panel reveal progress and completion.
+- Create: `DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs`
+  - Loads structural textures only when resources exist. Draws NX layers in virtual 1280x720 coordinates with sprite-font text.
+- Modify: `DTXMania.Game/Lib/Stage/ResultStage.cs`
+  - Build the model before score persistence, own reveal state, delegate drawing to renderer, play optional sounds, and update navigation behavior.
+- Modify: `DTXMania.Test/Resources/TexturePathTests.cs`
+  - Cover new texture constants and `GetAllTexturePaths()` entries.
+- Modify: `DTXMania.Test/UI/PerformanceUILayoutTests.cs`
+  - Extend `ResultUILayoutTests` for new NX coordinates and virtual viewport constants.
+- Create: `DTXMania.Test/Stage/Result/ResultScreenModelTests.cs`
+  - Cover rank thresholds, plate selection, formatting, preview fallback, and new-record detection.
+- Create: `DTXMania.Test/Stage/Result/ResultRevealStateTests.cs`
+  - Cover reveal progress, completion, and negative delta handling.
+- Create: `DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs`
+  - Cover resource load decisions and virtual viewport transform.
+- Modify: `DTXMania.Test/Stage/ResultStageTests.cs`
+  - Replace old centered-text/fallback-line assertions with model/reveal/navigation assertions.
+- Modify: `DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs`
+  - Update activation tests for renderer/model fields and sound no-throw paths.
+
+## Task 1: Add Result Asset Constants And NX Layout Coordinates
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Resources/TexturePath.cs`
+- Modify: `DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs`
+- Modify: `DTXMania.Test/Resources/TexturePathTests.cs`
+- Modify: `DTXMania.Test/UI/PerformanceUILayoutTests.cs`
+
+- [ ] **Step 1: Write failing texture path tests**
+
+Add these facts to `DTXMania.Test/Resources/TexturePathTests.cs` near the existing result/background tests:
+
+```csharp
+[Fact]
+public void ResultStageAssets_ShouldUseNXPaths()
+{
+    Assert.Equal("Graphics/8_rankSS.png", TexturePath.ResultRankSS);
+    Assert.Equal("Graphics/8_rankS.png", TexturePath.ResultRankS);
+    Assert.Equal("Graphics/8_rankA.png", TexturePath.ResultRankA);
+    Assert.Equal("Graphics/8_rankB.png", TexturePath.ResultRankB);
+    Assert.Equal("Graphics/8_rankC.png", TexturePath.ResultRankC);
+    Assert.Equal("Graphics/8_rankD.png", TexturePath.ResultRankD);
+    Assert.Equal("Graphics/8_rankE.png", TexturePath.ResultRankE);
+    Assert.Equal("Graphics/ScreenResult StageCleared.png", TexturePath.ResultPlateStageCleared);
+    Assert.Equal("Graphics/ScreenResult fullcombo.png", TexturePath.ResultPlateFullCombo);
+    Assert.Equal("Graphics/ScreenResult Excellent.png", TexturePath.ResultPlateExcellent);
+    Assert.Equal("Graphics/7_JacketPanel.png", TexturePath.ResultJacketPanel);
+    Assert.Equal("Graphics/7_SkillPanel.png", TexturePath.ResultSkillPanel);
+    Assert.Equal("Graphics/8_New Record.png", TexturePath.ResultNewRecord);
+    Assert.Equal("Graphics/5_preimage default.png", TexturePath.ResultDefaultPreview);
+}
+
+[Fact]
+public void ResultStageAssets_ShouldBeIncludedInAllTexturePaths()
+{
+    var paths = TexturePath.GetAllTexturePaths();
+
+    Assert.Contains(TexturePath.ResultRankSS, paths);
+    Assert.Contains(TexturePath.ResultRankS, paths);
+    Assert.Contains(TexturePath.ResultRankA, paths);
+    Assert.Contains(TexturePath.ResultRankB, paths);
+    Assert.Contains(TexturePath.ResultRankC, paths);
+    Assert.Contains(TexturePath.ResultRankD, paths);
+    Assert.Contains(TexturePath.ResultRankE, paths);
+    Assert.Contains(TexturePath.ResultPlateStageCleared, paths);
+    Assert.Contains(TexturePath.ResultPlateFullCombo, paths);
+    Assert.Contains(TexturePath.ResultPlateExcellent, paths);
+    Assert.Contains(TexturePath.ResultJacketPanel, paths);
+    Assert.Contains(TexturePath.ResultSkillPanel, paths);
+    Assert.Contains(TexturePath.ResultNewRecord, paths);
+    Assert.Contains(TexturePath.ResultDefaultPreview, paths);
+}
+```
+
+- [ ] **Step 2: Write failing layout tests**
+
+Add these facts to the existing `ResultUILayoutTests` class in `DTXMania.Test/UI/PerformanceUILayoutTests.cs`:
+
+```csharp
+[Fact]
+public void NXViewport_ShouldMatchResultAssetResolution()
+{
+    Assert.Equal(1280, ResultUILayout.NXViewport.Width);
+    Assert.Equal(720, ResultUILayout.NXViewport.Height);
+}
+
+[Fact]
+public void NXLayout_KeyPositions_ShouldMatchDrumsResultLayout()
+{
+    Assert.Equal(new Vector2(480, 0), ResultUILayout.Rank.BadgePosition);
+    Assert.Equal(new Vector2(315, 100), ResultUILayout.ResultPlate.Position);
+    Assert.Equal(new Vector2(467, 287), ResultUILayout.Jacket.PanelPosition);
+    Assert.Equal(new Rectangle(519, 338, 245, 245), ResultUILayout.Jacket.PreviewDestination);
+    Assert.Equal(new Vector2(180, 260), ResultUILayout.SkillPanel.PanelPosition);
+    Assert.Equal(new Vector2(30, 58), ResultUILayout.Score.Position);
+    Assert.Equal(new Vector2(500, 630), ResultUILayout.SongInfo.TitlePosition);
+    Assert.Equal(new Vector2(500, 665), ResultUILayout.SongInfo.ArtistPosition);
+}
+
+[Fact]
+public void NXLayout_FontSizes_ShouldBePositive()
+{
+    Assert.True(ResultUILayout.Fonts.Small > 0);
+    Assert.True(ResultUILayout.Fonts.Normal > 0);
+    Assert.True(ResultUILayout.Fonts.Large > 0);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~TexturePathTests|FullyQualifiedName~ResultUILayoutTests"
+```
+
+Expected: build fails because the new `TexturePath` and `ResultUILayout` members do not exist.
+
+- [ ] **Step 4: Add texture constants**
+
+In `DTXMania.Game/Lib/Resources/TexturePath.cs`, add this region after `ResultBackground`:
+
+```csharp
+        /// <summary>
+        /// Result stage rank-specific background textures. These are optional skin assets.
+        /// </summary>
+        public const string ResultBackgroundRankSS = "Graphics/8_background rankSS.png";
+        public const string ResultBackgroundRankS = "Graphics/8_background rankS.png";
+        public const string ResultBackgroundRankA = "Graphics/8_background rankA.png";
+        public const string ResultBackgroundRankB = "Graphics/8_background rankB.png";
+        public const string ResultBackgroundRankC = "Graphics/8_background rankC.png";
+        public const string ResultBackgroundRankD = "Graphics/8_background rankD.png";
+        public const string ResultBackgroundRankE = "Graphics/8_background rankE.png";
+
+        /// <summary>
+        /// Result stage rank badge textures.
+        /// </summary>
+        public const string ResultRankSS = "Graphics/8_rankSS.png";
+        public const string ResultRankS = "Graphics/8_rankS.png";
+        public const string ResultRankA = "Graphics/8_rankA.png";
+        public const string ResultRankB = "Graphics/8_rankB.png";
+        public const string ResultRankC = "Graphics/8_rankC.png";
+        public const string ResultRankD = "Graphics/8_rankD.png";
+        public const string ResultRankE = "Graphics/8_rankE.png";
+
+        /// <summary>
+        /// Result stage clear category plate textures.
+        /// </summary>
+        public const string ResultPlateStageCleared = "Graphics/ScreenResult StageCleared.png";
+        public const string ResultPlateFullCombo = "Graphics/ScreenResult fullcombo.png";
+        public const string ResultPlateExcellent = "Graphics/ScreenResult Excellent.png";
+
+        /// <summary>
+        /// Result stage structural panel textures.
+        /// </summary>
+        public const string ResultJacketPanel = "Graphics/7_JacketPanel.png";
+        public const string ResultSkillPanel = "Graphics/7_SkillPanel.png";
+        public const string ResultNewRecord = "Graphics/8_New Record.png";
+        public const string ResultDefaultPreview = "Graphics/5_preimage default.png";
+```
+
+In `GetAllTexturePaths()`, add the new constants immediately after `ResultBackground`:
+
+```csharp
+                ResultBackgroundRankSS,
+                ResultBackgroundRankS,
+                ResultBackgroundRankA,
+                ResultBackgroundRankB,
+                ResultBackgroundRankC,
+                ResultBackgroundRankD,
+                ResultBackgroundRankE,
+                ResultRankSS,
+                ResultRankS,
+                ResultRankA,
+                ResultRankB,
+                ResultRankC,
+                ResultRankD,
+                ResultRankE,
+                ResultPlateStageCleared,
+                ResultPlateFullCombo,
+                ResultPlateExcellent,
+                ResultJacketPanel,
+                ResultSkillPanel,
+                ResultNewRecord,
+                ResultDefaultPreview,
+```
+
+- [ ] **Step 5: Add NX layout constants while preserving old constants**
+
+In `DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs`, keep the existing `Background`, `ResultDisplay`, and `FallbackText` classes. Add these nested classes before `FallbackText`:
+
+```csharp
+        public static class NXViewport
+        {
+            public const int Width = 1280;
+            public const int Height = 720;
+        }
+
+        public static class Fonts
+        {
+            public const int Small = 16;
+            public const int Normal = 20;
+            public const int Large = 32;
+        }
+
+        public static class Rank
+        {
+            public static readonly Vector2 BadgePosition = new(480, 0);
+        }
+
+        public static class ResultPlate
+        {
+            public static readonly Vector2 Position = new(315, 100);
+            public static readonly Vector2 FailedTextPosition = new(420, 156);
+        }
+
+        public static class Jacket
+        {
+            public static readonly Vector2 PanelPosition = new(467, 287);
+            public static readonly Rectangle PreviewDestination = new(519, 338, 245, 245);
+        }
+
+        public static class SkillPanel
+        {
+            public static readonly Vector2 PanelPosition = new(180, 260);
+            public static readonly Vector2 LevelPosition = new(198, 550);
+            public static readonly Vector2 PlayingSkillPosition = new(238, 537);
+            public static readonly Vector2 GameSkillPosition = new(268, 623);
+            public static readonly Vector2 PerfectCountPosition = new(260, 332);
+            public static readonly Vector2 GreatCountPosition = new(260, 362);
+            public static readonly Vector2 GoodCountPosition = new(260, 392);
+            public static readonly Vector2 PoorCountPosition = new(260, 422);
+            public static readonly Vector2 MissCountPosition = new(260, 452);
+            public static readonly Vector2 MaxComboCountPosition = new(260, 482);
+            public static readonly Vector2 PerfectPercentPosition = new(347, 332);
+            public static readonly Vector2 GreatPercentPosition = new(347, 362);
+            public static readonly Vector2 GoodPercentPosition = new(347, 392);
+            public static readonly Vector2 PoorPercentPosition = new(347, 422);
+            public static readonly Vector2 MissPercentPosition = new(347, 452);
+            public static readonly Vector2 MaxComboPercentPosition = new(347, 482);
+        }
+
+        public static class Score
+        {
+            public static readonly Vector2 Position = new(30, 58);
+        }
+
+        public static class SongInfo
+        {
+            public static readonly Vector2 TitlePosition = new(500, 630);
+            public static readonly Vector2 ArtistPosition = new(500, 665);
+            public const int MaxWidth = 320;
+        }
+
+        public static class NewRecord
+        {
+            public static readonly Vector2 BadgePosition = new(298, 582);
+        }
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~TexturePathTests|FullyQualifiedName~ResultUILayoutTests"
+```
+
+Expected: tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Resources/TexturePath.cs DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs DTXMania.Test/Resources/TexturePathTests.cs DTXMania.Test/UI/PerformanceUILayoutTests.cs
+git commit -m "feat: add result stage NX asset constants"
+```
+
+## Task 2: Add `ResultScreenModel`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs`
+- Create: `DTXMania.Test/Stage/Result/ResultScreenModelTests.cs`
+
+- [ ] **Step 1: Write failing model tests**
+
+Create `DTXMania.Test/Stage/Result/ResultScreenModelTests.cs`:
+
+```csharp
+using System.IO;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
+using Xunit;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage.Result;
+
+[Trait("Category", "Unit")]
+public class ResultScreenModelTests
+{
+    [Theory]
+    [InlineData(95.0, ResultRank.SS, "SS")]
+    [InlineData(94.99, ResultRank.S, "S")]
+    [InlineData(80.0, ResultRank.S, "S")]
+    [InlineData(79.99, ResultRank.A, "A")]
+    [InlineData(73.0, ResultRank.A, "A")]
+    [InlineData(72.99, ResultRank.B, "B")]
+    [InlineData(63.0, ResultRank.B, "B")]
+    [InlineData(62.99, ResultRank.C, "C")]
+    [InlineData(53.0, ResultRank.C, "C")]
+    [InlineData(52.99, ResultRank.D, "D")]
+    [InlineData(45.0, ResultRank.D, "D")]
+    [InlineData(44.99, ResultRank.E, "E")]
+    public void Create_ShouldComputeNXRankFromPlayingSkill(double skill, ResultRank expectedRank, string expectedLabel)
+    {
+        var model = ResultScreenModel.Create(
+            Summary(playingSkill: skill, totalNotes: 100),
+            selectedSong: null,
+            selectedDifficulty: 0,
+            chart: null,
+            previousScore: null);
+
+        Assert.Equal(expectedRank, model.Rank);
+        Assert.Equal(expectedLabel, model.RankLabel);
+    }
+
+    [Fact]
+    public void Create_AllPerfect_ShouldSelectExcellentPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 100, totalNotes: 100, poor: 0, miss: 0, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.Excellent, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_ClearNoPoorNoMiss_ShouldSelectFullComboPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 90, great: 10, totalNotes: 100, poor: 0, miss: 0, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.FullCombo, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_ClearWithMiss_ShouldSelectStageClearedPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 90, great: 9, miss: 1, totalNotes: 100, clear: true),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.StageCleared, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_NotClear_ShouldSelectFailedPlate()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 20, miss: 80, totalNotes: 100, clear: false),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal(ResultPlateKind.Failed, model.PlateKind);
+    }
+
+    [Fact]
+    public void Create_ShouldFormatCoreValues()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(score: 123456, maxCombo: 87, perfect: 70, great: 20, good: 5, poor: 3, miss: 2, totalNotes: 100, playingSkill: 76.543, gameSkill: 133.456, level: 78, levelDec: 33),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal("0123456", model.ScoreText);
+        Assert.Equal("87", model.MaxComboText);
+        Assert.Equal("70", model.PerfectCountText);
+        Assert.Equal("70%", model.PerfectPercentText);
+        Assert.Equal("2", model.MissCountText);
+        Assert.Equal("2%", model.MissPercentText);
+        Assert.Equal("76.54", model.PlayingSkillText);
+        Assert.Equal("133.46", model.GameSkillText);
+        Assert.Equal("8.13", model.ChartLevelText);
+    }
+
+    [Fact]
+    public void Create_NoTotalNotes_ShouldFormatZeroPercents()
+    {
+        var model = ResultScreenModel.Create(
+            Summary(perfect: 1, great: 1, totalNotes: 0),
+            null,
+            0,
+            null,
+            null);
+
+        Assert.Equal("0%", model.PerfectPercentText);
+        Assert.Equal("0%", model.GreatPercentText);
+        Assert.Equal("0%", model.MaxComboPercentText);
+    }
+
+    [Fact]
+    public void Create_WithSongAndChart_ShouldUseMetadataAndPreviewPath()
+    {
+        var chartDirectory = Path.Combine(Path.GetTempPath(), "dtx-result-test");
+        var chart = new SongChart
+        {
+            FilePath = Path.Combine(chartDirectory, "chart.dtx"),
+            PreviewImage = "jacket.png",
+            DrumLevel = 80,
+            DrumLevelDec = 50
+        };
+        var song = new SongListNode
+        {
+            Title = "Fallback Title",
+            DatabaseSong = new SongEntity { Title = "Song Title", Artist = "Song Artist" },
+            DatabaseChart = chart
+        };
+
+        var model = ResultScreenModel.Create(Summary(), song, 0, chart, null);
+
+        Assert.Equal("Song Title", model.Title);
+        Assert.Equal("Song Artist", model.Artist);
+        Assert.Equal(Path.Combine(chartDirectory, "jacket.png"), model.PreviewImagePath);
+        Assert.Equal("8.50", model.ChartLevelText);
+    }
+
+    [Fact]
+    public void Create_WithoutPreviewImage_ShouldUseDefaultPreview()
+    {
+        var model = ResultScreenModel.Create(Summary(), null, 0, null, null);
+
+        Assert.Equal(TexturePath.ResultDefaultPreview, model.PreviewImagePath);
+    }
+
+    [Fact]
+    public void Create_WithPreviousScore_ShouldDetectNewRecord()
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 4,
+            BestScore = 500000,
+            HighSkill = 90.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: 500001, gameSkill: 89.0),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.True(model.NewRecord);
+    }
+
+    [Fact]
+    public void Create_WithPreviousBetterScoreAndSkill_ShouldNotMarkNewRecord()
+    {
+        var previous = new SongScore
+        {
+            PlayCount = 4,
+            BestScore = 900000,
+            HighSkill = 200.0
+        };
+
+        var model = ResultScreenModel.Create(
+            Summary(score: 800000, gameSkill: 199.0),
+            null,
+            0,
+            null,
+            previous);
+
+        Assert.False(model.NewRecord);
+    }
+
+    private static PerformanceSummary Summary(
+        int score = 0,
+        int maxCombo = 0,
+        bool clear = true,
+        int perfect = 0,
+        int great = 0,
+        int good = 0,
+        int poor = 0,
+        int miss = 0,
+        int totalNotes = 0,
+        double playingSkill = 0.0,
+        double gameSkill = 0.0,
+        int level = 0,
+        int levelDec = 0)
+    {
+        return new PerformanceSummary
+        {
+            Score = score,
+            MaxCombo = maxCombo,
+            ClearFlag = clear,
+            PerfectCount = perfect,
+            GreatCount = great,
+            GoodCount = good,
+            PoorCount = poor,
+            MissCount = miss,
+            TotalNotes = totalNotes,
+            PlayingSkill = playingSkill,
+            GameSkill = gameSkill,
+            ChartLevel = level,
+            ChartLevelDec = levelDec
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultScreenModelTests"
+```
+
+Expected: build fails because `ResultScreenModel`, `ResultRank`, and `ResultPlateKind` do not exist.
+
+- [ ] **Step 3: Add the model implementation**
+
+Create `DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.IO;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+
+namespace DTXMania.Game.Lib.Stage.Result
+{
+    public enum ResultRank
+    {
+        SS = 0,
+        S = 1,
+        A = 2,
+        B = 3,
+        C = 4,
+        D = 5,
+        E = 6
+    }
+
+    public enum ResultPlateKind
+    {
+        Excellent,
+        FullCombo,
+        StageCleared,
+        Failed
+    }
+
+    public sealed class ResultScreenModel
+    {
+        private ResultScreenModel() { }
+
+        public PerformanceSummary Summary { get; private init; } = new();
+        public ResultRank Rank { get; private init; }
+        public string RankLabel { get; private init; } = "E";
+        public ResultPlateKind PlateKind { get; private init; }
+        public string ScoreText { get; private init; } = "0000000";
+        public string MaxComboText { get; private init; } = "0";
+        public string PerfectCountText { get; private init; } = "0";
+        public string GreatCountText { get; private init; } = "0";
+        public string GoodCountText { get; private init; } = "0";
+        public string PoorCountText { get; private init; } = "0";
+        public string MissCountText { get; private init; } = "0";
+        public string PerfectPercentText { get; private init; } = "0%";
+        public string GreatPercentText { get; private init; } = "0%";
+        public string GoodPercentText { get; private init; } = "0%";
+        public string PoorPercentText { get; private init; } = "0%";
+        public string MissPercentText { get; private init; } = "0%";
+        public string MaxComboPercentText { get; private init; } = "0%";
+        public string PlayingSkillText { get; private init; } = "0.00";
+        public string GameSkillText { get; private init; } = "0.00";
+        public string ChartLevelText { get; private init; } = "--";
+        public string Title { get; private init; } = "Unknown Song";
+        public string Artist { get; private init; } = "Unknown Artist";
+        public string PreviewImagePath { get; private init; } = TexturePath.ResultDefaultPreview;
+        public bool NewRecord { get; private init; }
+
+        public static ResultScreenModel Create(
+            PerformanceSummary? summary,
+            SongListNode? selectedSong,
+            int selectedDifficulty,
+            SongChart? chart,
+            SongScore? previousScore)
+        {
+            var safeSummary = summary ?? new PerformanceSummary();
+            var rank = ComputeRank(safeSummary.PlayingSkill);
+
+            return new ResultScreenModel
+            {
+                Summary = safeSummary,
+                Rank = rank,
+                RankLabel = GetRankLabel(rank),
+                PlateKind = ComputePlateKind(safeSummary),
+                ScoreText = FormatScore(safeSummary.Score),
+                MaxComboText = FormatCount(safeSummary.MaxCombo),
+                PerfectCountText = FormatCount(safeSummary.PerfectCount),
+                GreatCountText = FormatCount(safeSummary.GreatCount),
+                GoodCountText = FormatCount(safeSummary.GoodCount),
+                PoorCountText = FormatCount(safeSummary.PoorCount),
+                MissCountText = FormatCount(safeSummary.MissCount),
+                PerfectPercentText = FormatPercent(safeSummary.PerfectCount, safeSummary.TotalNotes),
+                GreatPercentText = FormatPercent(safeSummary.GreatCount, safeSummary.TotalNotes),
+                GoodPercentText = FormatPercent(safeSummary.GoodCount, safeSummary.TotalNotes),
+                PoorPercentText = FormatPercent(safeSummary.PoorCount, safeSummary.TotalNotes),
+                MissPercentText = FormatPercent(safeSummary.MissCount, safeSummary.TotalNotes),
+                MaxComboPercentText = FormatPercent(safeSummary.MaxCombo, safeSummary.TotalNotes),
+                PlayingSkillText = FormatDecimal(safeSummary.PlayingSkill),
+                GameSkillText = FormatDecimal(safeSummary.GameSkill),
+                ChartLevelText = FormatLevel(chart?.DrumLevel ?? safeSummary.ChartLevel, chart?.DrumLevelDec ?? safeSummary.ChartLevelDec),
+                Title = ResolveTitle(selectedSong),
+                Artist = ResolveArtist(selectedSong),
+                PreviewImagePath = ResolvePreviewImagePath(chart),
+                NewRecord = IsNewRecord(safeSummary, previousScore)
+            };
+        }
+
+        public static ResultRank ComputeRank(double playingSkill)
+        {
+            if (playingSkill >= 95.0) return ResultRank.SS;
+            if (playingSkill >= 80.0) return ResultRank.S;
+            if (playingSkill >= 73.0) return ResultRank.A;
+            if (playingSkill >= 63.0) return ResultRank.B;
+            if (playingSkill >= 53.0) return ResultRank.C;
+            if (playingSkill >= 45.0) return ResultRank.D;
+            return ResultRank.E;
+        }
+
+        public static ResultPlateKind ComputePlateKind(PerformanceSummary summary)
+        {
+            if (summary.TotalNotes > 0 && summary.PerfectCount == summary.TotalNotes)
+                return ResultPlateKind.Excellent;
+
+            if (summary.ClearFlag && summary.PoorCount == 0 && summary.MissCount == 0)
+                return ResultPlateKind.FullCombo;
+
+            if (summary.ClearFlag)
+                return ResultPlateKind.StageCleared;
+
+            return ResultPlateKind.Failed;
+        }
+
+        public static string GetRankLabel(ResultRank rank)
+        {
+            return rank switch
+            {
+                ResultRank.SS => "SS",
+                ResultRank.S => "S",
+                ResultRank.A => "A",
+                ResultRank.B => "B",
+                ResultRank.C => "C",
+                ResultRank.D => "D",
+                ResultRank.E => "E",
+                _ => "E"
+            };
+        }
+
+        public static string FormatScore(int score)
+        {
+            return Math.Clamp(score, 0, 9_999_999).ToString("0000000", CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatCount(int count)
+        {
+            return Math.Max(0, count).ToString(CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatPercent(int value, int total)
+        {
+            if (total <= 0)
+                return "0%";
+
+            var percent = (int)Math.Round(value * 100.0 / total, MidpointRounding.AwayFromZero);
+            return $"{Math.Clamp(percent, 0, 100)}%";
+        }
+
+        public static string FormatDecimal(double value)
+        {
+            return Math.Max(0.0, value).ToString("0.00", CultureInfo.InvariantCulture);
+        }
+
+        public static string FormatLevel(int level, int levelDec)
+        {
+            if (level <= 0)
+                return "--";
+
+            double actual = level >= 100
+                ? level / 100.0
+                : (level / 10.0) + (levelDec / 100.0);
+
+            return actual.ToString("0.00", CultureInfo.InvariantCulture);
+        }
+
+        private static string ResolveTitle(SongListNode? selectedSong)
+        {
+            if (!string.IsNullOrWhiteSpace(selectedSong?.DatabaseSong?.Title))
+                return selectedSong.DatabaseSong.Title;
+
+            if (!string.IsNullOrWhiteSpace(selectedSong?.DisplayTitle))
+                return selectedSong.DisplayTitle;
+
+            return "Unknown Song";
+        }
+
+        private static string ResolveArtist(SongListNode? selectedSong)
+        {
+            if (!string.IsNullOrWhiteSpace(selectedSong?.DatabaseSong?.Artist))
+                return selectedSong.DatabaseSong.Artist;
+
+            return "Unknown Artist";
+        }
+
+        private static string ResolvePreviewImagePath(SongChart? chart)
+        {
+            if (chart == null || string.IsNullOrWhiteSpace(chart.PreviewImage))
+                return TexturePath.ResultDefaultPreview;
+
+            if (Path.IsPathRooted(chart.PreviewImage))
+                return chart.PreviewImage;
+
+            var chartDirectory = !string.IsNullOrWhiteSpace(chart.FilePath)
+                ? Path.GetDirectoryName(chart.FilePath)
+                : null;
+
+            return string.IsNullOrWhiteSpace(chartDirectory)
+                ? chart.PreviewImage
+                : Path.Combine(chartDirectory, chart.PreviewImage);
+        }
+
+        private static bool IsNewRecord(PerformanceSummary summary, SongScore? previousScore)
+        {
+            if (previousScore == null)
+                return false;
+
+            if (previousScore.PlayCount <= 0)
+                return summary.Score > 0 || summary.GameSkill > 0.0;
+
+            return summary.Score > previousScore.BestScore
+                || summary.GameSkill > previousScore.HighSkill;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultScreenModelTests"
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Result/ResultScreenModel.cs DTXMania.Test/Stage/Result/ResultScreenModelTests.cs
+git commit -m "feat: add result screen model"
+```
+
+## Task 3: Add Reveal State
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Result/ResultRevealState.cs`
+- Create: `DTXMania.Test/Stage/Result/ResultRevealStateTests.cs`
+
+- [ ] **Step 1: Write failing reveal state tests**
+
+Create `DTXMania.Test/Stage/Result/ResultRevealStateTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Stage.Result;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Result;
+
+[Trait("Category", "Unit")]
+public class ResultRevealStateTests
+{
+    [Fact]
+    public void NewState_ShouldStartAtZeroProgress()
+    {
+        var state = new ResultRevealState();
+
+        Assert.Equal(0.0, state.ElapsedSeconds);
+        Assert.Equal(0.0f, state.RankProgress);
+        Assert.Equal(0.0f, state.PanelProgress);
+        Assert.False(state.IsComplete);
+    }
+
+    [Fact]
+    public void Update_ShouldAdvanceRankBeforePanel()
+    {
+        var state = new ResultRevealState();
+
+        state.Update(ResultRevealState.RankRevealSeconds / 2.0);
+
+        Assert.InRange(state.RankProgress, 0.49f, 0.51f);
+        Assert.Equal(0.0f, state.PanelProgress);
+        Assert.False(state.IsComplete);
+    }
+
+    [Fact]
+    public void Update_AfterRankAndDelay_ShouldAdvancePanel()
+    {
+        var state = new ResultRevealState();
+
+        state.Update(ResultRevealState.RankRevealSeconds + ResultRevealState.PanelDelaySeconds + ResultRevealState.PanelRevealSeconds / 2.0);
+
+        Assert.Equal(1.0f, state.RankProgress);
+        Assert.InRange(state.PanelProgress, 0.49f, 0.51f);
+        Assert.False(state.IsComplete);
+    }
+
+    [Fact]
+    public void Update_PastTotalDuration_ShouldClampAndComplete()
+    {
+        var state = new ResultRevealState();
+
+        state.Update(ResultRevealState.TotalRevealSeconds + 10.0);
+
+        Assert.Equal(ResultRevealState.TotalRevealSeconds, state.ElapsedSeconds);
+        Assert.Equal(1.0f, state.RankProgress);
+        Assert.Equal(1.0f, state.PanelProgress);
+        Assert.True(state.IsComplete);
+    }
+
+    [Fact]
+    public void Update_WithNegativeDelta_ShouldNotMoveBackwards()
+    {
+        var state = new ResultRevealState();
+
+        state.Update(0.25);
+        state.Update(-1.0);
+
+        Assert.Equal(0.25, state.ElapsedSeconds);
+    }
+
+    [Fact]
+    public void Complete_ShouldJumpToEnd()
+    {
+        var state = new ResultRevealState();
+
+        state.Complete();
+
+        Assert.Equal(ResultRevealState.TotalRevealSeconds, state.ElapsedSeconds);
+        Assert.True(state.IsComplete);
+        Assert.Equal(1.0f, state.RankProgress);
+        Assert.Equal(1.0f, state.PanelProgress);
+    }
+
+    [Fact]
+    public void Reset_ShouldReturnToBeginning()
+    {
+        var state = new ResultRevealState();
+        state.Complete();
+
+        state.Reset();
+
+        Assert.Equal(0.0, state.ElapsedSeconds);
+        Assert.False(state.IsComplete);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultRevealStateTests"
+```
+
+Expected: build fails because `ResultRevealState` does not exist.
+
+- [ ] **Step 3: Add reveal state implementation**
+
+Create `DTXMania.Game/Lib/Stage/Result/ResultRevealState.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+
+namespace DTXMania.Game.Lib.Stage.Result
+{
+    public sealed class ResultRevealState
+    {
+        public const double RankRevealSeconds = 0.5;
+        public const double PanelDelaySeconds = 0.15;
+        public const double PanelRevealSeconds = 0.5;
+        public const double TotalRevealSeconds = RankRevealSeconds + PanelDelaySeconds + PanelRevealSeconds;
+
+        public double ElapsedSeconds { get; private set; }
+
+        public bool IsComplete => ElapsedSeconds >= TotalRevealSeconds;
+
+        public float RankProgress => Clamp01(ElapsedSeconds / RankRevealSeconds);
+
+        public float PanelProgress => Clamp01(
+            (ElapsedSeconds - RankRevealSeconds - PanelDelaySeconds) / PanelRevealSeconds);
+
+        public void Update(double deltaSeconds)
+        {
+            if (deltaSeconds <= 0.0)
+                return;
+
+            ElapsedSeconds = Math.Min(TotalRevealSeconds, ElapsedSeconds + deltaSeconds);
+        }
+
+        public void Complete()
+        {
+            ElapsedSeconds = TotalRevealSeconds;
+        }
+
+        public void Reset()
+        {
+            ElapsedSeconds = 0.0;
+        }
+
+        private static float Clamp01(double value)
+        {
+            if (value <= 0.0) return 0.0f;
+            if (value >= 1.0) return 1.0f;
+            return (float)value;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultRevealStateTests"
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Result/ResultRevealState.cs DTXMania.Test/Stage/Result/ResultRevealStateTests.cs
+git commit -m "feat: add result reveal timing"
+```
+
+## Task 4: Add Result Screen Renderer
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs`
+- Create: `DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs`
+
+- [ ] **Step 1: Write failing renderer tests**
+
+Create `DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Game.Lib.Stage.Result;
+using Microsoft.Xna.Framework;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Stage.Result;
+
+[Trait("Category", "Unit")]
+public class ResultScreenRendererTests
+{
+    [Fact]
+    public void CreateViewportTransform_ExactNXSize_ShouldUseIdentityScale()
+    {
+        var matrix = ResultScreenRenderer.CreateViewportTransform(new Viewport(0, 0, 1280, 720));
+
+        Assert.Equal(1.0f, matrix.M11, 3);
+        Assert.Equal(1.0f, matrix.M22, 3);
+        Assert.Equal(0.0f, matrix.M41, 3);
+        Assert.Equal(0.0f, matrix.M42, 3);
+    }
+
+    [Fact]
+    public void CreateViewportTransform_FourByThreeViewport_ShouldLetterboxVertically()
+    {
+        var matrix = ResultScreenRenderer.CreateViewportTransform(new Viewport(0, 0, 1024, 768));
+
+        Assert.Equal(0.8f, matrix.M11, 3);
+        Assert.Equal(0.8f, matrix.M22, 3);
+        Assert.Equal(0.0f, matrix.M41, 3);
+        Assert.Equal(96.0f, matrix.M42, 3);
+    }
+
+    [Fact]
+    public void Load_ShouldLoadStructuralAssetsThatExist()
+    {
+        var resources = new Mock<IResourceManager>();
+        var texture = new Mock<ITexture>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = true, PerfectCount = 100, TotalNotes = 100, PlayingSkill = 100.0 },
+            null,
+            0,
+            null,
+            null);
+
+        renderer.Load(model);
+
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultBackground), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultBackgroundRankSS), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultRankSS), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateExcellent), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultJacketPanel), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultSkillPanel), Times.Once);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultDefaultPreview), Times.Once);
+    }
+
+    [Fact]
+    public void Load_FailedPlate_ShouldNotLoadClearPlateTexture()
+    {
+        var resources = new Mock<IResourceManager>();
+        var texture = new Mock<ITexture>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = false, MissCount = 1, TotalNotes = 1 },
+            null,
+            0,
+            null,
+            null);
+
+        renderer.Load(model);
+
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateExcellent), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateFullCombo), Times.Never);
+        resources.Verify(r => r.LoadTexture(TexturePath.ResultPlateStageCleared), Times.Never);
+    }
+
+    [Fact]
+    public void Dispose_ShouldReleaseLoadedTextures()
+    {
+        var resources = new Mock<IResourceManager>();
+        var texture = new Mock<ITexture>();
+        resources.Setup(r => r.ResourceExists(It.IsAny<string>())).Returns(true);
+        resources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(texture.Object);
+        var renderer = new ResultScreenRenderer(resources.Object, null, null, null);
+        var model = ResultScreenModel.Create(
+            new PerformanceSummary { ClearFlag = true, PerfectCount = 100, TotalNotes = 100, PlayingSkill = 100.0 },
+            null,
+            0,
+            null,
+            null);
+
+        renderer.Load(model);
+        renderer.Dispose();
+
+        texture.Verify(t => t.RemoveReference(), Times.AtLeastOnce);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultScreenRendererTests"
+```
+
+Expected: build fails because `ResultScreenRenderer` does not exist.
+
+- [ ] **Step 3: Add renderer implementation**
+
+Create `DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace DTXMania.Game.Lib.Stage.Result
+{
+    public sealed class ResultScreenRenderer : IDisposable
+    {
+        private readonly IResourceManager _resources;
+        private readonly IFont? _smallFont;
+        private readonly IFont? _normalFont;
+        private readonly IFont? _largeFont;
+        private readonly List<ITexture> _loadedTextures = new();
+
+        private ITexture? _backgroundTexture;
+        private ITexture? _rankBackgroundTexture;
+        private ITexture? _rankTexture;
+        private ITexture? _plateTexture;
+        private ITexture? _jacketPanelTexture;
+        private ITexture? _skillPanelTexture;
+        private ITexture? _previewTexture;
+        private ITexture? _newRecordTexture;
+        private bool _disposed;
+
+        public ResultScreenRenderer(
+            IResourceManager resources,
+            IFont? smallFont,
+            IFont? normalFont,
+            IFont? largeFont)
+        {
+            _resources = resources ?? throw new ArgumentNullException(nameof(resources));
+            _smallFont = smallFont;
+            _normalFont = normalFont;
+            _largeFont = largeFont;
+        }
+
+        public static Matrix CreateViewportTransform(Viewport viewport)
+        {
+            float scaleX = viewport.Width / (float)ResultUILayout.NXViewport.Width;
+            float scaleY = viewport.Height / (float)ResultUILayout.NXViewport.Height;
+            float scale = Math.Min(scaleX, scaleY);
+            float offsetX = (viewport.Width - ResultUILayout.NXViewport.Width * scale) / 2.0f;
+            float offsetY = (viewport.Height - ResultUILayout.NXViewport.Height * scale) / 2.0f;
+
+            return Matrix.CreateScale(scale, scale, 1.0f)
+                * Matrix.CreateTranslation(offsetX, offsetY, 0.0f);
+        }
+
+        public void Load(ResultScreenModel model)
+        {
+            if (model == null) throw new ArgumentNullException(nameof(model));
+
+            ReleaseLoadedTextures();
+
+            _backgroundTexture = LoadIfExists(TexturePath.ResultBackground);
+            _rankBackgroundTexture = LoadIfExists(GetRankBackgroundPath(model.Rank));
+            _rankTexture = LoadIfExists(GetRankTexturePath(model.Rank));
+            _plateTexture = model.PlateKind == ResultPlateKind.Failed
+                ? null
+                : LoadIfExists(GetPlateTexturePath(model.PlateKind));
+            _jacketPanelTexture = LoadIfExists(TexturePath.ResultJacketPanel);
+            _skillPanelTexture = LoadIfExists(TexturePath.ResultSkillPanel);
+            _previewTexture = LoadIfExists(model.PreviewImagePath) ?? LoadIfExists(TexturePath.ResultDefaultPreview);
+            _newRecordTexture = model.NewRecord ? LoadIfExists(TexturePath.ResultNewRecord) : null;
+        }
+
+        [ExcludeFromCodeCoverage]
+        public void Draw(SpriteBatch spriteBatch, ResultScreenModel model, ResultRevealState reveal)
+        {
+            if (_disposed || spriteBatch == null || model == null || reveal == null)
+                return;
+
+            DrawTexture(spriteBatch, _backgroundTexture, Vector2.Zero);
+            DrawTexture(spriteBatch, _rankBackgroundTexture, Vector2.Zero);
+            DrawRank(spriteBatch, reveal);
+
+            if (reveal.PanelProgress > 0.0f)
+            {
+                DrawTexture(spriteBatch, _plateTexture, ResultUILayout.ResultPlate.Position);
+                if (model.PlateKind == ResultPlateKind.Failed)
+                    DrawText(spriteBatch, _largeFont, "FAILED", ResultUILayout.ResultPlate.FailedTextPosition, Color.Red);
+
+                DrawTexture(spriteBatch, _jacketPanelTexture, ResultUILayout.Jacket.PanelPosition);
+                DrawPreview(spriteBatch);
+                DrawTexture(spriteBatch, _skillPanelTexture, ResultUILayout.SkillPanel.PanelPosition);
+                DrawModelText(spriteBatch, model);
+
+                if (model.NewRecord)
+                    DrawTexture(spriteBatch, _newRecordTexture, ResultUILayout.NewRecord.BadgePosition);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            ReleaseLoadedTextures();
+            _disposed = true;
+        }
+
+        private ITexture? LoadIfExists(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path) || !_resources.ResourceExists(path))
+                return null;
+
+            try
+            {
+                var texture = _resources.LoadTexture(path);
+                if (texture != null)
+                    _loadedTextures.Add(texture);
+                return texture;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ResultScreenRenderer: Failed to load texture '{path}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private void ReleaseLoadedTextures()
+        {
+            foreach (var texture in _loadedTextures)
+            {
+                texture.RemoveReference();
+            }
+
+            _loadedTextures.Clear();
+            _backgroundTexture = null;
+            _rankBackgroundTexture = null;
+            _rankTexture = null;
+            _plateTexture = null;
+            _jacketPanelTexture = null;
+            _skillPanelTexture = null;
+            _previewTexture = null;
+            _newRecordTexture = null;
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static void DrawTexture(SpriteBatch spriteBatch, ITexture? texture, Vector2 position)
+        {
+            texture?.Draw(spriteBatch, position);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void DrawRank(SpriteBatch spriteBatch, ResultRevealState reveal)
+        {
+            if (_rankTexture == null || reveal.RankProgress <= 0.0f)
+                return;
+
+            int visibleHeight = Math.Clamp(
+                (int)Math.Round(_rankTexture.Height * reveal.RankProgress),
+                0,
+                _rankTexture.Height);
+
+            if (visibleHeight <= 0)
+                return;
+
+            var source = new Rectangle(
+                0,
+                _rankTexture.Height - visibleHeight,
+                _rankTexture.Width,
+                visibleHeight);
+            var destination = new Rectangle(
+                (int)ResultUILayout.Rank.BadgePosition.X,
+                (int)ResultUILayout.Rank.BadgePosition.Y + _rankTexture.Height - visibleHeight,
+                _rankTexture.Width,
+                visibleHeight);
+
+            _rankTexture.Draw(spriteBatch, destination, source, Color.White, 0f, Vector2.Zero, SpriteEffects.None, 0f);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void DrawPreview(SpriteBatch spriteBatch)
+        {
+            if (_previewTexture == null)
+                return;
+
+            _previewTexture.Draw(
+                spriteBatch,
+                ResultUILayout.Jacket.PreviewDestination,
+                null,
+                Color.White,
+                0f,
+                Vector2.Zero,
+                SpriteEffects.None,
+                0f);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private void DrawModelText(SpriteBatch spriteBatch, ResultScreenModel model)
+        {
+            DrawText(spriteBatch, _largeFont, model.ScoreText, ResultUILayout.Score.Position, Color.White);
+            DrawText(spriteBatch, _normalFont, model.Title, ResultUILayout.SongInfo.TitlePosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.Artist, ResultUILayout.SongInfo.ArtistPosition, Color.LightGray);
+
+            DrawText(spriteBatch, _normalFont, model.ChartLevelText, ResultUILayout.SkillPanel.LevelPosition, Color.White);
+            DrawText(spriteBatch, _normalFont, model.PlayingSkillText, ResultUILayout.SkillPanel.PlayingSkillPosition, Color.White);
+            DrawText(spriteBatch, _normalFont, model.GameSkillText, ResultUILayout.SkillPanel.GameSkillPosition, Color.White);
+
+            DrawText(spriteBatch, _smallFont, model.PerfectCountText, ResultUILayout.SkillPanel.PerfectCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GreatCountText, ResultUILayout.SkillPanel.GreatCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GoodCountText, ResultUILayout.SkillPanel.GoodCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.PoorCountText, ResultUILayout.SkillPanel.PoorCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MissCountText, ResultUILayout.SkillPanel.MissCountPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MaxComboText, ResultUILayout.SkillPanel.MaxComboCountPosition, Color.White);
+
+            DrawText(spriteBatch, _smallFont, model.PerfectPercentText, ResultUILayout.SkillPanel.PerfectPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GreatPercentText, ResultUILayout.SkillPanel.GreatPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.GoodPercentText, ResultUILayout.SkillPanel.GoodPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.PoorPercentText, ResultUILayout.SkillPanel.PoorPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MissPercentText, ResultUILayout.SkillPanel.MissPercentPosition, Color.White);
+            DrawText(spriteBatch, _smallFont, model.MaxComboPercentText, ResultUILayout.SkillPanel.MaxComboPercentPosition, Color.White);
+        }
+
+        [ExcludeFromCodeCoverage]
+        private static void DrawText(SpriteBatch spriteBatch, IFont? font, string text, Vector2 position, Color color)
+        {
+            if (font == null || string.IsNullOrEmpty(text))
+                return;
+
+            font.DrawString(spriteBatch, text, position, color);
+        }
+
+        private static string GetRankTexturePath(ResultRank rank)
+        {
+            return rank switch
+            {
+                ResultRank.SS => TexturePath.ResultRankSS,
+                ResultRank.S => TexturePath.ResultRankS,
+                ResultRank.A => TexturePath.ResultRankA,
+                ResultRank.B => TexturePath.ResultRankB,
+                ResultRank.C => TexturePath.ResultRankC,
+                ResultRank.D => TexturePath.ResultRankD,
+                ResultRank.E => TexturePath.ResultRankE,
+                _ => TexturePath.ResultRankE
+            };
+        }
+
+        private static string GetRankBackgroundPath(ResultRank rank)
+        {
+            return rank switch
+            {
+                ResultRank.SS => TexturePath.ResultBackgroundRankSS,
+                ResultRank.S => TexturePath.ResultBackgroundRankS,
+                ResultRank.A => TexturePath.ResultBackgroundRankA,
+                ResultRank.B => TexturePath.ResultBackgroundRankB,
+                ResultRank.C => TexturePath.ResultBackgroundRankC,
+                ResultRank.D => TexturePath.ResultBackgroundRankD,
+                ResultRank.E => TexturePath.ResultBackgroundRankE,
+                _ => TexturePath.ResultBackgroundRankE
+            };
+        }
+
+        private static string GetPlateTexturePath(ResultPlateKind plateKind)
+        {
+            return plateKind switch
+            {
+                ResultPlateKind.Excellent => TexturePath.ResultPlateExcellent,
+                ResultPlateKind.FullCombo => TexturePath.ResultPlateFullCombo,
+                ResultPlateKind.StageCleared => TexturePath.ResultPlateStageCleared,
+                _ => TexturePath.ResultPlateStageCleared
+            };
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultScreenRendererTests"
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Result/ResultScreenRenderer.cs DTXMania.Test/Stage/Result/ResultScreenRendererTests.cs
+git commit -m "feat: add result screen renderer"
+```
+
+## Task 5: Wire NX Result Screen Into `ResultStage`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/ResultStage.cs`
+- Modify: `DTXMania.Test/Stage/ResultStageTests.cs`
+- Modify: `DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs`
+
+- [ ] **Step 1: Write failing stage behavior tests**
+
+In `DTXMania.Test/Stage/ResultStageTests.cs`, add these tests near the existing input tests:
+
+```csharp
+[Fact]
+public void ExecuteInputCommand_WhenRevealIncomplete_ShouldCompleteRevealWithoutNavigating()
+{
+#pragma warning disable SYSLIB0050
+    var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+    var game = DTXMania.Test.TestData.ReflectionHelpers.CreateGame(totalGameTime: 2.0, lastStageTransitionTime: 0.0);
+    var stageManager = new Mock<IStageManager>();
+    var reveal = new DTXMania.Game.Lib.Stage.Result.ResultRevealState();
+
+    SetPrivateField(stage, "_game", game);
+    stage.StageManager = stageManager.Object;
+    SetPrivateField(stage, "_revealState", reveal);
+
+    InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
+
+    Assert.True(reveal.IsComplete);
+    stageManager.Verify(
+        manager => manager.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+        Times.Never);
+}
+
+[Fact]
+public void OnUpdate_WhenRevealCompletesAndNewRecordSoundExists_ShouldPlayNewRecordSoundOnce()
+{
+#pragma warning disable SYSLIB0050
+    var stage = (ResultStage)FormatterServices.GetUninitializedObject(typeof(ResultStage));
+#pragma warning restore SYSLIB0050
+    var sound = new Mock<ISound>();
+    var model = DTXMania.Game.Lib.Stage.Result.ResultScreenModel.Create(
+        new PerformanceSummary { Score = 900000, GameSkill = 100.0 },
+        null,
+        0,
+        null,
+        new SongScore { PlayCount = 1, BestScore = 100, HighSkill = 1.0 });
+    var reveal = new DTXMania.Game.Lib.Stage.Result.ResultRevealState();
+
+    SetPrivateField(stage, "_inputManager", null);
+    SetPrivateField(stage, "_uiManager", new UIManager());
+    SetPrivateField(stage, "_elapsedTime", 0.0);
+    SetPrivateField(stage, "_resultModel", model);
+    SetPrivateField(stage, "_revealState", reveal);
+    SetPrivateField(stage, "_newRecordSound", sound.Object);
+    SetPrivateField(stage, "_newRecordSoundPlayed", false);
+
+    InvokePrivateMethod(stage, "OnUpdate", DTXMania.Game.Lib.Stage.Result.ResultRevealState.TotalRevealSeconds);
+    InvokePrivateMethod(stage, "OnUpdate", 0.1);
+
+    sound.Verify(s => s.Play(), Times.Once);
+}
+```
+
+In `DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs`, add this activation test:
+
+```csharp
+[Fact]
+public void OnActivate_ShouldBuildModelBeforePersistenceAndInitializeReveal()
+{
+#pragma warning disable SYSLIB0050
+    var stage = (InspectableNullInputResultStage)FormatterServices.GetUninitializedObject(typeof(InspectableNullInputResultStage));
+#pragma warning restore SYSLIB0050
+    var summary = new PerformanceSummary
+    {
+        Score = 123456,
+        ClearFlag = true,
+        PerfectCount = 10,
+        TotalNotes = 10,
+        PlayingSkill = 100.0,
+        GameSkill = 100.0
+    };
+
+    SetPrivateField(stage, "_inputManager", null);
+    SetPrivateField(stage, "_sharedData", new Dictionary<string, object>
+    {
+        ["performanceSummary"] = summary
+    });
+
+    var exception = Record.Exception(() => InvokePrivateMethod(stage, "OnActivate"));
+
+    Assert.Null(exception);
+    Assert.True(stage.ResultFontRequested);
+    Assert.NotNull(GetPrivateField<object>(stage, "_resultModel"));
+    Assert.NotNull(GetPrivateField<object>(stage, "_revealState"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultStageTests|FullyQualifiedName~ResultStageAdditionalCoverageTests"
+```
+
+Expected: build fails because `ResultStage` has no `_revealState`, `_resultModel`, `_newRecordSound`, or updated behavior.
+
+- [ ] **Step 3: Add new usings and fields to `ResultStage`**
+
+In `DTXMania.Game/Lib/Stage/ResultStage.cs`, add:
+
+```csharp
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Result;
+```
+
+Add these fields near the existing UI fields:
+
+```csharp
+        private ResultScreenModel _resultModel;
+        private ResultRevealState _revealState;
+        private ResultScreenRenderer _resultRenderer;
+        private IFont _smallResultFont;
+        private IFont _largeResultFont;
+        private ISound _resultSound;
+        private ISound _newRecordSound;
+        private bool _newRecordSoundPlayed;
+```
+
+Add sound path constants near the fields:
+
+```csharp
+        private const string StageClearSoundPath = "Sounds/Stage Clear.ogg";
+        private const string FullComboSoundPath = "Sounds/Full Combo.ogg";
+        private const string ExcellentSoundPath = "Sounds/Excellent.ogg";
+        private const string NewRecordSoundPath = "Sounds/New Record.ogg";
+```
+
+- [ ] **Step 4: Replace activation flow**
+
+In `OnActivate`, replace the body before input queue clearing with this sequence:
+
+```csharp
+            ExtractSharedData();
+
+            var selectedChart = ResolveSelectedChart();
+            var previousScore = ResolvePreviousScore(selectedChart);
+            _resultModel = CreateResultScreenModel(_performanceSummary, _selectedSong, _selectedDifficulty, selectedChart, previousScore);
+
+            PersistPerformanceSummary(selectedChart);
+
+            InitializeComponents();
+            _revealState = new ResultRevealState();
+            _newRecordSoundPlayed = false;
+            PlayResultSound();
+```
+
+Keep the existing input queue clearing and debug line after this sequence.
+
+Add these helper methods under `Components`:
+
+```csharp
+        internal virtual SongChart ResolveSelectedChart()
+        {
+            return _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
+        }
+
+        internal virtual SongScore ResolvePreviousScore(SongChart selectedChart)
+        {
+            if (_selectedSong?.Scores != null && selectedChart != null)
+            {
+                foreach (var score in _selectedSong.Scores)
+                {
+                    if (score?.ChartId == selectedChart.Id && selectedChart.Id != 0)
+                        return score;
+                }
+            }
+
+            return _selectedSong?.GetScore(_selectedDifficulty);
+        }
+
+        internal virtual ResultScreenModel CreateResultScreenModel(
+            PerformanceSummary summary,
+            SongListNode selectedSong,
+            int selectedDifficulty,
+            SongChart selectedChart,
+            SongScore previousScore)
+        {
+            return ResultScreenModel.Create(summary, selectedSong, selectedDifficulty, selectedChart, previousScore);
+        }
+
+        private void PersistPerformanceSummary(SongChart selectedChart)
+        {
+            if (selectedChart == null || selectedChart.Id <= 0 || _performanceSummary == null)
+                return;
+
+            _ = SongManager.Instance.UpdateScoreAsync(
+                    selectedChart.Id,
+                    EInstrumentPart.DRUMS,
+                    _performanceSummary)
+                .ContinueWith(
+                    task => System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to persist score: {task.Exception?.GetBaseException().Message}"),
+                    TaskContinuationOptions.OnlyOnFaulted);
+        }
+```
+
+- [ ] **Step 5: Update component initialization and cleanup**
+
+Change `CreateResultFont()` to load a 20px font:
+
+```csharp
+        internal virtual IFont CreateResultFont()
+        {
+            return _resourceManager.LoadFont("NotoSerifJP", ResultUILayout.Fonts.Normal);
+        }
+```
+
+Add:
+
+```csharp
+        internal virtual IFont CreateSmallResultFont()
+        {
+            return _resourceManager.LoadFont("NotoSerifJP", ResultUILayout.Fonts.Small);
+        }
+
+        internal virtual IFont CreateLargeResultFont()
+        {
+            return _resourceManager.LoadFont("NotoSerifJP", ResultUILayout.Fonts.Large, FontStyle.Bold);
+        }
+
+        internal virtual ResultScreenRenderer CreateResultRenderer()
+        {
+            return new ResultScreenRenderer(_resourceManager, _smallResultFont, _resultFont, _largeResultFont);
+        }
+```
+
+In `InitializeComponents`, after `_resultFont = CreateResultFont();`, add:
+
+```csharp
+                _smallResultFont = CreateSmallResultFont();
+                _largeResultFont = CreateLargeResultFont();
+                _resultRenderer = CreateResultRenderer();
+                _resultRenderer.Load(_resultModel);
+                _resultSound = LoadSoundForPlate(_resultModel?.PlateKind ?? ResultPlateKind.StageCleared);
+                _newRecordSound = _resultModel?.NewRecord == true ? TryLoadSound(NewRecordSoundPath) : null;
+```
+
+In the `catch`, clear all font and renderer fields:
+
+```csharp
+                _resultFont = null;
+                _smallResultFont = null;
+                _largeResultFont = null;
+                _resultRenderer = null;
+```
+
+In `CleanupComponents`, add releases:
+
+```csharp
+            _smallResultFont?.RemoveReference();
+            _smallResultFont = null;
+            _largeResultFont?.RemoveReference();
+            _largeResultFont = null;
+            _resultRenderer?.Dispose();
+            _resultRenderer = null;
+            _resultSound?.RemoveReference();
+            _resultSound = null;
+            _newRecordSound?.RemoveReference();
+            _newRecordSound = null;
+```
+
+- [ ] **Step 6: Add result sound helpers**
+
+Add these methods under input or components:
+
+```csharp
+        private ISound LoadSoundForPlate(ResultPlateKind plateKind)
+        {
+            return plateKind switch
+            {
+                ResultPlateKind.Excellent => TryLoadSound(ExcellentSoundPath),
+                ResultPlateKind.FullCombo => TryLoadSound(FullComboSoundPath),
+                _ => TryLoadSound(StageClearSoundPath)
+            };
+        }
+
+        private ISound TryLoadSound(string path)
+        {
+            if (_resourceManager == null || string.IsNullOrWhiteSpace(path))
+                return null;
+
+            try
+            {
+                if (!_resourceManager.ResourceExists(path))
+                    return null;
+
+                return _resourceManager.LoadSound(path);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ResultStage: Failed to load sound '{path}': {ex.Message}");
+                return null;
+            }
+        }
+
+        private void PlayResultSound()
+        {
+            _resultSound?.Play();
+        }
+
+        private void PlayNewRecordSoundIfReady()
+        {
+            if (_newRecordSoundPlayed || _resultModel?.NewRecord != true || _revealState?.IsComplete != true)
+                return;
+
+            _newRecordSound?.Play();
+            _newRecordSoundPlayed = true;
+        }
+```
+
+- [ ] **Step 7: Update `OnUpdate` and input handling**
+
+In `OnUpdate`, after `_elapsedTime += deltaTime;`, add:
+
+```csharp
+            _revealState?.Update(deltaTime);
+            PlayNewRecordSoundIfReady();
+```
+
+In `ExecuteInputCommand`, replace the activate/back case body with:
+
+```csharp
+                    if (_revealState != null && !_revealState.IsComplete)
+                    {
+                        _revealState.Complete();
+                        PlayNewRecordSoundIfReady();
+                        break;
+                    }
+
+                    if (_game is BaseGame baseGame && baseGame.CanPerformStageTransition())
+                    {
+                        baseGame.MarkStageTransition();
+                        ReturnToSongSelect();
+                    }
+                    break;
+```
+
+- [ ] **Step 8: Replace drawing**
+
+Replace `OnDraw` with:
+
+```csharp
+        [ExcludeFromCodeCoverage]
+        protected override void OnDraw(double deltaTime)
+        {
+            if (_spriteBatch == null)
+                return;
+
+            var viewport = _spriteBatch.GraphicsDevice.Viewport;
+            var transform = ResultScreenRenderer.CreateViewportTransform(viewport);
+
+            _spriteBatch.Begin(transformMatrix: transform);
+
+            if (_resultRenderer != null && _resultModel != null && _revealState != null)
+            {
+                _resultRenderer.Draw(_spriteBatch, _resultModel, _revealState);
+            }
+            else
+            {
+                DrawBackground();
+            }
+
+            _spriteBatch.End();
+        }
+```
+
+Leave `DrawBackground`, `DrawFallbackBackground`, and `DrawTexture` in place for existing fallback tests. Remove `DrawResults` and `DrawResultLine` only after updating tests that invoke them.
+
+- [ ] **Step 9: Update test subclass overrides**
+
+In `ResultStageTests.cs`, update `InspectableResultStage` with these overrides:
+
+```csharp
+            internal override IFont CreateSmallResultFont()
+            {
+                return null!;
+            }
+
+            internal override IFont CreateLargeResultFont()
+            {
+                return null!;
+            }
+
+            internal override ResultScreenRenderer CreateResultRenderer()
+            {
+                return null!;
+            }
+```
+
+In `ResultStageAdditionalCoverageTests.cs`, update `InspectableNullInputResultStage` similarly:
+
+```csharp
+        internal override IFont CreateSmallResultFont()
+        {
+            return null!;
+        }
+
+        internal override IFont CreateLargeResultFont()
+        {
+            return null!;
+        }
+
+        internal override ResultScreenRenderer CreateResultRenderer()
+        {
+            return null!;
+        }
+```
+
+Delete or rewrite the old `DrawResultLine_WhenTextIsEmpty_ShouldNotAdvanceCurrentY` test, because centered text lines are no longer part of result rendering. Replace it with:
+
+```csharp
+[Fact]
+public void ExecuteInputCommand_WhenRevealAlreadyComplete_ShouldNavigate()
+{
+    var stage = CreateUninitializedResultStageWithStageManager();
+    var reveal = new DTXMania.Game.Lib.Stage.Result.ResultRevealState();
+    reveal.Complete();
+    SetPrivateField(stage, "_revealState", reveal);
+
+    InvokePrivateMethod(stage, "ExecuteInputCommand", new InputCommand(InputCommandType.Activate, 0.0));
+
+    VerifySongSelectTransition(stage);
+}
+```
+
+- [ ] **Step 10: Run focused result-stage tests**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultStageTests|FullyQualifiedName~ResultStageAdditionalCoverageTests"
+```
+
+Expected: tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ResultStage.cs DTXMania.Test/Stage/ResultStageTests.cs DTXMania.Test/Stage/ResultStageAdditionalCoverageTests.cs
+git commit -m "feat: show NX-style result stage"
+```
+
+## Task 6: Verification And Cleanup
+
+**Files:**
+- Inspect: `DTXMania.Game/Lib/Stage/ResultStage.cs`
+- Inspect: `DTXMania.Game/Lib/Stage/Result/*.cs`
+- Inspect: `DTXMania.Test/Stage/Result*.cs`
+- Inspect: `DTXMania.Test/Stage/Result/*.cs`
+
+- [ ] **Step 1: Run all focused result tests**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~Result"
+```
+
+Expected: all result-related tests pass.
+
+- [ ] **Step 2: Run the Mac test suite**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: all Mac-safe tests pass.
+
+- [ ] **Step 3: Build the Mac game project**
+
+Run:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Expected: build succeeds without warnings introduced by this change.
+
+- [ ] **Step 4: Inspect changed files for accidental broad scope**
+
+Run:
+
+```bash
+git diff --stat HEAD
+```
+
+Expected: changes are limited to result-stage model/renderer/reveal code, result layout/texture constants, and result tests.
+
+Run:
+
+```bash
+git diff -- DTXManiaNX
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit verification-only cleanup if any was needed**
+
+If Step 1-4 required small fixes, commit those fixes:
+
+```bash
+git add DTXMania.Game/Lib/Stage/ResultStage.cs DTXMania.Game/Lib/Stage/Result DTXMania.Game/Lib/Resources/TexturePath.cs DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs DTXMania.Test/Stage DTXMania.Test/Resources/TexturePathTests.cs DTXMania.Test/UI/PerformanceUILayoutTests.cs
+git commit -m "test: verify result stage NX parity"
+```
+
+If no fixes were needed after Task 5, skip this commit.

--- a/docs/superpowers/plans/2026-05-31-result-stage-nx-parity.md
+++ b/docs/superpowers/plans/2026-05-31-result-stage-nx-parity.md
@@ -47,6 +47,8 @@
 - Modify: `DTXMania.Test/Resources/TexturePathTests.cs`
 - Modify: `DTXMania.Test/UI/PerformanceUILayoutTests.cs`
 
+Correction: `ResultBackgroundRankSS/S/A/B/C/D/E` are optional skin override assets and must stay out of `TexturePath.GetAllTexturePaths()`, which is used for required preload/validation paths. Expose those seven rank background paths through `GetOptionalResultTexturePaths()` instead; keep only required structural result assets in `GetAllTexturePaths()`.
+
 - [ ] **Step 1: Write failing texture path tests**
 
 Add these facts to `DTXMania.Test/Resources/TexturePathTests.cs` near the existing result/background tests:
@@ -180,16 +182,9 @@ In `DTXMania.Game/Lib/Resources/TexturePath.cs`, add this region after `ResultBa
         public const string ResultDefaultPreview = "Graphics/5_preimage default.png";
 ```
 
-In `GetAllTexturePaths()`, add the new constants immediately after `ResultBackground`:
+In `GetAllTexturePaths()`, add the required structural result constants immediately after `ResultBackground`; do not include the optional rank-specific background overrides:
 
 ```csharp
-                ResultBackgroundRankSS,
-                ResultBackgroundRankS,
-                ResultBackgroundRankA,
-                ResultBackgroundRankB,
-                ResultBackgroundRankC,
-                ResultBackgroundRankD,
-                ResultBackgroundRankE,
                 ResultRankSS,
                 ResultRankS,
                 ResultRankA,

--- a/docs/superpowers/specs/2026-05-31-result-stage-nx-parity-design.md
+++ b/docs/superpowers/specs/2026-05-31-result-stage-nx-parity-design.md
@@ -1,0 +1,208 @@
+# Result Stage NX Parity - Design
+
+Date: 2026-05-31
+Status: Approved design, pending implementation plan
+
+## Goal
+
+Make the CX result stage look and behave like DTXManiaNX as much as possible using the data and assets CX already has. This replaces the current centered text report with an NX-style result screen while avoiding parser and persistence expansion in this slice.
+
+## Background
+
+CX already loads `Graphics/8_background.jpg` for `ResultStage`, but the foreground is still a simple centered text list. NX's result screen is asset-driven: it layers a result background, rank badge, clear/full-combo/excellent plate, jacket/result image area, skill panel, score, judgement breakdown, song metadata, and delayed result reveal behavior.
+
+The required structural assets already exist in `System/Graphics`, including `8_background.jpg`, `8_rank*.png`, `ScreenResult StageCleared.png`, `ScreenResult fullcombo.png`, `ScreenResult Excellent.png`, `7_JacketPanel.png`, `7_SkillPanel.png`, and `8_New Record.png`.
+
+## Scope
+
+In scope:
+
+- Draw an NX-style 1280x720 result layout for drums.
+- Use existing CX result data from `PerformanceSummary`, `selectedSong`, `selectedDifficulty`, and the selected chart.
+- Use NX structural bitmap assets for the background, rank badge, result plate, jacket frame, skill panel frame, and new-record badge.
+- Use MonoGame sprite fonts through CX's existing `IFont`/`ManagedFont` path for score, judgement counts, percentages, level, skill values, title, and artist.
+- Add NX-style reveal timing.
+- Make confirm/back complete the reveal first, then return to song select after the reveal is complete.
+- Select result sounds based on the visible result category when CX has matching sound resources.
+- Fall back cleanly when optional assets, selected song data, or chart data are missing.
+
+Out of scope:
+
+- Parsing or honoring `#RESULTIMAGE_*`, `#RESULTMOVIE_*`, and `#RESULTSOUND_*`.
+- Result movie playback.
+- Result screen capture and auto-save.
+- Guitar/bass result panels.
+- Ghost and progress bar compatibility.
+- Broad result persistence changes beyond the existing `SongManager.UpdateScoreAsync` call.
+
+## Decisions
+
+| Area | Decision | Rationale |
+|---|---|---|
+| Implementation shape | Split into a result model and result renderer | Keeps `ResultStage` from becoming a dense drawing/data-conversion class. |
+| Coordinate system | Draw in NX's native 1280x720 layout | Preserves NX placement and asset proportions. |
+| Non-1280x720 viewport | Uniform scale from 1280x720 | Keeps the result screen faithful instead of reflowing. |
+| Numeric rendering | Use `IFont`/`ManagedFont` | Simpler, more robust, and aligns with the user's preference over bitmap number sheets. |
+| NX metadata support | Use existing CX chart metadata only | Avoids expanding the DTX parser and runtime contract in this slice. |
+| New record | Infer from pre-save in-memory score/skill when available | Gives the NX cue without changing persistence semantics. |
+
+## Architecture
+
+`ResultStage` remains the stage lifecycle owner. It extracts shared data, persists the result, updates reveal state, handles input, and transitions back to song select.
+
+Add `ResultScreenModel` as the testable display-data layer. It is built from:
+
+- `PerformanceSummary`
+- `SongListNode? selectedSong`
+- selected difficulty index
+- selected `SongChart?`
+- previous `SongScore?` for new-record detection
+
+The model computes:
+
+- Rank index and rank label.
+- Result plate category: Excellent, Full Combo, Stage Cleared, Failed.
+- Formatted score, max combo, judgement counts, judgement percentages, playing skill, game skill, and chart level.
+- Song title and artist fallbacks.
+- Preview image path or default preview fallback.
+- New-record flag.
+
+Add a result-specific renderer, preferably `ResultScreenRenderer`, to own resource loading and NX-style drawing. The renderer depends on `IResourceManager`, `GraphicsDevice`, and the existing result font. It should expose a narrow surface such as:
+
+```csharp
+public sealed class ResultScreenRenderer : IDisposable
+{
+    public ResultScreenRenderer(IResourceManager resources, GraphicsDevice graphicsDevice, IFont font);
+    public void Load(ResultScreenModel model);
+    public void Draw(SpriteBatch spriteBatch, ResultScreenModel model, ResultRevealState reveal, Viewport viewport);
+}
+```
+
+Move fixed layout coordinates into `ResultUILayout`. Move structural result asset paths into `TexturePath` constants.
+
+## Data Flow
+
+On activation:
+
+1. Extract `performanceSummary`, `selectedSong`, and `selectedDifficulty`.
+2. Resolve the selected chart via `selectedSong.GetCurrentDifficultyChart(selectedDifficulty)`.
+3. Resolve the previous score for that chart/difficulty before persistence. Prefer a score whose `ChartId` matches the selected chart; otherwise use `selectedSong.GetScore(selectedDifficulty)` as the legacy UI fallback.
+4. Build `ResultScreenModel`.
+5. Persist the result with the existing `SongManager.Instance.UpdateScoreAsync(...)` path.
+6. Initialize renderer resources and reveal state.
+7. Clear pending input commands to avoid immediate transition.
+
+Build the model before persistence so new-record detection compares against the old in-memory score/skill values.
+
+## Rank And Plate Rules
+
+Rank uses the NX modern rank thresholds over the current play's `PlayingSkill`:
+
+| Rank | Threshold |
+|---|---:|
+| SS | `>= 95` |
+| S | `>= 80` |
+| A | `>= 73` |
+| B | `>= 63` |
+| C | `>= 53` |
+| D | `>= 45` |
+| E | below `45` |
+
+The result plate is selected in priority order:
+
+1. Excellent: `TotalNotes > 0` and `PerfectCount == TotalNotes`.
+2. Full Combo: `ClearFlag == true`, `PoorCount == 0`, and `MissCount == 0`.
+3. Stage Cleared: `ClearFlag == true`.
+4. Failed: no NX failed plate exists in the current skin, so use the same layout with a clear text fallback instead of a missing texture.
+
+## Rendering
+
+The renderer draws in this layer order:
+
+1. Result background, normally `TexturePath.ResultBackground`.
+2. Rank-specific background if a matching NX skin asset exists, using paths such as `Graphics/8_background rankSS.png` through `Graphics/8_background rankE.png`; otherwise keep `TexturePath.ResultBackground`.
+3. Rank badge, using `8_rankSS.png` through `8_rankE.png`.
+4. Result plate: Excellent, Full Combo, or Stage Cleared.
+5. Jacket frame: `7_JacketPanel.png`.
+6. Preview/default image, scaled into the NX jacket area.
+7. Skill panel frame: `7_SkillPanel.png`.
+8. Font-rendered judgement counts and percentages.
+9. Font-rendered playing skill, game skill, chart level, and score.
+10. Font-rendered song title and artist.
+11. New-record badge when applicable.
+
+The renderer should use `IResourceManager.ResourceExists` for optional structural assets before loading, because `LoadTexture` returns fallback textures. Missing optional assets should disable that element, not draw a fallback placeholder that looks like a real result component.
+
+## Reveal Behavior
+
+Use elapsed-time based reveal state, independent of frame rate.
+
+Recommended reveal phases:
+
+- `RankReveal`: rank badge reveals with an NX-like vertical crop.
+- `PanelReveal`: result plate, jacket, and skill panel become visible.
+- `Complete`: all static elements visible and navigation is allowed.
+
+Input behavior:
+
+- Confirm/back during reveal completes all reveal phases immediately.
+- Confirm/back after reveal returns to song select using the existing `DTXManiaFadeTransition`.
+- Navigation still respects `BaseGame.CanPerformStageTransition()`.
+
+## Sounds
+
+When the result stage starts, choose a sound category from the same model state used for the plate:
+
+- Excellent -> excellent sound if available.
+- Full Combo -> full-combo sound if available.
+- Otherwise cleared/failed -> stage-clear sound if available.
+
+If CX does not expose one of these skin sounds through the current resource layer, skip that sound rather than introducing a broad skin-system change in this slice.
+
+## Error Handling
+
+- Missing `PerformanceSummary`: build the existing default zero summary.
+- Missing selected song/chart: render "Unknown Song", "Unknown Artist", zero level, and default preview.
+- Missing preview image: draw `Graphics/5_preimage default.png`.
+- Missing structural asset: omit only that layer and keep the rest of the result screen usable.
+- Missing font: keep the current rectangle fallback only for essential navigation/text placeholders.
+- Persistence failure should not block showing the result screen; log and continue.
+
+## Tests
+
+Add or update unit tests for model behavior:
+
+- Rank threshold boundaries.
+- Plate selection for excellent, full combo, stage cleared, and failed.
+- Judgement percentage formatting with non-zero and zero totals.
+- Score, level, playing skill, and game skill formatting.
+- Preview image fallback selection.
+- New-record detection from previous score and skill data.
+
+Add or update `ResultStage` tests:
+
+- Activation builds the model before save.
+- Confirm/back during reveal completes reveal without navigating.
+- Confirm/back after reveal navigates to song select.
+- Missing selected song/chart does not throw.
+- Missing optional assets do not throw.
+
+Focused verification:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ResultStage"
+```
+
+Final verification:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+## Implementation Notes
+
+- Prefer `ResultScreenModel` tests over graphics-device tests for formatting and decision logic.
+- Keep renderer seams narrow so tests can verify load/draw decisions without requiring real MonoGame rendering.
+- Avoid changing DTX parser entities for `RESULTIMAGE`, `RESULTMOVIE`, or `RESULTSOUND` in this slice.
+- Keep legacy `DTXManiaNX` as reference only.


### PR DESCRIPTION
## Summary
- Replace CX's centered result text screen with an NX-style result screen using existing CX performance data.
- Add `ResultScreenModel` for rank computation, plate category, formatting, preview fallback, and new-record detection.
- Add `ResultRevealState` for frame-rate independent reveal timing.
- Add `ResultScreenRenderer` for resource loading and drawing in virtual 1280x720 coordinates with sprite-font text.
- Update `ResultStage` to own the model, reveal state, and renderer delegation.
- Add NX structural result texture constants to `TexturePath` and layout coordinates to `ResultUILayout`.
- Comprehensive test coverage for model, reveal state, renderer, layout, and updated stage tests.

#### Test plan
- [x] `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj` passes
- [x] All new components have dedicated unit tests
- [x] `TexturePath` and `ResultUILayout` tests updated

Generated with [Devin](https://cli.devin.ai/docs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced animated result screen with rank display, performance statistics, skill ratings, and achievement indicators.
  * Implemented phased reveal animation for progressive result element display.

* **Tests**
  * Added comprehensive unit test coverage for result screen rendering, model logic, and display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->