### PR TITLE
feat: add song bookmarks with dedicated tab and star markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ DTXMania.Game.Lib.Utilities - AppPaths, CacheManager, PathValidator
 - **Factory**: ResourceManagerFactory, ManagedFont
 - **Strategy**: Transition types (FadeTransition, CrossfadeTransition, etc.)
 - **Observer**: Stage lifecycle events, Graphics device events, lane hit events
-- **Component**: PerformanceStage composition of 18 subsystems
+- **Component**: PerformanceStage composition of 23 subsystems
 - **Reference Counting**: Resource management (AddReference/RemoveReference)
 
 ## Development Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ DTXMania.Game.Lib.Resources - ResourceManager, ManagedTexture/Sound/Font, SkinMa
 DTXMania.Game.Lib.Song      - SongManager, DTXChartParser, ChartManager
 DTXMania.Game.Lib.Song.Entities - Song, SongScore, PerformanceHistory
 DTXMania.Game.Lib.Stage     - BaseStage, StageManager, 7 stage types, 6 transition types
-DTXMania.Game.Lib.Stage.Performance - 18 specialized performance components
+DTXMania.Game.Lib.Stage.Performance - 23 specialized performance components
 DTXMania.Game.Lib.UI        - UIManager, UIElement, UIContainer, DTXManiaVisualTheme
 DTXMania.Game.Lib.UI.Components - UILabel, UIButton, UIImage, UIPanel, UIList
 DTXMania.Game.Lib.UI.Layout - SongSelectionUILayout, PerformanceUILayout, ResultUILayout
@@ -106,12 +106,13 @@ DTXMania.Game.Lib.Utilities - AppPaths, CacheManager, PathValidator
 - BaseStage is the abstract base class; all stages implement IStage
 - `KeyAssign/` subdirectory: DrumKeyAssignPanel, SystemKeyAssignPanel, KeyConflictChecker for input mapping UI
 
-**Performance Stage** (`Lib/Stage/Performance/`): The most complex stage, composed of 18 specialized components:
-- AudioLoader, BackgroundRenderer, ComboDisplay, ComboManager, EffectsManager
+**Performance Stage** (`Lib/Stage/Performance/`): The most complex stage, composed of 23 specialized components:
+- AudioLoader, ChipSoundCache, BackgroundRenderer, LaneBackgroundRenderer, NoteRenderer, PadRenderer
+- ComboDisplay, ComboManager, EffectsManager, PooledEffectsManager
 - GaugeDisplay, GaugeManager, JudgementLineRenderer, JudgementManager, JudgementTextPopup
-- LaneBackgroundRenderer, NoteRenderer, PadRenderer, PerformanceSummary
-- PooledEffectsManager, ScoreDisplay, ScoreManager, SongTimer
-- Event-driven: JudgementManager raises events consumed by ScoreManager, ComboManager, GaugeManager
+- ScoreDisplay, ScoreManager, PerformanceSummary, ScrollSpeedIndicator, SongTimer
+- Skill scoring subsystem: SkillManager, SkillMeterDisplay, SkillPanelDisplay
+- Event-driven: JudgementManager raises events consumed by ScoreManager, ComboManager, GaugeManager, SkillManager
 
 **Resource Management** (`Lib/Resources/`): Reference-counted caching with statistics tracking
 - Interfaces: ITexture, ISound, IFont with managed wrappers (ManagedTexture, ManagedSpriteTexture, ManagedSound, ManagedFont)

--- a/DTXMania.Game/Content/NotoSerifJP-24.spritefont
+++ b/DTXMania.Game/Content/NotoSerifJP-24.spritefont
@@ -83,6 +83,11 @@ with.
         <Start>&#65280;</Start>
         <End>&#65519;</End>
       </CharacterRegion>
+      <!-- Bookmark star marker (★ U+2605) -->
+      <CharacterRegion>
+        <Start>&#9733;</Start>
+        <End>&#9733;</End>
+      </CharacterRegion>
     </CharacterRegions>
   </Asset>
 </XnaContent>

--- a/DTXMania.Game/Content/NotoSerifJP-48.spritefont
+++ b/DTXMania.Game/Content/NotoSerifJP-48.spritefont
@@ -83,6 +83,11 @@ with.
         <Start>&#65280;</Start>
         <End>&#65519;</End>
       </CharacterRegion>
+      <!-- Bookmark star marker (★ U+2605) -->
+      <CharacterRegion>
+        <Start>&#9733;</Start>
+        <End>&#9733;</End>
+      </CharacterRegion>
     </CharacterRegions>
   </Asset>
 </XnaContent>

--- a/DTXMania.Game/Content/NotoSerifJP-Bold.spritefont
+++ b/DTXMania.Game/Content/NotoSerifJP-Bold.spritefont
@@ -36,6 +36,11 @@
         <Start>&#65280;</Start>
         <End>&#65519;</End>
       </CharacterRegion>
+      <!-- Bookmark star marker (★ U+2605) -->
+      <CharacterRegion>
+        <Start>&#9733;</Start>
+        <End>&#9733;</End>
+      </CharacterRegion>
     </CharacterRegions>
   </Asset>
 </XnaContent>

--- a/DTXMania.Game/Content/NotoSerifJP.spritefont
+++ b/DTXMania.Game/Content/NotoSerifJP.spritefont
@@ -83,6 +83,11 @@ with.
         <Start>&#65280;</Start>
         <End>&#65519;</End>
       </CharacterRegion>
+      <!-- Bookmark star marker (★ U+2605) -->
+      <CharacterRegion>
+        <Start>&#9733;</Start>
+        <End>&#9733;</End>
+      </CharacterRegion>
     </CharacterRegions>
   </Asset>
 </XnaContent>

--- a/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
+++ b/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
@@ -27,7 +27,14 @@ namespace DTXMania.Game.Lib.Song.Components
                 if (node == null)
                     continue;
 
-                if (node.DatabaseSong != null && node.DatabaseSong.Id == songId)
+                // Match by the persisted id (DatabaseSongId) when available, falling back to
+                // the entity id. SET.def duplicates can carry a populated DatabaseSongId while
+                // their DatabaseSong.Id is still 0 (AddSongAsync returns the existing id
+                // without stamping it onto the parsed entity), so matching solely on
+                // DatabaseSong.Id would miss them — or worse, match every zero-id node when
+                // songId itself is 0.
+                int? effectiveId = node.DatabaseSongId ?? node.DatabaseSong?.Id;
+                if (node.DatabaseSong != null && effectiveId == songId)
                     node.DatabaseSong.IsBookmarked = isBookmarked;
 
                 if (node.Children.Count > 0)

--- a/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
+++ b/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
@@ -30,7 +30,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 if (node.DatabaseSong != null && node.DatabaseSong.Id == songId)
                     node.DatabaseSong.IsBookmarked = isBookmarked;
 
-                if (node.Children != null && node.Children.Count > 0)
+                if (node.Children.Count > 0)
                     Apply(node.Children, songId, isBookmarked);
             }
         }

--- a/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
+++ b/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace DTXMania.Game.Lib.Song.Components
@@ -15,7 +17,7 @@ namespace DTXMania.Game.Lib.Song.Components
         /// (and descendant) whose <c>DatabaseSong.Id</c> equals <paramref name="songId"/>.
         /// Null-safe: a null collection is ignored.
         /// </summary>
-        public static void Apply(IEnumerable<SongListNode> nodes, int songId, bool isBookmarked)
+        public static void Apply(IEnumerable<SongListNode?>? nodes, int songId, bool isBookmarked)
         {
             if (nodes == null)
                 return;

--- a/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
+++ b/DTXMania.Game/Lib/Song/Components/BookmarkStateReconciler.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    /// <summary>
+    /// Propagates a bookmark-state change to every in-memory <see cref="SongListNode"/>
+    /// representing the same song. The browse tree, Recent list, and Bookmarks list each hold
+    /// distinct node/entity instances per song, so a toggle must reconcile all of them by song
+    /// Id to keep the star marker consistent across tabs without a full reload.
+    /// </summary>
+    public static class BookmarkStateReconciler
+    {
+        /// <summary>
+        /// Recursively sets <c>DatabaseSong.IsBookmarked = isBookmarked</c> on every node
+        /// (and descendant) whose <c>DatabaseSong.Id</c> equals <paramref name="songId"/>.
+        /// Null-safe: a null collection is ignored.
+        /// </summary>
+        public static void Apply(IEnumerable<SongListNode> nodes, int songId, bool isBookmarked)
+        {
+            if (nodes == null)
+                return;
+
+            foreach (var node in nodes)
+            {
+                if (node == null)
+                    continue;
+
+                if (node.DatabaseSong != null && node.DatabaseSong.Id == songId)
+                    node.DatabaseSong.IsBookmarked = isBookmarked;
+
+                if (node.Children != null && node.Children.Count > 0)
+                    Apply(node.Children, songId, isBookmarked);
+            }
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using DTXMania.Game.Lib.Song;
 
 namespace DTXMania.Game.Lib.Song.Components
@@ -14,7 +16,7 @@ namespace DTXMania.Game.Lib.Song.Components
         /// <summary>
         /// True when the node is a real song whose database entity is bookmarked.
         /// </summary>
-        public static bool ShouldShow(SongListNode node)
+        public static bool ShouldShow(SongListNode? node)
         {
             return node != null
                 && node.Type == NodeType.Score

--- a/DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs
@@ -1,0 +1,24 @@
+using DTXMania.Game.Lib.Song;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    /// <summary>
+    /// Render-agnostic decision logic for the bookmark star marker on song bars.
+    /// Kept separate from the renderer so it is unit-testable without a GraphicsDevice.
+    /// </summary>
+    public static class SongBookmarkIndicator
+    {
+        /// <summary>The glyph drawn on a bookmarked song bar.</summary>
+        public const string Glyph = "★";
+
+        /// <summary>
+        /// True when the node is a real song whose database entity is bookmarked.
+        /// </summary>
+        public static bool ShouldShow(SongListNode node)
+        {
+            return node != null
+                && node.Type == NodeType.Score
+                && node.DatabaseSong?.IsBookmarked == true;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -1085,6 +1085,17 @@ namespace DTXMania.Game.Lib.Song.Components
                     spriteBatch.Draw(_whitePixel, textBounds, fallbackColor);
                 }
             }
+
+            // Bookmark star marker (overlay so bookmark toggles don't require rebuilding any
+            // cached text). Mirrors DrawBarInfoWithPerspective so the indicator appears in the
+            // basic rendering path as well.
+            if (_font != null && SongBookmarkIndicator.ShouldShow(node))
+            {
+                var starPos = new Vector2(
+                    itemBounds.X + SongSelectionUILayout.SongBars.BookmarkStarOffsetX,
+                    itemBounds.Y + SongSelectionUILayout.SongBars.BookmarkStarOffsetY);
+                spriteBatch.DrawString(_font, SongBookmarkIndicator.Glyph, starPos, Color.Gold * opacityFactor);
+            }
         }
 
         private string GetDisplayText(SongListNode node)

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -983,6 +983,16 @@ namespace DTXMania.Game.Lib.Song.Components
             {
                 DrawArtistName(spriteBatch, barInfo.SongNode.DatabaseSong.Artist, itemBounds, new Vector2(scaleFactor, scaleFactor), opacityFactor);
             }
+
+            // Bookmark star marker (drawn as an overlay so the cached title texture is not
+            // invalidated when bookmark state changes).
+            if (_font != null && SongBookmarkIndicator.ShouldShow(barInfo.SongNode))
+            {
+                var starPos = new Vector2(
+                    itemBounds.X + SongSelectionUILayout.SongBars.BookmarkStarOffsetX,
+                    itemBounds.Y + SongSelectionUILayout.SongBars.BookmarkStarOffsetY);
+                spriteBatch.DrawString(_font, SongBookmarkIndicator.Glyph, starPos, Color.Gold * opacityFactor);
+            }
         }
 
         private void DrawBasicSongItemWithPerspective(SpriteBatch spriteBatch, SongListNode node, Rectangle itemBounds, bool isSelected, bool isCenter, int barIndex, float scaleFactor, float opacityFactor)

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -986,13 +986,28 @@ namespace DTXMania.Game.Lib.Song.Components
 
             // Bookmark star marker (drawn as an overlay so the cached title texture is not
             // invalidated when bookmark state changes).
-            if (_font != null && SongBookmarkIndicator.ShouldShow(barInfo.SongNode))
-            {
-                var starPos = new Vector2(
-                    itemBounds.X + SongSelectionUILayout.SongBars.BookmarkStarOffsetX,
-                    itemBounds.Y + SongSelectionUILayout.SongBars.BookmarkStarOffsetY);
-                spriteBatch.DrawString(_font, SongBookmarkIndicator.Glyph, starPos, Color.Gold * opacityFactor);
-            }
+            DrawBookmarkGlyph(spriteBatch, barInfo.SongNode, itemBounds, opacityFactor);
+        }
+
+        /// <summary>
+        /// Draw the bookmark star glyph at the NX offset. Renders via the SpriteFont when
+        /// available, otherwise via the managed font, so the indicator stays visible in both
+        /// SpriteFont-only and managed-font-only rendering modes.
+        /// </summary>
+        private void DrawBookmarkGlyph(SpriteBatch spriteBatch, SongListNode node, Rectangle itemBounds, float opacityFactor)
+        {
+            if (!SongBookmarkIndicator.ShouldShow(node) || (_font == null && _managedFont == null))
+                return;
+
+            var starPos = new Vector2(
+                itemBounds.X + SongSelectionUILayout.SongBars.BookmarkStarOffsetX,
+                itemBounds.Y + SongSelectionUILayout.SongBars.BookmarkStarOffsetY);
+            var starColor = Color.Gold * opacityFactor;
+
+            if (_font != null)
+                spriteBatch.DrawString(_font, SongBookmarkIndicator.Glyph, starPos, starColor);
+            else
+                _managedFont!.DrawString(spriteBatch, SongBookmarkIndicator.Glyph, starPos, starColor);
         }
 
         private void DrawBasicSongItemWithPerspective(SpriteBatch spriteBatch, SongListNode node, Rectangle itemBounds, bool isSelected, bool isCenter, int barIndex, float scaleFactor, float opacityFactor)
@@ -1089,13 +1104,7 @@ namespace DTXMania.Game.Lib.Song.Components
             // Bookmark star marker (overlay so bookmark toggles don't require rebuilding any
             // cached text). Mirrors DrawBarInfoWithPerspective so the indicator appears in the
             // basic rendering path as well.
-            if (_font != null && SongBookmarkIndicator.ShouldShow(node))
-            {
-                var starPos = new Vector2(
-                    itemBounds.X + SongSelectionUILayout.SongBars.BookmarkStarOffsetX,
-                    itemBounds.Y + SongSelectionUILayout.SongBars.BookmarkStarOffsetY);
-                spriteBatch.DrawString(_font, SongBookmarkIndicator.Glyph, starPos, Color.Gold * opacityFactor);
-            }
+            DrawBookmarkGlyph(spriteBatch, node, itemBounds, opacityFactor);
         }
 
         private string GetDisplayText(SongListNode node)

--- a/DTXMania.Game/Lib/Song/Entities/Song.cs
+++ b/DTXMania.Game/Lib/Song/Entities/Song.cs
@@ -28,8 +28,8 @@ namespace DTXMania.Game.Lib.Song.Entities
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 
-        // Whether the player has bookmarked this song. Surfaced in the Bookmarks tab
-        // and as a star marker in the All Songs list.
+        // Whether the player has bookmarked this song. Surfaced in the Bookmarks tab and as a
+        // star marker on song bars across all song-list tabs.
         public bool IsBookmarked { get; set; } = false;
 
         // Navigation Properties
@@ -134,6 +134,10 @@ namespace DTXMania.Game.Lib.Song.Entities
                 IsBookmarked = IsBookmarked,
                 CreatedAt = CreatedAt,
                 UpdatedAt = UpdatedAt
+                // Id is intentionally NOT copied: a clone is a detached metadata snapshot,
+                // not a tracked entity. Copying the primary key would make two entities claim
+                // the same identity, which could confuse EF Core change tracking. Call sites
+                // that need a tracked entity hold the original node's DatabaseSong instead.
                 // Note: Charts are not cloned to avoid deep copy complexity
             };
         }

--- a/DTXMania.Game/Lib/Song/Entities/Song.cs
+++ b/DTXMania.Game/Lib/Song/Entities/Song.cs
@@ -131,6 +131,7 @@ namespace DTXMania.Game.Lib.Song.Entities
                 Artist = Artist,
                 Genre = Genre,
                 Comment = Comment,
+                IsBookmarked = IsBookmarked,
                 CreatedAt = CreatedAt,
                 UpdatedAt = UpdatedAt
                 // Note: Charts are not cloned to avoid deep copy complexity

--- a/DTXMania.Game/Lib/Song/Entities/Song.cs
+++ b/DTXMania.Game/Lib/Song/Entities/Song.cs
@@ -27,7 +27,11 @@ namespace DTXMania.Game.Lib.Song.Entities
         // Timestamps
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
         public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
-        
+
+        // Whether the player has bookmarked this song. Surfaced in the Bookmarks tab
+        // and as a star marker in the All Songs list.
+        public bool IsBookmarked { get; set; } = false;
+
         // Navigation Properties
         public virtual ICollection<SongChart> Charts { get; set; } = new List<SongChart>();
         

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -300,11 +300,21 @@ namespace DTXMania.Game.Lib.Song.Entities
 
                 // Check if a chart with this file path already exists
                 var existingChart = await context.SongCharts
+                    .Include(c => c.Song)
                     .FirstOrDefaultAsync(c => c.FilePath == chart.FilePath);
 
                 if (existingChart != null)
                 {
-                    // Song already exists, return the existing song ID
+                    // Song already exists. Hydrate the caller's parsed entity with the
+                    // persisted id and bookmark so in-memory nodes built from it reflect
+                    // real DB state after a rescan. Without the bookmark copy, a bookmarked
+                    // song re-parsed during enumeration keeps its default IsBookmarked ==
+                    // false, hiding the star marker and inverting the B-key toggle (it sets
+                    // the bookmark instead of clearing it). The new-song branch below gets
+                    // the id for free via EF change-tracking; this branch mirrors that.
+                    song.Id = existingChart.SongId;
+                    if (existingChart.Song != null)
+                        song.IsBookmarked = existingChart.Song.IsBookmarked;
                     return existingChart.SongId;
                 }
 
@@ -314,8 +324,12 @@ namespace DTXMania.Game.Lib.Song.Entities
 
                 if (existingSong != null)
                 {
-                    // Song exists, add chart to existing song
-                    
+                    // Song exists, add chart to existing song. Mirror the persisted id and
+                    // bookmark onto the caller's parsed entity for the same reason as the
+                    // duplicate-file-path branch above.
+                    song.Id = existingSong.Id;
+                    song.IsBookmarked = existingSong.IsBookmarked;
+
                     // Calculate file hash if not already set
                     if (string.IsNullOrEmpty(chart.FileHash) && !string.IsNullOrEmpty(chart.FilePath))
                     {

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -745,28 +745,34 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// </summary>
         private async Task ConfigureUtf8EncodingAsync(SongDbContext context)
         {
+            // UTF-8 pragma configuration is best-effort: most modern SQLite installations
+            // default to UTF-8, so a pragma failure here should not abort initialization.
             try
             {
                 // Ensure we can write to the database
                 await context.Database.ExecuteSqlRawAsync("PRAGMA journal_mode = DELETE");
-                
+
                 // Set SQLite pragmas for UTF-8 and case-insensitive comparisons
                 await context.Database.ExecuteSqlRawAsync("PRAGMA case_sensitive_like = OFF");
-                
+
                 System.Diagnostics.Debug.WriteLine("SongDatabaseService: UTF-8 encoding configured for database");
-
-                // Create/update version table to mark Unicode configuration
-                await EnsureDatabaseVersionTableAsync(context);
-
-                // Additive schema upgrade for existing databases: EnsureCreated never
-                // alters an existing schema, so add new columns here, idempotently.
-                await EnsureBookmarkColumnAsync(context);
             }
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not configure UTF-8 encoding: {ex.Message}");
                 // Continue anyway - most modern SQLite installations default to UTF-8
             }
+
+            // Schema migrations must NOT be swallowed by the UTF-8 best-effort catch above:
+            // a failed bookmark-column migration would otherwise leave init reporting success
+            // while bookmark queries fail later with confusing errors. These run unguarded so
+            // real errors propagate (fail fast) during startup.
+            // Create/update version table to mark Unicode configuration as configured.
+            await EnsureDatabaseVersionTableAsync(context);
+
+            // Additive schema upgrade for existing databases: EnsureCreated never alters an
+            // existing schema, so add new columns here, idempotently.
+            await EnsureBookmarkColumnAsync(context);
         }
 
         /// <summary>
@@ -800,36 +806,40 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// <summary>
         /// Ensures the Songs.IsBookmarked column exists. Fresh databases already have it via
         /// EnsureCreated; pre-existing databases get it added here exactly once. Idempotent and
-        /// defensive: a duplicate-column error is treated as success.
+        /// defensive: a duplicate-column error (concurrent caller) is treated as success, but a
+        /// genuine migration failure propagates so initialization fails fast rather than leaving
+        /// the bookmark schema broken for later queries.
         /// </summary>
         private async Task EnsureBookmarkColumnAsync(SongDbContext context)
         {
-            try
+            var columnCount = await context.Database.SqlQueryRaw<int>(
+                "SELECT COUNT(*) FROM pragma_table_info('Songs') WHERE name='IsBookmarked'"
+            ).ToListAsync();
+
+            if (columnCount.FirstOrDefault() == 0)
             {
-                var columnCount = await context.Database.SqlQueryRaw<int>(
-                    "SELECT COUNT(*) FROM pragma_table_info('Songs') WHERE name='IsBookmarked'"
-                ).ToListAsync();
-
-                if (columnCount.FirstOrDefault() > 0)
-                    return; // Column already present (fresh DB or prior upgrade).
-
-                await context.Database.ExecuteSqlRawAsync(
-                    "ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0");
-
-                // Match the EF model's index (fresh DBs get it from EnsureCreated); idempotent.
-                await context.Database.ExecuteSqlRawAsync(
-                    "CREATE INDEX IF NOT EXISTS IX_Songs_IsBookmarked ON Songs(IsBookmarked)");
-
-                System.Diagnostics.Debug.WriteLine("SongDatabaseService: Added Songs.IsBookmarked column");
+                try
+                {
+                    await context.Database.ExecuteSqlRawAsync(
+                        "ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0");
+                    System.Diagnostics.Debug.WriteLine("SongDatabaseService: Added Songs.IsBookmarked column");
+                }
+                catch (Exception ex) when (ex.Message.Contains("duplicate column"))
+                {
+                    // Another caller added it concurrently; nothing to do.
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        "SongDatabaseService: Failed to add IsBookmarked column during schema migration.", ex);
+                }
             }
-            catch (Exception ex) when (ex.Message.Contains("duplicate column"))
-            {
-                // Another caller added it concurrently; nothing to do.
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not add IsBookmarked column: {ex.Message}");
-            }
+
+            // Always ensure the index exists, even on columns added by older versions that
+            // predate the index, so bookmark queries stay fast on partially migrated DBs.
+            // CREATE INDEX IF NOT EXISTS is idempotent.
+            await context.Database.ExecuteSqlRawAsync(
+                "CREATE INDEX IF NOT EXISTS IX_Songs_IsBookmarked ON Songs(IsBookmarked)");
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -582,6 +582,37 @@ namespace DTXMania.Game.Lib.Song.Entities
             return result;
         }
 
+        /// <summary>
+        /// Sets or clears the bookmark flag on a song. No-op if the song id is not found.
+        /// </summary>
+        public async Task SetBookmarkAsync(int songId, bool bookmarked)
+        {
+            using var context = CreateContext();
+            var song = await context.Songs.FirstOrDefaultAsync(s => s.Id == songId);
+            if (song == null) return;
+            song.IsBookmarked = bookmarked;
+            song.UpdatedAt = DateTime.UtcNow;
+            await context.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Returns all bookmarked songs ordered alphabetically by Title (Id as a stable
+        /// tiebreak). Each Song has its Charts and the charts' Scores eagerly loaded so
+        /// callers can build fully-populated SongListNodes, mirroring
+        /// <see cref="GetRecentlyPlayedSongsAsync"/>.
+        /// </summary>
+        public async Task<List<SongEntity>> GetBookmarkedSongsAsync()
+        {
+            using var context = CreateContext();
+            return await context.Songs
+                .Where(s => s.IsBookmarked)
+                .Include(s => s.Charts)
+                    .ThenInclude(c => c.Scores)
+                .OrderBy(s => s.Title)
+                .ThenBy(s => s.Id)
+                .ToListAsync();
+        }
+
         /// Add a score record for a chart
         private async Task AddScoreRecordAsync(SongDbContext context, int chartId, EInstrumentPart instrument)
         {

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -763,10 +763,12 @@ namespace DTXMania.Game.Lib.Song.Entities
                 // Continue anyway - most modern SQLite installations default to UTF-8
             }
 
-            // Schema migrations must NOT be swallowed by the UTF-8 best-effort catch above:
-            // a failed bookmark-column migration would otherwise leave init reporting success
-            // while bookmark queries fail later with confusing errors. These run unguarded so
-            // real errors propagate (fail fast) during startup.
+            // The bookmark-column migration below must NOT be swallowed by the UTF-8
+            // best-effort catch above: a failed migration would otherwise leave init reporting
+            // success while bookmark queries fail later with confusing errors. Note that
+            // EnsureDatabaseVersionTableAsync has its own swallow-all catch and therefore does
+            // NOT fail fast — only EnsureBookmarkColumnAsync propagates real errors. It runs
+            // unguarded so a genuine schema error fails initialization fast.
             // Create/update version table to mark Unicode configuration as configured.
             await EnsureDatabaseVersionTableAsync(context);
 
@@ -824,7 +826,14 @@ namespace DTXMania.Game.Lib.Song.Entities
                         "ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0");
                     System.Diagnostics.Debug.WriteLine("SongDatabaseService: Added Songs.IsBookmarked column");
                 }
-                catch (Exception ex) when (ex.Message.Contains("duplicate column"))
+                // The COUNT guard above already confirmed the column is absent, so the only way
+                // to reach this ALTER and still get a "duplicate column" error is a concurrent
+                // initializer racing us between the check and the ALTER. Microsoft.Data.Sqlite
+                // surfaces SQLite's stable, English-only error messages (SQLite is not localized),
+                // so matching on the message here is reliable and more precise than the generic
+                // error code (SQLITE_ERROR == 1). Narrowing to SqliteException keeps unrelated
+                // faults reaching the rethrow below.
+                catch (SqliteException ex) when (ex.Message.Contains("duplicate column"))
                 {
                     // Another caller added it concurrently; nothing to do.
                 }

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -757,6 +757,10 @@ namespace DTXMania.Game.Lib.Song.Entities
 
                 // Create/update version table to mark Unicode configuration
                 await EnsureDatabaseVersionTableAsync(context);
+
+                // Additive schema upgrade for existing databases: EnsureCreated never
+                // alters an existing schema, so add new columns here, idempotently.
+                await EnsureBookmarkColumnAsync(context);
             }
             catch (Exception ex)
             {
@@ -790,6 +794,37 @@ namespace DTXMania.Game.Lib.Song.Entities
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not create version table: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Ensures the Songs.IsBookmarked column exists. Fresh databases already have it via
+        /// EnsureCreated; pre-existing databases get it added here exactly once. Idempotent and
+        /// defensive: a duplicate-column error is treated as success.
+        /// </summary>
+        private async Task EnsureBookmarkColumnAsync(SongDbContext context)
+        {
+            try
+            {
+                var columnCount = await context.Database.SqlQueryRaw<int>(
+                    "SELECT COUNT(*) FROM pragma_table_info('Songs') WHERE name='IsBookmarked'"
+                ).ToListAsync();
+
+                if (columnCount.FirstOrDefault() > 0)
+                    return; // Column already present (fresh DB or prior upgrade).
+
+                await context.Database.ExecuteSqlRawAsync(
+                    "ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0");
+
+                System.Diagnostics.Debug.WriteLine("SongDatabaseService: Added Songs.IsBookmarked column");
+            }
+            catch (Exception ex) when (ex.Message.Contains("duplicate column"))
+            {
+                // Another caller added it concurrently; nothing to do.
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not add IsBookmarked column: {ex.Message}");
             }
         }
 

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -816,6 +816,10 @@ namespace DTXMania.Game.Lib.Song.Entities
                 await context.Database.ExecuteSqlRawAsync(
                     "ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0");
 
+                // Match the EF model's index (fresh DBs get it from EnsureCreated); idempotent.
+                await context.Database.ExecuteSqlRawAsync(
+                    "CREATE INDEX IF NOT EXISTS IX_Songs_IsBookmarked ON Songs(IsBookmarked)");
+
                 System.Diagnostics.Debug.WriteLine("SongDatabaseService: Added Songs.IsBookmarked column");
             }
             catch (Exception ex) when (ex.Message.Contains("duplicate column"))

--- a/DTXMania.Game/Lib/Song/Entities/SongDbContext.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDbContext.cs
@@ -59,6 +59,8 @@ namespace DTXMania.Game.Lib.Song.Entities
                 .HasIndex(s => s.Artist);
             modelBuilder.Entity<Song>()
                 .HasIndex(s => s.Genre);
+            modelBuilder.Entity<Song>()
+                .HasIndex(s => s.IsBookmarked);
 
             // Configure Unicode support for SongChart text fields
             modelBuilder.Entity<SongChart>()

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1350,10 +1350,12 @@ namespace DTXMania.Game.Lib.Song
                                         {
                                             var songId = await _databaseService.AddSongAsync(diffSong, diffChart);
                                             currentSong.DatabaseSongId = songId;
-                                            // AddSongAsync returns the existing DB id for duplicate charts
-                                            // without assigning it to the parsed entity (diffSong.Id stays 0).
-                                            // Stamp the persisted id so DatabaseSong.Id matches DatabaseSongId —
-                                            // consumers (bookmark toggle, reconciler, telemetry) key off the id.
+                                            // AddSongAsync hydrates diffSong with the persisted id and
+                                            // bookmark for duplicate charts (a freshly parsed entity
+                                            // defaults to Id=0, IsBookmarked=false). The explicit id
+                                            // stamp below is a defensive guarantee that DatabaseSong.Id
+                                            // matches DatabaseSongId — consumers (bookmark toggle,
+                                            // reconciler, telemetry) key off the id.
                                             diffSong.Id = songId;
                                             
                                             // Update the current song's database entities to reflect the latest data

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1605,6 +1605,41 @@ namespace DTXMania.Game.Lib.Song
             return nodes;
         }
 
+        /// <summary>
+        /// Returns bookmarked songs as flat Score nodes, alphabetical by title. Returns an
+        /// empty list if the database is unavailable. Reuses the same node builder as the
+        /// browse list so difficulty cycling, status panel, preview, and activation behave
+        /// identically. Exceptions from the database layer propagate so the caller
+        /// (BeginBookmarksLoad) can distinguish a genuine failure from an empty result.
+        /// </summary>
+        public async Task<List<SongListNode>> GetBookmarkedNodesAsync()
+        {
+            var db = GetDatabaseServiceSnapshot();
+            if (db == null) return new List<SongListNode>();
+
+            var songs = await db.GetBookmarkedSongsAsync().ConfigureAwait(false);
+            var nodes = new List<SongListNode>(songs.Count);
+            foreach (var song in songs)
+            {
+                var charts = song.Charts?.ToArray() ?? Array.Empty<SongChart>();
+                var node = CreateSongNodeFromDatabaseEntities(song, charts);
+                if (node != null)
+                    nodes.Add(node);
+            }
+            return nodes;
+        }
+
+        /// <summary>
+        /// Sets or clears the bookmark flag on a song. Safe no-op when the database is
+        /// unavailable.
+        /// </summary>
+        public async Task SetBookmarkAsync(int songId, bool bookmarked)
+        {
+            var db = GetDatabaseServiceSnapshot();
+            if (db == null) return;
+            await db.SetBookmarkAsync(songId, bookmarked).ConfigureAwait(false);
+        }
+
         #endregion
 
         #region Helper Methods

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1350,6 +1350,11 @@ namespace DTXMania.Game.Lib.Song
                                         {
                                             var songId = await _databaseService.AddSongAsync(diffSong, diffChart);
                                             currentSong.DatabaseSongId = songId;
+                                            // AddSongAsync returns the existing DB id for duplicate charts
+                                            // without assigning it to the parsed entity (diffSong.Id stays 0).
+                                            // Stamp the persisted id so DatabaseSong.Id matches DatabaseSongId —
+                                            // consumers (bookmark toggle, reconciler, telemetry) key off the id.
+                                            diffSong.Id = songId;
                                             
                                             // Update the current song's database entities to reflect the latest data
                                             if (scoreIndex == 0)

--- a/DTXMania.Game/Lib/Song/SongSelectionTab.cs
+++ b/DTXMania.Game/Lib/Song/SongSelectionTab.cs
@@ -8,7 +8,8 @@ namespace DTXMania.Game.Lib.Song
     public enum SongSelectionTab
     {
         AllSongs = 0,
-        RecentPlays = 1
+        RecentPlays = 1,
+        Bookmarks = 2
     }
 
     public static class SongSelectionTabExtensions
@@ -19,7 +20,9 @@ namespace DTXMania.Game.Lib.Song
             return tab switch
             {
                 SongSelectionTab.AllSongs => SongSelectionTab.RecentPlays,
-                SongSelectionTab.RecentPlays => SongSelectionTab.AllSongs
+                SongSelectionTab.RecentPlays => SongSelectionTab.Bookmarks,
+                SongSelectionTab.Bookmarks => SongSelectionTab.AllSongs,
+                _ => SongSelectionTab.AllSongs
             };
         }
 
@@ -30,6 +33,7 @@ namespace DTXMania.Game.Lib.Song
             {
                 SongSelectionTab.AllSongs => "All Songs",
                 SongSelectionTab.RecentPlays => "Recent",
+                SongSelectionTab.Bookmarks => "Bookmarks",
                 _ => tab.ToString()
             };
         }

--- a/DTXMania.Game/Lib/Song/SongSelectionTab.cs
+++ b/DTXMania.Game/Lib/Song/SongSelectionTab.cs
@@ -17,12 +17,13 @@ namespace DTXMania.Game.Lib.Song
         /// <summary>Cycles to the next tab, wrapping back to the first.</summary>
         public static SongSelectionTab Next(this SongSelectionTab tab)
         {
+            // No default arm: a future enum value must add an explicit arm here so the
+            // switch stays exhaustive instead of silently falling through to AllSongs.
             return tab switch
             {
                 SongSelectionTab.AllSongs => SongSelectionTab.RecentPlays,
                 SongSelectionTab.RecentPlays => SongSelectionTab.Bookmarks,
                 SongSelectionTab.Bookmarks => SongSelectionTab.AllSongs,
-                _ => SongSelectionTab.AllSongs
             };
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -2101,7 +2101,17 @@ namespace DTXMania.Game.Lib.Stage
                 BeginRecentPlaysLoad();
 
             if (_activeTab == SongSelectionTab.Bookmarks)
-                BeginBookmarksLoad();
+            {
+                // Chain the load after any in-flight bookmark writes so the DB query reflects
+                // the latest toggles instead of the pre-toggle snapshot. Without this, a
+                // bookmark-on followed by a quick tab switch can query the DB before
+                // SetBookmarkAsync commits, returning a stale list that omits the
+                // just-bookmarked song (the optimistic reconciler only updates nodes already
+                // present in _bookmarkNodes, so a newly bookmarked song wouldn't appear until
+                // the next reload). Task.WhenAll of an empty/completed set settles immediately.
+                var pending = _pendingBookmarkWrites.Values.ToArray();
+                _ = Task.WhenAll(pending).ContinueWith(_ => BeginBookmarksLoad(), TaskScheduler.Default);
+            }
 
             _tabListNeedsRefresh = true;
             PlayCursorMoveSound();
@@ -2214,7 +2224,12 @@ namespace DTXMania.Game.Lib.Stage
 
             bool newState = !song.IsBookmarked;
             song.IsBookmarked = newState; // immediate, in-memory; star refreshes next draw.
-            int songId = song.Id;
+            // Prefer the persisted id over the in-memory entity id. When re-enumerating
+            // SET.def songs that already exist in the DB, AddSongAsync returns the existing
+            // id without assigning it to the parsed SongEntity.Id (left at 0), while
+            // DatabaseSongId holds the real persisted id. Using song.Id would pass 0 to
+            // SetBookmarkAsync (a no-op) and reconcile against every zero-id node.
+            int songId = node.DatabaseSongId ?? song.Id;
             // Bump the per-song toggle generation so a fault from THIS toggle can be told apart
             // from a fault of an older, already-superseded toggle at rollback time.
             int toggleVersion = _bookmarkToggleVersion.AddOrUpdate(songId, 1, (_, v) => v + 1);
@@ -2260,7 +2275,7 @@ namespace DTXMania.Game.Lib.Stage
                 // just swapped, the removal is harmlessly lost — _tabListNeedsRefresh forces the next
                 // update to repopulate from the new list regardless.
                 _bookmarkNodes?.RemoveAll(n =>
-                    ReferenceEquals(n, node) || n.DatabaseSong?.Id == songId);
+                    ReferenceEquals(n, node) || (n.DatabaseSongId ?? n.DatabaseSong?.Id) == songId);
                 _tabListNeedsRefresh = true;
             }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -67,6 +67,13 @@ namespace DTXMania.Game.Lib.Stage
         // IO error, etc.). Distinct from _showEmptyRecentMessage so a corrupted/locked
         // score DB doesn't look identical to "no plays yet."
         private bool _recentPlaysLoadFailed;
+        // Cached bookmark nodes (flat Score nodes), refreshed on activation and on switching
+        // into the Bookmarks tab. Null until first load. volatile: published from a background
+        // load continuation and read on the update thread, paired with _tabListNeedsRefresh.
+        private volatile List<SongListNode>? _bookmarkNodes;
+        private bool _showEmptyBookmarksMessage;
+        // True when the most recent BeginBookmarksLoad continuation failed (DB/IO error).
+        private bool _bookmarksLoadFailed;
         // Set when the active tab's list must be repopulated on the next OnUpdate.
         // Used so background recent-plays loads and lane-hit/Tab switches never mutate
         // SongListDisplay off the update thread. volatile so the update thread reliably
@@ -261,6 +268,9 @@ namespace DTXMania.Game.Lib.Stage
             _recentPlayNodes = null;
             _showEmptyRecentMessage = false;
             _recentPlaysLoadFailed = false;
+            _bookmarkNodes = null;
+            _showEmptyBookmarksMessage = false;
+            _bookmarksLoadFailed = false;
             // Clear any stale refresh flag from the previous activation (e.g., a tab-switch
             // that set the flag just before Deactivate). Without this, the first OnUpdate
             // would repopulate the All Songs list and reset selection/scroll to index 0.
@@ -269,6 +279,7 @@ namespace DTXMania.Game.Lib.Stage
             // from a prior activation discards its stale result.
             _activationVersion++;
             BeginRecentPlaysLoad();
+            BeginBookmarksLoad();
 
             SubscribeTabSwitchLaneHits();
 
@@ -1010,6 +1021,8 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (_activeTab == SongSelectionTab.RecentPlays)
                 PopulateRecentPlaysList();
+            else if (_activeTab == SongSelectionTab.Bookmarks)
+                PopulateBookmarksList();
             else
                 PopulateSongListForCurrentMode();
         }
@@ -1021,6 +1034,15 @@ namespace DTXMania.Game.Lib.Stage
             // Show empty message only when the load succeeded but returned nothing.
             // A failed load gets its own distinct message in the draw path.
             _showEmptyRecentMessage = !_recentPlaysLoadFailed && nodes.Count == 0;
+        }
+
+        private void PopulateBookmarksList()
+        {
+            var nodes = _bookmarkNodes ?? new List<SongListNode>();
+            _songListDisplay.CurrentList = new List<SongListNode>(nodes);
+            // Show empty message only when the load succeeded but returned nothing.
+            // A failed load gets its own distinct message in the draw path.
+            _showEmptyBookmarksMessage = !_bookmarksLoadFailed && nodes.Count == 0;
         }
 
         private void PopulateFilteredSongList()
@@ -1142,6 +1164,20 @@ namespace DTXMania.Game.Lib.Stage
                 string msg = _recentPlaysLoadFailed
                     ? "Could not load recent plays"
                     : "No recent plays yet";
+                _font.DrawString(_spriteBatch, msg,
+                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
+                    Microsoft.Xna.Framework.Color.LightGray);
+            }
+
+            // Draw status message for the Bookmarks tab: distinct text for load failure vs.
+            // genuinely empty, mirroring the Recent-tab status block above.
+            if (_activeTab == SongSelectionTab.Bookmarks && _font != null
+                && (_searchFilterModal == null || !_searchFilterModal.IsOpen)
+                && (_bookmarksLoadFailed || _showEmptyBookmarksMessage))
+            {
+                string msg = _bookmarksLoadFailed
+                    ? "Could not load bookmarks"
+                    : "No bookmarks yet";
                 _font.DrawString(_spriteBatch, msg,
                     new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
                     Microsoft.Xna.Framework.Color.LightGray);
@@ -2019,6 +2055,9 @@ namespace DTXMania.Game.Lib.Stage
             if (_activeTab == SongSelectionTab.RecentPlays)
                 BeginRecentPlaysLoad();
 
+            if (_activeTab == SongSelectionTab.Bookmarks)
+                BeginBookmarksLoad();
+
             _tabListNeedsRefresh = true;
             PlayCursorMoveSound();
         }
@@ -2064,6 +2103,39 @@ namespace DTXMania.Game.Lib.Stage
                     // and reset selection/scroll. Tab switches into Recent already request a
                     // refresh via SwitchToNextTab and rely on this load to populate the list.
                     if (_activeTab == SongSelectionTab.RecentPlays)
+                        _tabListNeedsRefresh = true;
+                }, TaskScheduler.Default);
+        }
+
+        /// <summary>
+        /// Loads bookmark nodes in the background and flags a repopulate when done.
+        /// Safe when the DB is unavailable (returns an empty list). Captures
+        /// <see cref="_activationVersion"/> so a completion that lands after a later
+        /// Deactivate/Activate cycle is discarded instead of overwriting fresh state.
+        /// </summary>
+        private void BeginBookmarksLoad()
+        {
+            int capturedVersion = _activationVersion;
+            _ = SongManager.Instance.GetBookmarkedNodesAsync()
+                .ContinueWith(task =>
+                {
+                    if (task.IsFaulted || task.IsCanceled)
+                    {
+                        System.Diagnostics.Debug.WriteLine(
+                            $"SongSelectionStage: bookmarks load failed:\n{task.Exception}");
+                        if (capturedVersion == _activationVersion)
+                        {
+                            _bookmarksLoadFailed = true;
+                            if (_activeTab == SongSelectionTab.Bookmarks)
+                                _tabListNeedsRefresh = true;
+                        }
+                        return;
+                    }
+                    if (capturedVersion != _activationVersion)
+                        return;
+                    _bookmarksLoadFailed = false;
+                    _bookmarkNodes = task.Result;
+                    if (_activeTab == SongSelectionTab.Bookmarks)
                         _tabListNeedsRefresh = true;
                 }, TaskScheduler.Default);
         }

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -135,6 +135,10 @@ namespace DTXMania.Game.Lib.Stage
         // NOTE: distinct from the visual PerformanceUILayout.LaneType.LT (=6).
         private const int LowTomLaneIndex = 8;
 
+        // Floor Tom in the lane-hit (KeyBindings) numbering; used to toggle a bookmark on the
+        // highlighted song. Distinct from the tab-switch pad (Low Tom = lane 8).
+        private const int FloorTomLaneIndex = 1;
+
         // RenderTarget management for stage-level resource pooling
         private RenderTarget2D _stageRenderTarget;
 
@@ -1227,6 +1231,7 @@ namespace DTXMania.Game.Lib.Stage
             // UI uses it as a meta cancel-capture key, so we poll raw keyboard state here.
             DetectOpenSearchKey();
             DetectTabSwitchKey();
+            DetectBookmarkKey();
 
             // If the modal was just opened this frame, skip processing normal
             // input commands so queued navigation/Back inputs don't leak through
@@ -1256,6 +1261,18 @@ namespace DTXMania.Game.Lib.Stage
                 _inputManager.IsKeyPressed((int)Microsoft.Xna.Framework.Input.Keys.Tab))
             {
                 SwitchToNextTab();
+            }
+        }
+
+        private void DetectBookmarkKey()
+        {
+            // 'B' toggles a bookmark on the highlighted song. Routed through InputManager so
+            // MCP/E2E injected keys are honored. Suppressed implicitly while the search modal
+            // is open because HandleInput early-returns before calling this.
+            if (_inputManager != null &&
+                _inputManager.IsKeyPressed((int)Microsoft.Xna.Framework.Input.Keys.B))
+            {
+                ToggleBookmarkForSelectedSong();
             }
         }
 
@@ -2152,6 +2169,52 @@ namespace DTXMania.Game.Lib.Stage
                 }, TaskScheduler.Default);
         }
 
+        /// <summary>
+        /// Toggles the bookmark flag on the highlighted song. No-op for non-song nodes
+        /// (folders/back boxes). Updates the in-memory flag immediately so the star marker
+        /// refreshes this frame, persists asynchronously, and—on the Bookmarks tab when
+        /// un-bookmarking—removes the row from the cached list and requests a repopulate.
+        /// </summary>
+        private void ToggleBookmarkForSelectedSong()
+        {
+            var node = _songListDisplay?.SelectedSong;
+            if (node == null || node.Type != NodeType.Score)
+                return;
+
+            var song = node.DatabaseSong;
+            if (song == null)
+                return;
+
+            bool newState = !song.IsBookmarked;
+            song.IsBookmarked = newState; // immediate, in-memory; star refreshes next draw.
+            int songId = song.Id;
+
+            // Persist asynchronously; log faults without crashing the stage.
+            _ = SongManager.Instance.SetBookmarkAsync(songId, newState)
+                .ContinueWith(task =>
+                {
+                    if (task.IsFaulted || task.IsCanceled)
+                        System.Diagnostics.Debug.WriteLine(
+                            $"SongSelectionStage: bookmark persist failed:\n{task.Exception}");
+                }, TaskScheduler.Default);
+
+            // On the Bookmarks tab, an un-bookmark should drop the row from view.
+            if (_activeTab == SongSelectionTab.Bookmarks && !newState)
+            {
+                _bookmarkNodes?.RemoveAll(n =>
+                    ReferenceEquals(n, node) || n.DatabaseSong?.Id == songId);
+                _tabListNeedsRefresh = true;
+            }
+
+            PlayCursorMoveSound();
+        }
+
+        private void HandleLaneHitForBookmark(int lane)
+        {
+            if (lane == FloorTomLaneIndex)
+                ToggleBookmarkForSelectedSong();
+        }
+
         private void OnTabSwitchLaneHit(object? sender, DTXMania.Game.Lib.Input.LaneHitEventArgs e)
         {
             // Ignore pad-driven tab switches while the search modal is open, matching the
@@ -2160,6 +2223,7 @@ namespace DTXMania.Game.Lib.Stage
                 return;
 
             HandleLaneHitForTabSwitch(e.Lane);
+            HandleLaneHitForBookmark(e.Lane);
         }
 
         private void HandleLaneHitForTabSwitch(int lane)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -75,6 +75,16 @@ namespace DTXMania.Game.Lib.Stage
         private bool _showEmptyBookmarksMessage;
         // True when the most recent BeginBookmarksLoad continuation failed (DB/IO error).
         private bool _bookmarksLoadFailed;
+        // Per-load sequence guard for BeginBookmarksLoad. Incremented on every call so a
+        // completion from an older same-activation load (e.g., the activation-time warm load
+        // still in flight when the user bookmarks a song and switches to the Bookmarks tab)
+        // can detect it has been superseded by a newer load and discard its stale result
+        // instead of overwriting _bookmarkNodes with a pre-toggle snapshot that omits the
+        // just-bookmarked song. Interlocked because BeginBookmarksLoad is called from both
+        // the update thread (Activate, ProcessPendingBookmarkReverts) and thread-pool
+        // continuations (SwitchToNextTab's Task.WhenAll chain). volatile so the plain read
+        // in the continuation observes the latest increment.
+        private volatile int _bookmarksLoadVersion;
         // Set when the active tab's list must be repopulated on the next OnUpdate.
         // Used so background recent-plays loads and lane-hit/Tab switches never mutate
         // SongListDisplay off the update thread. volatile so the update thread reliably
@@ -2166,11 +2176,18 @@ namespace DTXMania.Game.Lib.Stage
         /// Loads bookmark nodes in the background and flags a repopulate when done.
         /// Safe when the DB is unavailable (returns an empty list). Captures
         /// <see cref="_activationVersion"/> so a completion that lands after a later
-        /// Deactivate/Activate cycle is discarded instead of overwriting fresh state.
+        /// Deactivate/Activate cycle is discarded, and assigns a per-load sequence id
+        /// (<see cref="_bookmarksLoadVersion"/>) so an older same-activation load
+        /// cannot overwrite the result of a newer load.
         /// </summary>
         private void BeginBookmarksLoad()
         {
             int capturedVersion = _activationVersion;
+            // Assign a monotonic per-load id so an older same-activation load (e.g., the
+            // activation-time warm load still in flight when the user bookmarks a song and
+            // switches to the Bookmarks tab) can detect it has been superseded by a newer
+            // load and discard its stale result.
+            int capturedLoadVersion = Interlocked.Increment(ref _bookmarksLoadVersion);
             _ = SongManager.Instance.GetBookmarkedNodesAsync()
                 .ContinueWith(task =>
                 {
@@ -2180,8 +2197,10 @@ namespace DTXMania.Game.Lib.Stage
                         // so DB/IO failures are diagnosable from the debug output.
                         System.Diagnostics.Debug.WriteLine(
                             $"SongSelectionStage: bookmarks load failed:\n{task.Exception}");
-                        // Discard stale completions from a prior activation.
-                        if (capturedVersion == _activationVersion)
+                        // Discard stale completions from a prior activation or a newer
+                        // same-activation load.
+                        if (capturedVersion == _activationVersion
+                            && capturedLoadVersion == _bookmarksLoadVersion)
                         {
                             _bookmarksLoadFailed = true;
                             if (_activeTab == SongSelectionTab.Bookmarks)
@@ -2193,6 +2212,13 @@ namespace DTXMania.Game.Lib.Stage
                     // a slow load from activation N can overwrite the _bookmarkNodes that
                     // activation N+1 already populated, and trigger an unwanted list rebuild.
                     if (capturedVersion != _activationVersion)
+                        return;
+                    // Discard completions from an older same-activation load. Without this
+                    // guard, the activation-time warm load (which queried the DB before a
+                    // bookmark toggle committed) can complete after a newer load triggered
+                    // by a tab switch, overwriting _bookmarkNodes with a stale pre-toggle
+                    // result that omits the just-bookmarked song.
+                    if (capturedLoadVersion != _bookmarksLoadVersion)
                         return;
                     _bookmarksLoadFailed = false;
                     _bookmarkNodes = task.Result;

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -135,8 +135,10 @@ namespace DTXMania.Game.Lib.Stage
         // NOTE: distinct from the visual PerformanceUILayout.LaneType.LT (=6).
         private const int LowTomLaneIndex = 8;
 
-        // Floor Tom in the lane-hit (KeyBindings) numbering; used to toggle a bookmark on the
-        // highlighted song. Distinct from the tab-switch pad (Low Tom = lane 8).
+        // Floor Tom in the lane-hit (KeyBindings) numbering; toggles a bookmark on the
+        // highlighted song. Lane 1 is shared by Floor Tom and Left Cymbal (channels 18 & 11),
+        // so either pad triggers the toggle. Distinct from the tab-switch pad (Low Tom = lane 8,
+        // itself shared with Right Cymbal).
         private const int FloorTomLaneIndex = 1;
 
         // RenderTarget management for stage-level resource pooling
@@ -2201,6 +2203,10 @@ namespace DTXMania.Game.Lib.Stage
             // On the Bookmarks tab, an un-bookmark should drop the row from view.
             if (_activeTab == SongSelectionTab.Bookmarks && !newState)
             {
+                // _bookmarkNodes is volatile and may be replaced by a background BeginBookmarksLoad
+                // continuation. RemoveAll targets the list reference seen here; if that reference was
+                // just swapped, the removal is harmlessly lost — _tabListNeedsRefresh forces the next
+                // update to repopulate from the new list regardless.
                 _bookmarkNodes?.RemoveAll(n =>
                     ReferenceEquals(n, node) || n.DatabaseSong?.Id == songId);
                 _tabListNeedsRefresh = true;

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -94,6 +94,20 @@ namespace DTXMania.Game.Lib.Stage
         // on the update thread, so dictionary access here is single-threaded.
         private readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task> _pendingBookmarkWrites = new();
 
+        // Monotonic per-song toggle generation. Bumped on every toggle so a persist fault from
+        // an older toggle can be detected and its rollback discarded when a newer toggle has
+        // since changed the in-memory flag (otherwise a stale fault would override a successful
+        // later toggle). Accessed only on the update thread; the value is captured immutably by
+        // the background write continuation.
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<int, int> _bookmarkToggleVersion = new();
+
+        // Pending bookmark reverts enqueued by a faulted persist continuation (which runs on a
+        // thread-pool thread). OnUpdate drains this queue on the update thread so the in-memory
+        // flag and the reconciled lists roll back safely without racing the draw/input path.
+        // Each entry carries the toggle generation that triggered it so a superseded revert is
+        // skipped.
+        private readonly System.Collections.Concurrent.ConcurrentQueue<(int SongId, bool RevertTo, int ToggleVersion)> _pendingBookmarkReverts = new();
+
         // Async initialization management
         private Task<List<SongListNode>> _songInitializationTask;
         private bool _songInitializationProcessed = false;
@@ -1123,6 +1137,10 @@ namespace DTXMania.Game.Lib.Stage
             // Update phase
             UpdatePhase(deltaTime);
 
+            // Roll back any bookmark toggles whose persist failed, so the in-memory star does
+            // not silently diverge from the database. Must run on the update thread.
+            ProcessPendingBookmarkReverts();
+
             // Handle input
             HandleInput();
 
@@ -1179,7 +1197,7 @@ namespace DTXMania.Game.Lib.Stage
                     ? "Could not load recent plays"
                     : "No recent plays yet";
                 _font.DrawString(_spriteBatch, msg,
-                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
+                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + SongSelectionUILayout.SongBars.EmptyMessageOffsetX, SongSelectionUILayout.SongBars.SelectedBarY),
                     Microsoft.Xna.Framework.Color.LightGray);
             }
 
@@ -1193,7 +1211,7 @@ namespace DTXMania.Game.Lib.Stage
                     ? "Could not load bookmarks"
                     : "No bookmarks yet";
                 _font.DrawString(_spriteBatch, msg,
-                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
+                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + SongSelectionUILayout.SongBars.EmptyMessageOffsetX, SongSelectionUILayout.SongBars.SelectedBarY),
                     Microsoft.Xna.Framework.Color.LightGray);
             }
 
@@ -2197,24 +2215,34 @@ namespace DTXMania.Game.Lib.Stage
             bool newState = !song.IsBookmarked;
             song.IsBookmarked = newState; // immediate, in-memory; star refreshes next draw.
             int songId = song.Id;
+            // Bump the per-song toggle generation so a fault from THIS toggle can be told apart
+            // from a fault of an older, already-superseded toggle at rollback time.
+            int toggleVersion = _bookmarkToggleVersion.AddOrUpdate(songId, 1, (_, v) => v + 1);
 
             // Persist asynchronously, serialized per song so rapid toggles apply in order and
-            // the last user intent (song.IsBookmarked) is what lands in the database. Each
-            // write chains after the previous in-flight write for the same song; without this,
-            // two overlapping fire-and-forget calls could complete out of order and leave the
-            // DB divergent from the in-memory flag.
+            // the last user intent (the captured newState above) is what lands in the database.
+            // Each write chains after the previous in-flight write for the same song; without
+            // this, two overlapping fire-and-forget calls could complete out of order and leave
+            // the DB divergent from the in-memory flag.
             var prior = _pendingBookmarkWrites.GetOrAdd(songId, _ => Task.CompletedTask);
             var write = prior.ContinueWith(
                 _ => SongManager.Instance.SetBookmarkAsync(songId, newState),
                 TaskScheduler.Default).Unwrap();
             _pendingBookmarkWrites[songId] = write;
 
-            // Log faults without crashing the stage.
+            // If the persist fails, the optimistic in-memory flip would otherwise diverge from
+            // the database (the star would vanish on next load with no feedback). Enqueue a
+            // rollback to the pre-toggle state; OnUpdate applies it on the update thread so it
+            // can't race the draw path. The captured toggleVersion lets the rollback be skipped
+            // if a newer toggle has since superseded this one.
             write.ContinueWith(task =>
             {
                 if (task.IsFaulted || task.IsCanceled)
+                {
                     Debug.WriteLine(
                         $"SongSelectionStage: bookmark persist failed:\n{task.Exception}");
+                    _pendingBookmarkReverts.Enqueue((songId, !newState, toggleVersion));
+                }
             }, TaskScheduler.Default);
 
             // Reconcile the flag across every in-memory representation of this song (browse
@@ -2237,6 +2265,37 @@ namespace DTXMania.Game.Lib.Stage
             }
 
             PlayCursorMoveSound();
+        }
+
+        /// <summary>
+        /// Drains <see cref="_pendingBookmarkReverts"/> on the update thread. For each rollback
+        /// whose toggle generation is still current, the pre-toggle bookmark state is restored
+        /// across every in-memory representation (browse tree, Recent list, Bookmarks list) so the
+        /// star marker matches the database after a failed persist. Superseded reverts — those
+        /// superseded by a newer toggle — are skipped so a stale fault cannot override a later,
+        /// possibly successful toggle.
+        /// </summary>
+        private void ProcessPendingBookmarkReverts()
+        {
+            while (_pendingBookmarkReverts.TryDequeue(out var revert))
+            {
+                if (_bookmarkToggleVersion.TryGetValue(revert.SongId, out var current)
+                    && current != revert.ToggleVersion)
+                {
+                    // A newer toggle has since changed the flag; this fault is stale.
+                    continue;
+                }
+
+                BookmarkStateReconciler.Apply(SongManager.Instance.RootSongs, revert.SongId, revert.RevertTo);
+                BookmarkStateReconciler.Apply(_recentPlayNodes, revert.SongId, revert.RevertTo);
+                BookmarkStateReconciler.Apply(_bookmarkNodes, revert.SongId, revert.RevertTo);
+
+                // On the Bookmarks tab, an un-bookmark that failed to persist wrongly removed
+                // the row from view (the song is still bookmarked in the DB). Re-sync from the
+                // authoritative store so the row reappears.
+                if (_activeTab == SongSelectionTab.Bookmarks)
+                    BeginBookmarksLoad();
+            }
         }
 
         private void HandleLaneHitForBookmark(int lane)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -2200,6 +2200,13 @@ namespace DTXMania.Game.Lib.Stage
                             $"SongSelectionStage: bookmark persist failed:\n{task.Exception}");
                 }, TaskScheduler.Default);
 
+            // Reconcile the flag across every in-memory representation of this song (browse
+            // tree, Recent list, Bookmarks list) so the star marker stays consistent across
+            // tabs without a reload — each surface holds a distinct node/entity instance.
+            BookmarkStateReconciler.Apply(SongManager.Instance.RootSongs, songId, newState);
+            BookmarkStateReconciler.Apply(_recentPlayNodes, songId, newState);
+            BookmarkStateReconciler.Apply(_bookmarkNodes, songId, newState);
+
             // On the Bookmarks tab, an un-bookmark should drop the row from view.
             if (_activeTab == SongSelectionTab.Bookmarks && !newState)
             {

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -69,7 +69,8 @@ namespace DTXMania.Game.Lib.Stage
         private bool _recentPlaysLoadFailed;
         // Cached bookmark nodes (flat Score nodes), refreshed on activation and on switching
         // into the Bookmarks tab. Null until first load. volatile: published from a background
-        // load continuation and read on the update thread, paired with _tabListNeedsRefresh.
+        // load continuation and read on the update thread (release-acquire pair with
+        // _tabListNeedsRefresh).
         private volatile List<SongListNode>? _bookmarkNodes;
         private bool _showEmptyBookmarksMessage;
         // True when the most recent BeginBookmarksLoad continuation failed (DB/IO error).
@@ -2121,8 +2122,11 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     if (task.IsFaulted || task.IsCanceled)
                     {
+                        // Log the full exception (type + stack), not just the base message,
+                        // so DB/IO failures are diagnosable from the debug output.
                         System.Diagnostics.Debug.WriteLine(
                             $"SongSelectionStage: bookmarks load failed:\n{task.Exception}");
+                        // Discard stale completions from a prior activation.
                         if (capturedVersion == _activationVersion)
                         {
                             _bookmarksLoadFailed = true;
@@ -2131,10 +2135,18 @@ namespace DTXMania.Game.Lib.Stage
                         }
                         return;
                     }
+                    // Discard stale completions from a prior activation. Without this guard,
+                    // a slow load from activation N can overwrite the _bookmarkNodes that
+                    // activation N+1 already populated, and trigger an unwanted list rebuild.
                     if (capturedVersion != _activationVersion)
                         return;
                     _bookmarksLoadFailed = false;
                     _bookmarkNodes = task.Result;
+                    // Only request a list repopulate when the user is actually viewing the
+                    // Bookmarks tab. Activate() warms the cache while the user is on All Songs;
+                    // flagging a refresh there would spuriously rebuild the All Songs list
+                    // and reset selection/scroll. Tab switches into Bookmarks already request a
+                    // refresh via SwitchToNextTab and rely on this load to populate the list.
                     if (_activeTab == SongSelectionTab.Bookmarks)
                         _tabListNeedsRefresh = true;
                 }, TaskScheduler.Default);

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -2256,6 +2256,15 @@ namespace DTXMania.Game.Lib.Stage
             // DatabaseSongId holds the real persisted id. Using song.Id would pass 0 to
             // SetBookmarkAsync (a no-op) and reconcile against every zero-id node.
             int songId = node.DatabaseSongId ?? song.Id;
+            // When neither the persisted id nor the entity id is set (e.g. an unpersisted
+            // fallback node whose DatabaseSong.Id is still 0), keying the persistence write
+            // and the cross-list reconciliation on the sentinel 0 would (a) be a silent
+            // no-op in the DB and (b) flip IsBookmarked on EVERY unrelated zero-id node via
+            // BookmarkStateReconciler.Apply. The optimistic in-memory flip on the selected
+            // node above already refreshed its star marker, so bail out before touching the
+            // shared persistence/reconciliation state to leave unrelated nodes untouched.
+            if (songId <= 0)
+                return;
             // Bump the per-song toggle generation so a fault from THIS toggle can be told apart
             // from a fault of an older, already-superseded toggle at rollback time.
             int toggleVersion = _bookmarkToggleVersion.AddOrUpdate(songId, 1, (_, v) => v + 1);

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -87,6 +87,13 @@ namespace DTXMania.Game.Lib.Stage
         // continuation thread; ensures the continuation sees the latest bump.
         private volatile int _activationVersion;
 
+        // Serializes bookmark persistence writes per song. Each toggle chains after the
+        // in-flight write for the same song so rapid double-toggles apply in order and the
+        // last user intent wins in the database, instead of a fire-and-forget race that can
+        // leave the DB divergent from the in-memory flag. ToggleBookmarkForSelectedSong runs
+        // on the update thread, so dictionary access here is single-threaded.
+        private readonly System.Collections.Concurrent.ConcurrentDictionary<int, Task> _pendingBookmarkWrites = new();
+
         // Async initialization management
         private Task<List<SongListNode>> _songInitializationTask;
         private bool _songInitializationProcessed = false;
@@ -2191,14 +2198,24 @@ namespace DTXMania.Game.Lib.Stage
             song.IsBookmarked = newState; // immediate, in-memory; star refreshes next draw.
             int songId = song.Id;
 
-            // Persist asynchronously; log faults without crashing the stage.
-            _ = SongManager.Instance.SetBookmarkAsync(songId, newState)
-                .ContinueWith(task =>
-                {
-                    if (task.IsFaulted || task.IsCanceled)
-                        System.Diagnostics.Debug.WriteLine(
-                            $"SongSelectionStage: bookmark persist failed:\n{task.Exception}");
-                }, TaskScheduler.Default);
+            // Persist asynchronously, serialized per song so rapid toggles apply in order and
+            // the last user intent (song.IsBookmarked) is what lands in the database. Each
+            // write chains after the previous in-flight write for the same song; without this,
+            // two overlapping fire-and-forget calls could complete out of order and leave the
+            // DB divergent from the in-memory flag.
+            var prior = _pendingBookmarkWrites.GetOrAdd(songId, _ => Task.CompletedTask);
+            var write = prior.ContinueWith(
+                _ => SongManager.Instance.SetBookmarkAsync(songId, newState),
+                TaskScheduler.Default).Unwrap();
+            _pendingBookmarkWrites[songId] = write;
+
+            // Log faults without crashing the stage.
+            write.ContinueWith(task =>
+            {
+                if (task.IsFaulted || task.IsCanceled)
+                    Debug.WriteLine(
+                        $"SongSelectionStage: bookmark persist failed:\n{task.Exception}");
+            }, TaskScheduler.Default);
 
             // Reconcile the flag across every in-memory representation of this song (browse
             // tree, Recent list, Bookmarks list) so the star marker stays consistent across

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -248,6 +248,10 @@ namespace DTXMania.Game.Lib.UI.Layout
             public const int SelectedBarY = 269;       // Y position for selected song bar (center position)
             public const int UnselectedBarX = 709;     // Fixed X position for all unselected bars; 18px gap from difficulty panel
             public const int BarWidth = 510;           // Maximum width for song bars
+
+            // Bookmark star marker offsets, relative to the bar's top-left (itemBounds).
+            public const int BookmarkStarOffsetX = 20;
+            public const int BookmarkStarOffsetY = 6;
             
             // Visual constants
             public const int VisibleItems = 13;        // Number of visible song bars

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -252,6 +252,10 @@ namespace DTXMania.Game.Lib.UI.Layout
             // Bookmark star marker offsets, relative to the bar's top-left (itemBounds).
             public const int BookmarkStarOffsetX = 20;
             public const int BookmarkStarOffsetY = 6;
+
+            // Horizontal inset for the Recent/Bookmarks empty-state status text, relative to
+            // UnselectedBarX. Shared by both tabs' "No … yet" / "Could not load …" messages.
+            public const int EmptyMessageOffsetX = 100;
             
             // Visual constants
             public const int VisibleItems = 13;        // Number of visible song bars

--- a/DTXMania.Test/Song/BookmarkStateReconcilerTests.cs
+++ b/DTXMania.Test/Song/BookmarkStateReconcilerTests.cs
@@ -57,5 +57,48 @@ namespace DTXMania.Test.Song
             BookmarkStateReconciler.Apply(new List<SongListNode> { folderNoSong, other }, 42, true);
             Assert.False(other.DatabaseSong!.IsBookmarked);
         }
+
+        // SET.def duplicates can carry a populated DatabaseSongId while their DatabaseSong.Id
+        // is still 0 (AddSongAsync returns the existing id without stamping it onto the parsed
+        // entity). The reconciler must match these by DatabaseSongId so the star propagates,
+        // instead of missing them (or, when songId is 0, mass-updating every zero-id node).
+        [Fact]
+        public void Apply_WhenNodeHasDatabaseSongIdButZeroEntityId_MatchesByPersistedId()
+        {
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSongId = 42,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, IsBookmarked = false }
+            };
+
+            BookmarkStateReconciler.Apply(new List<SongListNode> { node }, songId: 42, isBookmarked: true);
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+        }
+
+        // Guards the zero-id mass-update regression: when reconciling a real songId, nodes
+        // whose DatabaseSongId differs must be left untouched even though their entity id is 0.
+        [Fact]
+        public void Apply_WhenMultipleNodesHaveZeroEntityId_OnlyMatchesByPersistedId()
+        {
+            var match = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSongId = 42,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, IsBookmarked = false }
+            };
+            var other = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSongId = 99,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, IsBookmarked = false }
+            };
+
+            BookmarkStateReconciler.Apply(new List<SongListNode> { match, other }, songId: 42, isBookmarked: true);
+
+            Assert.True(match.DatabaseSong!.IsBookmarked);
+            Assert.False(other.DatabaseSong!.IsBookmarked);
+        }
     }
 }

--- a/DTXMania.Test/Song/BookmarkStateReconcilerTests.cs
+++ b/DTXMania.Test/Song/BookmarkStateReconcilerTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class BookmarkStateReconcilerTests
+    {
+        private static SongListNode Score(int id, bool bookmarked) => new SongListNode
+        {
+            Type = NodeType.Score,
+            DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = id, IsBookmarked = bookmarked }
+        };
+
+        [Fact]
+        public void Apply_SetsFlagOnAllNodesWithMatchingId_AcrossNestedChildren()
+        {
+            var match1 = Score(42, false);
+            var nonMatch = Score(7, false);
+            var folder = new SongListNode
+            {
+                Type = NodeType.Box,
+                Children = new List<SongListNode> { Score(42, false), nonMatch }
+            };
+            var roots = new List<SongListNode> { match1, folder };
+
+            BookmarkStateReconciler.Apply(roots, songId: 42, isBookmarked: true);
+
+            Assert.True(match1.DatabaseSong!.IsBookmarked);
+            Assert.True(folder.Children[0].DatabaseSong!.IsBookmarked);
+            Assert.False(nonMatch.DatabaseSong!.IsBookmarked); // id 7 untouched
+        }
+
+        [Fact]
+        public void Apply_CanClearFlag()
+        {
+            var n = Score(42, true);
+            BookmarkStateReconciler.Apply(new List<SongListNode> { n }, 42, false);
+            Assert.False(n.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void Apply_WithNullCollection_DoesNotThrow()
+        {
+            var ex = Record.Exception(() => BookmarkStateReconciler.Apply(null, 1, true));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void Apply_IgnoresNodesWithoutDatabaseSongOrNonMatchingId()
+        {
+            var folderNoSong = new SongListNode { Type = NodeType.Box };
+            var other = Score(99, false);
+            BookmarkStateReconciler.Apply(new List<SongListNode> { folderNoSong, other }, 42, true);
+            Assert.False(other.DatabaseSong!.IsBookmarked);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongBookmarkIndicatorTests.cs
+++ b/DTXMania.Test/Song/SongBookmarkIndicatorTests.cs
@@ -1,0 +1,53 @@
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongBookmarkIndicatorTests
+    {
+        [Fact]
+        public void ShouldShow_WhenNull_ReturnsFalse()
+        {
+            Assert.False(SongBookmarkIndicator.ShouldShow(null));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenFolderNode_ReturnsFalse()
+        {
+            var node = new SongListNode { Type = NodeType.Box };
+            Assert.False(SongBookmarkIndicator.ShouldShow(node));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenScoreNotBookmarked_ReturnsFalse()
+        {
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { IsBookmarked = false }
+            };
+            Assert.False(SongBookmarkIndicator.ShouldShow(node));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenScoreBookmarked_ReturnsTrue()
+        {
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { IsBookmarked = true }
+            };
+            Assert.True(SongBookmarkIndicator.ShouldShow(node));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenScoreNodeHasNoDatabaseSong_ReturnsFalse()
+        {
+            var node = new SongListNode { Type = NodeType.Score, DatabaseSong = null };
+            Assert.False(SongBookmarkIndicator.ShouldShow(node));
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongDatabaseServiceBookmarkMigrationTests : IDisposable
+    {
+        private readonly string _dbPath;
+
+        public SongDatabaseServiceBookmarkMigrationTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"bookmark_mig_{Guid.NewGuid()}.db");
+        }
+
+        public void Dispose()
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(_dbPath))
+            {
+                try { File.Delete(_dbPath); } catch { /* ignore */ }
+            }
+        }
+
+        private async Task<int> ColumnCountAsync()
+        {
+            SqliteConnection.ClearAllPools();
+            using var conn = new SqliteConnection($"Data Source={_dbPath}");
+            await conn.OpenAsync();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('Songs') WHERE name='IsBookmarked'";
+            return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        }
+
+        [Fact]
+        public async Task InitializeDatabaseAsync_OnLegacyDbMissingColumn_AddsColumn()
+        {
+            // Create a normal DB (has the column + Unicode version table), then drop the
+            // column to simulate a legacy database created before this feature.
+            var first = new SongDatabaseService(_dbPath);
+            await first.InitializeDatabaseAsync();
+            first.Dispose();
+
+            SqliteConnection.ClearAllPools();
+            using (var conn = new SqliteConnection($"Data Source={_dbPath}"))
+            {
+                await conn.OpenAsync();
+                // Drop the index first (SQLite requires this before dropping the indexed column)
+                using var dropIdx = conn.CreateCommand();
+                dropIdx.CommandText = "DROP INDEX IF EXISTS IX_Songs_IsBookmarked";
+                await dropIdx.ExecuteNonQueryAsync();
+
+                using var drop = conn.CreateCommand();
+                drop.CommandText = "ALTER TABLE Songs DROP COLUMN IsBookmarked";
+                await drop.ExecuteNonQueryAsync();
+            }
+            Assert.Equal(0, await ColumnCountAsync()); // confirm the legacy state
+
+            // Re-initialize: the Unicode version table is present so the DB is NOT wiped;
+            // the migration must re-add the column.
+            var second = new SongDatabaseService(_dbPath);
+            await second.InitializeDatabaseAsync();
+            second.Dispose();
+
+            Assert.Equal(1, await ColumnCountAsync());
+        }
+
+        [Fact]
+        public async Task InitializeDatabaseAsync_OnFreshDb_IsIdempotentAndKeepsSingleColumn()
+        {
+            var svc = new SongDatabaseService(_dbPath);
+            await svc.InitializeDatabaseAsync();
+            svc.Dispose();
+
+            // A second service initializing the same file must not error or duplicate.
+            var again = new SongDatabaseService(_dbPath);
+            await again.InitializeDatabaseAsync();
+            again.Dispose();
+
+            Assert.Equal(1, await ColumnCountAsync());
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
@@ -123,5 +123,33 @@ namespace DTXMania.Test.Song
 
             Assert.Equal(1, await ColumnCountAsync());
         }
+
+        // Guards the fail-fast rethrow in EnsureBookmarkColumnAsync: a genuine ALTER failure
+        // (not the tolerated "duplicate column" race) must propagate as an
+        // InvalidOperationException instead of being swallowed and leaving the bookmark schema
+        // broken for later queries. We drop the Songs table (keeping the version table so
+        // EnsureCreated is skipped) so the ADD COLUMN fails with "no such table".
+        [Fact]
+        public async Task EnsureBookmarkColumnAsync_OnGenuineAlterFailure_RethrowsAsInvalidOperationException()
+        {
+            var first = new SongDatabaseService(_dbPath);
+            await first.InitializeDatabaseAsync();
+            first.Dispose();
+
+            SqliteConnection.ClearAllPools();
+            using (var conn = new SqliteConnection($"Data Source={_dbPath}"))
+            {
+                await conn.OpenAsync();
+                using var drop = conn.CreateCommand();
+                drop.CommandText = "DROP TABLE Songs";
+                await drop.ExecuteNonQueryAsync();
+            }
+
+            var second = new SongDatabaseService(_dbPath);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => second.InitializeDatabaseAsync());
+            Assert.Contains("IsBookmarked", ex.Message);
+            second.Dispose();
+        }
     }
 }

--- a/DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
@@ -37,6 +37,16 @@ namespace DTXMania.Test.Song
             return Convert.ToInt32(await cmd.ExecuteScalarAsync());
         }
 
+        private async Task<int> IndexCountAsync()
+        {
+            SqliteConnection.ClearAllPools();
+            using var conn = new SqliteConnection($"Data Source={_dbPath}");
+            await conn.OpenAsync();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name='IX_Songs_IsBookmarked'";
+            return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        }
+
         [Fact]
         public async Task InitializeDatabaseAsync_OnLegacyDbMissingColumn_AddsColumn()
         {
@@ -68,6 +78,35 @@ namespace DTXMania.Test.Song
             second.Dispose();
 
             Assert.Equal(1, await ColumnCountAsync());
+        }
+
+        [Fact]
+        public async Task InitializeDatabaseAsync_OnDbWithColumnButNoIndex_CreatesIndex()
+        {
+            // Simulate a partially migrated DB: the column exists (from an older upgrade) but
+            // the supporting index was never created. Re-initialization must add the index even
+            // though the column is already present (the early-return used to skip index creation).
+            var first = new SongDatabaseService(_dbPath);
+            await first.InitializeDatabaseAsync();
+            first.Dispose();
+
+            SqliteConnection.ClearAllPools();
+            using (var conn = new SqliteConnection($"Data Source={_dbPath}"))
+            {
+                await conn.OpenAsync();
+                using var dropIdx = conn.CreateCommand();
+                dropIdx.CommandText = "DROP INDEX IF EXISTS IX_Songs_IsBookmarked";
+                await dropIdx.ExecuteNonQueryAsync();
+            }
+            Assert.Equal(0, await IndexCountAsync()); // confirm the partially-migrated state
+
+            // Re-initialize: the column is present so only the index should be (re)created.
+            var second = new SongDatabaseService(_dbPath);
+            await second.InitializeDatabaseAsync();
+            second.Dispose();
+
+            Assert.Equal(1, await ColumnCountAsync()); // unchanged
+            Assert.Equal(1, await IndexCountAsync());  // index now enforced
         }
 
         [Fact]

--- a/DTXMania.Test/Song/SongDatabaseServiceBookmarkTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceBookmarkTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongDatabaseServiceBookmarkTests : IDisposable
+    {
+        private readonly SongDatabaseService _db;
+        private readonly string _dbPath;
+
+        public SongDatabaseServiceBookmarkTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"bookmark_db_{Guid.NewGuid()}.db");
+            _db = new SongDatabaseService(_dbPath);
+        }
+
+        public void Dispose()
+        {
+            _db?.Dispose();
+            if (File.Exists(_dbPath))
+            {
+                try { File.Delete(_dbPath); } catch { /* ignore */ }
+            }
+        }
+
+        private async Task<int> AddSongAsync(string title)
+        {
+            var song = new DTXMania.Game.Lib.Song.Entities.Song { Title = title, Artist = "A" };
+            var chart = new SongChart { FilePath = $"/c/{Guid.NewGuid():N}.dtx", HasDrumChart = true, DrumLevel = 30 };
+            await _db.AddSongAsync(song, chart);
+            return (await _db.GetSongsAsync()).Single(s => s.Title == title).Id;
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_TogglesFlagOnAndOff()
+        {
+            await _db.InitializeDatabaseAsync();
+            var id = await AddSongAsync("Song");
+
+            await _db.SetBookmarkAsync(id, true);
+            Assert.True((await _db.GetSongsAsync()).Single(s => s.Id == id).IsBookmarked);
+
+            await _db.SetBookmarkAsync(id, false);
+            Assert.False((await _db.GetSongsAsync()).Single(s => s.Id == id).IsBookmarked);
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_WithUnknownId_DoesNotThrow()
+        {
+            await _db.InitializeDatabaseAsync();
+            var ex = await Record.ExceptionAsync(() => _db.SetBookmarkAsync(999999, true));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task GetBookmarkedSongsAsync_ReturnsOnlyBookmarked_AlphabeticalByTitle()
+        {
+            await _db.InitializeDatabaseAsync();
+            var charlie = await AddSongAsync("Charlie");
+            var alpha = await AddSongAsync("Alpha");
+            var bravo = await AddSongAsync("Bravo");
+            await AddSongAsync("Unmarked");
+
+            await _db.SetBookmarkAsync(charlie, true);
+            await _db.SetBookmarkAsync(alpha, true);
+            await _db.SetBookmarkAsync(bravo, true);
+
+            var result = await _db.GetBookmarkedSongsAsync();
+
+            Assert.Equal(new[] { "Alpha", "Bravo", "Charlie" }, result.Select(s => s.Title).ToArray());
+        }
+
+        [Fact]
+        public async Task GetBookmarkedSongsAsync_EagerLoadsChartsAndScores()
+        {
+            await _db.InitializeDatabaseAsync();
+            var id = await AddSongAsync("Song");
+            await _db.SetBookmarkAsync(id, true);
+
+            var result = await _db.GetBookmarkedSongsAsync();
+
+            Assert.Single(result);
+            Assert.NotNull(result[0].Charts);
+            Assert.Single(result[0].Charts);
+            // Scores collection is eager-loaded (non-null) even if empty.
+            Assert.NotNull(result[0].Charts.Single().Scores);
+        }
+
+        [Fact]
+        public async Task GetBookmarkedSongsAsync_WhenNoneBookmarked_ReturnsEmptyList()
+        {
+            await _db.InitializeDatabaseAsync();
+            await AddSongAsync("Song");
+
+            var result = await _db.GetBookmarkedSongsAsync();
+
+            Assert.Empty(result);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongDatabaseServiceTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceTests.cs
@@ -254,6 +254,78 @@ namespace DTXMania.Test.Song
             Assert.Single(testSongs[0].Charts);
         }
 
+        // Regression: when a SET.def difficulty already exists in the DB and is bookmarked,
+        // a rescan re-parses a fresh Song entity (IsBookmarked defaults false) for the same
+        // chart file path. AddSongAsync must hydrate the persisted id AND bookmark onto the
+        // caller's entity, otherwise the in-memory node built from it loses the star marker
+        // and the B-key toggle inverts (sets instead of clears).
+        [Fact]
+        public async Task AddSongAsync_WithDuplicateBookmarkedSong_HydratesIdAndBookmarkOntoParsedEntity()
+        {
+            await _databaseService.InitializeDatabaseAsync();
+
+            var song = new DTXMania.Game.Lib.Song.Entities.Song
+            {
+                Title = "Bookmarked Rescan", Artist = "A"
+            };
+            var chart = new SongChart
+            {
+                FilePath = "/dup/bookmarked.dtx", HasDrumChart = true, DrumLevel = 30
+            };
+            var songId = await _databaseService.AddSongAsync(song, chart);
+            await _databaseService.SetBookmarkAsync(songId, true);
+
+            // Simulate a rescan: a freshly parsed entity (Id=0, IsBookmarked=false) for the
+            // exact same chart file path.
+            var rescannedSong = new DTXMania.Game.Lib.Song.Entities.Song
+            {
+                Title = "Bookmarked Rescan", Artist = "A"
+            };
+            var rescannedChart = new SongChart
+            {
+                FilePath = "/dup/bookmarked.dtx", HasDrumChart = true, DrumLevel = 30
+            };
+            var returnedId = await _databaseService.AddSongAsync(rescannedSong, rescannedChart);
+
+            Assert.Equal(songId, returnedId);            // same persisted row
+            Assert.Equal(songId, rescannedSong.Id);      // id hydrated onto parsed entity
+            Assert.True(rescannedSong.IsBookmarked);     // bookmark hydrated from DB
+        }
+
+        // Same bug class for the title+artist duplicate branch: a new chart file for an
+        // existing (bookmarked) song must hydrate the bookmark onto the parsed entity.
+        [Fact]
+        public async Task AddSongAsync_WithNewChartForBookmarkedSong_HydratesIdAndBookmarkOntoParsedEntity()
+        {
+            await _databaseService.InitializeDatabaseAsync();
+
+            var song = new DTXMania.Game.Lib.Song.Entities.Song
+            {
+                Title = "Multi Chart Bookmark", Artist = "A"
+            };
+            var basChart = new SongChart
+            {
+                FilePath = "/multi/bas.dtx", HasDrumChart = true, DrumLevel = 30
+            };
+            var songId = await _databaseService.AddSongAsync(song, basChart);
+            await _databaseService.SetBookmarkAsync(songId, true);
+
+            // A different chart file for the same title+artist (a new difficulty).
+            var rescannedSong = new DTXMania.Game.Lib.Song.Entities.Song
+            {
+                Title = "Multi Chart Bookmark", Artist = "A"
+            };
+            var advChart = new SongChart
+            {
+                FilePath = "/multi/adv.dtx", HasDrumChart = true, DrumLevel = 60
+            };
+            var returnedId = await _databaseService.AddSongAsync(rescannedSong, advChart);
+
+            Assert.Equal(songId, returnedId);            // grouped into existing song
+            Assert.Equal(songId, rescannedSong.Id);      // id hydrated
+            Assert.True(rescannedSong.IsBookmarked);     // bookmark hydrated
+        }
+
         [Fact]
         public async Task AddSongAsync_WithMultipleChartsForSameSong_ShouldMaintainCorrectDurations()
         {

--- a/DTXMania.Test/Song/SongManagerBookmarkTests.cs
+++ b/DTXMania.Test/Song/SongManagerBookmarkTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongManagerBookmarkTests : IDisposable
+    {
+        private readonly SongManager _manager;
+        private readonly string _dbPath;
+
+        public SongManagerBookmarkTests()
+        {
+            SongManager.ResetInstanceForTesting();
+            _manager = SongManager.Instance;
+            _dbPath = Path.Combine(Path.GetTempPath(), $"mgr_bookmark_{Guid.NewGuid()}.db");
+        }
+
+        public void Dispose()
+        {
+            _manager.Clear();
+            SongManager.ResetInstanceForTesting();
+            if (File.Exists(_dbPath))
+            {
+                try { File.Delete(_dbPath); } catch { /* ignore */ }
+            }
+        }
+
+        private async Task<int> AddSong(SongDatabaseService db, string title)
+        {
+            var song = new DTXMania.Game.Lib.Song.Entities.Song { Title = title, Artist = "A" };
+            var chart = new SongChart { FilePath = $"/c/{Guid.NewGuid():N}.dtx", HasDrumChart = true, DrumLevel = 30 };
+            await db.AddSongAsync(song, chart);
+            return (await db.GetSongsAsync()).Single(s => s.Title == title).Id;
+        }
+
+        [Fact]
+        public async Task GetBookmarkedNodesAsync_ReturnsScoreNodesAlphabetically()
+        {
+            await _manager.InitializeDatabaseServiceAsync(_dbPath, purgeDatabaseFirst: true);
+            var db = _manager.DatabaseService!;
+            var b = await AddSong(db, "Bravo");
+            var a = await AddSong(db, "Alpha");
+            await db.SetBookmarkAsync(b, true);
+            await db.SetBookmarkAsync(a, true);
+
+            var nodes = await _manager.GetBookmarkedNodesAsync();
+
+            Assert.Equal(2, nodes.Count);
+            Assert.All(nodes, n => Assert.Equal(NodeType.Score, n.Type));
+            Assert.Equal("Alpha", nodes[0].DisplayTitle);
+            Assert.Equal("Bravo", nodes[1].DisplayTitle);
+        }
+
+        [Fact]
+        public async Task GetBookmarkedNodesAsync_WhenDatabaseServiceNull_ReturnsEmptyList()
+        {
+            // Not initializing the DB service: the null-guard returns empty, no throw.
+            var nodes = await _manager.GetBookmarkedNodesAsync();
+            Assert.Empty(nodes);
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_PersistsThroughManager()
+        {
+            await _manager.InitializeDatabaseServiceAsync(_dbPath, purgeDatabaseFirst: true);
+            var db = _manager.DatabaseService!;
+            var id = await AddSong(db, "Song");
+
+            await _manager.SetBookmarkAsync(id, true);
+
+            Assert.True((await db.GetSongsAsync()).Single(s => s.Id == id).IsBookmarked);
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_WhenDatabaseServiceNull_DoesNotThrow()
+        {
+            var ex = await Record.ExceptionAsync(() => _manager.SetBookmarkAsync(1, true));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongSelectionTabTests.cs
+++ b/DTXMania.Test/Song/SongSelectionTabTests.cs
@@ -27,7 +27,7 @@ namespace DTXMania.Test.Song
         // explicit arm must fail loudly (SwitchExpressionException) instead of silently
         // falling through to AllSongs. This guards the exhaustive-switch contract.
         [Fact]
-        public void Next_ForUnhandledEnumValue_Throws()
+        public void Next_ForUnhandledEnumValue_ShouldThrow()
         {
             Assert.Throws<SwitchExpressionException>(() => ((SongSelectionTab)999).Next());
         }

--- a/DTXMania.Test/Song/SongSelectionTabTests.cs
+++ b/DTXMania.Test/Song/SongSelectionTabTests.cs
@@ -21,5 +21,17 @@ namespace DTXMania.Test.Song
             Assert.Equal("Recent", SongSelectionTab.RecentPlays.DisplayLabel());
             Assert.Equal("Bookmarks", SongSelectionTab.Bookmarks.DisplayLabel());
         }
+
+        [Fact]
+        public void Next_ForInvalidEnumValue_FallsBackToAllSongs()
+        {
+            Assert.Equal(SongSelectionTab.AllSongs, ((SongSelectionTab)999).Next());
+        }
+
+        [Fact]
+        public void DisplayLabel_ForInvalidEnumValue_FallsBackToString()
+        {
+            Assert.Equal("999", ((SongSelectionTab)999).DisplayLabel());
+        }
     }
 }

--- a/DTXMania.Test/Song/SongSelectionTabTests.cs
+++ b/DTXMania.Test/Song/SongSelectionTabTests.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Song;
 using Xunit;
 
@@ -9,40 +7,19 @@ namespace DTXMania.Test.Song
     public class SongSelectionTabTests
     {
         [Fact]
-        public void FromAllSongs_ShouldReturnRecentPlays()
+        public void Next_CyclesAllSongs_Recent_Bookmarks_AndWraps()
         {
-            Assert.Equal(SongSelectionTab.RecentPlays,
-                SongSelectionTab.AllSongs.Next());
+            Assert.Equal(SongSelectionTab.RecentPlays, SongSelectionTab.AllSongs.Next());
+            Assert.Equal(SongSelectionTab.Bookmarks, SongSelectionTab.RecentPlays.Next());
+            Assert.Equal(SongSelectionTab.AllSongs, SongSelectionTab.Bookmarks.Next());
         }
 
         [Fact]
-        public void FromRecentPlays_ShouldWrapToAllSongs()
-        {
-            Assert.Equal(SongSelectionTab.AllSongs,
-                SongSelectionTab.RecentPlays.Next());
-        }
-
-        [Fact]
-        public void DisplayLabel_ShouldReturnHumanReadableNames()
+        public void DisplayLabel_ReturnsExpectedLabels()
         {
             Assert.Equal("All Songs", SongSelectionTab.AllSongs.DisplayLabel());
             Assert.Equal("Recent", SongSelectionTab.RecentPlays.DisplayLabel());
-        }
-
-        // Without a default arm, Next() throws for invalid enum values instead of
-        // silently returning AllSongs. This makes future enum additions visible at
-        // runtime rather than masked by a fallback.
-        [Fact]
-        public void Next_ForInvalidEnumValue_Throws()
-        {
-            Assert.Throws<SwitchExpressionException>(
-                () => ((SongSelectionTab)999).Next());
-        }
-
-        [Fact]
-        public void DisplayLabel_ForInvalidEnumValue_FallsBackToString()
-        {
-            Assert.Equal("999", ((SongSelectionTab)999).DisplayLabel());
+            Assert.Equal("Bookmarks", SongSelectionTab.Bookmarks.DisplayLabel());
         }
     }
 }

--- a/DTXMania.Test/Song/SongSelectionTabTests.cs
+++ b/DTXMania.Test/Song/SongSelectionTabTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using DTXMania.Game.Lib.Song;
 using Xunit;
 
@@ -22,10 +23,13 @@ namespace DTXMania.Test.Song
             Assert.Equal("Bookmarks", SongSelectionTab.Bookmarks.DisplayLabel());
         }
 
+        // The Next() switch has no default arm by design: a future enum member that lacks an
+        // explicit arm must fail loudly (SwitchExpressionException) instead of silently
+        // falling through to AllSongs. This guards the exhaustive-switch contract.
         [Fact]
-        public void Next_ForInvalidEnumValue_FallsBackToAllSongs()
+        public void Next_ForUnhandledEnumValue_Throws()
         {
-            Assert.Equal(SongSelectionTab.AllSongs, ((SongSelectionTab)999).Next());
+            Assert.Throws<SwitchExpressionException>(() => ((SongSelectionTab)999).Next());
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionStageBookmarkTests
+    {
+        private static SongListNode ScoreNode(string title) => new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = title
+        };
+
+        [Fact]
+        public void RefreshSongListForActiveTab_OnBookmarksTab_ShowsCachedNodes()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes",
+                new List<SongListNode> { ScoreNode("B1"), ScoreNode("B2") });
+
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
+
+            Assert.Equal(2, display.CurrentList.Count);
+            Assert.Equal("B1", display.CurrentList[0].Title);
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
+        }
+
+        [Fact]
+        public void RefreshSongListForActiveTab_OnBookmarksTab_WhenEmpty_SetsEmptyFlag()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode>());
+
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
+
+            Assert.Empty(display.CurrentList);
+            Assert.True(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
+        }
+
+        [Fact]
+        public void RefreshSongListForActiveTab_OnBookmarksTab_WhenLoadFailed_DoesNotShowEmptyMessage()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode>());
+            SetPrivateField(stage, "_bookmarksLoadFailed", true);
+
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
+
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
+            Assert.True(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
+        }
+
+        [Fact]
+        public void SwitchToNextTab_FromRecent_GoesToBookmarks()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.RecentPlays);
+
+            InvokePrivateMethod(stage, "SwitchToNextTab");
+
+            Assert.Equal(SongSelectionTab.Bookmarks,
+                GetPrivateField<SongSelectionTab>(stage, "_activeTab"));
+            Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+        }
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs
@@ -67,18 +67,18 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SwitchToNextTab_FromRecent_GoesToBookmarks()
+        public void RefreshSongListForActiveTab_OnBookmarksTab_WhenNodeListIsNull_ShowsEmptyAndSetsFlag()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();
             AttachCoreUi(stage, display);
-            SetPrivateField(stage, "_activeTab", SongSelectionTab.RecentPlays);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            // _bookmarkNodes deliberately left null (never loaded).
 
-            InvokePrivateMethod(stage, "SwitchToNextTab");
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
 
-            Assert.Equal(SongSelectionTab.Bookmarks,
-                GetPrivateField<SongSelectionTab>(stage, "_activeTab"));
-            Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+            Assert.Empty(display.CurrentList);
+            Assert.True(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
         }
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -59,6 +59,24 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ToggleBookmarkForSelectedSong_RegistersPendingSerializedWrite()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            // The per-song serialization dictionary must track an in-flight write so rapid
+            // toggles apply in order and the last user intent wins in the database.
+            var pending = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, System.Threading.Tasks.Task>>(stage, "_pendingBookmarkWrites");
+            Assert.NotNull(pending);
+            Assert.True(pending!.ContainsKey(node.DatabaseSong!.Id));
+        }
+
+        [Fact]
         public void ToggleBookmarkForSelectedSong_OnFolderNode_DoesNothing()
         {
             var stage = CreateStage();

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -401,6 +401,63 @@ namespace DTXMania.Test.Stage
             }
         }
 
+        // Zero-id guard regression: when the selected node has neither a persisted id
+        // (DatabaseSongId is null) nor a stamped entity id (DatabaseSong.Id == 0) — e.g. an
+        // unpersisted fallback node — the toggle must NOT key persistence/reconciliation on
+        // the sentinel 0. Doing so would (a) queue a silent no-op DB write and (b) flip
+        // IsBookmarked on every OTHER unrelated zero-id node via BookmarkStateReconciler.
+        // The selected node's own optimistic flip (done before the id resolution) is allowed
+        // to stand so its star marker refreshes, but the shared path must be skipped.
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_WhenNoPersistedIdAndZeroEntityId_SkipsSharedPath()
+        {
+            var stage = CreateStage();
+            // Selected node: no persisted id, entity id 0.
+            var selectedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, Title = "S", IsBookmarked = false };
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "S",
+                DatabaseSong = selectedSong,
+                DatabaseSongId = null
+            };
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+            // An unrelated zero-id node in RootSongs that must NOT be touched.
+            var bystanderSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, Title = "Other", IsBookmarked = false };
+            var bystander = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "Other",
+                DatabaseSong = bystanderSong,
+                DatabaseSongId = null
+            };
+            var roots = GetPrivateField<List<SongListNode>>(SongManager.Instance, "_rootSongs");
+            var savedRoots = roots.ToList();
+            roots.Clear();
+            roots.Add(bystander);
+
+            try
+            {
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+                // The selected node's optimistic flip is allowed to stand (visual feedback).
+                Assert.True(selectedSong.IsBookmarked);
+                // The bystander zero-id node must be untouched.
+                Assert.False(bystanderSong.IsBookmarked);
+                // No persistence queued under the sentinel key 0.
+                var pending = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, Task>>(stage, "_pendingBookmarkWrites");
+                Assert.False(pending.ContainsKey(0));
+            }
+            finally
+            {
+                roots.Clear();
+                roots.AddRange(savedRoots);
+            }
+        }
+
         // Comment 2 regression: switching to the Bookmarks tab must wait for any in-flight
         // bookmark writes before querying the DB, otherwise a just-bookmarked song won't
         // appear (the optimistic reconciler only updates nodes already in _bookmarkNodes).

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -1,4 +1,8 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Components;
@@ -156,6 +160,193 @@ namespace DTXMania.Test.Stage
 
             var ex = Record.Exception(() => InvokePrivateMethod(stage, "DetectBookmarkKey"));
             Assert.Null(ex);
+        }
+
+        // Cross-tab reconciliation: a toggle must propagate the new flag to every in-memory
+        // representation of the song (browse tree, Recent list, Bookmarks list), each of which
+        // holds a distinct entity instance. Dropping any of the three Apply calls would leave
+        // one surface's star out of sync.
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_ReconcilesFlagAcrossAllTabs()
+        {
+            var stage = CreateStage();
+            var selectedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "S", IsBookmarked = false };
+            var rootSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "S", IsBookmarked = false };
+            var recentSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "S", IsBookmarked = false };
+            var bookmarkSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "S", IsBookmarked = false };
+
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode>
+                {
+                    new() { Type = NodeType.Score, Title = "S", DatabaseSong = selectedSong }
+                }
+            };
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+            SetPrivateField(stage, "_recentPlayNodes",
+                new List<SongListNode> { new() { Type = NodeType.Score, DatabaseSong = recentSong } });
+            SetPrivateField(stage, "_bookmarkNodes",
+                new List<SongListNode> { new() { Type = NodeType.Score, DatabaseSong = bookmarkSong } });
+
+            var roots = GetPrivateField<List<SongListNode>>(SongManager.Instance, "_rootSongs");
+            var savedRoots = roots.ToList();
+            roots.Clear();
+            roots.Add(new SongListNode { Type = NodeType.Score, Title = "S", DatabaseSong = rootSong });
+
+            try
+            {
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+                Assert.True(selectedSong.IsBookmarked);   // direct flip on the selected node
+                Assert.True(rootSong.IsBookmarked);        // reconciled via RootSongs
+                Assert.True(recentSong.IsBookmarked);      // reconciled via _recentPlayNodes
+                Assert.True(bookmarkSong.IsBookmarked);    // reconciled via _bookmarkNodes
+            }
+            finally
+            {
+                roots.Clear();
+                roots.AddRange(savedRoots);
+            }
+        }
+
+        // Guards the "&& !newState" condition: bookmarking ON while on the Bookmarks tab must
+        // flip the flag but must NOT remove the row (only an un-bookmark removes it).
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnBookmarksTab_BookmarkOn_DoesNotRemoveRow()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode> { node });
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+            var remaining = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.Single(remaining); // row NOT removed because newState == true
+            Assert.False(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+        }
+
+        // Rapid double-toggle must serialize so the last user intent lands in the DB. Without
+        // the per-song chaining in _pendingBookmarkWrites, two fire-and-forget writes could
+        // complete out of order and leave the DB divergent from the in-memory flag.
+        [Fact]
+        public async Task ToggleBookmarkForSelectedSong_RapidDoubleToggle_LastIntentWinsInDb()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), $"bm_order_{Guid.NewGuid():N}.db");
+            SongManager.ResetInstanceForTesting();
+            var manager = SongManager.Instance;
+            await manager.InitializeDatabaseServiceAsync(dbPath, purgeDatabaseFirst: true);
+            var db = manager.DatabaseService!;
+            var seed = new DTXMania.Game.Lib.Song.Entities.Song { Title = "Song", Artist = "A" };
+            var chart = new SongChart { FilePath = $"/c/{Guid.NewGuid():N}.dtx", HasDrumChart = true, DrumLevel = 30 };
+            await db.AddSongAsync(seed, chart);
+            var songId = (await db.GetSongsAsync()).Single(s => s.Title == "Song").Id;
+
+            try
+            {
+                var stage = CreateStage();
+                var nodeEntity = new DTXMania.Game.Lib.Song.Entities.Song { Id = songId, Title = "Song", IsBookmarked = false };
+                var node = new SongListNode { Type = NodeType.Score, Title = "Song", DatabaseSong = nodeEntity };
+                var display = new SongListDisplay { CurrentList = new List<SongListNode> { node } };
+                AttachCoreUi(stage, display);
+                SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong"); // ON
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong"); // OFF
+
+                var pending = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, Task>>(stage, "_pendingBookmarkWrites");
+                await pending[songId]; // await the serialized chain so both writes settle
+
+                var persisted = (await db.GetSongsAsync()).Single(s => s.Id == songId);
+                Assert.False(persisted.IsBookmarked); // last intent (OFF) won
+            }
+            finally
+            {
+                SongManager.ResetInstanceForTesting();
+                if (File.Exists(dbPath))
+                    try { File.Delete(dbPath); } catch { }
+            }
+        }
+
+        // The optimistic flip must roll back when the persist faults, so the star does not
+        // silently diverge from the DB. Here the DB is purged after seeding so the write
+        // faults; after draining the revert queue the in-memory flag must return to its
+        // pre-toggle value.
+        [Fact]
+        public async Task ToggleBookmarkForSelectedSong_WhenPersistFaults_RevertsInMemoryFlag()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), $"bm_revert_{Guid.NewGuid():N}.db");
+            SongManager.ResetInstanceForTesting();
+            var manager = SongManager.Instance;
+            await manager.InitializeDatabaseServiceAsync(dbPath, purgeDatabaseFirst: true);
+            var db = manager.DatabaseService!;
+            var seed = new DTXMania.Game.Lib.Song.Entities.Song { Title = "Song", Artist = "A" };
+            var chart = new SongChart { FilePath = $"/c/{Guid.NewGuid():N}.dtx", HasDrumChart = true, DrumLevel = 30 };
+            await db.AddSongAsync(seed, chart);
+            var songId = (await db.GetSongsAsync()).Single(s => s.Title == "Song").Id;
+            await db.PurgeDatabaseAsync(); // make the bookmark write fault
+
+            try
+            {
+                var stage = CreateStage();
+                var nodeEntity = new DTXMania.Game.Lib.Song.Entities.Song { Id = songId, Title = "Song", IsBookmarked = false };
+                var node = new SongListNode { Type = NodeType.Score, Title = "Song", DatabaseSong = nodeEntity };
+                var display = new SongListDisplay { CurrentList = new List<SongListNode> { node } };
+                AttachCoreUi(stage, display);
+                SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+                // Mirror real All-Songs behavior: the selected node's entity lives in RootSongs,
+                // so the revert (which applies by song Id across RootSongs) reaches it.
+                var roots = GetPrivateField<List<SongListNode>>(SongManager.Instance, "_rootSongs");
+                roots.Clear();
+                roots.Add(node);
+
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong"); // optimistic flip to true
+                Assert.True(nodeEntity.IsBookmarked);
+
+                var pending = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, Task>>(stage, "_pendingBookmarkWrites");
+                try { await pending[songId]; } catch { /* expected persist fault */ }
+
+                // The fault continuation enqueues a revert on the thread pool; poll for it.
+                var queue = GetPrivateField<System.Collections.Concurrent.ConcurrentQueue<(int, bool, int)>>(stage, "_pendingBookmarkReverts");
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (queue.IsEmpty && DateTime.UtcNow < deadline)
+                    await Task.Delay(20);
+                Assert.False(queue.IsEmpty); // the fault enqueued a rollback
+
+                InvokePrivateMethod(stage, "ProcessPendingBookmarkReverts");
+
+                Assert.False(nodeEntity.IsBookmarked); // reverted to pre-toggle state
+            }
+            finally
+            {
+                SongManager.ResetInstanceForTesting();
+                if (File.Exists(dbPath))
+                    try { File.Delete(dbPath); } catch { }
+            }
+        }
+
+        // Stale-revert guard: a revert from an older, superseded toggle must be skipped so it
+        // cannot override a newer toggle's in-memory flag.
+        [Fact]
+        public void ProcessPendingBookmarkReverts_WhenSupersededByNewerToggle_SkipsStaleRevert()
+        {
+            var stage = CreateStage();
+            var recentSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 7, IsBookmarked = true };
+            SetPrivateField(stage, "_recentPlayNodes",
+                new List<SongListNode> { new() { Type = NodeType.Score, DatabaseSong = recentSong } });
+
+            var queue = GetPrivateField<System.Collections.Concurrent.ConcurrentQueue<(int, bool, int)>>(stage, "_pendingBookmarkReverts");
+            queue.Enqueue((7, false, toggleVersion: 1)); // stale: a newer toggle bumped to 2
+            var versions = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, int>>(stage, "_bookmarkToggleVersion");
+            versions[7] = 2;
+
+            InvokePrivateMethod(stage, "ProcessPendingBookmarkReverts");
+
+            Assert.True(recentSong.IsBookmarked); // newer toggle's flag preserved
         }
 
         // Reports the B key as pressed exactly once.

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using Microsoft.Xna.Framework.Input;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionStageBookmarkToggleTests
+    {
+        private static SongListNode BookmarkableNode(string title, bool bookmarked = false)
+        {
+            var song = new DTXMania.Game.Lib.Song.Entities.Song
+            {
+                Id = 42,
+                Title = title,
+                IsBookmarked = bookmarked
+            };
+            return new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = title,
+                DatabaseSong = song
+            };
+        }
+
+        private static SongListDisplay DisplayWithSelection(SongListNode node)
+        {
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode> { node }
+            };
+            // CurrentList setter resets SelectedIndex to 0 -> SelectedSong == node.
+            return display;
+        }
+
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnScoreNode_FlipsBookmarkFlag()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+            Assert.False(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnFolderNode_DoesNothing()
+        {
+            var stage = CreateStage();
+            var folder = new SongListNode { Type = NodeType.Box, Title = "Folder" };
+            var display = DisplayWithSelection(folder);
+            AttachCoreUi(stage, display);
+
+            var ex = Record.Exception(() =>
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong"));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnBookmarksTab_Unbookmark_RemovesNodeAndFlagsRefresh()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: true);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode> { node });
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            Assert.False(node.DatabaseSong!.IsBookmarked);
+            var remaining = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.Empty(remaining);
+            Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+        }
+
+        [Fact]
+        public void HandleLaneHitForBookmark_OnFloorTom_TogglesBookmark()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+
+            InvokePrivateMethod(stage, "HandleLaneHitForBookmark", 1); // Floor Tom = lane 1
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void HandleLaneHitForBookmark_OnOtherLane_DoesNotToggle()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+
+            InvokePrivateMethod(stage, "HandleLaneHitForBookmark", 4); // Snare
+
+            Assert.False(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void DetectBookmarkKey_WhenBPressed_TogglesBookmark()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_inputManager", new BookmarkKeyInputManager());
+
+            InvokePrivateMethod(stage, "DetectBookmarkKey");
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void DetectBookmarkKey_WhenInputManagerNull_DoesNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_inputManager", null);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "DetectBookmarkKey"));
+            Assert.Null(ex);
+        }
+
+        // Reports the B key as pressed exactly once.
+        private sealed class BookmarkKeyInputManager : DTXMania.Game.Lib.Input.InputManager
+        {
+            private bool _consumed;
+            public override bool IsKeyPressed(int keyCode)
+            {
+                if (keyCode == (int)Keys.B && !_consumed)
+                {
+                    _consumed = true;
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -329,6 +329,115 @@ namespace DTXMania.Test.Stage
             }
         }
 
+        // SET.def duplicate regression: when the persisted id (DatabaseSongId) is set but the
+        // parsed SongEntity.Id was never stamped (AddSongAsync returned the existing id), the
+        // toggle must key persistence/reconciliation on the persisted id — not 0. Otherwise
+        // SetBookmarkAsync(0,...) is a no-op and the per-song write chain collides on key 0.
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_WhenDatabaseSongIdSetButEntityIdZero_UsesPersistedId()
+        {
+            var stage = CreateStage();
+            var song = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, Title = "S", IsBookmarked = false };
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "S",
+                DatabaseSong = song,
+                DatabaseSongId = 77
+            };
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            var pending = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, Task>>(stage, "_pendingBookmarkWrites");
+            // Must key on the persisted id (77), not the zero entity id.
+            Assert.True(pending.ContainsKey(77));
+            Assert.False(pending.ContainsKey(0));
+        }
+
+        // SET.def duplicate reconciliation: a browse-tree node whose DatabaseSong.Id is 0 but
+        // whose DatabaseSongId matches the toggled song must receive the new flag via the
+        // reconciler (otherwise the star marker never refreshes in the All Songs list).
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_WhenZeroEntityIdNodeInRoots_ReconcilesByPersistedId()
+        {
+            var stage = CreateStage();
+            var selectedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, Title = "S", IsBookmarked = false };
+            var rootNode = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "S",
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 0, Title = "S", IsBookmarked = false },
+                DatabaseSongId = 77
+            };
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode>
+                {
+                    new() { Type = NodeType.Score, Title = "S", DatabaseSong = selectedSong, DatabaseSongId = 77 }
+                }
+            };
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+            var roots = GetPrivateField<List<SongListNode>>(SongManager.Instance, "_rootSongs");
+            var savedRoots = roots.ToList();
+            roots.Clear();
+            roots.Add(rootNode);
+
+            try
+            {
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+                Assert.True(selectedSong.IsBookmarked);   // direct flip on the selected node
+                Assert.True(rootNode.DatabaseSong!.IsBookmarked); // reconciled via persisted id
+            }
+            finally
+            {
+                roots.Clear();
+                roots.AddRange(savedRoots);
+            }
+        }
+
+        // Comment 2 regression: switching to the Bookmarks tab must wait for any in-flight
+        // bookmark writes before querying the DB, otherwise a just-bookmarked song won't
+        // appear (the optimistic reconciler only updates nodes already in _bookmarkNodes).
+        // Here an incomplete pending write defers the load; settling it triggers the reload.
+        [Fact]
+        public async Task SwitchToNextTab_ToBookmarks_ChainsLoadAfterPendingWrites()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.RecentPlays); // -> Bookmarks
+            SetPrivateField(stage, "_activationVersion", 0);
+
+            // Stale bookmark list from before the toggle.
+            SetPrivateField(stage, "_bookmarkNodes",
+                new List<SongListNode> { new() { Type = NodeType.Score, Title = "Stale" } });
+
+            // In-flight bookmark write that has not yet committed.
+            var tcs = new TaskCompletionSource<bool>();
+            var pending = GetPrivateField<System.Collections.Concurrent.ConcurrentDictionary<int, Task>>(stage, "_pendingBookmarkWrites");
+            pending[42] = tcs.Task;
+
+            InvokePrivateMethod(stage, "SwitchToNextTab");
+
+            // Load is deferred until the pending write settles; stale list remains.
+            var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.Single(nodes);
+
+            // Settle the write; the chained load fires and (no DB connected) overwrites with
+            // an empty list.
+            tcs.SetResult(true);
+            await Task.Delay(400);
+
+            nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.Empty(nodes);
+        }
+
         // Stale-revert guard: a revert from an older, superseded toggle must be skipped so it
         // cannot override a newer toggle's in-memory flag.
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
@@ -744,6 +744,105 @@ namespace DTXMania.Test.Stage
             Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
         }
 
+        // --- BeginBookmarksLoad per-load sequence guard tests ---
+        // These verify the _bookmarksLoadVersion guard, which prevents an older
+        // same-activation load (e.g., the activation-time warm load still in flight
+        // when the user bookmarks a song and switches to the Bookmarks tab) from
+        // overwriting the result of a newer load with a stale pre-toggle snapshot.
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenNewerSameActivationLoadSupersedes_PreservesFreshResult()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+
+            // Simulate the result of a newer load already landing.
+            var freshNodes = new List<SongListNode> { ScoreNode("Fresh") };
+            SetPrivateField(stage, "_bookmarkNodes", freshNodes);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+
+            // Start the older background load — captures load version 1.
+            InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+            // Simulate a newer same-activation load starting (e.g., from a tab switch
+            // after a bookmark toggle). This bumps _bookmarksLoadVersion past the
+            // captured value so the older load's completion is treated as stale.
+            SetPrivateField(stage, "_bookmarksLoadVersion", 2);
+
+            await Task.Delay(300);
+
+            // The stale continuation must NOT have overwritten _bookmarkNodes with
+            // the empty no-DB result.
+            var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(nodes);
+            Assert.Single(nodes);
+            Assert.Equal("Fresh", nodes[0].Title);
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenFaultedAndLoadVersionSuperseded_DiscardsStaleFault()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), $"stage_bm_stale_load_{Guid.NewGuid():N}.db");
+            SongManager.ResetInstanceForTesting();
+            var manager = SongManager.Instance;
+            await manager.InitializeDatabaseServiceAsync(dbPath, purgeDatabaseFirst: true);
+            await manager.DatabaseService!.PurgeDatabaseAsync();
+
+            try
+            {
+                var stage = CreateStage();
+                var display = new SongListDisplay();
+                AttachCoreUi(stage, display);
+                SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+                SetPrivateField(stage, "_activationVersion", 0);
+
+                // Start the older faulting load — captures load version 1.
+                InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+                // Simulate a newer same-activation load starting before the older
+                // load's fault lands. The older fault must be discarded so it does
+                // not spuriously set _bookmarksLoadFailed over the newer load's result.
+                SetPrivateField(stage, "_bookmarksLoadVersion", 2);
+
+                await Task.Delay(500);
+
+                Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
+            }
+            finally
+            {
+                SongManager.ResetInstanceForTesting();
+                if (File.Exists(dbPath))
+                    try { File.Delete(dbPath); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenLoadVersionUnchanged_OverwritesNodes()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+
+            var staleNodes = new List<SongListNode> { ScoreNode("Stale") };
+            SetPrivateField(stage, "_bookmarkNodes", staleNodes);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+
+            // Start the load — captures the current load version. No newer load
+            // supersedes it, so the continuation should be accepted.
+            InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+            await Task.Delay(300);
+
+            // The continuation ran un-superseded and overwrote _bookmarkNodes
+            // with the empty result from the no-DB load.
+            var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(nodes);
+            Assert.Empty(nodes);
+        }
+
         // Fake InputManager that reports Tab key pressed on the first poll.
         private sealed class TabKeyDetectInputManager : DTXMania.Game.Lib.Input.InputManager
         {

--- a/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
@@ -608,7 +608,7 @@ namespace DTXMania.Test.Stage
         // _bookmarksLoadFailed only when the activation is still current.
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenActivationVersionBumped_PreservesExistingNodes()
+        public async Task BeginBookmarksLoad_WhenActivationVersionBumped_ShouldPreserveExistingNodes()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();
@@ -635,7 +635,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenActivationVersionUnchanged_OverwritesNodes()
+        public async Task BeginBookmarksLoad_WhenActivationVersionUnchanged_ShouldOverwriteNodes()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();
@@ -659,7 +659,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenDbThrows_SetsLoadFailedAndFlagsRefresh()
+        public async Task BeginBookmarksLoad_WhenDbThrows_ShouldSetLoadFailedAndFlagsRefresh()
         {
             var dbPath = Path.Combine(Path.GetTempPath(), $"stage_bm_fault_{Guid.NewGuid():N}.db");
             SongManager.ResetInstanceForTesting();
@@ -691,7 +691,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenDbThrowsAndVersionBumped_DiscardsStaleFault()
+        public async Task BeginBookmarksLoad_WhenDbThrowsAndVersionBumped_ShouldDiscardStaleFault()
         {
             var dbPath = Path.Combine(Path.GetTempPath(), $"stage_bm_stale_fault_{Guid.NewGuid():N}.db");
             SongManager.ResetInstanceForTesting();
@@ -726,7 +726,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task BeginBookmarksLoad_OnSuccess_ClearsPreExistingLoadFailedFlag()
+        public async Task BeginBookmarksLoad_OnSuccess_ShouldClearPreExistingLoadFailedFlag()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();
@@ -751,7 +751,7 @@ namespace DTXMania.Test.Stage
         // overwriting the result of a newer load with a stale pre-toggle snapshot.
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenNewerSameActivationLoadSupersedes_PreservesFreshResult()
+        public async Task BeginBookmarksLoad_WhenNewerSameActivationLoadSupersedes_ShouldPreserveFreshResult()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();
@@ -782,7 +782,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenFaultedAndLoadVersionSuperseded_DiscardsStaleFault()
+        public async Task BeginBookmarksLoad_WhenFaultedAndLoadVersionSuperseded_ShouldDiscardStaleFault()
         {
             var dbPath = Path.Combine(Path.GetTempPath(), $"stage_bm_stale_load_{Guid.NewGuid():N}.db");
             SongManager.ResetInstanceForTesting();
@@ -819,7 +819,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public async Task BeginBookmarksLoad_WhenLoadVersionUnchanged_OverwritesNodes()
+        public async Task BeginBookmarksLoad_WhenLoadVersionUnchanged_ShouldOverwriteNodes()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();

--- a/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
@@ -108,7 +108,7 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void SwitchToNextTab_FromRecent_WrapsBackToAllSongs()
+        public void SwitchToNextTab_FromRecent_GoesToBookmarks()
         {
             var stage = CreateStage();
             var display = new SongListDisplay();
@@ -117,7 +117,7 @@ namespace DTXMania.Test.Stage
 
             InvokePrivateMethod(stage, "SwitchToNextTab");
 
-            Assert.Equal(SongSelectionTab.AllSongs, GetPrivateField<SongSelectionTab>(stage, "_activeTab"));
+            Assert.Equal(SongSelectionTab.Bookmarks, GetPrivateField<SongSelectionTab>(stage, "_activeTab"));
             Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
         }
 

--- a/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
@@ -601,6 +601,149 @@ namespace DTXMania.Test.Stage
             Assert.False(GetPrivateField<bool>(stage, "_recentPlaysLoadFailed"));
         }
 
+        // --- BeginBookmarksLoad staleness/fault tests ---
+        // These mirror the BeginRecentPlaysLoad pair above. BeginBookmarksLoad has an
+        // identical _activationVersion guard; these prove the bookmark load discards stale
+        // completions instead of overwriting fresh state, and that DB faults set
+        // _bookmarksLoadFailed only when the activation is still current.
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenActivationVersionBumped_PreservesExistingNodes()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+
+            var freshNodes = new List<SongListNode> { ScoreNode("Fresh") };
+            SetPrivateField(stage, "_bookmarkNodes", freshNodes);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+
+            // Start the background load — captures version=0.
+            InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+            // Simulate re-Activate: bump the version so the in-flight continuation is stale.
+            SetPrivateField(stage, "_activationVersion", 1);
+
+            await Task.Delay(300);
+
+            // The stale continuation must NOT have overwritten _bookmarkNodes.
+            var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(nodes);
+            Assert.Single(nodes);
+            Assert.Equal("Fresh", nodes[0].Title);
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenActivationVersionUnchanged_OverwritesNodes()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+
+            var staleNodes = new List<SongListNode> { ScoreNode("Stale") };
+            SetPrivateField(stage, "_bookmarkNodes", staleNodes);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+
+            InvokePrivateMethod(stage, "BeginBookmarksLoad");
+            // Do NOT bump version — continuation should be accepted.
+
+            await Task.Delay(300);
+
+            // The continuation ran with matching version and overwrote _bookmarkNodes
+            // with the empty result from the no-DB load.
+            var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(nodes);
+            Assert.Empty(nodes);
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenDbThrows_SetsLoadFailedAndFlagsRefresh()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), $"stage_bm_fault_{Guid.NewGuid():N}.db");
+            SongManager.ResetInstanceForTesting();
+            var manager = SongManager.Instance;
+            await manager.InitializeDatabaseServiceAsync(dbPath, purgeDatabaseFirst: true);
+            await manager.DatabaseService!.PurgeDatabaseAsync();
+
+            try
+            {
+                var stage = CreateStage();
+                var display = new SongListDisplay();
+                AttachCoreUi(stage, display);
+                SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+                SetPrivateField(stage, "_activationVersion", 0);
+
+                InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+                await Task.Delay(500);
+
+                Assert.True(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
+                Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+            }
+            finally
+            {
+                SongManager.ResetInstanceForTesting();
+                if (File.Exists(dbPath))
+                    try { File.Delete(dbPath); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenDbThrowsAndVersionBumped_DiscardsStaleFault()
+        {
+            var dbPath = Path.Combine(Path.GetTempPath(), $"stage_bm_stale_fault_{Guid.NewGuid():N}.db");
+            SongManager.ResetInstanceForTesting();
+            var manager = SongManager.Instance;
+            await manager.InitializeDatabaseServiceAsync(dbPath, purgeDatabaseFirst: true);
+            await manager.DatabaseService!.PurgeDatabaseAsync();
+
+            try
+            {
+                var stage = CreateStage();
+                var display = new SongListDisplay();
+                AttachCoreUi(stage, display);
+                SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+                SetPrivateField(stage, "_activationVersion", 0);
+
+                InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+                // Bump version to simulate re-Activate — the faulted continuation
+                // must be discarded.
+                SetPrivateField(stage, "_activationVersion", 1);
+
+                await Task.Delay(500);
+
+                Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
+            }
+            finally
+            {
+                SongManager.ResetInstanceForTesting();
+                if (File.Exists(dbPath))
+                    try { File.Delete(dbPath); } catch { }
+            }
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_OnSuccess_ClearsPreExistingLoadFailedFlag()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_bookmarksLoadFailed", true);
+
+            InvokePrivateMethod(stage, "BeginBookmarksLoad");
+
+            await Task.Delay(300);
+
+            // The success continuation must clear the failure flag so the draw
+            // path shows the normal empty message instead of the error message.
+            Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
+        }
+
         // Fake InputManager that reports Tab key pressed on the first poll.
         private sealed class TabKeyDetectInputManager : DTXMania.Game.Lib.Input.InputManager
         {

--- a/docs/superpowers/plans/2026-06-05-song-bookmarks.md
+++ b/docs/superpowers/plans/2026-06-05-song-bookmarks.md
@@ -1,0 +1,1368 @@
+# Song Bookmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let players bookmark whole songs, toggle bookmarks with the `B` key or Floor Tom pad, browse bookmarks in a new alphabetically-sorted Bookmarks tab, and see a star marker on bookmarked song bars.
+
+**Architecture:** A single `IsBookmarked` boolean column on the `Songs` table is the source of truth. The DB service gains read/write methods; `SongManager` exposes thin async wrappers; `SongSelectionStage` gains a third tab (`Bookmarks`) that mirrors the existing Recent-tab async-load machinery, plus a toggle action wired to a key and a drum pad. A render-agnostic helper decides when to draw the star; the draw itself lives in the song-list display.
+
+**Tech Stack:** .NET 8, EF Core + SQLite (Microsoft.EntityFrameworkCore.Sqlite), MonoGame, xUnit + Moq.
+
+**Reference patterns (read before starting):** the Recent-plays feature is the template this plan copies. Key files:
+- `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs` — `GetRecentlyPlayedSongsAsync` (~line 545), init flow (~line 69), `ConfigureUtf8EncodingAsync`/`EnsureDatabaseVersionTableAsync` (~line 715–763).
+- `DTXMania.Game/Lib/Song/SongManager.cs` — `GetRecentlyPlayedNodesAsync` (~line 1591), `CreateSongNodeFromDatabaseEntities` (~line 2221).
+- `DTXMania.Game/Lib/Song/SongSelectionTab.cs` — the tab enum + extensions.
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs` — recent-plays fields (~line 59–80), `BeginRecentPlaysLoad`/`SwitchToNextTab` (~line 2014–2069), `RefreshSongListForActiveTab`/`PopulateRecentPlaysList` (~line 1009–1024), `HandleInput`/`DetectTabSwitchKey` (~line 1177–1223), `OnTabSwitchLaneHit`/`HandleLaneHitForTabSwitch` (~line 2071–2085), draw messages (~line 1138–1148), `DrawTabBar` (~line 1510).
+- Tests to mirror: `DTXMania.Test/Song/SongDatabaseServiceRecentPlaysTests.cs`, `DTXMania.Test/Song/SongManagerRecentPlaysTests.cs`, `DTXMania.Test/Stage/SongSelectionStageTabTests.cs`.
+
+**Conventions:**
+- Build (Mac): `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+- Test one class (Mac): `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~CLASSNAME"`
+- The Mac test csproj auto-includes new `*.cs` test files via a glob; no csproj edit needed as long as tests don't require a `GraphicsDevice`.
+- Commit after every task with a Conventional Commit subject under 72 chars.
+
+---
+
+### Task 1: Add `IsBookmarked` to the Song entity and the DB read/write methods
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Entities/Song.cs` (add property after `UpdatedAt`, ~line 29)
+- Modify: `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs` (add two methods next to `GetRecentlyPlayedSongsAsync`, ~line 583)
+- Test: `DTXMania.Test/Song/SongDatabaseServiceBookmarkTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Song/SongDatabaseServiceBookmarkTests.cs`:
+
+```csharp
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongDatabaseServiceBookmarkTests : IDisposable
+    {
+        private readonly SongDatabaseService _db;
+        private readonly string _dbPath;
+
+        public SongDatabaseServiceBookmarkTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"bookmark_db_{Guid.NewGuid()}.db");
+            _db = new SongDatabaseService(_dbPath);
+        }
+
+        public void Dispose()
+        {
+            _db?.Dispose();
+            if (File.Exists(_dbPath))
+            {
+                try { File.Delete(_dbPath); } catch { /* ignore */ }
+            }
+        }
+
+        private async Task<int> AddSongAsync(string title)
+        {
+            var song = new DTXMania.Game.Lib.Song.Entities.Song { Title = title, Artist = "A" };
+            var chart = new SongChart { FilePath = $"/c/{Guid.NewGuid():N}.dtx", HasDrumChart = true, DrumLevel = 30 };
+            await _db.AddSongAsync(song, chart);
+            return (await _db.GetSongsAsync()).Single(s => s.Title == title).Id;
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_TogglesFlagOnAndOff()
+        {
+            await _db.InitializeDatabaseAsync();
+            var id = await AddSongAsync("Song");
+
+            await _db.SetBookmarkAsync(id, true);
+            Assert.True((await _db.GetSongsAsync()).Single(s => s.Id == id).IsBookmarked);
+
+            await _db.SetBookmarkAsync(id, false);
+            Assert.False((await _db.GetSongsAsync()).Single(s => s.Id == id).IsBookmarked);
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_WithUnknownId_DoesNotThrow()
+        {
+            await _db.InitializeDatabaseAsync();
+            var ex = await Record.ExceptionAsync(() => _db.SetBookmarkAsync(999999, true));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task GetBookmarkedSongsAsync_ReturnsOnlyBookmarked_AlphabeticalByTitle()
+        {
+            await _db.InitializeDatabaseAsync();
+            var charlie = await AddSongAsync("Charlie");
+            var alpha = await AddSongAsync("Alpha");
+            var bravo = await AddSongAsync("Bravo");
+            await AddSongAsync("Unmarked");
+
+            await _db.SetBookmarkAsync(charlie, true);
+            await _db.SetBookmarkAsync(alpha, true);
+            await _db.SetBookmarkAsync(bravo, true);
+
+            var result = await _db.GetBookmarkedSongsAsync();
+
+            Assert.Equal(new[] { "Alpha", "Bravo", "Charlie" }, result.Select(s => s.Title).ToArray());
+        }
+
+        [Fact]
+        public async Task GetBookmarkedSongsAsync_EagerLoadsChartsAndScores()
+        {
+            await _db.InitializeDatabaseAsync();
+            var id = await AddSongAsync("Song");
+            await _db.SetBookmarkAsync(id, true);
+
+            var result = await _db.GetBookmarkedSongsAsync();
+
+            Assert.Single(result);
+            Assert.NotNull(result[0].Charts);
+            Assert.Single(result[0].Charts);
+            // Scores collection is eager-loaded (non-null) even if empty.
+            Assert.NotNull(result[0].Charts.Single().Scores);
+        }
+
+        [Fact]
+        public async Task GetBookmarkedSongsAsync_WhenNoneBookmarked_ReturnsEmptyList()
+        {
+            await _db.InitializeDatabaseAsync();
+            await AddSongAsync("Song");
+
+            var result = await _db.GetBookmarkedSongsAsync();
+
+            Assert.Empty(result);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceBookmarkTests"`
+Expected: FAIL — compile error (`IsBookmarked`, `SetBookmarkAsync`, `GetBookmarkedSongsAsync` do not exist).
+
+- [ ] **Step 3: Add the entity property**
+
+In `DTXMania.Game/Lib/Song/Entities/Song.cs`, after the `UpdatedAt` property (~line 29) inside the Timestamps region:
+
+```csharp
+        // Whether the player has bookmarked this song. Surfaced in the Bookmarks tab
+        // and as a star marker in the All Songs list.
+        public bool IsBookmarked { get; set; } = false;
+```
+
+- [ ] **Step 4: Add the DB service methods**
+
+In `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs`, immediately after the closing brace of `GetRecentlyPlayedSongsAsync` (~line 583):
+
+```csharp
+        /// <summary>
+        /// Sets or clears the bookmark flag on a song. No-op if the song id is not found.
+        /// </summary>
+        public async Task SetBookmarkAsync(int songId, bool bookmarked)
+        {
+            using var context = CreateContext();
+            var song = await context.Songs.FirstOrDefaultAsync(s => s.Id == songId);
+            if (song == null) return;
+            song.IsBookmarked = bookmarked;
+            song.UpdatedAt = DateTime.UtcNow;
+            await context.SaveChangesAsync();
+        }
+
+        /// <summary>
+        /// Returns all bookmarked songs ordered alphabetically by Title (Id as a stable
+        /// tiebreak). Each Song has its Charts and the charts' Scores eagerly loaded so
+        /// callers can build fully-populated SongListNodes, mirroring
+        /// <see cref="GetRecentlyPlayedSongsAsync"/>.
+        /// </summary>
+        public async Task<List<SongEntity>> GetBookmarkedSongsAsync()
+        {
+            using var context = CreateContext();
+            return await context.Songs
+                .Where(s => s.IsBookmarked)
+                .Include(s => s.Charts)
+                    .ThenInclude(c => c.Scores)
+                .OrderBy(s => s.Title)
+                .ThenBy(s => s.Id)
+                .ToListAsync();
+        }
+```
+
+(`SongEntity` is the file's alias for `Entities.Song`; `CreateContext`, `FirstOrDefaultAsync`, `Include`/`ThenInclude` are all already used in this file.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceBookmarkTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Entities/Song.cs DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs DTXMania.Test/Song/SongDatabaseServiceBookmarkTests.cs
+git commit -m "feat: add IsBookmarked column and bookmark DB methods"
+```
+
+---
+
+### Task 2: Auto-add the `IsBookmarked` column to pre-existing databases
+
+The project uses `EnsureCreatedAsync()`, which never alters an existing schema. Players with an existing song DB (that already has the Unicode version table, so it is NOT wiped on startup) need the column added by a guarded, idempotent `ALTER TABLE`.
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs` (call site inside `ConfigureUtf8EncodingAsync` ~line 728; new method after `EnsureDatabaseVersionTableAsync` ~line 763)
+- Test: `DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs`:
+
+```csharp
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song.Entities;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongDatabaseServiceBookmarkMigrationTests : IDisposable
+    {
+        private readonly string _dbPath;
+
+        public SongDatabaseServiceBookmarkMigrationTests()
+        {
+            _dbPath = Path.Combine(Path.GetTempPath(), $"bookmark_mig_{Guid.NewGuid()}.db");
+        }
+
+        public void Dispose()
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(_dbPath))
+            {
+                try { File.Delete(_dbPath); } catch { /* ignore */ }
+            }
+        }
+
+        private async Task<int> ColumnCountAsync()
+        {
+            SqliteConnection.ClearAllPools();
+            using var conn = new SqliteConnection($"Data Source={_dbPath}");
+            await conn.OpenAsync();
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM pragma_table_info('Songs') WHERE name='IsBookmarked'";
+            return Convert.ToInt32(await cmd.ExecuteScalarAsync());
+        }
+
+        [Fact]
+        public async Task InitializeDatabaseAsync_OnLegacyDbMissingColumn_AddsColumn()
+        {
+            // Create a normal DB (has the column + Unicode version table), then drop the
+            // column to simulate a legacy database created before this feature.
+            var first = new SongDatabaseService(_dbPath);
+            await first.InitializeDatabaseAsync();
+            first.Dispose();
+
+            SqliteConnection.ClearAllPools();
+            using (var conn = new SqliteConnection($"Data Source={_dbPath}"))
+            {
+                await conn.OpenAsync();
+                using var drop = conn.CreateCommand();
+                drop.CommandText = "ALTER TABLE Songs DROP COLUMN IsBookmarked";
+                await drop.ExecuteNonQueryAsync();
+            }
+            Assert.Equal(0, await ColumnCountAsync()); // confirm the legacy state
+
+            // Re-initialize: the Unicode version table is present so the DB is NOT wiped;
+            // the migration must re-add the column.
+            var second = new SongDatabaseService(_dbPath);
+            await second.InitializeDatabaseAsync();
+            second.Dispose();
+
+            Assert.Equal(1, await ColumnCountAsync());
+        }
+
+        [Fact]
+        public async Task InitializeDatabaseAsync_OnFreshDb_IsIdempotentAndKeepsSingleColumn()
+        {
+            var svc = new SongDatabaseService(_dbPath);
+            await svc.InitializeDatabaseAsync();
+            svc.Dispose();
+
+            // A second service initializing the same file must not error or duplicate.
+            var again = new SongDatabaseService(_dbPath);
+            await again.InitializeDatabaseAsync();
+            again.Dispose();
+
+            Assert.Equal(1, await ColumnCountAsync());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceBookmarkMigrationTests"`
+Expected: FAIL — `InitializeDatabaseAsync_OnLegacyDbMissingColumn_AddsColumn` ends with column count 0 (no migration yet). (The idempotent test may already pass because `EnsureCreated` adds the column on a fresh DB.)
+
+- [ ] **Step 3: Add the migration call and method**
+
+In `DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs`, inside `ConfigureUtf8EncodingAsync`, immediately after the `await EnsureDatabaseVersionTableAsync(context);` line (~line 728):
+
+```csharp
+                // Additive schema upgrade for existing databases: EnsureCreated never
+                // alters an existing schema, so add new columns here, idempotently.
+                await EnsureBookmarkColumnAsync(context);
+```
+
+Then add this method immediately after `EnsureDatabaseVersionTableAsync` (~line 763):
+
+```csharp
+        /// <summary>
+        /// Ensures the Songs.IsBookmarked column exists. Fresh databases already have it via
+        /// EnsureCreated; pre-existing databases get it added here exactly once. Idempotent and
+        /// defensive: a duplicate-column error is treated as success.
+        /// </summary>
+        private async Task EnsureBookmarkColumnAsync(SongDbContext context)
+        {
+            try
+            {
+                var columnCount = await context.Database.SqlQueryRaw<int>(
+                    "SELECT COUNT(*) AS Value FROM pragma_table_info('Songs') WHERE name='IsBookmarked'"
+                ).ToListAsync();
+
+                if (columnCount.FirstOrDefault() > 0)
+                    return; // Column already present (fresh DB or prior upgrade).
+
+                await context.Database.ExecuteSqlRawAsync(
+                    "ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0");
+
+                System.Diagnostics.Debug.WriteLine("SongDatabaseService: Added Songs.IsBookmarked column");
+            }
+            catch (Exception ex) when (ex.Message.Contains("duplicate column"))
+            {
+                // Another caller added it concurrently; nothing to do.
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not add IsBookmarked column: {ex.Message}");
+            }
+        }
+```
+
+(`SqlQueryRaw<int>` requires the projected column be named `Value`; the existing version-check queries in this file rely on the same convention. `ExecuteSqlRawAsync`, `ToListAsync`, and `FirstOrDefault()` are all already used here.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceBookmarkMigrationTests"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the Task 1 tests to confirm no regression**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongDatabaseServiceBookmarkTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs DTXMania.Test/Song/SongDatabaseServiceBookmarkMigrationTests.cs
+git commit -m "feat: add idempotent IsBookmarked column migration"
+```
+
+---
+
+### Task 3: SongManager wrappers (`GetBookmarkedNodesAsync`, `SetBookmarkAsync`)
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/SongManager.cs` (add after `GetRecentlyPlayedNodesAsync`, ~line 1606)
+- Test: `DTXMania.Test/Song/SongManagerBookmarkTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Song/SongManagerBookmarkTests.cs`:
+
+```csharp
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongManagerBookmarkTests : IDisposable
+    {
+        private readonly SongManager _manager;
+        private readonly string _dbPath;
+
+        public SongManagerBookmarkTests()
+        {
+            SongManager.ResetInstanceForTesting();
+            _manager = SongManager.Instance;
+            _dbPath = Path.Combine(Path.GetTempPath(), $"mgr_bookmark_{Guid.NewGuid()}.db");
+        }
+
+        public void Dispose()
+        {
+            _manager.Clear();
+            SongManager.ResetInstanceForTesting();
+            if (File.Exists(_dbPath))
+            {
+                try { File.Delete(_dbPath); } catch { /* ignore */ }
+            }
+        }
+
+        private async Task<int> AddSong(SongDatabaseService db, string title)
+        {
+            var song = new DTXMania.Game.Lib.Song.Entities.Song { Title = title, Artist = "A" };
+            var chart = new SongChart { FilePath = $"/c/{Guid.NewGuid():N}.dtx", HasDrumChart = true, DrumLevel = 30 };
+            await db.AddSongAsync(song, chart);
+            return (await db.GetSongsAsync()).Single(s => s.Title == title).Id;
+        }
+
+        [Fact]
+        public async Task GetBookmarkedNodesAsync_ReturnsScoreNodesAlphabetically()
+        {
+            await _manager.InitializeDatabaseServiceAsync(_dbPath, purgeDatabaseFirst: true);
+            var db = _manager.DatabaseService!;
+            var b = await AddSong(db, "Bravo");
+            var a = await AddSong(db, "Alpha");
+            await db.SetBookmarkAsync(b, true);
+            await db.SetBookmarkAsync(a, true);
+
+            var nodes = await _manager.GetBookmarkedNodesAsync();
+
+            Assert.Equal(2, nodes.Count);
+            Assert.All(nodes, n => Assert.Equal(NodeType.Score, n.Type));
+            Assert.Equal("Alpha", nodes[0].DisplayTitle);
+            Assert.Equal("Bravo", nodes[1].DisplayTitle);
+        }
+
+        [Fact]
+        public async Task GetBookmarkedNodesAsync_WhenDatabaseServiceNull_ReturnsEmptyList()
+        {
+            // Not initializing the DB service: the null-guard returns empty, no throw.
+            var nodes = await _manager.GetBookmarkedNodesAsync();
+            Assert.Empty(nodes);
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_PersistsThroughManager()
+        {
+            await _manager.InitializeDatabaseServiceAsync(_dbPath, purgeDatabaseFirst: true);
+            var db = _manager.DatabaseService!;
+            var id = await AddSong(db, "Song");
+
+            await _manager.SetBookmarkAsync(id, true);
+
+            Assert.True((await db.GetSongsAsync()).Single(s => s.Id == id).IsBookmarked);
+        }
+
+        [Fact]
+        public async Task SetBookmarkAsync_WhenDatabaseServiceNull_DoesNotThrow()
+        {
+            var ex = await Record.ExceptionAsync(() => _manager.SetBookmarkAsync(1, true));
+            Assert.Null(ex);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongManagerBookmarkTests"`
+Expected: FAIL — compile error (`GetBookmarkedNodesAsync`, `SetBookmarkAsync` do not exist on SongManager).
+
+- [ ] **Step 3: Add the wrappers**
+
+In `DTXMania.Game/Lib/Song/SongManager.cs`, immediately after the closing brace of `GetRecentlyPlayedNodesAsync` (~line 1606):
+
+```csharp
+        /// <summary>
+        /// Returns bookmarked songs as flat Score nodes, alphabetical by title. Returns an
+        /// empty list if the database is unavailable. Reuses the same node builder as the
+        /// browse list so difficulty cycling, status panel, preview, and activation behave
+        /// identically. Exceptions from the database layer propagate so the caller
+        /// (BeginBookmarksLoad) can distinguish a genuine failure from an empty result.
+        /// </summary>
+        public async Task<List<SongListNode>> GetBookmarkedNodesAsync()
+        {
+            var db = GetDatabaseServiceSnapshot();
+            if (db == null) return new List<SongListNode>();
+
+            var songs = await db.GetBookmarkedSongsAsync().ConfigureAwait(false);
+            var nodes = new List<SongListNode>(songs.Count);
+            foreach (var song in songs)
+            {
+                var charts = song.Charts?.ToArray() ?? Array.Empty<SongChart>();
+                var node = CreateSongNodeFromDatabaseEntities(song, charts);
+                if (node != null)
+                    nodes.Add(node);
+            }
+            return nodes;
+        }
+
+        /// <summary>
+        /// Sets or clears the bookmark flag on a song. Safe no-op when the database is
+        /// unavailable.
+        /// </summary>
+        public async Task SetBookmarkAsync(int songId, bool bookmarked)
+        {
+            var db = GetDatabaseServiceSnapshot();
+            if (db == null) return;
+            await db.SetBookmarkAsync(songId, bookmarked).ConfigureAwait(false);
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongManagerBookmarkTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/SongManager.cs DTXMania.Test/Song/SongManagerBookmarkTests.cs
+git commit -m "feat: add SongManager bookmark node and toggle wrappers"
+```
+
+---
+
+### Task 4: Extend the tab enum with `Bookmarks`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Song/SongSelectionTab.cs`
+- Test: `DTXMania.Test/Song/SongSelectionTabTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Song/SongSelectionTabTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongSelectionTabTests
+    {
+        [Fact]
+        public void Next_CyclesAllSongs_Recent_Bookmarks_AndWraps()
+        {
+            Assert.Equal(SongSelectionTab.RecentPlays, SongSelectionTab.AllSongs.Next());
+            Assert.Equal(SongSelectionTab.Bookmarks, SongSelectionTab.RecentPlays.Next());
+            Assert.Equal(SongSelectionTab.AllSongs, SongSelectionTab.Bookmarks.Next());
+        }
+
+        [Fact]
+        public void DisplayLabel_ReturnsExpectedLabels()
+        {
+            Assert.Equal("All Songs", SongSelectionTab.AllSongs.DisplayLabel());
+            Assert.Equal("Recent", SongSelectionTab.RecentPlays.DisplayLabel());
+            Assert.Equal("Bookmarks", SongSelectionTab.Bookmarks.DisplayLabel());
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionTabTests"`
+Expected: FAIL — compile error (`SongSelectionTab.Bookmarks` does not exist).
+
+- [ ] **Step 3: Extend the enum and extensions**
+
+In `DTXMania.Game/Lib/Song/SongSelectionTab.cs`, add the enum member:
+
+```csharp
+    public enum SongSelectionTab
+    {
+        AllSongs = 0,
+        RecentPlays = 1,
+        Bookmarks = 2
+    }
+```
+
+Update `Next()` (note the switch is currently exhaustive without a default; add the new arm and re-point RecentPlays):
+
+```csharp
+        public static SongSelectionTab Next(this SongSelectionTab tab)
+        {
+            return tab switch
+            {
+                SongSelectionTab.AllSongs => SongSelectionTab.RecentPlays,
+                SongSelectionTab.RecentPlays => SongSelectionTab.Bookmarks,
+                SongSelectionTab.Bookmarks => SongSelectionTab.AllSongs,
+                _ => SongSelectionTab.AllSongs
+            };
+        }
+```
+
+Update `DisplayLabel()`:
+
+```csharp
+        public static string DisplayLabel(this SongSelectionTab tab)
+        {
+            return tab switch
+            {
+                SongSelectionTab.AllSongs => "All Songs",
+                SongSelectionTab.RecentPlays => "Recent",
+                SongSelectionTab.Bookmarks => "Bookmarks",
+                _ => tab.ToString()
+            };
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionTabTests"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the existing tab tests to confirm no regression**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageTabTests"`
+Expected: PASS — note `SwitchToNextTab_FromRecent_WrapsBackToAllSongs` now lands on `Bookmarks`, not `AllSongs`. **Update that existing test** in `DTXMania.Test/Stage/SongSelectionStageTabTests.cs` (~line 110): rename to `SwitchToNextTab_FromRecent_GoesToBookmarks` and change the assertion to `Assert.Equal(SongSelectionTab.Bookmarks, ...)`. Re-run; expected PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/SongSelectionTab.cs DTXMania.Test/Song/SongSelectionTabTests.cs DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+git commit -m "feat: add Bookmarks tab to song-selection tab cycle"
+```
+
+---
+
+### Task 5: Wire the Bookmarks tab into SongSelectionStage (async load + populate + draw)
+
+This mirrors the recent-plays machinery. All new state is reset in `OnActivate` alongside the recent-plays reset.
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Test: `DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionStageBookmarkTests
+    {
+        private static SongListNode ScoreNode(string title) => new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = title
+        };
+
+        [Fact]
+        public void RefreshSongListForActiveTab_OnBookmarksTab_ShowsCachedNodes()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes",
+                new List<SongListNode> { ScoreNode("B1"), ScoreNode("B2") });
+
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
+
+            Assert.Equal(2, display.CurrentList.Count);
+            Assert.Equal("B1", display.CurrentList[0].Title);
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
+        }
+
+        [Fact]
+        public void RefreshSongListForActiveTab_OnBookmarksTab_WhenEmpty_SetsEmptyFlag()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode>());
+
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
+
+            Assert.Empty(display.CurrentList);
+            Assert.True(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
+        }
+
+        [Fact]
+        public void RefreshSongListForActiveTab_OnBookmarksTab_WhenLoadFailed_DoesNotShowEmptyMessage()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode>());
+            SetPrivateField(stage, "_bookmarksLoadFailed", true);
+
+            InvokePrivateMethod(stage, "RefreshSongListForActiveTab");
+
+            Assert.False(GetPrivateField<bool>(stage, "_showEmptyBookmarksMessage"));
+            Assert.True(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
+        }
+
+        [Fact]
+        public void SwitchToNextTab_FromRecent_GoesToBookmarks()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.RecentPlays);
+
+            InvokePrivateMethod(stage, "SwitchToNextTab");
+
+            Assert.Equal(SongSelectionTab.Bookmarks,
+                GetPrivateField<SongSelectionTab>(stage, "_activeTab"));
+            Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageBookmarkTests"`
+Expected: FAIL — fields `_bookmarkNodes`, `_showEmptyBookmarksMessage`, `_bookmarksLoadFailed` do not exist.
+
+- [ ] **Step 3: Add the bookmark state fields**
+
+In `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`, immediately after the `_recentPlaysLoadFailed` field (~line 69):
+
+```csharp
+        // Cached bookmark nodes (flat Score nodes), refreshed on activation and on switching
+        // into the Bookmarks tab. Null until first load. volatile: published from a background
+        // load continuation and read on the update thread, paired with _tabListNeedsRefresh.
+        private volatile List<SongListNode>? _bookmarkNodes;
+        private bool _showEmptyBookmarksMessage;
+        // True when the most recent BeginBookmarksLoad continuation failed (DB/IO error).
+        private bool _bookmarksLoadFailed;
+```
+
+- [ ] **Step 4: Reset bookmark state in OnActivate**
+
+In `OnActivate` (~line 260), immediately after the `_recentPlaysLoadFailed = false;` line (~line 263), add:
+
+```csharp
+            _bookmarkNodes = null;
+            _showEmptyBookmarksMessage = false;
+            _bookmarksLoadFailed = false;
+```
+
+- [ ] **Step 5: Route the Bookmarks tab through refresh + populate**
+
+In `RefreshSongListForActiveTab` (~line 1009), change the body to handle the third tab:
+
+```csharp
+        private void RefreshSongListForActiveTab()
+        {
+            if (_activeTab == SongSelectionTab.RecentPlays)
+                PopulateRecentPlaysList();
+            else if (_activeTab == SongSelectionTab.Bookmarks)
+                PopulateBookmarksList();
+            else
+                PopulateSongListForCurrentMode();
+        }
+```
+
+Add `PopulateBookmarksList` immediately after `PopulateRecentPlaysList` (~line 1024):
+
+```csharp
+        private void PopulateBookmarksList()
+        {
+            var nodes = _bookmarkNodes ?? new List<SongListNode>();
+            _songListDisplay.CurrentList = new List<SongListNode>(nodes);
+            _showEmptyBookmarksMessage = !_bookmarksLoadFailed && nodes.Count == 0;
+        }
+```
+
+- [ ] **Step 6: Kick the load on tab switch**
+
+In `SwitchToNextTab` (~line 2014), after the `if (_activeTab == SongSelectionTab.RecentPlays) BeginRecentPlaysLoad();` block, add:
+
+```csharp
+            if (_activeTab == SongSelectionTab.Bookmarks)
+                BeginBookmarksLoad();
+```
+
+Add `BeginBookmarksLoad` immediately after `BeginRecentPlaysLoad` (~line 2069):
+
+```csharp
+        /// <summary>
+        /// Loads bookmark nodes in the background and flags a repopulate when done.
+        /// Safe when the DB is unavailable (returns an empty list). Captures
+        /// <see cref="_activationVersion"/> so a completion that lands after a later
+        /// Deactivate/Activate cycle is discarded instead of overwriting fresh state.
+        /// </summary>
+        private void BeginBookmarksLoad()
+        {
+            int capturedVersion = _activationVersion;
+            _ = SongManager.Instance.GetBookmarkedNodesAsync()
+                .ContinueWith(task =>
+                {
+                    if (task.IsFaulted || task.IsCanceled)
+                    {
+                        System.Diagnostics.Debug.WriteLine(
+                            $"SongSelectionStage: bookmarks load failed:\n{task.Exception}");
+                        if (capturedVersion == _activationVersion)
+                        {
+                            _bookmarksLoadFailed = true;
+                            if (_activeTab == SongSelectionTab.Bookmarks)
+                                _tabListNeedsRefresh = true;
+                        }
+                        return;
+                    }
+                    if (capturedVersion != _activationVersion)
+                        return;
+                    _bookmarksLoadFailed = false;
+                    _bookmarkNodes = task.Result;
+                    if (_activeTab == SongSelectionTab.Bookmarks)
+                        _tabListNeedsRefresh = true;
+                }, TaskScheduler.Default);
+        }
+```
+
+- [ ] **Step 7: Warm the cache on activation**
+
+In `OnActivate`, find the existing `BeginRecentPlaysLoad();` call (~line 271) and add directly after it:
+
+```csharp
+            BeginBookmarksLoad();
+```
+
+- [ ] **Step 8: Draw the Bookmarks empty/failed message**
+
+In `OnDraw`, immediately after the Recent-tab status-message block (~line 1148, the `}` closing the `if (_activeTab == SongSelectionTab.RecentPlays ...)`), add:
+
+```csharp
+            if (_activeTab == SongSelectionTab.Bookmarks && _font != null
+                && (_searchFilterModal == null || !_searchFilterModal.IsOpen)
+                && (_bookmarksLoadFailed || _showEmptyBookmarksMessage))
+            {
+                string msg = _bookmarksLoadFailed
+                    ? "Could not load bookmarks"
+                    : "No bookmarks yet";
+                _font.DrawString(_spriteBatch, msg,
+                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
+                    Microsoft.Xna.Framework.Color.LightGray);
+            }
+```
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageBookmarkTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 10: Build the game project to confirm it compiles**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs DTXMania.Test/Stage/SongSelectionStageBookmarkTests.cs
+git commit -m "feat: wire Bookmarks tab into song selection stage"
+```
+
+---
+
+### Task 6: Toggle bookmark via `B` key and Floor Tom pad
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Test: `DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using Microsoft.Xna.Framework.Input;
+using Xunit;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionStageBookmarkToggleTests
+    {
+        private static SongListNode BookmarkableNode(string title, bool bookmarked = false)
+        {
+            var song = new DTXMania.Game.Lib.Song.Entities.Song
+            {
+                Id = 42,
+                Title = title,
+                IsBookmarked = bookmarked
+            };
+            return new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = title,
+                DatabaseSong = song
+            };
+        }
+
+        private static SongListDisplay DisplayWithSelection(SongListNode node)
+        {
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode> { node }
+            };
+            // CurrentList setter resets SelectedIndex to 0 -> SelectedSong == node.
+            return display;
+        }
+
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnScoreNode_FlipsBookmarkFlag()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+            Assert.False(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnFolderNode_DoesNothing()
+        {
+            var stage = CreateStage();
+            var folder = new SongListNode { Type = NodeType.Box, Title = "Folder" };
+            var display = DisplayWithSelection(folder);
+            AttachCoreUi(stage, display);
+
+            var ex = Record.Exception(() =>
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong"));
+
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_OnBookmarksTab_Unbookmark_RemovesNodeAndFlagsRefresh()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: true);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_bookmarkNodes", new List<SongListNode> { node });
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            Assert.False(node.DatabaseSong!.IsBookmarked);
+            var remaining = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.Empty(remaining);
+            Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+        }
+
+        [Fact]
+        public void HandleLaneHitForBookmark_OnFloorTom_TogglesBookmark()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+
+            InvokePrivateMethod(stage, "HandleLaneHitForBookmark", 1); // Floor Tom = lane 1
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void HandleLaneHitForBookmark_OnOtherLane_DoesNotToggle()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+
+            InvokePrivateMethod(stage, "HandleLaneHitForBookmark", 4); // Snare
+
+            Assert.False(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void DetectBookmarkKey_WhenBPressed_TogglesBookmark()
+        {
+            var stage = CreateStage();
+            var node = BookmarkableNode("Song", bookmarked: false);
+            var display = DisplayWithSelection(node);
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_inputManager", new BookmarkKeyInputManager());
+
+            InvokePrivateMethod(stage, "DetectBookmarkKey");
+
+            Assert.True(node.DatabaseSong!.IsBookmarked);
+        }
+
+        [Fact]
+        public void DetectBookmarkKey_WhenInputManagerNull_DoesNotThrow()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_inputManager", null);
+
+            var ex = Record.Exception(() => InvokePrivateMethod(stage, "DetectBookmarkKey"));
+            Assert.Null(ex);
+        }
+
+        // Reports the B key as pressed exactly once.
+        private sealed class BookmarkKeyInputManager : DTXMania.Game.Lib.Input.InputManager
+        {
+            private bool _consumed;
+            public override bool IsKeyPressed(int keyCode)
+            {
+                if (keyCode == (int)Keys.B && !_consumed)
+                {
+                    _consumed = true;
+                    return true;
+                }
+                return false;
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageBookmarkToggleTests"`
+Expected: FAIL — methods `ToggleBookmarkForSelectedSong`, `HandleLaneHitForBookmark`, `DetectBookmarkKey` do not exist.
+
+- [ ] **Step 3: Add the Floor Tom lane constant**
+
+In `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`, immediately after the `LowTomLaneIndex` constant (~line 128):
+
+```csharp
+        // Floor Tom in the lane-hit (KeyBindings) numbering; used to toggle a bookmark on the
+        // highlighted song. Distinct from the tab-switch pad (Low Tom = lane 8).
+        private const int FloorTomLaneIndex = 1;
+```
+
+- [ ] **Step 4: Add the toggle method**
+
+In `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`, add this method immediately after `BeginBookmarksLoad` (added in Task 5, ~within the Tab Switching region):
+
+```csharp
+        /// <summary>
+        /// Toggles the bookmark flag on the highlighted song. No-op for non-song nodes
+        /// (folders/back boxes). Updates the in-memory flag immediately so the star marker
+        /// refreshes this frame, persists asynchronously, and—on the Bookmarks tab when
+        /// un-bookmarking—removes the row from the cached list and requests a repopulate.
+        /// </summary>
+        private void ToggleBookmarkForSelectedSong()
+        {
+            var node = _songListDisplay?.SelectedSong;
+            if (node == null || node.Type != NodeType.Score)
+                return;
+
+            var song = node.DatabaseSong;
+            if (song == null)
+                return;
+
+            bool newState = !song.IsBookmarked;
+            song.IsBookmarked = newState; // immediate, in-memory; star refreshes next draw.
+            int songId = song.Id;
+
+            // Persist asynchronously; log faults without crashing the stage.
+            _ = SongManager.Instance.SetBookmarkAsync(songId, newState)
+                .ContinueWith(task =>
+                {
+                    if (task.IsFaulted || task.IsCanceled)
+                        System.Diagnostics.Debug.WriteLine(
+                            $"SongSelectionStage: bookmark persist failed:\n{task.Exception}");
+                }, TaskScheduler.Default);
+
+            // On the Bookmarks tab, an un-bookmark should drop the row from view.
+            if (_activeTab == SongSelectionTab.Bookmarks && !newState)
+            {
+                _bookmarkNodes?.RemoveAll(n =>
+                    ReferenceEquals(n, node) || n.DatabaseSong?.Id == songId);
+                _tabListNeedsRefresh = true;
+            }
+
+            PlayCursorMoveSound();
+        }
+
+        private void HandleLaneHitForBookmark(int lane)
+        {
+            if (lane == FloorTomLaneIndex)
+                ToggleBookmarkForSelectedSong();
+        }
+```
+
+- [ ] **Step 5: Wire the Floor Tom pad into the existing lane-hit handler**
+
+In `OnTabSwitchLaneHit` (~line 2071), after the `HandleLaneHitForTabSwitch(e.Lane);` line, add:
+
+```csharp
+            HandleLaneHitForBookmark(e.Lane);
+```
+
+(The modal-open early-return above already suppresses both tab-switch and bookmark while the search modal is open.)
+
+- [ ] **Step 6: Add the `B` key detection**
+
+Add the method after `DetectTabSwitchKey` (~line 1223):
+
+```csharp
+        private void DetectBookmarkKey()
+        {
+            // 'B' toggles a bookmark on the highlighted song. Routed through InputManager so
+            // MCP/E2E injected keys are honored. Suppressed implicitly while the search modal
+            // is open because HandleInput early-returns before calling this.
+            if (_inputManager != null &&
+                _inputManager.IsKeyPressed((int)Microsoft.Xna.Framework.Input.Keys.B))
+            {
+                ToggleBookmarkForSelectedSong();
+            }
+        }
+```
+
+Then call it in `HandleInput` (~line 1192), immediately after `DetectTabSwitchKey();`:
+
+```csharp
+            DetectBookmarkKey();
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageBookmarkToggleTests"`
+Expected: PASS (7 tests).
+
+- [ ] **Step 8: Run the existing tab tests to confirm no regression**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStageTabTests"`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+git commit -m "feat: toggle song bookmark via B key and Floor Tom pad"
+```
+
+---
+
+### Task 7: Star marker on bookmarked song bars
+
+A render-agnostic helper decides whether to show the star (unit-tested on Mac); the draw call lives in the graphics-bound display (not unit-tested on Mac, consistent with other rendering).
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs`
+- Modify: `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs` (add star offset constants to the `SongBars` class, ~line 242)
+- Modify: `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs` (`DrawBarInfoWithPerspective`, ~line 885)
+- Test: `DTXMania.Test/Song/SongBookmarkIndicatorTests.cs` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Song/SongBookmarkIndicatorTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Unit")]
+    public class SongBookmarkIndicatorTests
+    {
+        [Fact]
+        public void ShouldShow_WhenNull_ReturnsFalse()
+        {
+            Assert.False(SongBookmarkIndicator.ShouldShow(null));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenFolderNode_ReturnsFalse()
+        {
+            var node = new SongListNode { Type = NodeType.Box };
+            Assert.False(SongBookmarkIndicator.ShouldShow(node));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenScoreNotBookmarked_ReturnsFalse()
+        {
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { IsBookmarked = false }
+            };
+            Assert.False(SongBookmarkIndicator.ShouldShow(node));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenScoreBookmarked_ReturnsTrue()
+        {
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                DatabaseSong = new DTXMania.Game.Lib.Song.Entities.Song { IsBookmarked = true }
+            };
+            Assert.True(SongBookmarkIndicator.ShouldShow(node));
+        }
+
+        [Fact]
+        public void ShouldShow_WhenScoreNodeHasNoDatabaseSong_ReturnsFalse()
+        {
+            var node = new SongListNode { Type = NodeType.Score, DatabaseSong = null };
+            Assert.False(SongBookmarkIndicator.ShouldShow(node));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongBookmarkIndicatorTests"`
+Expected: FAIL — `SongBookmarkIndicator` does not exist.
+
+- [ ] **Step 3: Create the helper**
+
+Create `DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs`:
+
+```csharp
+namespace DTXMania.Game.Lib.Song.Components
+{
+    /// <summary>
+    /// Render-agnostic decision logic for the bookmark star marker on song bars.
+    /// Kept separate from the renderer so it is unit-testable without a GraphicsDevice.
+    /// </summary>
+    public static class SongBookmarkIndicator
+    {
+        /// <summary>The glyph drawn on a bookmarked song bar.</summary>
+        public const string Glyph = "★";
+
+        /// <summary>
+        /// True when the node is a real song whose database entity is bookmarked.
+        /// </summary>
+        public static bool ShouldShow(SongListNode? node)
+        {
+            return node != null
+                && node.Type == NodeType.Score
+                && node.DatabaseSong?.IsBookmarked == true;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongBookmarkIndicatorTests"`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Add star layout offset constants**
+
+In `DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs`, inside the `SongBars` static class (~line 242, near `UnselectedBarX`), add:
+
+```csharp
+            // Bookmark star marker offsets, relative to the bar's top-left (itemBounds).
+            public const int BookmarkStarOffsetX = 20;
+            public const int BookmarkStarOffsetY = 6;
+```
+
+- [ ] **Step 6: Draw the star in the bar renderer path**
+
+In `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`, inside `DrawBarInfoWithPerspective`, immediately before the method's closing brace (after the title is drawn), add:
+
+```csharp
+            // Bookmark star marker (drawn as an overlay so the cached title texture is not
+            // invalidated when bookmark state changes).
+            if (_font != null && SongBookmarkIndicator.ShouldShow(barInfo.SongNode))
+            {
+                var starPos = new Vector2(
+                    itemBounds.X + SongSelectionUILayout.SongBars.BookmarkStarOffsetX,
+                    itemBounds.Y + SongSelectionUILayout.SongBars.BookmarkStarOffsetY);
+                spriteBatch.DrawString(_font, SongBookmarkIndicator.Glyph, starPos, Color.Gold * opacityFactor);
+            }
+```
+
+(`_font` is the `SpriteFont` field already used in this file; `opacityFactor` is the method parameter; `barInfo.SongNode` is populated by `SongBarRenderer.GenerateBarInfo`. `SongBookmarkIndicator` is in the same `DTXMania.Game.Lib.Song.Components` namespace, so no extra `using` is needed.)
+
+- [ ] **Step 7: Build the game project**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeded. (If the font lacks the `★` glyph and renders as a missing-glyph box, that is a cosmetic follow-up, not a build failure — note it but proceed.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Song/Components/SongBookmarkIndicator.cs DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs DTXMania.Game/Lib/Song/Components/SongListDisplay.cs DTXMania.Test/Song/SongBookmarkIndicatorTests.cs
+git commit -m "feat: draw star marker on bookmarked song bars"
+```
+
+---
+
+### Task 8: Full regression pass
+
+- [ ] **Step 1: Build the game**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeded, 0 errors.
+
+- [ ] **Step 2: Run the full Mac test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: All tests pass, including the new bookmark suites and the updated `SongSelectionStageTabTests`.
+
+- [ ] **Step 3: Manual smoke (optional but recommended)**
+
+Run: `dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj`
+Verify: In Song Select, highlight a song and press `B` (or hit the Floor Tom pad) → a star appears on its bar. Press `Tab` twice to reach the Bookmarks tab → the song is listed. Un-bookmark it there → it disappears from the list. Restart the app → the bookmark persists.
+
+- [ ] **Step 4: Final commit (only if Step 3 surfaced fixes)**
+
+```bash
+git add -A
+git commit -m "test: verify song bookmarks end to end"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** Data-model boolean column (Task 1) ✓; idempotent schema upgrade for existing DBs (Task 2) ✓; DB read/write methods alphabetical by title, uncapped (Task 1) ✓; SongManager wrappers (Task 3) ✓; `B` key + Floor Tom toggle, modal-guarded, song-nodes-only (Task 6) ✓; Bookmarks tab with async load/stale guard/empty+failed states (Task 5) ✓; star marker in All Songs via testable helper (Task 7) ✓; un-bookmark removes row on Bookmarks tab (Task 6) ✓; DB + stage tests (all tasks) ✓.
+
+**Type consistency:** `IsBookmarked` (entity), `SetBookmarkAsync`/`GetBookmarkedSongsAsync` (DB service), `GetBookmarkedNodesAsync`/`SetBookmarkAsync` (SongManager), `_bookmarkNodes`/`_showEmptyBookmarksMessage`/`_bookmarksLoadFailed` (stage fields), `BeginBookmarksLoad`/`PopulateBookmarksList`/`ToggleBookmarkForSelectedSong`/`HandleLaneHitForBookmark`/`DetectBookmarkKey` (stage methods), `FloorTomLaneIndex = 1`, `SongBookmarkIndicator.ShouldShow`/`.Glyph` — all referenced consistently across tasks.
+
+**Known cross-task touch:** Task 4 changes the Recent→next-tab target, so the existing `SongSelectionStageTabTests.SwitchToNextTab_FromRecent_WrapsBackToAllSongs` is updated in Task 4 Step 5.

--- a/docs/superpowers/specs/2026-06-05-song-bookmarks-design.md
+++ b/docs/superpowers/specs/2026-06-05-song-bookmarks-design.md
@@ -1,0 +1,166 @@
+# Song Bookmarks — Design
+
+**Date:** 2026-06-05
+**Status:** Approved (pending implementation plan)
+
+## Overview
+
+Let players bookmark songs they want to find again. A bookmark is a per-song on/off
+flag toggled from the song list with a dedicated key and drum pad. Bookmarked songs are
+surfaced two ways: a new **Bookmarks** tab in the Song Selection stage (a flat,
+alphabetically-sorted list), and a small star marker on bookmarked song bars in the
+**All Songs** list.
+
+This feature mirrors the existing **Recent** tab (`2026-06-03-recent-plays-tab-design.md`)
+wherever possible — the tab enum, async node loading, stale-continuation guard, and
+empty/failed states are the same patterns — plus a new write path (toggling the flag) and a
+single additive schema change.
+
+## Goals
+
+- Let players mark/unmark any song and quickly find marked songs later.
+- Reuse the existing song-list rendering, difficulty cycling, status panel, preview audio,
+  and activation flow so Bookmark rows behave identically to browse rows.
+- Allow toggling from both keyboard and the drum kit (Floor Tom pad), since this is a drum game.
+- Persist bookmarks across app restarts and song-library rescans.
+
+## Non-Goals
+
+- No per-chart/per-difficulty bookmarks — a bookmark applies to the whole song.
+- No folders/boxes in the Bookmarks list — it is flat.
+- No filtering/search within the Bookmarks tab.
+- No cap/limit on the number of bookmarks.
+- No bookmark indicator on the song status/detail panel (only the list star + the tab).
+
+## Requirements Summary
+
+| Decision | Choice |
+| --- | --- |
+| Granularity | One bookmark per song (whole song) |
+| Storage | `IsBookmarked` boolean column on the `Songs` table |
+| Toggle input | `B` key **and** Floor Tom drum pad (lane-hit index 1) |
+| Surfacing | Dedicated **Bookmarks** tab **and** a star marker in the All Songs list |
+| Bookmarks list order | Alphabetical by `Title` (stable tiebreak by `Id`) |
+| Bookmarks list size | Uncapped |
+| Schema upgrade | Guarded, idempotent `ALTER TABLE` gated by a `__DatabaseVersion` feature row |
+
+## Data Model & Schema Upgrade
+
+Add a single column to the `Song` entity:
+
+```csharp
+public bool IsBookmarked { get; set; } = false;
+```
+
+- The column is `NOT NULL DEFAULT 0` (`INTEGER` in SQLite).
+- **Fresh databases** get the column automatically via `EnsureCreated`/`OnModelCreating`.
+- **Existing databases** need a one-time additive migration because the project uses
+  `EnsureCreatedAsync()` (not EF migrations), which never alters an existing schema. During
+  `SongDatabaseService` initialization, run an idempotent
+  `ALTER TABLE Songs ADD COLUMN IsBookmarked INTEGER NOT NULL DEFAULT 0`, gated by a new
+  `__DatabaseVersion` feature row (`Feature='SongBookmarks'`) so it executes exactly once.
+  This mirrors the existing Unicode-collation reconfiguration path
+  (`SongDatabaseService.cs` ~line 676–760).
+- The `ALTER TABLE` is also guarded defensively against the column already existing
+  (e.g. inspect `PRAGMA table_info(Songs)` or treat a duplicate-column error as success), so
+  a missing/partial version row can never crash startup.
+
+**Durability across rescans:** songs are matched by chart `FilePath` during re-enumeration,
+so an existing `Song` row (and its `Id`) is preserved across rescans — the bookmark flag
+rides along with it. When a song is orphaned (its files vanish) and removed during cleanup,
+its bookmark is removed with the row. No separate cleanup logic is required. This is the
+primary reason a column on `Songs` is preferred over a separate `Bookmark` table.
+
+## Database Service (`SongDatabaseService`)
+
+Two new methods, following the shape of `GetRecentlyPlayedSongsAsync`:
+
+- `Task SetBookmarkAsync(int songId, bool bookmarked)` — loads the `Song` by id, sets
+  `IsBookmarked`, saves. No-op (and no throw) if the song id is not found.
+- `Task<List<Song>> GetBookmarkedSongsAsync()` — `Where(s => s.IsBookmarked)`, eager-loads
+  `Charts` then `Charts.Scores` (same graph the Recent query loads so callers can build
+  fully-populated `SongListNode`s), ordered `OrderBy(s => s.Title).ThenBy(s => s.Id)`.
+  Uncapped.
+
+`SongManager` gets a thin async wrapper `GetBookmarkedNodesAsync()` returning
+`List<SongListNode>`, mirroring the existing `GetRecentlyPlayedNodesAsync()`, plus a
+`SetBookmarkAsync(int songId, bool bookmarked)` pass-through used by the toggle path.
+
+## Toggle Interaction (`SongSelectionStage`)
+
+New private method `ToggleBookmarkForSelectedSong()`:
+
+1. Resolve the highlighted `SongListNode`. Ignore the action if it is not a real song
+   (`NodeType.Score`) — folders/back-boxes are not bookmarkable.
+2. Flip the song's `IsBookmarked` state in memory so the star refreshes immediately on the
+   current frame.
+3. Persist via `SongManager.SetBookmarkAsync(songId, newState)` (fire-and-forget with the
+   same stale-safe continuation/error-logging discipline used by `BeginRecentPlaysLoad`; a
+   persistence failure logs and does not crash the stage).
+4. If the active tab is **Bookmarks** and the song was just **un**-bookmarked, remove its row
+   from the displayed list (and reconcile the selection index) so the list stays consistent.
+
+Input wiring:
+
+- **Keyboard:** the `B` key, routed through `InputManager` so MCP/API key injection works,
+  added to the appropriate handled-keys set in `HandleInput()`.
+- **Drum pad:** Floor Tom, lane-hit index **1** in the KeyBindings numbering (distinct from
+  the tab-switch pad, Low Tom = lane 8). Handled through the same `OnLaneHit` subscription
+  the tab switch already uses — extend the existing `OnTabSwitchLaneHit`/`HandleLaneHit...`
+  path (or add a sibling handler) rather than adding a second subscription.
+- Both inputs are suppressed while the search modal is open, matching the existing
+  tab-switch guards.
+
+## Bookmarks Tab
+
+- Add `Bookmarks` to the `SongSelectionTab` enum.
+- Extend `SongSelectionTabExtensions.Next()` to cycle
+  `AllSongs → RecentPlays → Bookmarks → AllSongs`, and add the `Bookmarks` arm to
+  `DisplayLabel()` (label: `"Bookmarks"`).
+- Async load mirrors recent-plays exactly:
+  - `private volatile List<SongListNode>? _bookmarkNodes;`
+  - `BeginBookmarksLoad()` calls `SongManager.GetBookmarkedNodesAsync()` with the same
+    activation-token guard against stale continuations and a `_bookmarksLoadFailed` flag.
+  - Triggered on stage activation and when switching to the Bookmarks tab (`SwitchToNextTab`).
+  - `PopulateBookmarksList()` and an empty/failed-state message
+    (empty: "No bookmarks yet"; failure: an error message), gated to the active tab and
+    non-modal state like the Recent equivalents.
+- Back/navigation actions remain gated to the All Songs tab, as they already are.
+
+## Star Indicator in All Songs
+
+- Render a small star marker on song bars whose node is bookmarked, in the All Songs list
+  (and naturally in the Bookmarks tab, where every row is bookmarked).
+- The bookmarked state is read from the `SongListNode`/song the bar represents; toggling
+  updates that state in memory (see Toggle step 2) so the marker appears/disappears on the
+  next frame without a reload.
+- Keep the "is this bar bookmarked" decision in a render-agnostic, unit-testable spot; the
+  actual sprite draw lives on the song-bar rendering path. (Note: `SongBarRenderer` tests are
+  excluded from the Mac test project, so logic that must be tested on Mac should not live
+  inside the renderer.)
+
+## Testing
+
+`SongDatabaseService` (Mac-safe):
+- Set then read back a bookmark; clear it; toggling is idempotent.
+- `GetBookmarkedSongsAsync` returns only bookmarked songs, alphabetical by title with the
+  `Id` tiebreak, and eager-loads the Charts+Scores graph.
+- Schema upgrade: against a DB created without the column, initialization adds it once,
+  is idempotent on a second run, and tolerates the column already existing.
+- Orphan cleanup removes a bookmarked song's row when its files are gone (no dangling flag).
+
+`SongSelectionStage` (mirroring the recent-plays edge-case tests):
+- Toggle on a `Score` node flips state and persists; toggle on a folder/back node is a no-op.
+- Stale-continuation guard: a slow bookmarks load from a previous activation does not
+  overwrite the current activation's list.
+- Tab-switch gating and empty/failed-state rendering for the Bookmarks tab.
+- Un-bookmarking on the Bookmarks tab removes the row and keeps the selection valid.
+- Toggle inputs are ignored while the search modal is open.
+
+## Risks & Mitigations
+
+- **Schema upgrade on existing DBs is the main risk.** Mitigated by the version-gated,
+  idempotent, defensively-guarded `ALTER TABLE` and a dedicated test against a
+  column-less database.
+- **Floor Tom is a primary play pad**, but song-select consumes no lane hits except the
+  tab-switch (lane 8), so reusing it for the bookmark toggle has no conflict in this stage.


### PR DESCRIPTION
## Summary
- Add `IsBookmarked` column to the `Song` entity with idempotent migration for existing databases.
- Add `SetBookmarkAsync` / `GetBookmarkedSongsAsync` methods to `SongDatabaseService`.
- Add `ToggleBookmark` / `IsBookmarked` helpers on `SongManager`.
- Introduce a dedicated **Bookmarks** tab in the song-selection tab cycle.
- Draw a gold star (★) marker on bookmarked song bars in all tabs.
- Toggle bookmark state via **B key** or **Floor Tom pad**.
- Reconcile bookmark state across all in-memory `SongListNode` instances via `BookmarkStateReconciler`.
- Keep render logic testable with `SongBookmarkIndicator` helper.
- Add spritefont character regions for the star glyph (U+2605).

#### Test plan
- [x] `SongDatabaseServiceBookmarkTests` — toggle and query bookmarks
- [x] `SongDatabaseServiceBookmarkMigrationTests` — idempotent schema upgrade
- [x] `SongManagerBookmarkTests` — wrapper integration
- [x] `BookmarkStateReconcilerTests` — cross-node state propagation
- [x] `SongBookmarkIndicatorTests` — render-agnostic decision logic
- [x] `SongSelectionStageBookmarkTests` — Bookmarks tab wiring and display
- [x] `SongSelectionStageBookmarkToggleTests` — B key and Floor Tom toggle
- [x] `SongSelectionTabTests` — invalid-value fallbacks and tab cycle parity

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added song bookmarking with persistent storage, a Bookmarks tab, bookmark toggle (B hotkey and configurable lane), and star indicator on song rows.

* **Documentation**
  * Updated stage composition docs and component count; documented bookmark-related event flow.

* **Assets**
  * Font assets updated to include the bookmark star (★) glyph.

* **Tests**
  * Extensive unit/integration tests covering bookmarking, persistence, UI behavior, migration and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->