### PR TITLE
fix(parser): isolate retry state, guard #PANEL→#PAN misroute, and correct failure detection

### DIFF
--- a/DTXMania.Game/Lib/Song/Components/ParsedChart.cs
+++ b/DTXMania.Game/Lib/Song/Components/ParsedChart.cs
@@ -53,6 +53,66 @@ namespace DTXMania.Game.Lib.Song.Components
         }
 
         /// <summary>
+        /// WAV id → playback volume on the DTXMania 0–100 scale, from #VOLUMExx /
+        /// #WAVVOLxx definitions. WAV ids absent from this map play at full volume.
+        /// Use <see cref="GetVolume"/> to read a normalized 0.0–1.0 value.
+        /// </summary>
+        public IReadOnlyDictionary<string, int> WavVolumes => _wavVolumes;
+
+        private Dictionary<string, int> _wavVolumes = new Dictionary<string, int>();
+
+        /// <summary>
+        /// WAV id → stereo pan on the DTXMania -100 (full left) … +100 (full right)
+        /// scale, from #PANxx / #WAVPANxx definitions. WAV ids absent from this map
+        /// play centered. Use <see cref="GetPan"/> to read a normalized -1.0–1.0 value.
+        /// </summary>
+        public IReadOnlyDictionary<string, int> WavPans => _wavPans;
+
+        private Dictionary<string, int> _wavPans = new Dictionary<string, int>();
+
+        /// <summary>
+        /// Replaces the per-WAV volume table. Parser-internal use only.
+        /// </summary>
+        internal void SetWavVolumes(IDictionary<string, int> volumes)
+        {
+            _wavVolumes = volumes != null
+                ? new Dictionary<string, int>(volumes)
+                : new Dictionary<string, int>();
+        }
+
+        /// <summary>
+        /// Replaces the per-WAV pan table. Parser-internal use only.
+        /// </summary>
+        internal void SetWavPans(IDictionary<string, int> pans)
+        {
+            _wavPans = pans != null
+                ? new Dictionary<string, int>(pans)
+                : new Dictionary<string, int>();
+        }
+
+        /// <summary>
+        /// Gets the normalized playback volume (0.0–1.0) for a WAV id. Returns 1.0
+        /// (full volume) when the chart defines no #VOLUME/#WAVVOL for the id.
+        /// </summary>
+        public float GetVolume(string wavId)
+        {
+            if (!string.IsNullOrEmpty(wavId) && _wavVolumes.TryGetValue(wavId, out var volume))
+                return Math.Clamp(volume / 100f, 0f, 1f);
+            return 1.0f;
+        }
+
+        /// <summary>
+        /// Gets the normalized stereo pan (-1.0 = full left … +1.0 = full right) for a
+        /// WAV id. Returns 0.0 (centered) when the chart defines no #PAN/#WAVPAN for it.
+        /// </summary>
+        public float GetPan(string wavId)
+        {
+            if (!string.IsNullOrEmpty(wavId) && _wavPans.TryGetValue(wavId, out var pan))
+                return Math.Clamp(pan / 100f, -1f, 1f);
+            return 0.0f;
+        }
+
+        /// <summary>
         /// Base BPM of the song (from #BPM header)
         /// Default is 120 if not specified
         /// </summary>
@@ -63,6 +123,14 @@ namespace DTXMania.Game.Lib.Song.Components
         /// Relative to the DTX file location
         /// </summary>
         public string BackgroundAudioPath { get; set; } = "";
+
+        /// <summary>
+        /// WAV id backing <see cref="BackgroundAudioPath"/>, when known. Lets the
+        /// master background track honor that WAV's #VOLUME/#PAN via
+        /// <see cref="GetVolume"/>/<see cref="GetPan"/>. Empty when no background
+        /// WAV was resolved.
+        /// </summary>
+        public string BackgroundWavId { get; set; } = "";
 
         /// <summary>
         /// Original DTX file path

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -348,7 +348,7 @@ namespace DTXMania.Game.Lib.Song
                     {
                         TryStoreVolume(command.Substring(7), value, wavVolumes);
                     }
-                    else if (command.StartsWith("#PAN") && command.Length > 4)
+                    else if (command.StartsWith("#PAN") && !command.StartsWith("#PANEL") && command.Length > 4)
                     {
                         TryStorePan(command.Substring(4), value, wavPans);
                     }

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -104,15 +104,6 @@ namespace DTXMania.Game.Lib.Song
             if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
                 throw new FileNotFoundException($"DTX file not found: {filePath}");
 
-            var chart = new ParsedChart(filePath);
-            var wavDefinitions = new Dictionary<string, string>(); // WAV ID -> file path
-            // NOTE: These maps (like wavDefinitions/chart.Notes) are declared outside the
-            // encoding-retry loop below. If the first encoding throws mid-parse, the retry
-            // accumulates into the same dicts. This is harmless — dict keys overwrite — and
-            // matches the pre-existing pattern, but is a latent design smell.
-            var wavVolumes = new Dictionary<string, int>();        // WAV ID -> volume (0-100)
-            var wavPans = new Dictionary<string, int>();           // WAV ID -> pan (-100..100)
-
             // Try different encodings for Japanese text support
             var encodings = new List<Encoding>
             {
@@ -130,10 +121,25 @@ namespace DTXMania.Game.Lib.Song
                 // Shift_JIS not available, continue with available encodings
             }
 
+            // Each encoding attempt gets fresh chart/dict state. If an attempt throws
+            // mid-parse, its partial Notes (a List, not a dict) and NotesPerLane counters
+            // are discarded rather than carried into the next attempt where they would
+            // duplicate. The three WAV dicts use key assignment so they would self-heal,
+            // but the list-based state does not — hence per-attempt instantiation.
+            ParsedChart chart = null!;
+            Dictionary<string, string> wavDefinitions = null!; // WAV ID -> file path
+            Dictionary<string, int> wavVolumes = null!;        // WAV ID -> volume (0-100)
+            Dictionary<string, int> wavPans = null!;           // WAV ID -> pan (-100..100)
+
             Exception lastException = null;
 
             foreach (var encoding in encodings)
             {
+                chart = new ParsedChart(filePath);
+                wavDefinitions = new Dictionary<string, string>();
+                wavVolumes = new Dictionary<string, int>();
+                wavPans = new Dictionary<string, int>();
+
                 try
                 {
                     using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -609,7 +609,11 @@ namespace DTXMania.Game.Lib.Song
             if (!string.IsNullOrEmpty(backgroundWav))
             {
                 chart.BackgroundAudioPath = ResolveBGMPath(backgroundWav, dtxFilePath);
-                chart.BackgroundWavId = backgroundWavId ?? "";
+                // backgroundWavId is guaranteed non-null here: it is set from a
+                // Dictionary<string,string> key (which cannot be null) in the same
+                // branches that set backgroundWav to a non-empty value. The guard
+                // above ensures we only reach this assignment when that is the case.
+                chart.BackgroundWavId = backgroundWavId;
                 // Background audio path resolved
             }
         }

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -106,6 +106,10 @@ namespace DTXMania.Game.Lib.Song
 
             var chart = new ParsedChart(filePath);
             var wavDefinitions = new Dictionary<string, string>(); // WAV ID -> file path
+            // NOTE: These maps (like wavDefinitions/chart.Notes) are declared outside the
+            // encoding-retry loop below. If the first encoding throws mid-parse, the retry
+            // accumulates into the same dicts. This is harmless — dict keys overwrite — and
+            // matches the pre-existing pattern, but is a latent design smell.
             var wavVolumes = new Dictionary<string, int>();        // WAV ID -> volume (0-100)
             var wavPans = new Dictionary<string, int>();           // WAV ID -> pan (-100..100)
 

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -126,12 +126,32 @@ namespace DTXMania.Game.Lib.Song
             // are discarded rather than carried into the next attempt where they would
             // duplicate. The three WAV dicts use key assignment so they would self-heal,
             // but the list-based state does not — hence per-attempt instantiation.
+            //
+            // Note: the retry path is currently unreachable through this method because
+            // the parser is fully defensive (no throw on malformed input) and Encoding.UTF8
+            // uses replacement fallback (invalid bytes become U+FFFD, no throw). The
+            // per-attempt instantiation is defensive hardening for a future strict-encoding
+            // or test-seam scenario. See DTXChartParserAdditionalTests for the mechanical
+            // proof of why shared state would duplicate notes.
+            //
+            // Failure detection uses a `parsed` flag (set true only after a full,
+            // exception-free parse) rather than checking Notes.Count. The old Notes.Count
+            // check was inconsistent: success was "no throw" but failure was "zero notes,"
+            // so a file that added notes on a failed attempt before throwing would skip
+            // the failure throw and return a truncated chart. The flag makes success and
+            // failure symmetric on "did any attempt complete without throwing."
+            //
+            // The catch is narrowed to IOException (I/O errors during file reading) and
+            // DecoderFallbackException (strict-encoding decode failures, forward-looking).
+            // Programmer errors (NullReferenceException, IndexOutOfRangeException, etc.)
+            // propagate immediately rather than being swallowed as "encoding failures."
             ParsedChart chart = null!;
             Dictionary<string, string> wavDefinitions = null!; // WAV ID -> file path
             Dictionary<string, int> wavVolumes = null!;        // WAV ID -> volume (0-100)
             Dictionary<string, int> wavPans = null!;           // WAV ID -> pan (-100..100)
 
             Exception lastException = null;
+            bool parsed = false;
 
             foreach (var encoding in encodings)
             {
@@ -147,19 +167,21 @@ namespace DTXMania.Game.Lib.Song
 
                     await ParseFileContentAsync(reader, chart, wavDefinitions, wavVolumes, wavPans);
 
-                    // If we got here without exception, parsing succeeded
+                    // Full parse completed without exception — this attempt succeeded.
+                    parsed = true;
                     break;
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is IOException or DecoderFallbackException)
                 {
                     lastException = ex;
+                    Debug.WriteLine($"DTXChartParser: Failed to parse with encoding {encoding.EncodingName}: {ex.Message}");
                     // Try next encoding
                     continue;
                 }
             }
 
-            // If all encodings failed, throw the last exception
-            if (chart.Notes.Count == 0 && lastException != null)
+            // If no encoding fully succeeded, throw the last exception
+            if (!parsed && lastException != null)
             {
                 throw new InvalidOperationException($"Failed to parse DTX file with any encoding: {filePath}", lastException);
             }

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -106,6 +106,8 @@ namespace DTXMania.Game.Lib.Song
 
             var chart = new ParsedChart(filePath);
             var wavDefinitions = new Dictionary<string, string>(); // WAV ID -> file path
+            var wavVolumes = new Dictionary<string, int>();        // WAV ID -> volume (0-100)
+            var wavPans = new Dictionary<string, int>();           // WAV ID -> pan (-100..100)
 
             // Try different encodings for Japanese text support
             var encodings = new List<Encoding>
@@ -133,8 +135,8 @@ namespace DTXMania.Game.Lib.Song
                     using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
                     using var reader = new StreamReader(stream, encoding);
 
-                    await ParseFileContentAsync(reader, chart, wavDefinitions);
-                    
+                    await ParseFileContentAsync(reader, chart, wavDefinitions, wavVolumes, wavPans);
+
                     // If we got here without exception, parsing succeeded
                     break;
                 }
@@ -154,6 +156,10 @@ namespace DTXMania.Game.Lib.Song
 
             // Find background audio file
             FindBackgroundAudio(chart, wavDefinitions, filePath);
+
+            // Attach per-WAV volume/pan so playback honors #VOLUME/#PAN definitions
+            chart.SetWavVolumes(wavVolumes);
+            chart.SetWavPans(wavPans);
 
             // Finalize the chart
             chart.FinalizeChart();
@@ -248,7 +254,7 @@ namespace DTXMania.Game.Lib.Song
         /// <summary>
         /// Parses the content of a DTX file
         /// </summary>
-        private static async Task ParseFileContentAsync(StreamReader reader, ParsedChart chart, Dictionary<string, string> wavDefinitions)
+        private static async Task ParseFileContentAsync(StreamReader reader, ParsedChart chart, Dictionary<string, string> wavDefinitions, Dictionary<string, int> wavVolumes, Dictionary<string, int> wavPans)
         {
             string line;
             bool inDataSection = false;
@@ -270,7 +276,7 @@ namespace DTXMania.Game.Lib.Song
                 if (!inDataSection)
                 {
                     // Parse header commands
-                    ParseHeaderCommand(line, chart, wavDefinitions);
+                    ParseHeaderCommand(line, chart, wavDefinitions, wavVolumes, wavPans);
                 }
                 else
                 {
@@ -283,7 +289,7 @@ namespace DTXMania.Game.Lib.Song
         /// <summary>
         /// Parses header commands like #BPM and #WAV definitions
         /// </summary>
-        private static void ParseHeaderCommand(string line, ParsedChart chart, Dictionary<string, string> wavDefinitions)
+        private static void ParseHeaderCommand(string line, ParsedChart chart, Dictionary<string, string> wavDefinitions, Dictionary<string, int> wavVolumes, Dictionary<string, int> wavPans)
         {
             if (!line.StartsWith('#'))
                 return;
@@ -309,15 +315,59 @@ namespace DTXMania.Game.Lib.Song
                     break;
 
                 default:
+                    // Per-WAV volume: #WAVVOL01 / #VOLUME01 (0-100, default 100).
+                    // Per-WAV pan: #WAVPAN01 / #PAN01 (-100 left .. +100 right, default 0).
+                    // Checked before the generic #WAV branch since #WAVVOL/#WAVPAN
+                    // also start with "#WAV".
+                    if (command.StartsWith("#WAVVOL") && command.Length > 7)
+                    {
+                        TryStoreVolume(command.Substring(7), value, wavVolumes);
+                    }
+                    else if (command.StartsWith("#WAVPAN") && command.Length > 7)
+                    {
+                        TryStorePan(command.Substring(7), value, wavPans);
+                    }
                     // Check for WAV definitions: #WAV01, #WAV02, etc.
-                    if (command.StartsWith("#WAV") && command.Length > 4)
+                    else if (command.StartsWith("#WAV") && command.Length > 4)
                     {
                         var wavId = command.Substring(4);
                         wavDefinitions[wavId] = value;
                         // Found WAV definition
                     }
+                    else if (command.StartsWith("#VOLUME") && command.Length > 7)
+                    {
+                        TryStoreVolume(command.Substring(7), value, wavVolumes);
+                    }
+                    else if (command.StartsWith("#PAN") && command.Length > 4)
+                    {
+                        TryStorePan(command.Substring(4), value, wavPans);
+                    }
                     break;
             }
+        }
+
+        /// <summary>
+        /// Stores a per-WAV volume (clamped to DTXMania's 0-100 range) keyed by WAV id.
+        /// Silently ignores non-numeric parameters (e.g. the #PANEL metadata header).
+        /// </summary>
+        private static void TryStoreVolume(string wavId, string value, Dictionary<string, int> wavVolumes)
+        {
+            if (string.IsNullOrEmpty(wavId))
+                return;
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var volume))
+                wavVolumes[wavId] = Math.Clamp(volume, 0, 100);
+        }
+
+        /// <summary>
+        /// Stores a per-WAV pan (clamped to DTXMania's -100..+100 range) keyed by WAV id.
+        /// Silently ignores non-numeric parameters (e.g. the #PANEL metadata header).
+        /// </summary>
+        private static void TryStorePan(string wavId, string value, Dictionary<string, int> wavPans)
+        {
+            if (string.IsNullOrEmpty(wavId))
+                return;
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var pan))
+                wavPans[wavId] = Math.Clamp(pan, -100, 100);
         }
 
         /// <summary>
@@ -495,18 +545,21 @@ namespace DTXMania.Game.Lib.Song
             }
 
             // Find the background music WAV file for legacy compatibility
-            // Look for common background music filenames first
+            // Look for common background music filenames first. Track the WAV id too
+            // so the master background track can honor that WAV's #VOLUME/#PAN.
             string backgroundWav = null;
+            string backgroundWavId = null;
 
             // Strategy 1: Look for common background music filenames
             var commonBgmNames = new[] { "bgm.ogg", "bgm.wav", "bgm.mp3", "background.ogg", "background.wav", "background.mp3" };
             foreach (var bgmName in commonBgmNames)
             {
-                var matchingWav = wavDefinitions.Values.FirstOrDefault(wav =>
-                    string.Equals(Path.GetFileName(wav.Replace('\\', '/')), bgmName, StringComparison.OrdinalIgnoreCase));
-                if (!string.IsNullOrEmpty(matchingWav))
+                var matching = wavDefinitions.FirstOrDefault(kvp =>
+                    string.Equals(Path.GetFileName(kvp.Value.Replace('\\', '/')), bgmName, StringComparison.OrdinalIgnoreCase));
+                if (!string.IsNullOrEmpty(matching.Value))
                 {
-                    backgroundWav = matchingWav;
+                    backgroundWav = matching.Value;
+                    backgroundWavId = matching.Key;
                     // Found background music by filename
                     break;
                 }
@@ -515,13 +568,16 @@ namespace DTXMania.Game.Lib.Song
             // Strategy 2: If no common BGM name found and no BGM events, use the first WAV as fallback
             if (string.IsNullOrEmpty(backgroundWav) && chart.BGMEvents.Count == 0)
             {
-                backgroundWav = wavDefinitions.Values.FirstOrDefault();
+                var first = wavDefinitions.FirstOrDefault();
+                backgroundWav = first.Value;
+                backgroundWavId = first.Key;
                 // Using first WAV as background music fallback
             }
 
             if (!string.IsNullOrEmpty(backgroundWav))
             {
                 chart.BackgroundAudioPath = ResolveBGMPath(backgroundWav, dtxFilePath);
+                chart.BackgroundWavId = backgroundWavId ?? "";
                 // Background audio path resolved
             }
         }

--- a/DTXMania.Game/Lib/Stage/Performance/ChipSoundCache.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ChipSoundCache.cs
@@ -87,18 +87,33 @@ namespace DTXMania.Game.Lib.Stage.Performance
         }
 
         /// <summary>
-        /// Plays the sound for the given WAV id. Unknown ids are silent — not
-        /// exceptional, since charts often reference WAVs that aren't loaded.
+        /// Plays the sound for the given WAV id at full volume, centered.
+        /// </summary>
+        public void Play(string wavId) => Play(wavId, 1.0f, 0.0f);
+
+        /// <summary>
+        /// Plays the sound for the given WAV id with the supplied volume and pan,
+        /// honoring the chart's #VOLUME/#PAN definitions. Unknown ids are silent —
+        /// not exceptional, since charts often reference WAVs that aren't loaded.
         /// Tracks the returned SoundEffectInstance for lifecycle management.
         /// </summary>
-        public void Play(string wavId)
+        /// <param name="wavId">WAV id to play.</param>
+        /// <param name="volume">Normalized volume, 0.0–1.0.</param>
+        /// <param name="pan">Normalized stereo pan, -1.0 (left) to 1.0 (right).</param>
+        public void Play(string wavId, float volume, float pan)
         {
             if (_disposed || string.IsNullOrEmpty(wavId)) return;
             if (!_sounds.TryGetValue(wavId, out var sound)) return;
 
             try
             {
-                var instance = sound.Play();
+                // Keep the simple full-volume, centered path on Play() so the common
+                // case (charts with no #VOLUME/#PAN) behaves exactly as before.
+                SoundEffectInstance? instance =
+                    (volume >= 0.999f && Math.Abs(pan) < 0.001f)
+                        ? sound.Play()
+                        : sound.Play(volume, 0.0f, pan);
+
                 if (instance != null)
                 {
                     _activeInstances.Add(instance);

--- a/DTXMania.Game/Lib/Stage/Performance/SongTimer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SongTimer.cs
@@ -62,7 +62,11 @@ namespace DTXMania.Game.Lib.Stage.Performance
         }
 
         /// <summary>
-        /// Stereo pan of the audio (-1.0 = full left … +1.0 = full right)
+        /// Stereo pan of the audio (-1.0 = full left … +1.0 = full right).
+        /// Note: SoundEffectInstance.Pan is well-defined for mono sources but limited/
+        /// undefined for stereo sources (e.g. the typical stereo bgm.ogg master track).
+        /// This faithfully honors the chart's #PAN, but a panned stereo background may not
+        /// produce the expected effect — a MonoGame/XNA platform limitation, not a code defect.
         /// </summary>
         public float Pan
         {

--- a/DTXMania.Game/Lib/Stage/Performance/SongTimer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SongTimer.cs
@@ -62,6 +62,21 @@ namespace DTXMania.Game.Lib.Stage.Performance
         }
 
         /// <summary>
+        /// Stereo pan of the audio (-1.0 = full left … +1.0 = full right)
+        /// </summary>
+        public float Pan
+        {
+            get => _soundInstance?.Pan ?? 0f;
+            set
+            {
+                if (_soundInstance != null)
+                {
+                    _soundInstance.Pan = MathHelper.Clamp(value, -1f, 1f);
+                }
+            }
+        }
+
+        /// <summary>
         /// Whether the audio is looped
         /// </summary>
         public bool IsLooped

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -1084,6 +1084,8 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     // Honor the chart's per-WAV #VOLUME/#PAN for backing-track audio;
                     // defaults to full volume, centered when undefined.
+                    // NOTE: ConfigData.MasterVolume is not yet combined here — this is
+                    // the integration point once master-volume routing is wired into Lib/.
                     float volume = _parsedChart?.GetVolume(bgmEvent.WavId) ?? 1.0f;
                     float pan = _parsedChart?.GetPan(bgmEvent.WavId) ?? 0.0f;
                     sound.Play(volume, 0.0f, pan);
@@ -1377,6 +1379,8 @@ namespace DTXMania.Game.Lib.Stage
                 return;
 
             // Honor the chart's per-WAV #VOLUME/#PAN; defaults to full volume, centered.
+            // NOTE: ConfigData.MasterVolume is not yet combined here — this is the
+            // integration point once master-volume routing is wired into Lib/.
             float volume = _parsedChart?.GetVolume(note.Value) ?? 1.0f;
             float pan = _parsedChart?.GetPan(note.Value) ?? 0.0f;
             _chipSoundCache?.Play(note.Value, volume, pan);

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -635,15 +635,9 @@ namespace DTXMania.Game.Lib.Stage
                 }
                 _songTimer = songTimer;
 
-                // Honor the chart's per-WAV #VOLUME/#PAN for the master background track
-                // (no-op on the silent fallback timer, which has no sound instance).
-                var backgroundWavId = _parsedChart.BackgroundWavId;
-                if (!string.IsNullOrEmpty(backgroundWavId))
-                {
-                    _songTimer.Volume = _parsedChart.GetVolume(backgroundWavId);
-                    _songTimer.Pan = _parsedChart.GetPan(backgroundWavId);
-                }
-
+                // Note: per-WAV #VOLUME/#PAN for the background track are applied in
+                // StartSong() (no-BGM-events path) rather than here, because StartSong()
+                // overwrites Volume when playback begins.
                 _isLoading = false;
                 _isReady = true;
             }
@@ -768,8 +762,19 @@ namespace DTXMania.Game.Lib.Stage
                 }
                 else
                 {
-                    // Legacy approach: Play background audio immediately (no BGM events)
-                    _songTimer.Volume = 1.0f; // Ensure background audio is audible
+                    // Legacy approach: Play background audio immediately (no BGM events).
+                    // Honor the chart's per-WAV #VOLUME/#PAN for the master background track
+                    // when a background WAV id is defined; otherwise default to full volume.
+                    var backgroundWavId = _parsedChart?.BackgroundWavId;
+                    if (!string.IsNullOrEmpty(backgroundWavId))
+                    {
+                        _songTimer.Volume = _parsedChart.GetVolume(backgroundWavId);
+                        _songTimer.Pan = _parsedChart.GetPan(backgroundWavId);
+                    }
+                    else
+                    {
+                        _songTimer.Volume = 1.0f; // Ensure background audio is audible
+                    }
                 }
             }
         }

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -635,6 +635,15 @@ namespace DTXMania.Game.Lib.Stage
                 }
                 _songTimer = songTimer;
 
+                // Honor the chart's per-WAV #VOLUME/#PAN for the master background track
+                // (no-op on the silent fallback timer, which has no sound instance).
+                var backgroundWavId = _parsedChart.BackgroundWavId;
+                if (!string.IsNullOrEmpty(backgroundWavId))
+                {
+                    _songTimer.Volume = _parsedChart.GetVolume(backgroundWavId);
+                    _songTimer.Pan = _parsedChart.GetPan(backgroundWavId);
+                }
+
                 _isLoading = false;
                 _isReady = true;
             }
@@ -1073,8 +1082,11 @@ namespace DTXMania.Game.Lib.Stage
             {
                 try
                 {
-                    var instance = sound.CreateInstance();
-                    instance?.Play();
+                    // Honor the chart's per-WAV #VOLUME/#PAN for backing-track audio;
+                    // defaults to full volume, centered when undefined.
+                    float volume = _parsedChart?.GetVolume(bgmEvent.WavId) ?? 1.0f;
+                    float pan = _parsedChart?.GetPan(bgmEvent.WavId) ?? 0.0f;
+                    sound.Play(volume, 0.0f, pan);
                 }
                 catch (Exception ex)
                 {
@@ -1363,7 +1375,11 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (note == null || string.IsNullOrEmpty(note.Value))
                 return;
-            _chipSoundCache?.Play(note.Value);
+
+            // Honor the chart's per-WAV #VOLUME/#PAN; defaults to full volume, centered.
+            float volume = _parsedChart?.GetVolume(note.Value) ?? 1.0f;
+            float pan = _parsedChart?.GetPan(note.Value) ?? 0.0f;
+            _chipSoundCache?.Play(note.Value, volume, pan);
         }
 
         /// <summary>

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -873,6 +873,82 @@ namespace DTXMania.Test.Song
 
         #endregion
 
+        #region Encoding Retry Isolation Tests
+
+        /// <summary>
+        /// Regression guard: a valid UTF-8 DTX file must produce exactly the expected
+        /// note count. If chart/dict state were shared across encoding attempts (the old
+        /// design), a mid-parse throw + retry would duplicate notes. Per-attempt
+        /// instantiation in ParseAsync prevents this.
+        /// </summary>
+        [Fact]
+        public async Task ParseAsync_ValidFile_ProducesExactNoteCountWithoutDuplication()
+        {
+            // Channel 0x11 = LC lane. Note data is pairs of hex chars; "00" = rest.
+            // "01020300" → 3 notes (pairs 01, 02, 03); pair 00 is a rest.
+            var content =
+                "#BPM: 120.0\n" +
+                "#WAV01: kick.wav\n" +
+                "#WAV02: snare.wav\n" +
+                "#00011: 01020300\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(3, chart.TotalNotes);
+            // WAV definitions should also not be duplicated
+            Assert.Equal(2, chart.WavDefinitions.Count);
+        }
+
+        /// <summary>
+        /// Documents WHY ParseAsync uses per-attempt chart instantiation: calling
+        /// ParseFileContentAsync twice on the same ParsedChart (as the old shared-state
+        /// design would on encoding retry) doubles the notes because Notes is a List
+        /// populated via Add, not a dict that self-heals via key assignment.
+        /// </summary>
+        [Fact]
+        public async Task ParseFileContentAsync_CalledTwiceOnSameChart_AccumulatesNotesProvingSharedStateHazard()
+        {
+            var content =
+                "#BPM: 120.0\n" +
+                "#WAV01: kick.wav\n" +
+                "#00011: 01000200\n";
+            var path = CreateTempDtx(content);
+
+            var method = typeof(DTXChartParser).GetMethod(
+                "ParseFileContentAsync", BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var chart = new ParsedChart(path);
+            var wavDefinitions = new Dictionary<string, string>();
+            var wavVolumes = new Dictionary<string, int>();
+            var wavPans = new Dictionary<string, int>();
+
+            // First parse pass
+            using (var stream1 = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader1 = new StreamReader(stream1, System.Text.Encoding.UTF8))
+            {
+                var task = (Task)method!.Invoke(null, new object[] { reader1, chart, wavDefinitions, wavVolumes, wavPans })!;
+                await task;
+            }
+            var countAfterFirstPass = chart.Notes.Count;
+            Assert.True(countAfterFirstPass > 0, "Expected at least one note after first pass");
+
+            // Second parse pass on the SAME chart (simulates encoding retry with shared state)
+            using (var stream2 = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var reader2 = new StreamReader(stream2, System.Text.Encoding.UTF8))
+            {
+                var task = (Task)method!.Invoke(null, new object[] { reader2, chart, wavDefinitions, wavVolumes, wavPans })!;
+                await task;
+            }
+
+            // Notes DOUBLED because Notes is a List<Note> — this proves the shared-state
+            // hazard that ParseAsync's per-attempt instantiation eliminates.
+            Assert.Equal(countAfterFirstPass * 2, chart.Notes.Count);
+        }
+
+        #endregion
+
         private static T InvokePrivateStaticMethod<T>(string methodName, params object[] args)
         {
             var method = typeof(DTXChartParser).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -12,6 +12,7 @@ namespace DTXMania.Test.Song
     /// <summary>
     /// Additional tests for DTXChartParser covering uncovered code paths
     /// </summary>
+    [Trait("Category", "Unit")]
     public class DTXChartParserAdditionalTests : IDisposable
     {
         private readonly string _tempDir;

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -889,18 +889,76 @@ namespace DTXMania.Test.Song
             Assert.Empty(chart.WavPans);
         }
 
+        [Fact]
+        public async Task ParseAsync_PanelAndPanHeaders_CoexistWithoutInterference()
+        {
+            // Proves the #PANEL guard does not over-reject a valid #PAN01 entry.
+            // Both headers start with "#PAN"; the guard must exclude only "#PANEL"
+            // while still routing "#PAN01" into wavPans.
+            var content =
+                "#WAV01: a.wav\n" +
+                "#PANEL: 2\n" +
+                "#PAN01: 75\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.False(chart.WavPans.ContainsKey("EL"));
+            Assert.True(chart.WavPans.ContainsKey("01"));
+            Assert.Equal(75, chart.WavPans["01"]);
+        }
+
+        [Fact]
+        public async Task ParseAsync_LowercasePanHeader_NormalizedToUpperAndStored()
+        {
+            // ParseHeaderCommand uppercases the command via ToUpperInvariant before
+            // the #PAN branch, so "#pan01" must still produce wavPans["01"].
+            // Pins the normalization contract that note/WAV id lookups rely on.
+            var content =
+                "#WAV01: a.wav\n" +
+                "#pan01: -30\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.True(chart.WavPans.ContainsKey("01"));
+            Assert.Equal(-30, chart.WavPans["01"]);
+        }
+
+        [Fact]
+        public async Task ParseAsync_PanelHeaderWithWhitespaceValue_StillExcludedFromPanMap()
+        {
+            // A #PANEL value with surrounding whitespace must still be ignored by the
+            // pan branch. The guard checks the command prefix, not the value, so
+            // whitespace-only or non-numeric values must not leak into wavPans.
+            var content =
+                "#WAV01: a.wav\n" +
+                "#PANEL:  \n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.False(chart.WavPans.ContainsKey("EL"));
+            Assert.Empty(chart.WavPans);
+        }
+
         #endregion
 
         #region Encoding Retry Isolation Tests
 
         /// <summary>
-        /// Regression guard: a valid UTF-8 DTX file must produce exactly the expected
-        /// note count. If chart/dict state were shared across encoding attempts (the old
-        /// design), a mid-parse throw + retry would duplicate notes. Per-attempt
-        /// instantiation in ParseAsync prevents this.
+        /// Basic correctness: a valid UTF-8 DTX file produces exactly the expected
+        /// note count and WAV definition count. This is NOT a regression guard for
+        /// the per-attempt state isolation in ParseAsync — the retry path is
+        /// unreachable through the public API because the parser is fully defensive
+        /// (no throw on malformed input) and Encoding.UTF8 uses replacement fallback
+        /// (no throw on invalid bytes). See the reflection test below for why
+        /// per-attempt instantiation matters, and see the comment in ParseAsync for
+        /// why the retry path exists as defensive hardening despite being currently
+        /// unreachable.
         /// </summary>
         [Fact]
-        public async Task ParseAsync_ValidFile_ProducesExactNoteCountWithoutDuplication()
+        public async Task ParseAsync_ValidFile_ProducesExactNoteAndWavCount()
         {
             // Channel 0x11 = LC lane. Note data is pairs of hex chars; "00" = rest.
             // "01020300" → 3 notes (pairs 01, 02, 03); pair 00 is a rest.
@@ -914,7 +972,6 @@ namespace DTXMania.Test.Song
             var chart = await DTXChartParser.ParseAsync(path);
 
             Assert.Equal(3, chart.TotalNotes);
-            // WAV definitions should also not be duplicated
             Assert.Equal(2, chart.WavDefinitions.Count);
         }
 
@@ -923,6 +980,13 @@ namespace DTXMania.Test.Song
         /// ParseFileContentAsync twice on the same ParsedChart (as the old shared-state
         /// design would on encoding retry) doubles the notes because Notes is a List
         /// populated via Add, not a dict that self-heals via key assignment.
+        ///
+        /// This is a documentation test, not a regression guard. The retry path in
+        /// ParseAsync is currently unreachable through the public API (the parser is
+        /// fully defensive and Encoding.UTF8 uses replacement fallback), so no
+        /// behavioral test can exercise the retry decision. This test proves the
+        /// hazard exists at the mechanical level, which is the reason per-attempt
+        /// instantiation is correct defensive hardening.
         /// </summary>
         [Fact]
         public async Task ParseFileContentAsync_CalledTwiceOnSameChart_AccumulatesNotesProvingSharedStateHazard()
@@ -963,6 +1027,76 @@ namespace DTXMania.Test.Song
             // Notes DOUBLED because Notes is a List<Note> — this proves the shared-state
             // hazard that ParseAsync's per-attempt instantiation eliminates.
             Assert.Equal(countAfterFirstPass * 2, chart.Notes.Count);
+        }
+
+        #endregion
+
+        #region Parse Failure Detection Tests
+
+        /// <summary>
+        /// An empty file (zero bytes) must parse successfully and return an empty
+        /// chart, not throw. This guards the parsed-flag failure detection: success
+        /// is determined by "no exception during parse" (parsed=true), NOT by
+        /// "chart has notes." The old Notes.Count==0 check would incorrectly throw
+        /// InvalidOperationException for an empty file if lastException were non-null
+        /// for any reason, and would incorrectly return a truncated chart if a
+        /// failed attempt added notes before throwing.
+        /// </summary>
+        [Fact]
+        public async Task ParseAsync_EmptyFile_ReturnsEmptyChartWithoutThrowing()
+        {
+            var path = CreateTempDtx("");
+            // Write empty bytes explicitly (CreateTempDtx uses WriteAllText which
+            // may write a BOM; ensure truly empty)
+            File.WriteAllBytes(path, Array.Empty<byte>());
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(0, chart.TotalNotes);
+            Assert.Empty(chart.WavDefinitions);
+        }
+
+        /// <summary>
+        /// A file with only comments and whitespace must parse successfully and
+        /// return an empty chart. Same parsed-flag guard as the empty-file test,
+        /// but exercises the comment/whitespace skipping paths in ParseFileContentAsync.
+        /// </summary>
+        [Fact]
+        public async Task ParseAsync_FileWithOnlyCommentsAndWhitespace_ReturnsEmptyChart()
+        {
+            var content =
+                "// This is a comment\n" +
+                "   \n" +
+                "\n" +
+                "// Another comment\n" +
+                "  \t  \n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(0, chart.TotalNotes);
+            Assert.Empty(chart.WavDefinitions);
+        }
+
+        /// <summary>
+        /// A file with headers but no note data must parse successfully and return
+        /// a chart with zero notes. Guards that the parsed-flag check does not
+        /// conflate "no notes" with "parse failed."
+        /// </summary>
+        [Fact]
+        public async Task ParseAsync_HeadersOnly_NoNotes_ReturnsChartWithoutThrowing()
+        {
+            var content =
+                "#BPM: 120.0\n" +
+                "#WAV01: kick.wav\n" +
+                "#TITLE: Test Song\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(0, chart.TotalNotes);
+            Assert.Single(chart.WavDefinitions);
+            Assert.Equal(120.0, chart.Bpm);
         }
 
         #endregion

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -711,6 +711,168 @@ namespace DTXMania.Test.Song
 
         #endregion
 
+        #region Per-WAV Volume / Pan Tests
+
+        [Fact]
+        public async Task ParseAsync_WithVolumeHeaders_PopulatesNormalizedVolumes()
+        {
+            var content =
+                "#WAV01: snare.wav\n" +
+                "#WAV02: kick.wav\n" +
+                "#VOLUME01: 50\n" +
+                "#WAVVOL02: 100\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(50, chart.WavVolumes["01"]);
+            Assert.Equal(100, chart.WavVolumes["02"]);
+            Assert.Equal(0.5f, chart.GetVolume("01"));
+            Assert.Equal(1.0f, chart.GetVolume("02"));
+        }
+
+        [Fact]
+        public async Task ParseAsync_WithPanHeaders_PopulatesNormalizedPans()
+        {
+            var content =
+                "#WAV01: left.wav\n" +
+                "#WAV02: right.wav\n" +
+                "#PAN01: -100\n" +
+                "#WAVPAN02: 100\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(-100, chart.WavPans["01"]);
+            Assert.Equal(100, chart.WavPans["02"]);
+            Assert.Equal(-1.0f, chart.GetPan("01"));
+            Assert.Equal(1.0f, chart.GetPan("02"));
+        }
+
+        [Fact]
+        public async Task ParseAsync_WavVolAndPan_AreNotMisparsedAsWavDefinitions()
+        {
+            // #WAVVOL and #WAVPAN both start with "#WAV"; ensure they are not
+            // stored as WAV file definitions with bogus ids ("VOL01" / "PAN01").
+            var content =
+                "#WAV01: snare.wav\n" +
+                "#WAVVOL01: 70\n" +
+                "#WAVPAN01: -40\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.True(chart.WavDefinitions.ContainsKey("01"));
+            Assert.False(chart.WavDefinitions.ContainsKey("VOL01"));
+            Assert.False(chart.WavDefinitions.ContainsKey("PAN01"));
+            Assert.Equal(70, chart.WavVolumes["01"]);
+            Assert.Equal(-40, chart.WavPans["01"]);
+        }
+
+        [Fact]
+        public async Task ParseAsync_OutOfRangeVolumeAndPan_AreClamped()
+        {
+            var content =
+                "#WAV01: a.wav\n" +
+                "#WAV02: b.wav\n" +
+                "#VOLUME01: 250\n" +   // clamps to 100
+                "#PAN01: -500\n" +     // clamps to -100
+                "#PAN02: 500\n";       // clamps to 100
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal(100, chart.WavVolumes["01"]);
+            Assert.Equal(-100, chart.WavPans["01"]);
+            Assert.Equal(100, chart.WavPans["02"]);
+        }
+
+        [Fact]
+        public async Task ParseAsync_PanelHeader_IsNotTreatedAsPanDefinition()
+        {
+            // "#PANEL" starts with "#PAN" but its value is non-numeric, so it must
+            // not create a pan entry.
+            var content =
+                "#PANEL: GUITAR\n" +
+                "#WAV01: a.wav\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Empty(chart.WavPans);
+        }
+
+        [Fact]
+        public async Task ParseAsync_BackgroundWavId_TracksCommonBgmFilename()
+        {
+            var content =
+                "#WAV01: snare.wav\n" +
+                "#WAV02: bgm.ogg\n" +
+                "#00011: 0101\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal("02", chart.BackgroundWavId);
+        }
+
+        [Fact]
+        public async Task ParseAsync_BackgroundWavId_FallsBackToFirstWavWhenNoBgmEvents()
+        {
+            var content =
+                "#WAV05: only.ogg\n" +
+                "#00011: 0101\n"; // drum notes only, no BGM (channel 01) events
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal("05", chart.BackgroundWavId);
+        }
+
+        [Fact]
+        public async Task ParseAsync_BackgroundWavVolumeAndPan_AreResolvableViaWavId()
+        {
+            var content =
+                "#WAV01: bgm.ogg\n" +
+                "#VOLUME01: 60\n" +
+                "#PAN01: -50\n" +
+                "#00001: 01\n"; // BGM channel
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal("01", chart.BackgroundWavId);
+            Assert.Equal(0.6f, chart.GetVolume(chart.BackgroundWavId));
+            Assert.Equal(-0.5f, chart.GetPan(chart.BackgroundWavId));
+        }
+
+        [Fact]
+        public async Task ParseAsync_NoWavDefinitions_LeavesBackgroundWavIdEmpty()
+        {
+            var content = "#BPM: 120.0\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Equal("", chart.BackgroundWavId);
+        }
+
+        [Fact]
+        public async Task ParseAsync_NoVolumeOrPanHeaders_LeavesMapsEmpty()
+        {
+            var content =
+                "#WAV01: a.wav\n" +
+                "#00011: 0101\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Empty(chart.WavVolumes);
+            Assert.Empty(chart.WavPans);
+        }
+
+        #endregion
+
         private static T InvokePrivateStaticMethod<T>(string methodName, params object[] args)
         {
             var method = typeof(DTXChartParser).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -544,7 +544,7 @@ namespace DTXMania.Test.Song
         #region WAV Id Case Normalization Tests
 
         [Fact]
-        public async Task ParseAsync_LowercaseNoteValue_NormalizedToUppercase()
+        public async Task ParseAsync_WithLowercaseNoteValue_ShouldNormalizeToUppercase()
         {
             // #WAV0A header is stored as uppercase; measure data uses lowercase "0a"
             var content =
@@ -562,7 +562,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_LowercaseBGMValue_NormalizedToUppercase()
+        public async Task ParseAsync_WithLowercaseBGMValue_ShouldNormalizeToUppercase()
         {
             var content =
                 "#BPM:120\n" +
@@ -578,7 +578,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_MixedCaseNoteValues_AllNormalizedToUppercase()
+        public async Task ParseAsync_WithMixedCaseNoteValues_ShouldAllNormalizeToUppercase()
         {
             var content =
                 "#BPM:120\n" +
@@ -619,7 +619,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void IsTextProperlyDecoded_WithValidText_ReturnsTrue()
+        public void IsTextProperlyDecoded_WithValidText_ShouldReturnTrue()
         {
             Assert.True(InvokePrivateStaticMethod<bool>("IsTextProperlyDecoded", ""));
             Assert.True(InvokePrivateStaticMethod<bool>("IsTextProperlyDecoded", (string)null!));
@@ -698,14 +698,14 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void IsTextProperlyDecoded_WithControlCharacter_ReturnsFalse()
+        public void IsTextProperlyDecoded_WithControlCharacter_ShouldReturnFalse()
         {
             var result = InvokePrivateStaticMethod<bool>("IsTextProperlyDecoded", "test\x01value");
             Assert.False(result);
         }
 
         [Fact]
-        public void IsTextProperlyDecoded_WithTabAndNewline_ReturnsTrue()
+        public void IsTextProperlyDecoded_WithTabAndNewline_ShouldReturnTrue()
         {
             Assert.True(InvokePrivateStaticMethod<bool>("IsTextProperlyDecoded", "line1\tvalue\nline2"));
         }
@@ -715,7 +715,7 @@ namespace DTXMania.Test.Song
         #region Per-WAV Volume / Pan Tests
 
         [Fact]
-        public async Task ParseAsync_WithVolumeHeaders_PopulatesNormalizedVolumes()
+        public async Task ParseAsync_WithVolumeHeaders_ShouldPopulateNormalizedVolumes()
         {
             var content =
                 "#WAV01: snare.wav\n" +
@@ -733,7 +733,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_WithPanHeaders_PopulatesNormalizedPans()
+        public async Task ParseAsync_WithPanHeaders_ShouldPopulateNormalizedPans()
         {
             var content =
                 "#WAV01: left.wav\n" +
@@ -751,7 +751,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_WavVolAndPan_AreNotMisparsedAsWavDefinitions()
+        public async Task ParseAsync_WithWavVolAndPan_ShouldNotBeMisparsedAsWavDefinitions()
         {
             // #WAVVOL and #WAVPAN both start with "#WAV"; ensure they are not
             // stored as WAV file definitions with bogus ids ("VOL01" / "PAN01").
@@ -771,7 +771,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_OutOfRangeVolumeAndPan_AreClamped()
+        public async Task ParseAsync_WithOutOfRangeVolumeAndPan_ShouldBeClamped()
         {
             var content =
                 "#WAV01: a.wav\n" +
@@ -789,7 +789,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_PanelHeader_IsNotTreatedAsPanDefinition()
+        public async Task ParseAsync_WithPanelHeader_ShouldNotBeTreatedAsPanDefinition()
         {
             // "#PANEL" starts with "#PAN" but its value is non-numeric, so it must
             // not create a pan entry.
@@ -804,7 +804,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_BackgroundWavId_TracksCommonBgmFilename()
+        public async Task ParseAsync_BackgroundWavId_ShouldTrackCommonBgmFilename()
         {
             var content =
                 "#WAV01: snare.wav\n" +
@@ -818,7 +818,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_BackgroundWavId_FallsBackToFirstWavWhenNoBgmEvents()
+        public async Task ParseAsync_BackgroundWavId_ShouldFallBackToFirstWavWhenNoBgmEvents()
         {
             var content =
                 "#WAV05: only.ogg\n" +
@@ -831,7 +831,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_BackgroundWavVolumeAndPan_AreResolvableViaWavId()
+        public async Task ParseAsync_BackgroundWavVolumeAndPan_ShouldBeResolvableViaWavId()
         {
             var content =
                 "#WAV01: bgm.ogg\n" +
@@ -848,7 +848,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_NoWavDefinitions_LeavesBackgroundWavIdEmpty()
+        public async Task ParseAsync_WithNoWavDefinitions_ShouldLeaveBackgroundWavIdEmpty()
         {
             var content = "#BPM: 120.0\n";
             var path = CreateTempDtx(content);
@@ -859,7 +859,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_NoVolumeOrPanHeaders_LeavesMapsEmpty()
+        public async Task ParseAsync_WithNoVolumeOrPanHeaders_ShouldLeaveMapsEmpty()
         {
             var content =
                 "#WAV01: a.wav\n" +
@@ -873,7 +873,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_PanelHeader_DoesNotCreateBogusPanEntry()
+        public async Task ParseAsync_WithPanelHeader_ShouldNotCreateBogusPanEntry()
         {
             // #PANEL is metadata (player panel count), not a per-WAV pan directive.
             // Without a guard, "#PANEL" matches the "#PAN" prefix and would store
@@ -890,7 +890,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_PanelAndPanHeaders_CoexistWithoutInterference()
+        public async Task ParseAsync_WithPanelAndPanHeaders_ShouldCoexistWithoutInterference()
         {
             // Proves the #PANEL guard does not over-reject a valid #PAN01 entry.
             // Both headers start with "#PAN"; the guard must exclude only "#PANEL"
@@ -909,7 +909,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_LowercasePanHeader_NormalizedToUpperAndStored()
+        public async Task ParseAsync_WithLowercasePanHeader_ShouldBeNormalizedToUpperAndStored()
         {
             // ParseHeaderCommand uppercases the command via ToUpperInvariant before
             // the #PAN branch, so "#pan01" must still produce wavPans["01"].
@@ -926,7 +926,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public async Task ParseAsync_PanelHeaderWithWhitespaceValue_StillExcludedFromPanMap()
+        public async Task ParseAsync_WithPanelHeaderWithWhitespaceValue_ShouldStillBeExcludedFromPanMap()
         {
             // A #PANEL value with surrounding whitespace must still be ignored by the
             // pan branch. The guard checks the command prefix, not the value, so
@@ -958,7 +958,7 @@ namespace DTXMania.Test.Song
         /// unreachable.
         /// </summary>
         [Fact]
-        public async Task ParseAsync_ValidFile_ProducesExactNoteAndWavCount()
+        public async Task ParseAsync_WithValidFile_ShouldProduceExactNoteAndWavCount()
         {
             // Channel 0x11 = LC lane. Note data is pairs of hex chars; "00" = rest.
             // "01020300" → 3 notes (pairs 01, 02, 03); pair 00 is a rest.
@@ -989,7 +989,7 @@ namespace DTXMania.Test.Song
         /// instantiation is correct defensive hardening.
         /// </summary>
         [Fact]
-        public async Task ParseFileContentAsync_CalledTwiceOnSameChart_AccumulatesNotesProvingSharedStateHazard()
+        public async Task ParseFileContentAsync_WhenCalledTwiceOnSameChart_ShouldAccumulateNotesProvingSharedStateHazard()
         {
             var content =
                 "#BPM: 120.0\n" +
@@ -1043,7 +1043,7 @@ namespace DTXMania.Test.Song
         /// failed attempt added notes before throwing.
         /// </summary>
         [Fact]
-        public async Task ParseAsync_EmptyFile_ReturnsEmptyChartWithoutThrowing()
+        public async Task ParseAsync_WithEmptyFile_ShouldReturnEmptyChartWithoutThrowing()
         {
             var path = CreateTempDtx("");
             // Write empty bytes explicitly (CreateTempDtx uses WriteAllText which
@@ -1062,7 +1062,7 @@ namespace DTXMania.Test.Song
         /// but exercises the comment/whitespace skipping paths in ParseFileContentAsync.
         /// </summary>
         [Fact]
-        public async Task ParseAsync_FileWithOnlyCommentsAndWhitespace_ReturnsEmptyChart()
+        public async Task ParseAsync_WithFileWithOnlyCommentsAndWhitespace_ShouldReturnEmptyChart()
         {
             var content =
                 "// This is a comment\n" +
@@ -1084,7 +1084,7 @@ namespace DTXMania.Test.Song
         /// conflate "no notes" with "parse failed."
         /// </summary>
         [Fact]
-        public async Task ParseAsync_HeadersOnly_NoNotes_ReturnsChartWithoutThrowing()
+        public async Task ParseAsync_WithHeadersOnlyAndNoNotes_ShouldReturnChartWithoutThrowing()
         {
             var content =
                 "#BPM: 120.0\n" +

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -871,6 +871,23 @@ namespace DTXMania.Test.Song
             Assert.Empty(chart.WavPans);
         }
 
+        [Fact]
+        public async Task ParseAsync_PanelHeader_DoesNotCreateBogusPanEntry()
+        {
+            // #PANEL is metadata (player panel count), not a per-WAV pan directive.
+            // Without a guard, "#PANEL" matches the "#PAN" prefix and would store
+            // wavPans["EL"] = <value>, polluting the pan map with a bogus "EL" key.
+            var content =
+                "#WAV01: a.wav\n" +
+                "#PANEL: 50\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.False(chart.WavPans.ContainsKey("EL"));
+            Assert.Empty(chart.WavPans);
+        }
+
         #endregion
 
         #region Encoding Retry Isolation Tests

--- a/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
+++ b/DTXMania.Test/Song/DTXChartParserAdditionalTests.cs
@@ -1101,6 +1101,87 @@ namespace DTXMania.Test.Song
 
         #endregion
 
+        #region Encoding Retry / Failure Detection Tests
+
+        /// <summary>
+        /// When every encoding attempt fails with an IOException (here: the file is
+        /// held with an exclusive FileShare.None lock), ParseAsync must exhaust all
+        /// encodings, record each failure, and throw InvalidOperationException
+        /// wrapping the last exception. This exercises the narrowed catch filter
+        /// (IOException), the per-attempt Debug.WriteLine/continue, and the
+        /// `!parsed && lastException != null` failure throw — the defensive retry
+        /// path that is otherwise unreachable through well-formed input.
+        /// </summary>
+        [Fact]
+        public async Task ParseAsync_WhenAllEncodingsFailWithIoException_ShouldThrowInvalidOperationException()
+        {
+            var content = "#BPM: 120.0\n#00011: 01000000\n";
+            var path = CreateTempDtx(content);
+
+            // Hold an exclusive lock for the duration of the parse so every
+            // FileStream open (one per encoding attempt) throws IOException.
+            await using var lockStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.None);
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DTXChartParser.ParseAsync(path));
+            Assert.IsType<IOException>(ex.InnerException);
+            Assert.Contains(path, ex.Message);
+        }
+
+        #endregion
+
+        #region TryStoreVolume / TryStorePan Guard Tests
+
+        [Fact]
+        public async Task ParseAsync_WithNonNumericVolumeAndPanValues_ShouldSilentlyIgnoreEntries()
+        {
+            // Non-numeric #VOLUME/#PAN values must not throw and must not create
+            // entries — int.TryParse returns false and the value is dropped.
+            var content =
+                "#WAV01: a.wav\n" +
+                "#VOLUME01: not-a-number\n" +
+                "#PAN01: also-text\n";
+            var path = CreateTempDtx(content);
+
+            var chart = await DTXChartParser.ParseAsync(path);
+
+            Assert.Empty(chart.WavVolumes);
+            Assert.Empty(chart.WavPans);
+        }
+
+        [Fact]
+        public void TryStoreVolume_WithEmptyWavId_ShouldReturnWithoutStoring()
+        {
+            var wavVolumes = new Dictionary<string, int>();
+            InvokePrivateStaticMethodVoid("TryStoreVolume", "", "50", wavVolumes);
+            Assert.Empty(wavVolumes);
+        }
+
+        [Fact]
+        public void TryStoreVolume_WithNullWavId_ShouldReturnWithoutStoring()
+        {
+            var wavVolumes = new Dictionary<string, int>();
+            InvokePrivateStaticMethodVoid("TryStoreVolume", null!, "50", wavVolumes);
+            Assert.Empty(wavVolumes);
+        }
+
+        [Fact]
+        public void TryStorePan_WithEmptyWavId_ShouldReturnWithoutStoring()
+        {
+            var wavPans = new Dictionary<string, int>();
+            InvokePrivateStaticMethodVoid("TryStorePan", "", "50", wavPans);
+            Assert.Empty(wavPans);
+        }
+
+        [Fact]
+        public void TryStorePan_WithNonNumericValue_ShouldReturnWithoutStoring()
+        {
+            var wavPans = new Dictionary<string, int>();
+            InvokePrivateStaticMethodVoid("TryStorePan", "01", "abc", wavPans);
+            Assert.Empty(wavPans);
+        }
+
+        #endregion
+
         private static T InvokePrivateStaticMethod<T>(string methodName, params object[] args)
         {
             var method = typeof(DTXChartParser).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
@@ -1108,6 +1189,13 @@ namespace DTXMania.Test.Song
             var result = method!.Invoke(null, args);
             Assert.NotNull(result);
             return (T)result!;
+        }
+
+        private static void InvokePrivateStaticMethodVoid(string methodName, params object[] args)
+        {
+            var method = typeof(DTXChartParser).GetMethod(methodName, BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+            method!.Invoke(null, args);
         }
     }
 }

--- a/DTXMania.Test/Song/ParsedChartTests.cs
+++ b/DTXMania.Test/Song/ParsedChartTests.cs
@@ -18,6 +18,7 @@ namespace DTXMania.Test.Song
             var chart = new ParsedChart();
             Assert.Equal(120.0, chart.Bpm);
             Assert.Equal("", chart.BackgroundAudioPath);
+            Assert.Equal("", chart.BackgroundWavId);
             Assert.Equal("", chart.FilePath);
             Assert.Equal(0.0, chart.DurationMs);
             Assert.Empty(chart.Notes);
@@ -75,6 +76,83 @@ namespace DTXMania.Test.Song
             chart.SetWavDefinitions(new Dictionary<string, string> { ["01"] = "x" });
             chart.SetWavDefinitions(null);
             Assert.Empty(chart.WavDefinitions);
+        }
+
+        #endregion
+
+        #region WavVolumes / WavPans Tests
+
+        [Fact]
+        public void WavVolumesAndPans_DefaultToEmpty()
+        {
+            var chart = new ParsedChart();
+            Assert.NotNull(chart.WavVolumes);
+            Assert.Empty(chart.WavVolumes);
+            Assert.NotNull(chart.WavPans);
+            Assert.Empty(chart.WavPans);
+        }
+
+        [Fact]
+        public void GetVolume_UndefinedId_ReturnsFullVolume()
+        {
+            var chart = new ParsedChart();
+            Assert.Equal(1.0f, chart.GetVolume("01"));
+            Assert.Equal(1.0f, chart.GetVolume(null!));
+            Assert.Equal(1.0f, chart.GetVolume(""));
+        }
+
+        [Fact]
+        public void GetPan_UndefinedId_ReturnsCentered()
+        {
+            var chart = new ParsedChart();
+            Assert.Equal(0.0f, chart.GetPan("01"));
+            Assert.Equal(0.0f, chart.GetPan(null!));
+            Assert.Equal(0.0f, chart.GetPan(""));
+        }
+
+        [Fact]
+        public void GetVolume_NormalizesDtxScaleToZeroToOne()
+        {
+            var chart = new ParsedChart();
+            chart.SetWavVolumes(new Dictionary<string, int> { ["01"] = 50, ["02"] = 100, ["03"] = 0 });
+
+            Assert.Equal(0.5f, chart.GetVolume("01"));
+            Assert.Equal(1.0f, chart.GetVolume("02"));
+            Assert.Equal(0.0f, chart.GetVolume("03"));
+        }
+
+        [Fact]
+        public void GetPan_NormalizesDtxScaleToMinusOneToOne()
+        {
+            var chart = new ParsedChart();
+            chart.SetWavPans(new Dictionary<string, int> { ["01"] = -100, ["02"] = 0, ["03"] = 100, ["04"] = 50 });
+
+            Assert.Equal(-1.0f, chart.GetPan("01"));
+            Assert.Equal(0.0f, chart.GetPan("02"));
+            Assert.Equal(1.0f, chart.GetPan("03"));
+            Assert.Equal(0.5f, chart.GetPan("04"));
+        }
+
+        [Fact]
+        public void SetWavVolumes_StoresFrozenCopy()
+        {
+            var chart = new ParsedChart();
+            var input = new Dictionary<string, int> { ["01"] = 80 };
+
+            chart.SetWavVolumes(input);
+            input["02"] = 40; // Mutate after set — must not affect chart
+
+            Assert.Single(chart.WavVolumes);
+            Assert.Equal(80, chart.WavVolumes["01"]);
+        }
+
+        [Fact]
+        public void SetWavPans_NullInput_ClearsToEmpty()
+        {
+            var chart = new ParsedChart();
+            chart.SetWavPans(new Dictionary<string, int> { ["01"] = 50 });
+            chart.SetWavPans(null);
+            Assert.Empty(chart.WavPans);
         }
 
         #endregion

--- a/DTXMania.Test/Song/ParsedChartTests.cs
+++ b/DTXMania.Test/Song/ParsedChartTests.cs
@@ -148,6 +148,15 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
+        public void SetWavVolumes_WithNullInput_ShouldClearToEmpty()
+        {
+            var chart = new ParsedChart();
+            chart.SetWavVolumes(new Dictionary<string, int> { ["01"] = 60 });
+            chart.SetWavVolumes(null);
+            Assert.Empty(chart.WavVolumes);
+        }
+
+        [Fact]
         public void SetWavPans_WithNullInput_ShouldClearToEmpty()
         {
             var chart = new ParsedChart();

--- a/DTXMania.Test/Song/ParsedChartTests.cs
+++ b/DTXMania.Test/Song/ParsedChartTests.cs
@@ -8,6 +8,7 @@ namespace DTXMania.Test.Song
     /// <summary>
     /// Tests for ParsedChart methods and statistics
     /// </summary>
+    [Trait("Category", "Unit")]
     public class ParsedChartTests
     {
         #region Constructor Tests

--- a/DTXMania.Test/Song/ParsedChartTests.cs
+++ b/DTXMania.Test/Song/ParsedChartTests.cs
@@ -50,7 +50,7 @@ namespace DTXMania.Test.Song
         #region WavDefinitions Tests
 
         [Fact]
-        public void WavDefinitions_DefaultsToEmpty()
+        public void WavDefinitions_ShouldDefaultToEmpty()
         {
             var chart = new ParsedChart();
             Assert.NotNull(chart.WavDefinitions);
@@ -58,7 +58,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void SetWavDefinitions_StoresFrozenCopy()
+        public void SetWavDefinitions_ShouldStoreFrozenCopy()
         {
             var chart = new ParsedChart();
             var input = new Dictionary<string, string> { ["01"] = "/path/snare.wav" };
@@ -71,7 +71,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void SetWavDefinitions_NullInput_ClearsToEmpty()
+        public void SetWavDefinitions_WithNullInput_ShouldClearToEmpty()
         {
             var chart = new ParsedChart();
             chart.SetWavDefinitions(new Dictionary<string, string> { ["01"] = "x" });
@@ -84,7 +84,7 @@ namespace DTXMania.Test.Song
         #region WavVolumes / WavPans Tests
 
         [Fact]
-        public void WavVolumesAndPans_DefaultToEmpty()
+        public void WavVolumesAndPans_ShouldDefaultToEmpty()
         {
             var chart = new ParsedChart();
             Assert.NotNull(chart.WavVolumes);
@@ -94,7 +94,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void GetVolume_UndefinedId_ReturnsFullVolume()
+        public void GetVolume_WithUndefinedId_ShouldReturnFullVolume()
         {
             var chart = new ParsedChart();
             Assert.Equal(1.0f, chart.GetVolume("01"));
@@ -103,7 +103,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void GetPan_UndefinedId_ReturnsCentered()
+        public void GetPan_WithUndefinedId_ShouldReturnCentered()
         {
             var chart = new ParsedChart();
             Assert.Equal(0.0f, chart.GetPan("01"));
@@ -112,7 +112,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void GetVolume_NormalizesDtxScaleToZeroToOne()
+        public void GetVolume_ShouldNormalizeDtxScaleToZeroToOne()
         {
             var chart = new ParsedChart();
             chart.SetWavVolumes(new Dictionary<string, int> { ["01"] = 50, ["02"] = 100, ["03"] = 0 });
@@ -123,7 +123,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void GetPan_NormalizesDtxScaleToMinusOneToOne()
+        public void GetPan_ShouldNormalizeDtxScaleToMinusOneToOne()
         {
             var chart = new ParsedChart();
             chart.SetWavPans(new Dictionary<string, int> { ["01"] = -100, ["02"] = 0, ["03"] = 100, ["04"] = 50 });
@@ -135,7 +135,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void SetWavVolumes_StoresFrozenCopy()
+        public void SetWavVolumes_ShouldStoreFrozenCopy()
         {
             var chart = new ParsedChart();
             var input = new Dictionary<string, int> { ["01"] = 80 };
@@ -148,7 +148,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void SetWavPans_NullInput_ClearsToEmpty()
+        public void SetWavPans_WithNullInput_ShouldClearToEmpty()
         {
             var chart = new ParsedChart();
             chart.SetWavPans(new Dictionary<string, int> { ["01"] = 50 });
@@ -331,7 +331,7 @@ namespace DTXMania.Test.Song
         #region GetNotesInTimeRange Tests
 
         [Fact]
-        public void GetNotesInTimeRange_ReturnsOnlyNotesInRange()
+        public void GetNotesInTimeRange_ShouldReturnOnlyNotesInRange()
         {
             var chart = new ParsedChart();
             chart.Notes.Add(new Note(0, 0, 0, 0, "01") { TimeMs = 100.0 });
@@ -346,7 +346,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void GetNotesInTimeRange_EmptyRange_ReturnsNoNotes()
+        public void GetNotesInTimeRange_WithEmptyRange_ShouldReturnNoNotes()
         {
             var chart = new ParsedChart();
             chart.Notes.Add(new Note(0, 0, 0, 0, "01") { TimeMs = 5000.0 });
@@ -361,7 +361,7 @@ namespace DTXMania.Test.Song
         #region GetNotesForLane Tests
 
         [Fact]
-        public void GetNotesForLane_ReturnsOnlyNotesInThatLane()
+        public void GetNotesForLane_ShouldReturnOnlyNotesInThatLane()
         {
             var chart = new ParsedChart();
             chart.Notes.Add(new Note(laneIndex: 0, 0, 0, 0, "01") { TimeMs = 100.0 });
@@ -376,7 +376,7 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
-        public void GetNotesForLane_EmptyLane_ReturnsEmpty()
+        public void GetNotesForLane_WithEmptyLane_ShouldReturnEmpty()
         {
             var chart = new ParsedChart();
             chart.Notes.Add(new Note(0, 0, 0, 0, "01") { TimeMs = 100.0 });

--- a/DTXMania.Test/Stage/Performance/ChipSoundCacheTests.cs
+++ b/DTXMania.Test/Stage/Performance/ChipSoundCacheTests.cs
@@ -13,14 +13,14 @@ namespace DTXMania.Test.Stage.Performance
     public class ChipSoundCacheTests
     {
         [Fact]
-        public void Count_NewInstance_IsZero()
+        public void Count_OnNewInstance_ShouldBeZero()
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             Assert.Equal(0, cache.Count);
         }
 
         [Fact]
-        public void Play_UnknownWavId_DoesNotThrow()
+        public void Play_WithUnknownWavId_ShouldNotThrow()
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             var ex = Record.Exception(() => cache.Play("NOPE"));
@@ -28,7 +28,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Play_NullOrEmptyWavId_DoesNotThrow()
+        public void Play_WithNullOrEmptyWavId_ShouldNotThrow()
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             Assert.Null(Record.Exception(() => cache.Play(null!)));
@@ -36,7 +36,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task PreloadAsync_LoadsExistingFilesViaFactory()
+        public async Task PreloadAsync_ShouldLoadExistingFilesViaFactory()
         {
             var (dir, file1, file2) = CreateTempWavFiles("a.wav", "b.wav");
             try
@@ -67,7 +67,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task PreloadAsync_MissingFile_SkipsAndContinues()
+        public async Task PreloadAsync_WithMissingFile_ShouldSkipAndContinue()
         {
             var (dir, validFile, _) = CreateTempWavFiles("ok.wav", "ignored.wav");
             try
@@ -90,7 +90,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task PreloadAsync_FactoryThrows_SkipsThatEntry()
+        public async Task PreloadAsync_WhenFactoryThrows_ShouldSkipThatEntry()
         {
             var (dir, file1, file2) = CreateTempWavFiles("a.wav", "b.wav");
             try
@@ -120,7 +120,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task PreloadAsync_NullDict_DoesNothing()
+        public async Task PreloadAsync_WithNullDict_ShouldDoNothing()
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             await cache.PreloadAsync(null!);
@@ -128,7 +128,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task Play_KnownWavId_InvokesPlayOnSound()
+        public async Task Play_WithKnownWavId_ShouldInvokePlayOnSound()
         {
             var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
             try
@@ -148,7 +148,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task Play_WithReducedVolumeOrPan_InvokesVolumePanOverload()
+        public async Task Play_WithReducedVolumeOrPan_ShouldInvokeVolumePanOverload()
         {
             var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
             try
@@ -169,7 +169,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task Play_WithFullVolumeAndCenterPan_InvokesParameterlessPlay()
+        public async Task Play_WithFullVolumeAndCenterPan_ShouldInvokeParameterlessPlay()
         {
             // Full volume + centered should stay on the simple Play() path so the
             // common (no #VOLUME/#PAN) case is unchanged.
@@ -192,7 +192,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task Play_WithVolumePan_AfterDispose_IsSilent()
+        public async Task Play_WithVolumePanAfterDispose_ShouldBeSilent()
         {
             var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
             try
@@ -213,7 +213,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task Dispose_ReleasesAllSounds()
+        public async Task Dispose_ShouldReleaseAllSounds()
         {
             var (dir, file1, file2) = CreateTempWavFiles("a.wav", "b.wav");
             try
@@ -245,7 +245,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task PreloadAsync_AfterDispose_Throws()
+        public async Task PreloadAsync_AfterDispose_ShouldThrow()
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             cache.Dispose();
@@ -254,7 +254,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public async Task PreloadAsync_FilteredSubset_OnlyLoadsSubset()
+        public async Task PreloadAsync_WithFilteredSubset_ShouldOnlyLoadSubset()
         {
             // Simulates filtering WavDefinitions to only note-referenced ids,
             // excluding BGM-only ids that are loaded separately.
@@ -335,7 +335,7 @@ namespace DTXMania.Test.Stage.Performance
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Contains_WithNullOrEmptyWavId_ReturnsFalse(string? wavId)
+        public void Contains_WithNullOrEmptyWavId_ShouldReturnFalse(string? wavId)
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             Assert.False(cache.Contains(wavId!));
@@ -446,7 +446,7 @@ namespace DTXMania.Test.Stage.Performance
         // --- Instance tracking tests ---
 
         [Fact]
-        public void Play_SoundReturnsNullInstance_DoesNotThrow()
+        public void Play_WhenSoundReturnsNullInstance_ShouldNotThrow()
         {
             // ISound.Play() can return null (e.g. disposed sound). Should be handled gracefully.
             var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
@@ -469,7 +469,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void StopAll_AfterDispose_DoesNotThrow()
+        public void StopAll_AfterDispose_ShouldNotThrow()
         {
             var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             cache.Dispose();
@@ -480,7 +480,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void CleanupStoppedInstances_AfterDispose_DoesNotThrow()
+        public void CleanupStoppedInstances_AfterDispose_ShouldNotThrow()
         {
             var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             cache.Dispose();
@@ -491,7 +491,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void ActiveInstanceCount_NewInstance_IsZero()
+        public void ActiveInstanceCount_OnNewInstance_ShouldBeZero()
         {
             using var cache = new ChipSoundCache(_ => Mock.Of<ISound>());
             Assert.Equal(0, cache.ActiveInstanceCount);

--- a/DTXMania.Test/Stage/Performance/ChipSoundCacheTests.cs
+++ b/DTXMania.Test/Stage/Performance/ChipSoundCacheTests.cs
@@ -148,6 +148,71 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
+        public async Task Play_WithReducedVolumeOrPan_InvokesVolumePanOverload()
+        {
+            var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
+            try
+            {
+                var soundMock = new Mock<ISound>();
+                using var cache = new ChipSoundCache(_ => soundMock.Object);
+                await cache.PreloadAsync(new Dictionary<string, string> { ["01"] = file1 });
+
+                cache.Play("01", 0.5f, -0.3f);
+
+                soundMock.Verify(s => s.Play(0.5f, 0.0f, -0.3f), Times.Once);
+                soundMock.Verify(s => s.Play(), Times.Never);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task Play_WithFullVolumeAndCenterPan_InvokesParameterlessPlay()
+        {
+            // Full volume + centered should stay on the simple Play() path so the
+            // common (no #VOLUME/#PAN) case is unchanged.
+            var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
+            try
+            {
+                var soundMock = new Mock<ISound>();
+                using var cache = new ChipSoundCache(_ => soundMock.Object);
+                await cache.PreloadAsync(new Dictionary<string, string> { ["01"] = file1 });
+
+                cache.Play("01", 1.0f, 0.0f);
+
+                soundMock.Verify(s => s.Play(), Times.Once);
+                soundMock.Verify(s => s.Play(It.IsAny<float>(), It.IsAny<float>(), It.IsAny<float>()), Times.Never);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task Play_WithVolumePan_AfterDispose_IsSilent()
+        {
+            var (dir, file1, _) = CreateTempWavFiles("a.wav", null);
+            try
+            {
+                var soundMock = new Mock<ISound>();
+                var cache = new ChipSoundCache(_ => soundMock.Object);
+                await cache.PreloadAsync(new Dictionary<string, string> { ["01"] = file1 });
+                cache.Dispose();
+
+                cache.Play("01", 0.5f, 0.5f);
+
+                soundMock.Verify(s => s.Play(It.IsAny<float>(), It.IsAny<float>(), It.IsAny<float>()), Times.Never);
+            }
+            finally
+            {
+                Directory.Delete(dir, recursive: true);
+            }
+        }
+
+        [Fact]
         public async Task Dispose_ReleasesAllSounds()
         {
             var (dir, file1, file2) = CreateTempWavFiles("a.wav", "b.wav");

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -2404,18 +2404,37 @@ public class PerformanceStageDeterministicTests
     }
 
     [Fact]
-    public void TriggerBGMEvent_WhenCreateInstanceReturnsNull_ShouldAttemptPlaybackWithoutThrowing()
+    public void TriggerBGMEvent_WhenPlayReturnsNull_ShouldAttemptPlaybackWithoutThrowing()
     {
         var stage = CreateStage();
         var sound = CreateSoundMock();
-        sound.Setup(x => x.CreateInstance()).Returns((Microsoft.Xna.Framework.Audio.SoundEffectInstance)null!);
+        sound.Setup(x => x.Play(It.IsAny<float>(), It.IsAny<float>(), It.IsAny<float>()))
+            .Returns((Microsoft.Xna.Framework.Audio.SoundEffectInstance)null!);
         ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound> { ["01"] = sound.Object });
 
         var exception = Record.Exception(() =>
             ReflectionHelpers.InvokePrivateMethod(stage, "TriggerBGMEvent", new BGMEvent { WavId = "01" }));
 
         Assert.Null(exception);
-        sound.Verify(x => x.CreateInstance(), Times.Once);
+        // No chart loaded → defaults to full volume, centered, no pitch shift.
+        sound.Verify(x => x.Play(1.0f, 0.0f, 0.0f), Times.Once);
+    }
+
+    [Fact]
+    public void TriggerBGMEvent_ShouldHonorChartVolumeAndPan()
+    {
+        var stage = CreateStage();
+        var chart = new ParsedChart();
+        chart.SetWavVolumes(new Dictionary<string, int> { ["01"] = 50 });
+        chart.SetWavPans(new Dictionary<string, int> { ["01"] = -100 });
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", chart);
+
+        var sound = CreateSoundMock();
+        ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound> { ["01"] = sound.Object });
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "TriggerBGMEvent", new BGMEvent { WavId = "01" });
+
+        sound.Verify(x => x.Play(0.5f, 0.0f, -1.0f), Times.Once);
     }
 
     [Fact]
@@ -2431,11 +2450,12 @@ public class PerformanceStageDeterministicTests
     }
 
     [Fact]
-    public void TriggerBGMEvent_WhenCreateInstanceThrows_ShouldSwallowPlaybackFailure()
+    public void TriggerBGMEvent_WhenPlayThrows_ShouldSwallowPlaybackFailure()
     {
         var stage = CreateStage();
         var sound = CreateSoundMock();
-        sound.Setup(x => x.CreateInstance()).Throws(new InvalidOperationException("boom"));
+        sound.Setup(x => x.Play(It.IsAny<float>(), It.IsAny<float>(), It.IsAny<float>()))
+            .Throws(new InvalidOperationException("boom"));
         ReflectionHelpers.SetPrivateField(stage, "_bgmSounds", new Dictionary<string, ISound> { ["01"] = sound.Object });
 
         var exception = Record.Exception(() =>
@@ -2792,6 +2812,35 @@ public class PerformanceStageDeterministicTests
             ReflectionHelpers.InvokePrivateMethod(stage, "PlayChipForNote", note));
 
         Assert.Null(ex);
+    }
+
+    [Fact]
+    public void PlayChipForNote_ShouldHonorChartVolumeAndPan()
+    {
+        var stage = CreateStage();
+        var chart = new ParsedChart();
+        chart.SetWavVolumes(new Dictionary<string, int> { ["07"] = 50 });
+        chart.SetWavPans(new Dictionary<string, int> { ["07"] = 100 });
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", chart);
+
+        var soundMock = new Mock<ISound>();
+        var stubWavPath = WriteTempStubWav();
+        try
+        {
+            var cache = new ChipSoundCache(_ => soundMock.Object);
+            cache.PreloadAsync(new Dictionary<string, string> { ["07"] = stubWavPath }).GetAwaiter().GetResult();
+            ReflectionHelpers.SetPrivateField(stage, "_chipSoundCache", cache);
+
+            var note = new Note(laneIndex: 0, bar: 0, tick: 0, channel: 0x11, value: "07") { TimeMs = 100.0 };
+            ReflectionHelpers.InvokePrivateMethod(stage, "PlayChipForNote", note);
+
+            soundMock.Verify(s => s.Play(0.5f, 0.0f, 1.0f), Times.Once);
+            soundMock.Verify(s => s.Play(), Times.Never);
+        }
+        finally
+        {
+            File.Delete(stubWavPath);
+        }
     }
 
     [Fact]

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -19,6 +19,7 @@ using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Test.Helpers;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
 using Moq;
 
@@ -2727,6 +2728,57 @@ public class PerformanceStageDeterministicTests
     }
 
     [Fact]
+    public void StartSong_WhenLegacyBgmAndBackgroundWavIdDefined_ShouldApplyPerWavVolumeAndPan()
+    {
+        // Legacy (no-BGM-events) path: when the chart resolves a BackgroundWavId,
+        // StartSong must honor that WAV's #VOLUME/#PAN on the master background
+        // track rather than defaulting to full volume.
+        var stage = CreateStage();
+        var chart = new ParsedChart("legacy-bgm.dtx");
+        chart.SetWavVolumes(new Dictionary<string, int> { ["01"] = 40 });
+        chart.SetWavPans(new Dictionary<string, int> { ["01"] = -80 });
+        chart.BackgroundWavId = "01";
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", chart);
+
+        // Real SoundEffectInstance so SongTimer.Volume/Pan setters are exercised.
+        var instance = CreateSoundEffectInstance();
+        var songTimer = new SongTimer(instance);
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "StartSong");
+
+        // #VOLUME01=40 → 0.4f; #PAN01=-80 → -0.8f (clamped to [-1,1]).
+        Assert.Equal(0.4f, songTimer.Volume);
+        Assert.Equal(-0.8f, songTimer.Pan);
+        Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_isReady"));
+    }
+
+    [Fact]
+    public void StartSong_WhenLegacyBgmAndNoBackgroundWavId_ShouldDefaultToFullVolume()
+    {
+        // Legacy path with no resolved BackgroundWavId falls back to full volume.
+        var stage = CreateStage();
+        var chart = new ParsedChart("legacy-bgm-no-id.dtx");
+        ReflectionHelpers.SetPrivateField(stage, "_parsedChart", chart);
+
+        var instance = CreateSoundEffectInstance();
+        var songTimer = new SongTimer(instance);
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", songTimer);
+        ReflectionHelpers.SetPrivateField(stage, "_currentGameTime", new GameTime(TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(stage, "_judgementManager", new JudgementManager(new MockInputManagerCompat(), CreateChartManagerWithSingleNote()));
+        ReflectionHelpers.SetPrivateField(stage, "_scheduledBGMEvents", new List<BGMEvent>());
+        ReflectionHelpers.SetPrivateField(stage, "_isReady", true);
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "StartSong");
+
+        Assert.Equal(1.0f, songTimer.Volume);
+    }
+
+    [Fact]
     public void InitializeReadyFont_WhenSpriteBatchIsMissing_ShouldLeaveFontNull()
     {
         var stage = CreateStage();
@@ -3196,6 +3248,21 @@ public class PerformanceStageDeterministicTests
 #pragma warning restore SYSLIB0050
         ReflectionHelpers.SetPrivateField(timer, "_disposed", true);
         return timer;
+    }
+
+    /// <summary>
+    /// Creates a real SoundEffectInstance without invoking its constructor
+    /// (which requires a native audio device). Pan/Volume backing fields are
+    /// usable on the uninitialized instance, letting StartSong's per-WAV
+    /// volume/pan assignment be exercised without a graphics device.
+    /// Play() throws on this instance, but SongTimer.Play swallows that and
+    /// StartSong continues to the volume/pan assignment regardless.
+    /// </summary>
+    private static SoundEffectInstance CreateSoundEffectInstance()
+    {
+#pragma warning disable SYSLIB0050
+        return (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
+#pragma warning restore SYSLIB0050
     }
 
     private static SongTimer CreatePlayingSongTimer()

--- a/DTXMania.Test/Stage/Performance/SongTimerStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/SongTimerStateTests.cs
@@ -36,7 +36,7 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void IsPlaying_WhenInternalFlagTrueAndSoundInstanceNull_ReturnsTrue()
+        public void IsPlaying_WhenInternalFlagTrueAndSoundInstanceNull_ShouldReturnTrue()
         {
             // When the backing sound is absent, the timer should still report the stored playing state.
             var timer = CreateTimer(isPlaying: true);
@@ -44,7 +44,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void IsPlaying_WhenInternalFlagFalse_ReturnsFalse()
+        public void IsPlaying_WhenInternalFlagFalse_ShouldReturnFalse()
         {
             var timer = CreateTimer(isPlaying: false);
             Assert.False(timer.IsPlaying);
@@ -55,7 +55,7 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void GetCurrentMs_GameTime_WhenNotPlaying_ReturnsZero()
+        public void GetCurrentMs_GameTime_WhenNotPlaying_ShouldReturnZero()
         {
             var timer = CreateTimer(isPlaying: false);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(500), TimeSpan.Zero);
@@ -63,7 +63,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void GetCurrentMs_GameTime_WhenDisposed_ReturnsZero()
+        public void GetCurrentMs_GameTime_WhenDisposed_ShouldReturnZero()
         {
             var timer = CreateTimer(isPlaying: true, disposed: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(500), TimeSpan.Zero);
@@ -71,7 +71,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void GetCurrentMs_GameTime_WhenPlaying_ReturnsElapsedMs()
+        public void GetCurrentMs_GameTime_WhenPlaying_ShouldReturnElapsedMs()
         {
             // _startTime = 100 ms, totalGameTime = 500 ms → elapsed = 400 ms
             var timer = CreateTimer(isPlaying: true);
@@ -84,21 +84,21 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void GetCurrentMs_WhenNotPlaying_ReturnsZero()
+        public void GetCurrentMs_WhenNotPlaying_ShouldReturnZero()
         {
             var timer = CreateTimer(isPlaying: false);
             Assert.Equal(0.0, timer.GetCurrentMs());
         }
 
         [Fact]
-        public void GetCurrentMs_WhenDisposed_ReturnsZero()
+        public void GetCurrentMs_WhenDisposed_ShouldReturnZero()
         {
             var timer = CreateTimer(isPlaying: true, disposed: true);
             Assert.Equal(0.0, timer.GetCurrentMs());
         }
 
         [Fact]
-        public void GetCurrentMs_WhenPlaying_ReturnsPositiveElapsed()
+        public void GetCurrentMs_WhenPlaying_ShouldReturnPositiveElapsed()
         {
             // _systemStartTime is 250 ms in the past → result should be ≥ 250 ms
             var timer = CreateTimer(isPlaying: true);
@@ -111,14 +111,14 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void Volume_Get_WhenSoundInstanceNull_ReturnsZero()
+        public void Volume_Get_WhenSoundInstanceNull_ShouldReturnZero()
         {
             var timer = CreateTimer();
             Assert.Equal(0f, timer.Volume);
         }
 
         [Fact]
-        public void Volume_Set_WhenSoundInstanceNull_DoesNotThrow()
+        public void Volume_Set_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer();
             // Must not throw
@@ -127,14 +127,14 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Pan_Get_WhenSoundInstanceNull_ReturnsCentered()
+        public void Pan_Get_WhenSoundInstanceNull_ShouldReturnCentered()
         {
             var timer = CreateTimer();
             Assert.Equal(0f, timer.Pan);
         }
 
         [Fact]
-        public void Pan_Set_WhenSoundInstanceNull_DoesNotThrow()
+        public void Pan_Set_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer();
             var ex = Record.Exception(() => timer.Pan = -0.5f);
@@ -142,14 +142,14 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void IsLooped_Get_WhenSoundInstanceNull_ReturnsFalse()
+        public void IsLooped_Get_WhenSoundInstanceNull_ShouldReturnFalse()
         {
             var timer = CreateTimer();
             Assert.False(timer.IsLooped);
         }
 
         [Fact]
-        public void IsLooped_Set_WhenSoundInstanceNull_DoesNotThrow()
+        public void IsLooped_Set_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer();
             var ex = Record.Exception(() => timer.IsLooped = true);
@@ -161,7 +161,7 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void Pause_WhenDisposed_DoesNotThrow()
+        public void Pause_WhenDisposed_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true, disposed: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -170,7 +170,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Stop_WhenDisposed_DoesNotThrow()
+        public void Stop_WhenDisposed_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true, disposed: true);
             var ex = Record.Exception(() => timer.Stop());
@@ -178,7 +178,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_WhenDisposed_DoesNotThrow()
+        public void Update_WhenDisposed_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true, disposed: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -187,7 +187,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void SetPosition_WhenDisposed_DoesNotThrow()
+        public void SetPosition_WhenDisposed_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true, disposed: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -196,7 +196,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Resume_WhenDisposed_DoesNotThrow()
+        public void Resume_WhenDisposed_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: false, disposed: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -209,7 +209,7 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void Pause_WhenSoundInstanceNull_DoesNotThrow()
+        public void Pause_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -218,7 +218,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Stop_WhenSoundInstanceNull_DoesNotThrow()
+        public void Stop_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true);
             var ex = Record.Exception(() => timer.Stop());
@@ -226,7 +226,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Resume_WhenSoundInstanceNull_DoesNotThrow()
+        public void Resume_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: false);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -235,7 +235,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void SetPosition_WhenSoundInstanceNull_DoesNotThrow()
+        public void SetPosition_WhenSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -244,7 +244,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_WhenNotDisposed_DoesNotThrow()
+        public void Update_WhenNotDisposed_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: false);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -253,7 +253,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Update_WhenPlayingAndSoundInstanceNull_DoesNotThrow()
+        public void Update_WhenPlayingAndSoundInstanceNull_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -268,7 +268,7 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void Dispose_CalledTwice_DoesNotThrow()
+        public void Dispose_CalledTwice_ShouldNotThrow()
         {
             var timer = CreateTimer(isPlaying: false);
             // First Dispose() releases state; second Dispose() should be a no-op.
@@ -282,7 +282,7 @@ namespace DTXMania.Test.Stage.Performance
         // ---------------------------------------------------------------
 
         [Fact]
-        public void IsFinished_WhenSoundInstanceNull_ReturnsFalse()
+        public void IsFinished_WhenSoundInstanceNull_ShouldReturnFalse()
         {
             // _soundInstance?.State == SoundState.Stopped → null == Stopped → false
             var timer = CreateTimer(isPlaying: true);
@@ -306,7 +306,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Play_WhenDisposed_ReturnsFalse()
+        public void Play_WhenDisposed_ShouldReturnFalse()
         {
             var timer = CreateTimer(isPlaying: false, disposed: true);
             var gameTime = new GameTime(TimeSpan.FromMilliseconds(100), TimeSpan.Zero);
@@ -347,7 +347,7 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void Pause_CachesElapsedBeforeClearingIsPlaying()
+        public void Pause_ShouldCacheElapsedBeforeClearingIsPlaying()
         {
             var timer = new SongTimer();
             var start = new GameTime(TimeSpan.FromMilliseconds(0), TimeSpan.Zero);

--- a/DTXMania.Test/Stage/Performance/SongTimerStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/SongTimerStateTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 using DTXMania.Game.Lib.Stage.Performance;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
 using Xunit;
 
 namespace DTXMania.Test.Stage.Performance
@@ -139,6 +140,47 @@ namespace DTXMania.Test.Stage.Performance
             var timer = CreateTimer();
             var ex = Record.Exception(() => timer.Pan = -0.5f);
             Assert.Null(ex);
+        }
+
+        // ---------------------------------------------------------------
+        // Pan – non-null _soundInstance paths.
+        // SoundEffectInstance is created via GetUninitializedObject so its
+        // Pan/Volume backing fields are usable without a native audio device.
+        // ---------------------------------------------------------------
+
+        [Fact]
+        public void Pan_Get_WhenSoundInstancePresent_ShouldReturnInstancePan()
+        {
+            var instance = CreateSoundEffectInstance();
+            instance.Pan = 0.25f;
+            var timer = new SongTimer(instance);
+
+            Assert.Equal(0.25f, timer.Pan);
+        }
+
+        [Fact]
+        public void Pan_Set_WhenSoundInstancePresent_ShouldClampAndAssignToInstance()
+        {
+            var instance = CreateSoundEffectInstance();
+            var timer = new SongTimer(instance);
+
+            timer.Pan = 0.75f;
+            Assert.Equal(0.75f, instance.Pan);
+            Assert.Equal(0.75f, timer.Pan);
+        }
+
+        [Theory]
+        [InlineData(2.0f, 1.0f)]
+        [InlineData(-2.0f, -1.0f)]
+        public void Pan_Set_WhenSoundInstancePresent_ShouldClampToValidRange(float input, float expected)
+        {
+            var instance = CreateSoundEffectInstance();
+            var timer = new SongTimer(instance);
+
+            timer.Pan = input;
+
+            Assert.Equal(expected, instance.Pan);
+            Assert.Equal(expected, timer.Pan);
         }
 
         [Fact]
@@ -360,6 +402,23 @@ namespace DTXMania.Test.Stage.Performance
             // _cachedElapsedMs should be exactly 250 (GameTime-based, no jitter)
             var cachedMs = ReflectionHelpers.GetPrivateField<double>(timer, "_cachedElapsedMs");
             Assert.Equal(250.0, cachedMs);
+        }
+
+        // ---------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------
+
+        /// <summary>
+        /// Creates a real SoundEffectInstance without invoking its constructor
+        /// (which requires a native audio device). The Pan/Volume backing fields
+        /// are usable on the uninitialized instance, letting us exercise the
+        /// non-null _soundInstance paths in SongTimer without a graphics device.
+        /// </summary>
+        private static SoundEffectInstance CreateSoundEffectInstance()
+        {
+#pragma warning disable SYSLIB0050
+            return (SoundEffectInstance)FormatterServices.GetUninitializedObject(typeof(SoundEffectInstance));
+#pragma warning restore SYSLIB0050
         }
     }
 }

--- a/DTXMania.Test/Stage/Performance/SongTimerStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/SongTimerStateTests.cs
@@ -127,6 +127,21 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
+        public void Pan_Get_WhenSoundInstanceNull_ReturnsCentered()
+        {
+            var timer = CreateTimer();
+            Assert.Equal(0f, timer.Pan);
+        }
+
+        [Fact]
+        public void Pan_Set_WhenSoundInstanceNull_DoesNotThrow()
+        {
+            var timer = CreateTimer();
+            var ex = Record.Exception(() => timer.Pan = -0.5f);
+            Assert.Null(ex);
+        }
+
+        [Fact]
         public void IsLooped_Get_WhenSoundInstanceNull_ReturnsFalse()
         {
             var timer = CreateTimer();


### PR DESCRIPTION
## Summary
- **fix:** Prevent `#PANEL` metadata from being mis-routed into the per-WAV `#PAN` map by adding an explicit `!command.StartsWith("#PANEL")` guard.
- **fix:** Isolate `ParsedChart` and WAV dictionaries per encoding-retry attempt to avoid note duplication and partial-state pollution when a parse throws mid-stream.
- **fix:** Replace the inconsistent `chart.Notes.Count == 0` failure check with a symmetric `parsed` flag so that "success" and "failure" both depend on whether an attempt completed without throwing.
- **fix:** Narrow the retry catch to `IOException | DecoderFallbackException`; programmer errors (NRE, IOORE, etc.) now propagate immediately instead of being swallowed as "encoding failures."
- **docs:** Add inline comments in `SongTimer.Pan` explaining the MonoGame/XNA stereo-source pan limitation, and in `PerformanceStage` noting the future `MasterVolume` integration point.
- **test:** Tag existing parser test classes with `[Trait("Category", "Unit")]` for xUnit filtering consistency.
- **test:** Add comprehensive coverage for:
  - `#PANEL` exclusion and `#PANEL` + `#PAN` coexistence
  - Lowercase `#pan` normalization
  - Encoding-retry shared-state hazard (reflection proof)
  - Empty / whitespace-only / headers-only files with the new `parsed`-flag logic

## Test plan
- [x] `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~DTXChartParser"` passes
- [x] `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "Category=Unit"` passes

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* **Per-WAV volume and pan support**: Charts can now specify volume and panning per referenced audio WAV, applied during background music, BGM events, and note chip sounds.
* **Background audio honors chart settings**: Background playback now uses the WAV it was matched from, so per-WAV volume/pan definitions affect the master background track.
* **Enhanced DTX chart parsing**: Added support for `#VOLUME/#WAVVOL` and `#PAN/#WAVPAN` headers (with `#PANEL` safely ignored for pan).

## Tests
* Added/expanded unit tests covering parsing, normalization/clamping, background WAV resolution, and playback volume/pan behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->