### PR TITLE
feat: add NX bitmap number fonts and difficulty badge for song status panel

### DIFF
--- a/DTXMania.E2E/GameplayAutoPlaySmokeTests.cs
+++ b/DTXMania.E2E/GameplayAutoPlaySmokeTests.cs
@@ -114,9 +114,11 @@ public sealed class GameplayAutoPlaySmokeTests
     {
         try
         {
+            // The timer-backed CTS must have its own 'using' — wrapping it inline in
+            // CreateLinkedTokenSource leaks it because only the linked CTS is disposed.
+            using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
-                cancellationToken,
-                new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
+                cancellationToken, timeoutCts.Token);
             var imageData = await client.TakeScreenshotBase64Async(cancellation.Token);
             if (string.IsNullOrWhiteSpace(imageData))
                 return;
@@ -125,9 +127,12 @@ public sealed class GameplayAutoPlaySmokeTests
             Directory.CreateDirectory(fixture.ArtifactRoot);
             await File.WriteAllBytesAsync(Path.Combine(fixture.ArtifactRoot, fileName), imageBytes, cancellation.Token);
         }
-        catch
+        catch (Exception ex)
         {
-            // Screenshot artifacts should never hide the original E2E assertion or launch error.
+            // Screenshot artifacts should never hide the original E2E assertion or launch error,
+            // but log the reason so a missing CI artifact is explainable (e.g. the test's own
+            // cancellation budget surfaced here as OperationCanceledException).
+            Console.WriteLine($"[E2E] Screenshot capture skipped for '{fileName}': {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/DTXMania.E2E/GameplayAutoPlaySmokeTests.cs
+++ b/DTXMania.E2E/GameplayAutoPlaySmokeTests.cs
@@ -49,6 +49,12 @@ public sealed class GameplayAutoPlaySmokeTests
             await client.SendKeyAsync("Enter", TimeSpan.FromMilliseconds(50), cancellation.Token);
 
             await WaitForStageAsync(client, "SongSelect", TimeSpan.FromSeconds(45), cancellation.Token);
+
+            // Capture a screenshot of the song-select stage so the status-panel rendering
+            // (DrawBackground behavior against the default skin) can be visually inspected
+            // from CI artifacts without a separate manual smoke pass.
+            await SaveScreenshotAsync(client, fixture, "song-select-screenshot.png", cancellation.Token);
+
             await client.SendKeyAsync("Enter", TimeSpan.FromMilliseconds(50), cancellation.Token);
             await Task.Delay(500, cancellation.Token);
             await client.SendKeyAsync("Enter", TimeSpan.FromMilliseconds(50), cancellation.Token);
@@ -69,7 +75,7 @@ public sealed class GameplayAutoPlaySmokeTests
         catch (Exception ex)
         {
             await E2EArtifactWriter.WriteTextAsync(fixture, "failure.txt", ex.ToString());
-            await TryWriteScreenshotAsync(client, fixture);
+            await SaveScreenshotAsync(client, fixture, "failure-screenshot.png", CancellationToken.None);
             throw;
         }
         finally
@@ -95,22 +101,33 @@ public sealed class GameplayAutoPlaySmokeTests
             cancellationToken);
     }
 
-    private static async Task TryWriteScreenshotAsync(JsonRpcGameClient client, E2EFixture fixture)
+    /// <summary>
+    /// Captures a screenshot via the JSON-RPC takeScreenshot endpoint and saves it
+    /// as a PNG artifact. Used both for proactive stage screenshots (e.g. SongSelect
+    /// status-panel visual verification) and for failure diagnostics.
+    /// </summary>
+    private static async Task SaveScreenshotAsync(
+        JsonRpcGameClient client,
+        E2EFixture fixture,
+        string fileName,
+        CancellationToken cancellationToken)
     {
         try
         {
-            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
             var imageData = await client.TakeScreenshotBase64Async(cancellation.Token);
             if (string.IsNullOrWhiteSpace(imageData))
                 return;
 
             var imageBytes = Convert.FromBase64String(imageData);
             Directory.CreateDirectory(fixture.ArtifactRoot);
-            await File.WriteAllBytesAsync(Path.Combine(fixture.ArtifactRoot, "failure-screenshot.png"), imageBytes, cancellation.Token);
+            await File.WriteAllBytesAsync(Path.Combine(fixture.ArtifactRoot, fileName), imageBytes, cancellation.Token);
         }
         catch
         {
-            // Failure artifacts should never hide the original E2E assertion or launch error.
+            // Screenshot artifacts should never hide the original E2E assertion or launch error.
         }
     }
 

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -376,6 +376,12 @@ namespace DTXMania.Game.Lib.Resources
         /// Level number bitmap font texture
         /// </summary>
         public const string LevelNumbers = "Graphics/7_LevelNumber.png";
+
+        /// <summary>
+        /// Performance-stage difficulty badge sprite sheet (60x720, twelve 60x60 cells).
+        /// NX: tx難易度パネル. The cell is selected per difficulty label (Script/difficult.dtxs scene 7).
+        /// </summary>
+        public const string PerformanceDifficultyPanel = "Graphics/7_Difficulty.png";
         
         /// <summary>
         /// Large rate numbers texture
@@ -566,6 +572,7 @@ namespace DTXMania.Game.Lib.Resources
                 PerfGraphGauge,
                 PanelIcons,
                 LevelNumbers,
+                PerformanceDifficultyPanel,
                 RateNumbersLarge,
                 RatePercent,
                 SkillMax,

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -152,6 +152,33 @@ namespace DTXMania.Game.Lib.Resources
         public const string GraphPanelGuitarBass = "Graphics/5_graph panel guitar bass.png";
 
         /// <summary>
+        /// Difficulty/level number bitmap font for the song-select status panel (250x28).
+        /// Sprite layout: digits 0-9 at (d*20,0,20,28), '.' (200,0,10,28), '-' (210,0,20,28), '?' (230,0,20,28).
+        /// NX: txDifficultyNumber. Also used for the skill-point value.
+        /// </summary>
+        public const string SongSelectDifficultyNumber = "Graphics/5_level number.png";
+
+        /// <summary>
+        /// Achievement-rate number bitmap font for the song-select difficulty grid (138x20).
+        /// Sprite layout: digits 0-9 at (d*12,0,12,20), '.' (120,0,6,20), '%' (126,0,12,20).
+        /// NX: txAchievementRateNumber.
+        /// </summary>
+        public const string SongSelectAchievementNumber = "Graphics/5_skill number.png";
+
+        /// <summary>
+        /// Achievement-rate MAX badge drawn instead of the number when a cell is 100% (53x20).
+        /// NX: tx達成率MAX.
+        /// </summary>
+        public const string SongSelectAchievementMax = "Graphics/5_skill max.png";
+
+        /// <summary>
+        /// BPM/length/total-notes number bitmap font for the song-select status panel (132x20).
+        /// Sprite layout: digits 0-9 at (d*12,0,12,20), ':' (123,0,6,20).
+        /// NX: txBPM数字.
+        /// </summary>
+        public const string SongSelectBpmNumber = "Graphics/5_bpm font.png";
+
+        /// <summary>
         /// Comment bar background texture for artist name and song comments
         /// </summary>
         public const string CommentBar = "Graphics/5_comment bar.png";
@@ -498,6 +525,10 @@ namespace DTXMania.Game.Lib.Resources
                 DifficultyFrame,
                 GraphPanelDrums,
                 GraphPanelGuitarBass,
+                SongSelectDifficultyNumber,
+                SongSelectAchievementNumber,
+                SongSelectAchievementMax,
+                SongSelectBpmNumber,
                 SkillIcon,
                 CommentBar,
                 BarScore,
@@ -610,6 +641,10 @@ namespace DTXMania.Game.Lib.Resources
                 DifficultyFrame,
                 GraphPanelDrums,
                 GraphPanelGuitarBass,
+                SongSelectDifficultyNumber,
+                SongSelectAchievementNumber,
+                SongSelectAchievementMax,
+                SongSelectBpmNumber,
                 CommentBar,
                 BarScore,
                 BarScoreSelected,

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -1551,7 +1551,10 @@ namespace DTXMania.Game.Lib.Song.Components
                 {
                     chartLevels.Add(new ChartLevelInfo
                     {
-                        Level = chart.DrumLevel, // Use actual difficulty level (3.60, 6.00, etc.) for display
+                        // DrumLevel is tenths-encoded (e.g. 36 == 3.60), matching the level
+                        // convention in SkillPanelDisplay/SongScore. DrawDifficultyCellContent
+                        // divides by 10 to render the display value.
+                        Level = chart.DrumLevel,
                         InstrumentColumn = 0, // Drums column
                         InstrumentName = "DRUMS",
                         Chart = chart

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -987,14 +987,17 @@ namespace DTXMania.Game.Lib.Song.Components
             var cellPos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(gridRow, instrument);
             int nBoxX = (int)cellPos.X;
             int nBoxY = (int)cellPos.Y;
-            const int nPanelW = 187;
-            const int nPanelH = 60;
+            int nPanelW = SongSelectionUILayout.DifficultyGrid.CellWidth;
+            int nPanelH = SongSelectionUILayout.DifficultyGrid.CellHeight;
 
             // Difficulty level (e.g. "3.80"). NX: tDrawDifficulty(nBoxX + nPanelW - 77, nBoxY + nPanelH - 35).
             var levelText = (chartInfo.Level / 10.0f).ToString("F2", CultureInfo.InvariantCulture);
             if (_difficultyNumberTexture != null)
             {
-                DrawDifficultyNumberBitmap(spriteBatch, nBoxX + nPanelW - 77, nBoxY + nPanelH - 35, levelText);
+                DrawDifficultyNumberBitmap(spriteBatch,
+                    nBoxX + nPanelW - SongSelectionUILayout.DifficultyGrid.LevelTextOffsetFromRight,
+                    nBoxY + nPanelH - SongSelectionUILayout.DifficultyGrid.LevelTextOffsetFromBottom,
+                    levelText);
             }
             else
             {
@@ -1038,13 +1041,15 @@ namespace DTXMania.Game.Lib.Song.Components
             // 100% shows the MAX badge instead of digits (NX: tx達成率MAX at nBoxX + nPanelW - 142).
             if (rate >= 100.0 && _achievementMaxTexture != null)
             {
-                _achievementMaxTexture.Draw(spriteBatch, new Vector2(nBoxX + nPanelW - 142, nBoxY + nPanelH - 27));
+                _achievementMaxTexture.Draw(spriteBatch, new Vector2(
+                    nBoxX + nPanelW - SongSelectionUILayout.DifficultyGrid.AchievementMaxOffsetFromRight,
+                    nBoxY + nPanelH - SongSelectionUILayout.DifficultyGrid.AchievementRateOffsetFromBottom));
                 return;
             }
 
             var text = string.Format(CultureInfo.InvariantCulture, "{0,6:##0.00}%", rate);
-            float rateX = nBoxX + nPanelW - 157;
-            float rateY = nBoxY + nPanelH - 27;
+            float rateX = nBoxX + nPanelW - SongSelectionUILayout.DifficultyGrid.AchievementRateOffsetFromRight;
+            float rateY = nBoxY + nPanelH - SongSelectionUILayout.DifficultyGrid.AchievementRateOffsetFromBottom;
             if (_achievementNumberTexture != null)
             {
                 DrawAchievementNumberBitmap(spriteBatch, rateX, rateY, text);

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -1013,6 +1013,32 @@ namespace DTXMania.Game.Lib.Song.Components
         }
 
         /// <summary>
+        /// How to render a per-cell achievement rate. Extracted from <see cref="DrawAchievementRate"/>
+        /// so the boundary/source-field logic is unit-testable without a graphics device.
+        /// </summary>
+        internal enum AchievementRateMode { Skip, Max, Digits }
+
+        /// <summary>
+        /// Classifies how to render a per-cell achievement rate: <see cref="Skip"/> (no history or
+        /// zero), <see cref="Max"/> (perfect 100% rate), or <see cref="Digits"/> (a numeric rate).
+        /// Reads <see cref="SongScore.BestAchievementRate"/> — NOT <c>HighSkill</c>, which holds the
+        /// level-weighted game skill and routinely exceeds 100, wrongly triggering the MAX badge for
+        /// non-perfect plays. The input is clamped to [0,100] before classification.
+        /// </summary>
+        internal static AchievementRateMode ClassifyAchievementRate(SongScore? score)
+        {
+            if (score == null)
+                return AchievementRateMode.Skip;
+
+            double rate = Math.Clamp(score.BestAchievementRate, 0.0, 100.0);
+            if (rate <= 0.0)
+                return AchievementRateMode.Skip; // NX draws the rate only when the value is non-zero
+            if (rate >= 100.0)
+                return AchievementRateMode.Max;
+            return AchievementRateMode.Digits;
+        }
+
+        /// <summary>
         /// Draws the per-cell achievement rate (best skill) using the 5_skill number.png bitmap font,
         /// or a 100% MAX badge. Mirrors DTXManiaNX (only drawn when the value is non-zero).
         /// </summary>
@@ -1027,19 +1053,12 @@ namespace DTXMania.Game.Lib.Song.Components
             };
 
             var score = chartInfo.Chart.Scores?.FirstOrDefault(s => s.Instrument == instrumentPart);
-            if (score == null)
+            var mode = ClassifyAchievementRate(score);
+            if (mode == AchievementRateMode.Skip)
                 return;
 
-            // NX draws the achievement rate (達成率 / playing skill, 0-100) here — db現在選択中の曲の最高スキル値,
-            // sourced from SongInformation.HighSkill = dbPerformanceSkill. That maps to BestAchievementRate,
-            // NOT HighSkill (which holds the level-weighted game skill and routinely exceeds 100, wrongly
-            // triggering the MAX badge for non-perfect plays).
-            double rate = Math.Clamp(score.BestAchievementRate, 0.0, 100.0);
-            if (rate <= 0.0)
-                return; // NX draws the rate only when the value is non-zero
-
             // 100% shows the MAX badge instead of digits (NX: tx達成率MAX at nBoxX + nPanelW - 142).
-            if (rate >= 100.0 && _achievementMaxTexture != null)
+            if (mode == AchievementRateMode.Max && _achievementMaxTexture != null)
             {
                 _achievementMaxTexture.Draw(spriteBatch, new Vector2(
                     nBoxX + nPanelW - SongSelectionUILayout.DifficultyGrid.AchievementMaxOffsetFromRight,
@@ -1047,6 +1066,8 @@ namespace DTXMania.Game.Lib.Song.Components
                 return;
             }
 
+            // Digits, or the MAX-mode fallback when the MAX texture is unavailable.
+            double rate = Math.Clamp(score!.BestAchievementRate, 0.0, 100.0);
             var text = string.Format(CultureInfo.InvariantCulture, "{0,6:##0.00}%", rate);
             float rateX = nBoxX + nPanelW - SongSelectionUILayout.DifficultyGrid.AchievementRateOffsetFromRight;
             float rateY = nBoxY + nPanelH - SongSelectionUILayout.DifficultyGrid.AchievementRateOffsetFromBottom;
@@ -1234,7 +1255,6 @@ namespace DTXMania.Game.Lib.Song.Components
             
             // The count to display: current instrument when it has notes, otherwise the chart total.
             int displayCount = currentInstrumentCount > 0 ? currentInstrumentCount : total;
-            Color textColor = currentInstrumentCount > 0 ? Color.Yellow : Color.Cyan;
 
             // NX renders the total-notes count with the BPM bitmap font (5_bpm font.png), centered
             // on the counter point. position.X is the NX-authentic center anchor.
@@ -1242,12 +1262,16 @@ namespace DTXMania.Game.Lib.Song.Components
             {
                 var digits = displayCount.ToString(CultureInfo.InvariantCulture);
                 // NX: nGraphBaseX + 66 - (len-1)*(charWidth/2); position.X already equals nGraphBaseX + 66.
-                float startX = position.X - (digits.Length - 1) * 6f;
+                // Source the per-character advance from the shared table so a width change can't drift
+                // away from the unit-tested MeasureBpmNumberWidth helper.
+                float halfAdvance = BpmNumberAdvance('0') / 2f;
+                float startX = position.X - (digits.Length - 1) * halfAdvance;
                 DrawBpmNumberBitmap(spriteBatch, startX, position.Y, digits);
                 return;
             }
 
             // System-font fallback (keeps thousands separator when the bitmap font is unavailable).
+            Color textColor = currentInstrumentCount > 0 ? Color.Yellow : Color.Cyan;
             string notesText = currentInstrumentCount > 0
                 ? $"{currentInstrumentCount:N0}"
                 : chart.GetFormattedNoteCount(false);
@@ -1296,12 +1320,19 @@ namespace DTXMania.Game.Lib.Song.Components
             return null;
         }
 
-        /// <summary>Advance width per character for the BPM/level/achievement fonts (used for centering).</summary>
+        /// <summary>
+        /// Advance width per character for each bitmap font. The BPM advance is also the source of
+        /// the production centering offset (see <see cref="DrawNotesCounter"/>); the others are used
+        /// by the corresponding Draw*Bitmap renderers.
+        /// </summary>
         private static int DifficultyNumberAdvance(char c) => c == '.' ? 10 : 20;
         private static int AchievementNumberAdvance(char c) => c == '.' ? 6 : 12;
         private static int BpmNumberAdvance(char c) => c == ':' ? 6 : 12;
 
-        /// <summary>Total pixel width of a BPM-font string (used to center the total-notes count).</summary>
+        /// <summary>
+        /// Total pixel width of a BPM-font string. Unit-tested directly; production centering derives
+        /// from the same <see cref="BpmNumberAdvance"/> source so the two cannot drift apart.
+        /// </summary>
         internal static int MeasureBpmNumberWidth(string text)
         {
             int width = 0;
@@ -1416,7 +1447,7 @@ namespace DTXMania.Game.Lib.Song.Components
         private Color GetDrumLaneColor(int lane)
         {
             // Color each distribution bar by its drum lane, reusing the authentic gameplay lane
-            // palette (LC, HH, LP, SN, HT, DB, LT, FT, CY, RD) so the song-select bars match the
+            // palette (LC, HH, LP, SN, HT, BD, LT, FT, CY, RD) so the song-select bars match the
             // colors a player sees in the performance stage. The previous ad-hoc 9-entry table used
             // the wrong hues and left lane 9 (RD) white.
             if (lane >= 0 && lane < PerformanceUILayout.LaneCount)

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -1027,7 +1027,11 @@ namespace DTXMania.Game.Lib.Song.Components
             if (score == null)
                 return;
 
-            double rate = Math.Clamp(score.HighSkill, 0.0, 100.0);
+            // NX draws the achievement rate (達成率 / playing skill, 0-100) here — db現在選択中の曲の最高スキル値,
+            // sourced from SongInformation.HighSkill = dbPerformanceSkill. That maps to BestAchievementRate,
+            // NOT HighSkill (which holds the level-weighted game skill and routinely exceeds 100, wrongly
+            // triggering the MAX badge for non-perfect plays).
+            double rate = Math.Clamp(score.BestAchievementRate, 0.0, 100.0);
             if (rate <= 0.0)
                 return; // NX draws the rate only when the value is non-zero
 
@@ -1406,20 +1410,13 @@ namespace DTXMania.Game.Lib.Song.Components
 
         private Color GetDrumLaneColor(int lane)
         {
-            // Colors for drum lanes: LC, HH, LP, SD, HT, BD, LT, FT, CY
-            return lane switch
-            {
-                0 => Color.Purple,    // LC
-                1 => Color.Yellow,    // HH
-                2 => Color.Purple,    // LP
-                3 => Color.Red,       // SD
-                4 => Color.Blue,      // HT
-                5 => Color.Orange,    // BD
-                6 => Color.Blue,      // LT
-                7 => Color.Green,     // FT
-                8 => Color.Cyan,      // CY
-                _ => Color.White
-            };
+            // Color each distribution bar by its drum lane, reusing the authentic gameplay lane
+            // palette (LC, HH, LP, SN, HT, DB, LT, FT, CY, RD) so the song-select bars match the
+            // colors a player sees in the performance stage. The previous ad-hoc 9-entry table used
+            // the wrong hues and left lane 9 (RD) white.
+            if (lane >= 0 && lane < PerformanceUILayout.LaneCount)
+                return PerformanceUILayout.GetLaneColor(lane);
+            return Color.White;
         }
 
         private Color GetGuitarBassLaneColor(int lane)

--- a/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongStatusPanel.cs
@@ -6,6 +6,7 @@ using DTXMania.Game.Lib.Resources;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 
 // Type alias for SongScore to use the EF Core entity
@@ -60,6 +61,13 @@ namespace DTXMania.Game.Lib.Song.Components
 
         // Skill point panel background texture (5_skill point panel.png)
         private ITexture _skillPointPanelTexture;
+
+        // DTXManiaNX bitmap number fonts for panel numbers (replace approximate system-font
+        // rendering so numbers sit pixel-aligned inside the panel boxes — matches NX).
+        private ITexture _difficultyNumberTexture;   // 5_level number.png  (250x28): level + skill-point value
+        private ITexture _achievementNumberTexture;  // 5_skill number.png  (138x20): achievement rate per cell
+        private ITexture _achievementMaxTexture;      // 5_skill max.png     (53x20):  100% badge
+        private ITexture _bpmNumberTexture;           // 5_bpm font.png      (132x20): BPM / length / total notes
 
         // Skill/rank icon texture for 5_skill icon.png support (D8: performance history)
         private ITexture _skillIconTexture;
@@ -199,6 +207,7 @@ namespace DTXMania.Game.Lib.Song.Components
             LoadGraphPanelTextures();
             LoadSkillPointPanelTexture();
             LoadSkillIconTexture();
+            LoadNumberFontTextures();
             // Level number font will be loaded when graphics generator is initialized
             
             System.Diagnostics.Debug.WriteLine("SongStatusPanel: InitializeAuthenticGraphics completed. Waiting for graphics generator...");
@@ -359,6 +368,39 @@ namespace DTXMania.Game.Lib.Song.Components
             }
         }
 
+        /// <summary>
+        /// Load DTXManiaNX bitmap number fonts used for the panel numbers. Each is optional;
+        /// when a texture is missing the draw code falls back to the system font.
+        /// </summary>
+        private void LoadNumberFontTextures()
+        {
+            if (_resourceManager == null)
+                return;
+
+            ReleaseManagedTexture(ref _difficultyNumberTexture);
+            ReleaseManagedTexture(ref _achievementNumberTexture);
+            ReleaseManagedTexture(ref _achievementMaxTexture);
+            ReleaseManagedTexture(ref _bpmNumberTexture);
+
+            _difficultyNumberTexture = TryLoadNumberFont(TexturePath.SongSelectDifficultyNumber, "difficulty number font");
+            _achievementNumberTexture = TryLoadNumberFont(TexturePath.SongSelectAchievementNumber, "achievement number font");
+            _achievementMaxTexture = TryLoadNumberFont(TexturePath.SongSelectAchievementMax, "achievement MAX badge");
+            _bpmNumberTexture = TryLoadNumberFont(TexturePath.SongSelectBpmNumber, "BPM number font");
+        }
+
+        private ITexture TryLoadNumberFont(string path, string displayName)
+        {
+            try
+            {
+                return _resourceManager.LoadTexture(path);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SongStatusPanel: Failed to load {displayName}: {ex.Message}");
+                return null;
+            }
+        }
+
         #endregion
 
         #region Constructor
@@ -408,6 +450,10 @@ namespace DTXMania.Game.Lib.Song.Components
                 ReleaseManagedTexture(ref _graphPanelGuitarBassTexture);
                 ReleaseManagedTexture(ref _skillPointPanelTexture);
                 ReleaseManagedTexture(ref _skillIconTexture);
+                ReleaseManagedTexture(ref _difficultyNumberTexture);
+                ReleaseManagedTexture(ref _achievementNumberTexture);
+                ReleaseManagedTexture(ref _achievementMaxTexture);
+                ReleaseManagedTexture(ref _bpmNumberTexture);
             }
             base.Dispose(disposing);
         }
@@ -463,9 +509,19 @@ namespace DTXMania.Game.Lib.Song.Components
 
         private void DrawBackground(SpriteBatch spriteBatch, Rectangle bounds)
         {
-            // Always draw a visible background first (generated or solid color fallback),
-            // then overlay the skin texture. This ensures the panel is visible even when
-            // the skin's 5_status panel.png is fully transparent.
+            // When the skin supplies a status-panel texture, draw it alone. NX's
+            // 5_status panel.png is intentionally (near-)transparent — the difficulty
+            // and graph panels provide their own backgrounds. Painting a generated
+            // opaque fill behind a transparent skin produced a visible black square
+            // behind the drum panel, so the fallback fills are only used when the
+            // skin provides no texture at all.
+            if (_statusPanelTexture != null)
+            {
+                var sourceRect = new Rectangle(0, 0, _statusPanelTexture.Width, _statusPanelTexture.Height);
+                spriteBatch.Draw(_statusPanelTexture.Texture, bounds, sourceRect, Color.White);
+                return;
+            }
+
             if (_graphicsGenerator != null)
             {
                 if (_cachedBackgroundTexture == null || _cachedBackgroundSize != bounds)
@@ -486,13 +542,6 @@ namespace DTXMania.Game.Lib.Song.Components
                 spriteBatch.Draw(_whitePixel, new Rectangle(bounds.X, bounds.Bottom - borderThickness, bounds.Width, borderThickness), borderColor);
                 spriteBatch.Draw(_whitePixel, new Rectangle(bounds.X, bounds.Y, borderThickness, bounds.Height), borderColor);
                 spriteBatch.Draw(_whitePixel, new Rectangle(bounds.Right - borderThickness, bounds.Y, borderThickness, bounds.Height), borderColor);
-            }
-
-            // Overlay skin texture on top (transparent skin has no visual effect)
-            if (_statusPanelTexture != null)
-            {
-                var sourceRect = new Rectangle(0, 0, _statusPanelTexture.Width, _statusPanelTexture.Height);
-                spriteBatch.Draw(_statusPanelTexture.Texture, bounds, sourceRect, Color.White);
             }
         }
 
@@ -585,11 +634,33 @@ namespace DTXMania.Game.Lib.Song.Components
             // Draw BMP background texture first (5_BPM.png or fallback)
             DrawBPMBackground(spriteBatch);
 
-            // Compute text positions using actual font metrics for precise vertical centering
-            var font = _smallFont ?? _font;
-            float lineH = font?.LineSpacing ?? 16f;
             var bpmOrigin = GetBpmBackgroundOrigin();
             float textX = bpmOrigin.X + SongSelectionUILayout.BPMSection.TextX;
+
+            var formattedDuration = FormatDuration(chart.Duration);
+
+            // Preferred path: NX bitmap font (5_bpm font.png, 20px tall) centered in the dark boxes.
+            if (_bpmNumberTexture != null)
+            {
+                float lengthBitmapY = bpmOrigin.Y + SongSelectionUILayout.BPMSection.LengthBoxTop
+                                      + (SongSelectionUILayout.BPMSection.DarkBoxHeight - 20) / 2f;
+                float bpmBitmapY = bpmOrigin.Y + SongSelectionUILayout.BPMSection.BPMBoxTop
+                                   + (SongSelectionUILayout.BPMSection.DarkBoxHeight - 20) / 2f;
+
+                DrawBpmNumberBitmap(spriteBatch, textX, lengthBitmapY, formattedDuration);
+
+                if (chart.Bpm > 0)
+                {
+                    // NX: string.Format("{0,3:###}", bpm) — right-aligned in a 3-char field.
+                    var bpmText = string.Format(CultureInfo.InvariantCulture, "{0,3:###}", Math.Round(chart.Bpm));
+                    DrawBpmNumberBitmap(spriteBatch, textX, bpmBitmapY, bpmText);
+                }
+                return;
+            }
+
+            // System-font fallback. Compute positions using actual font metrics for centering.
+            var font = _smallFont ?? _font;
+            float lineH = font?.LineSpacing ?? 16f;
             float lengthY = bpmOrigin.Y + SongSelectionUILayout.BPMSection.LengthBoxTop
                             + (SongSelectionUILayout.BPMSection.DarkBoxHeight - lineH) / 2f;
             float bpmY    = bpmOrigin.Y + SongSelectionUILayout.BPMSection.BPMBoxTop
@@ -598,12 +669,9 @@ namespace DTXMania.Game.Lib.Song.Components
             // When using authentic 5_BPM.png, don't draw redundant labels
             bool useAuthenticTexture = _bpmBackgroundTexture != null;
 
-            // Draw song duration
-            var formattedDuration = FormatDuration(chart.Duration);
             var durationText = useAuthenticTexture ? formattedDuration : $"Length: {formattedDuration}";
             DrawTextWithShadow(spriteBatch, font, durationText, new Vector2(textX, lengthY), DTXManiaVisualTheme.SongSelection.StatusValueText);
 
-            // Draw BPM value
             if (chart.Bpm > 0)
             {
                 var bpmText = useAuthenticTexture ? $"{chart.Bpm:F0}" : $"BPM: {chart.Bpm:F0}";
@@ -775,13 +843,27 @@ namespace DTXMania.Game.Lib.Song.Components
                 spriteBatch.Draw(_whitePixel, skillPanelRect, Color.DarkBlue * 0.7f);
             }
 
-            // Compute skill text position dynamically using actual font metrics
+            var skillValue = score.HasBeenPlayed
+                ? score.HighSkill.ToString("F2", CultureInfo.InvariantCulture)
+                : "---";
+
+            // Preferred path: NX difficulty bitmap font (5_level number.png, 28px tall).
+            // NX: tDrawSkillPoints(32 + 60, 200, strSP) → x = X + DarkBoxLeft, centered in the dark box.
+            if (_difficultyNumberTexture != null)
+            {
+                float skillBitmapX = SongSelectionUILayout.SkillPointSection.X + SongSelectionUILayout.SkillPointSection.DarkBoxLeft;
+                float skillBitmapY = SongSelectionUILayout.SkillPointSection.Y + SongSelectionUILayout.SkillPointSection.DarkBoxTop
+                                     + (SongSelectionUILayout.SkillPointSection.DarkBoxHeight - 28) / 2f;
+                DrawDifficultyNumberBitmap(spriteBatch, skillBitmapX, skillBitmapY, skillValue);
+                return;
+            }
+
+            // System-font fallback positioned dynamically using actual font metrics.
             var skillFont = _smallFont ?? _font;
             float skillLineH = skillFont?.LineSpacing ?? 16f;
             float skillTextX = SongSelectionUILayout.SkillPointSection.X + SongSelectionUILayout.SkillPointSection.DarkBoxLeft + 8f;
             float skillTextY = SongSelectionUILayout.SkillPointSection.Y + SongSelectionUILayout.SkillPointSection.DarkBoxTop
                                + (SongSelectionUILayout.SkillPointSection.DarkBoxHeight - skillLineH) / 2f;
-            var skillValue = score.HasBeenPlayed ? score.HighSkill.ToString("F2") : "---";
             DrawTextWithShadow(spriteBatch, skillFont, skillValue, new Vector2(skillTextX, skillTextY), Color.Yellow);
         }
 
@@ -900,17 +982,73 @@ namespace DTXMania.Game.Lib.Song.Components
 
         private void DrawDifficultyCellContent(SpriteBatch spriteBatch, int x, int y, int cellWidth, int cellHeight, int gridRow, int instrument, ChartLevelInfo chartInfo)
         {
-            // Display the actual chart level from SET.def (divide by 10 for proper decimal format)
-            var levelText = (chartInfo.Level / 10.0f).ToString("F2"); // Show 38 as "3.80", 60 as "6.00", etc.
+            // Numbers are positioned relative to the panel cell origin (not the +20px content
+            // offset) so they sit pixel-aligned inside the cell's dark box, matching NX.
+            var cellPos = SongSelectionUILayout.DifficultyGrid.GetCellPosition(gridRow, instrument);
+            int nBoxX = (int)cellPos.X;
+            int nBoxY = (int)cellPos.Y;
+            const int nPanelW = 187;
+            const int nPanelH = 60;
 
-            // Determine if this chart is currently selected
-            var isSelected = IsChartSelected(chartInfo);
-            var textColor = isSelected ? Color.Yellow : Color.White;
+            // Difficulty level (e.g. "3.80"). NX: tDrawDifficulty(nBoxX + nPanelW - 77, nBoxY + nPanelH - 35).
+            var levelText = (chartInfo.Level / 10.0f).ToString("F2", CultureInfo.InvariantCulture);
+            if (_difficultyNumberTexture != null)
+            {
+                DrawDifficultyNumberBitmap(spriteBatch, nBoxX + nPanelW - 77, nBoxY + nPanelH - 35, levelText);
+            }
+            else
+            {
+                var isSelected = IsChartSelected(chartInfo);
+                DrawDifficultyText(spriteBatch, levelText, x, y, cellWidth, cellHeight, isSelected ? Color.Yellow : Color.White);
+            }
 
-            DrawDifficultyText(spriteBatch, levelText, x, y, cellWidth, cellHeight, textColor);
-
-            // D8: draw rank and FC badge if player has history for this cell
+            // D8: draw rank and FC badge if player has history for this cell (NX nBoxY+5).
             DrawRankSymbol(spriteBatch, x, y, chartInfo, instrument);
+
+            // Achievement rate per cell. NX: tDrawAchievementRate(nBoxX + nPanelW - 157, nBoxY + nPanelH - 27).
+            DrawAchievementRate(spriteBatch, nBoxX, nBoxY, nPanelW, nPanelH, chartInfo, instrument);
+        }
+
+        /// <summary>
+        /// Draws the per-cell achievement rate (best skill) using the 5_skill number.png bitmap font,
+        /// or a 100% MAX badge. Mirrors DTXManiaNX (only drawn when the value is non-zero).
+        /// </summary>
+        private void DrawAchievementRate(SpriteBatch spriteBatch, int nBoxX, int nBoxY, int nPanelW, int nPanelH, ChartLevelInfo chartInfo, int instrumentColumn)
+        {
+            var instrumentPart = instrumentColumn switch
+            {
+                0 => EInstrumentPart.DRUMS,
+                1 => EInstrumentPart.GUITAR,
+                2 => EInstrumentPart.BASS,
+                _ => EInstrumentPart.DRUMS
+            };
+
+            var score = chartInfo.Chart.Scores?.FirstOrDefault(s => s.Instrument == instrumentPart);
+            if (score == null)
+                return;
+
+            double rate = Math.Clamp(score.HighSkill, 0.0, 100.0);
+            if (rate <= 0.0)
+                return; // NX draws the rate only when the value is non-zero
+
+            // 100% shows the MAX badge instead of digits (NX: tx達成率MAX at nBoxX + nPanelW - 142).
+            if (rate >= 100.0 && _achievementMaxTexture != null)
+            {
+                _achievementMaxTexture.Draw(spriteBatch, new Vector2(nBoxX + nPanelW - 142, nBoxY + nPanelH - 27));
+                return;
+            }
+
+            var text = string.Format(CultureInfo.InvariantCulture, "{0,6:##0.00}%", rate);
+            float rateX = nBoxX + nPanelW - 157;
+            float rateY = nBoxY + nPanelH - 27;
+            if (_achievementNumberTexture != null)
+            {
+                DrawAchievementNumberBitmap(spriteBatch, rateX, rateY, text);
+            }
+            else
+            {
+                DrawTextWithShadow(spriteBatch, _smallFont ?? _font, text, new Vector2(rateX, rateY), Color.Yellow);
+            }
         }
 
         /// <summary>
@@ -1085,24 +1223,25 @@ namespace DTXMania.Game.Lib.Song.Components
             var currentInstrument = GetInstrumentFromDifficulty(_currentDifficulty);
             var currentInstrumentCount = chart.GetInstrumentNoteCount(currentInstrument);
             
-            // Create formatted text based on current context
-            string notesText;
-            Color textColor;
-            
-            if (currentInstrumentCount > 0)
+            // The count to display: current instrument when it has notes, otherwise the chart total.
+            int displayCount = currentInstrumentCount > 0 ? currentInstrumentCount : total;
+            Color textColor = currentInstrumentCount > 0 ? Color.Yellow : Color.Cyan;
+
+            // NX renders the total-notes count with the BPM bitmap font (5_bpm font.png), centered
+            // on the counter point. position.X is the NX-authentic center anchor.
+            if (_bpmNumberTexture != null)
             {
-                // Show only current instrument count (remove duplicate total text)
-                notesText = $"{currentInstrumentCount:N0}";
-                textColor = Color.Yellow; // Highlight current instrument
-            }
-            else
-            {
-                // No notes for current instrument, show total only
-                notesText = chart.GetFormattedNoteCount(false);
-                textColor = Color.Cyan;
+                var digits = displayCount.ToString(CultureInfo.InvariantCulture);
+                // NX: nGraphBaseX + 66 - (len-1)*(charWidth/2); position.X already equals nGraphBaseX + 66.
+                float startX = position.X - (digits.Length - 1) * 6f;
+                DrawBpmNumberBitmap(spriteBatch, startX, position.Y, digits);
+                return;
             }
 
-            // Center the number at the NX-authentic center point (position.X is the center, not left edge)
+            // System-font fallback (keeps thousands separator when the bitmap font is unavailable).
+            string notesText = currentInstrumentCount > 0
+                ? $"{currentInstrumentCount:N0}"
+                : chart.GetFormattedNoteCount(false);
             var font = _smallFont ?? _font ?? _managedFont?.SpriteFont;
             var textSize = font != null
                 ? font.MeasureString(notesText)
@@ -1112,6 +1251,86 @@ namespace DTXMania.Game.Lib.Song.Components
             {
                 var centeredPos = new Vector2(position.X - textSize.X / 2, position.Y);
                 DrawTextWithShadow(spriteBatch, font, notesText, centeredPos, textColor);
+            }
+        }
+
+        #endregion
+
+        #region DTXManiaNX Bitmap Number Rendering
+
+        // Source-rect lookups mirror the sprite tables in DTXManiaNX CActSelectStatusPanel.
+
+        /// <summary>5_level number.png (250x28): digits 20px, '.' 10px, '-'/'?' 20px.</summary>
+        private static Rectangle? GetDifficultyNumberRect(char c)
+        {
+            if (c >= '0' && c <= '9') return new Rectangle((c - '0') * 20, 0, 20, 28);
+            if (c == '.') return new Rectangle(200, 0, 10, 28);
+            if (c == '-') return new Rectangle(210, 0, 20, 28);
+            if (c == '?') return new Rectangle(230, 0, 20, 28);
+            return null;
+        }
+
+        /// <summary>5_skill number.png (138x20): digits 12px, '.' 6px, '%' 12px.</summary>
+        private static Rectangle? GetAchievementNumberRect(char c)
+        {
+            if (c >= '0' && c <= '9') return new Rectangle((c - '0') * 12, 0, 12, 20);
+            if (c == '.') return new Rectangle(120, 0, 6, 20);
+            if (c == '%') return new Rectangle(126, 0, 12, 20);
+            return null;
+        }
+
+        /// <summary>5_bpm font.png (132x20): digits 12px, ':' 6px.</summary>
+        private static Rectangle? GetBpmNumberRect(char c)
+        {
+            if (c >= '0' && c <= '9') return new Rectangle((c - '0') * 12, 0, 12, 20);
+            if (c == ':') return new Rectangle(123, 0, 6, 20);
+            return null;
+        }
+
+        /// <summary>Advance width per character for the BPM/level/achievement fonts (used for centering).</summary>
+        private static int DifficultyNumberAdvance(char c) => c == '.' ? 10 : 20;
+        private static int AchievementNumberAdvance(char c) => c == '.' ? 6 : 12;
+        private static int BpmNumberAdvance(char c) => c == ':' ? 6 : 12;
+
+        /// <summary>Total pixel width of a BPM-font string (used to center the total-notes count).</summary>
+        internal static int MeasureBpmNumberWidth(string text)
+        {
+            int width = 0;
+            foreach (var c in text)
+                width += BpmNumberAdvance(c);
+            return width;
+        }
+
+        private void DrawDifficultyNumberBitmap(SpriteBatch spriteBatch, float x, float y, string text)
+        {
+            foreach (var c in text)
+            {
+                var rect = GetDifficultyNumberRect(c);
+                if (rect.HasValue)
+                    _difficultyNumberTexture.Draw(spriteBatch, new Vector2(x, y), rect.Value);
+                x += DifficultyNumberAdvance(c);
+            }
+        }
+
+        private void DrawAchievementNumberBitmap(SpriteBatch spriteBatch, float x, float y, string text)
+        {
+            foreach (var c in text)
+            {
+                var rect = GetAchievementNumberRect(c);
+                if (rect.HasValue)
+                    _achievementNumberTexture.Draw(spriteBatch, new Vector2(x, y), rect.Value);
+                x += AchievementNumberAdvance(c);
+            }
+        }
+
+        private void DrawBpmNumberBitmap(SpriteBatch spriteBatch, float x, float y, string text)
+        {
+            foreach (var c in text)
+            {
+                var rect = GetBpmNumberRect(c);
+                if (rect.HasValue)
+                    _bpmNumberTexture.Draw(spriteBatch, new Vector2(x, y), rect.Value);
+                x += BpmNumberAdvance(c);
             }
         }
 

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -529,6 +529,10 @@ namespace DTXMania.Game.Lib.Song.Entities
             if (summary.GameSkill > score.HighSkill)
             {
                 score.HighSkill = summary.GameSkill;
+                // NX stores the achievement rate (達成率 / playing skill, 0-100) on a new skill record
+                // (CStageResult: HighSkill[m] = dbPerformanceSkill when bNewRecordSkill). The song-select
+                // panel reads this as the per-cell percentage, so it must be persisted alongside HighSkill.
+                score.BestAchievementRate = summary.PlayingSkill;
             }
             score.SongSkill = summary.GameSkill;
 

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1249,7 +1249,14 @@ namespace DTXMania.Game.Lib.Song
                 {
                     return File.ReadAllLines(setDefPath, encoding);
                 }
-                catch (Exception ex)
+                // Only realistic failures here are I/O (the path is pre-validated and UTF-8 uses
+                // DecoderReplacementFallback, so encoding mismatches never throw). Let genuinely
+                // unexpected exceptions (OOM, contract changes) propagate instead of being masked.
+                catch (IOException ex)
+                {
+                    Debug.WriteLine($"SongManager: Failed to read SET.def with {encoding.EncodingName}: {ex.Message}");
+                }
+                catch (UnauthorizedAccessException ex)
                 {
                     Debug.WriteLine($"SongManager: Failed to read SET.def with {encoding.EncodingName}: {ex.Message}");
                 }
@@ -1373,7 +1380,15 @@ namespace DTXMania.Game.Lib.Song
                         lines = await File.ReadAllLinesAsync(setDefPath, encoding, cancellationToken);
                         break; // Success, use this encoding
                     }
-                    catch (Exception ex)
+                    // Only realistic failures here are I/O (UTF-8 uses DecoderReplacementFallback,
+                    // so encoding mismatches never throw). Let genuinely unexpected exceptions
+                    // propagate instead of being masked.
+                    catch (IOException ex)
+                    {
+                        Debug.WriteLine($"SongManager: Failed to read SET.def with {encoding.EncodingName}: {ex.Message}");
+                        continue;
+                    }
+                    catch (UnauthorizedAccessException ex)
                     {
                         Debug.WriteLine($"SongManager: Failed to read SET.def with {encoding.EncodingName}: {ex.Message}");
                         continue;

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1197,12 +1197,13 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Reads a SET.def file, trying the same encodings as enumeration (UTF-8 first, then
-        /// the system default and Shift_JIS). Returns null when the file cannot be read with
-        /// any encoding. NormalizeSetDefLine repairs the BOM/null-byte/spaced artifacts that
-        /// result from reading a Shift_JIS or UTF-16 SET.def as UTF-8.
+        /// Builds the encoding fallback chain used to read SET.def files: UTF-8 first, then the
+        /// system default, then Shift_JIS (for legacy Japanese charts). Shift_JIS is added
+        /// defensively because it needs a registered code-page provider on some runtimes.
+        /// Shared by <see cref="ReadSetDefLines"/> (synchronous database-load path) and
+        /// <see cref="ParseSetDefinitionAsync"/> (async enumeration path) so the two never drift.
         /// </summary>
-        private static string[]? ReadSetDefLines(string setDefPath)
+        private static List<Encoding> BuildSetDefEncodings()
         {
             var encodings = new List<Encoding> { Encoding.UTF8, Encoding.Default };
             try
@@ -1213,8 +1214,23 @@ namespace DTXMania.Game.Lib.Song
             {
                 Debug.WriteLine("SongManager: Shift_JIS encoding not available for SET.def parsing");
             }
+            return encodings;
+        }
 
-            foreach (var encoding in encodings)
+        /// <summary>
+        /// Reads a SET.def file, trying the same encodings as enumeration (UTF-8 first, then
+        /// the system default and Shift_JIS). Returns null when the file cannot be read with
+        /// any encoding. NormalizeSetDefLine repairs the BOM/null-byte/spaced artifacts that
+        /// result from reading a Shift_JIS or UTF-16 SET.def as UTF-8.
+        /// </summary>
+        /// <remarks>
+        /// Synchronous by design: the only caller is <see cref="GetSetDefLabelsByFile"/>, which
+        /// runs on the synchronous database-load path. The async enumeration path reads via
+        /// <see cref="File.ReadAllLinesAsync"/> in <see cref="ParseSetDefinitionAsync"/>.
+        /// </remarks>
+        private static string[]? ReadSetDefLines(string setDefPath)
+        {
+            foreach (var encoding in BuildSetDefEncodings())
             {
                 try
                 {
@@ -1332,22 +1348,8 @@ namespace DTXMania.Game.Lib.Song
 
             try
             {
-                // Try different encodings for Japanese text support
-                var encodings = new List<Encoding>
-                {
-                    Encoding.UTF8,
-                    Encoding.Default
-                };
-
-                // Try to add Shift_JIS if available
-                try
-                {
-                    encodings.Add(Encoding.GetEncoding("Shift_JIS"));
-                }
-                catch (ArgumentException)
-                {
-                    Debug.WriteLine("SongManager: Shift_JIS encoding not available for SET.def parsing");
-                }
+                // Try different encodings for Japanese text support (shared with ReadSetDefLines)
+                var encodings = BuildSetDefEncodings();
 
                 string[]? lines = null;
                 foreach (var encoding in encodings)

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1197,12 +1197,23 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Builds the encoding fallback chain used to read SET.def files: UTF-8 first, then the
-        /// system default, then Shift_JIS (for legacy Japanese charts). Shift_JIS is added
-        /// defensively because it needs a registered code-page provider on some runtimes.
-        /// Shared by <see cref="ReadSetDefLines"/> (synchronous database-load path) and
+        /// Builds the list of encodings used to read SET.def files. Shared by
+        /// <see cref="ReadSetDefLines"/> (synchronous database-load path) and
         /// <see cref="ParseSetDefinitionAsync"/> (async enumeration path) so the two never drift.
         /// </summary>
+        /// <remarks>
+        /// NOTE: this is <b>not</b> a true encoding fallback chain as written today.
+        /// <see cref="Encoding.UTF8"/> uses <see cref="DecoderReplacementFallback"/>, so
+        /// <c>File.ReadAllLines(UTF-8)</c> never throws on bad bytes — it emits U+FFFD and
+        /// "succeeds" on the first entry, and the subsequent system-default / Shift_JIS entries
+        /// are never exercised for decoding reasons. (The <c>catch</c> below only catches I/O
+        /// errors, which fail identically across the whole list.) Shift_JIS is retained so that a
+        /// future switch to <c>new UTF8Encoding(false, throwOnInvalidBytes: true)</c> could enable a
+        /// real fallback for legacy Japanese charts; it is added defensively because it needs a
+        /// registered code-page provider on some runtimes. The actual repair of the
+        /// BOM/null-byte/spaced artifacts produced by reading a Shift_JIS or UTF-16 SET.def as
+        /// UTF-8 happens after the read, in <see cref="NormalizeSetDefLine"/>.
+        /// </remarks>
         private static List<Encoding> BuildSetDefEncodings()
         {
             var encodings = new List<Encoding> { Encoding.UTF8, Encoding.Default };
@@ -1218,10 +1229,12 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Reads a SET.def file, trying the same encodings as enumeration (UTF-8 first, then
-        /// the system default and Shift_JIS). Returns null when the file cannot be read with
-        /// any encoding. NormalizeSetDefLine repairs the BOM/null-byte/spaced artifacts that
-        /// result from reading a Shift_JIS or UTF-16 SET.def as UTF-8.
+        /// Reads a SET.def file using <see cref="BuildSetDefEncodings"/>. Returns null only when the
+        /// file cannot be read at all (it does not exist or an I/O error occurs). Because UTF-8 uses
+        /// <see cref="DecoderReplacementFallback"/>, a read with invalid bytes never throws and the
+        /// later encodings in the list are not retried — see the remarks on
+        /// <see cref="BuildSetDefEncodings"/>. <see cref="NormalizeSetDefLine"/> repairs the
+        /// BOM/null-byte/spaced artifacts that result from reading a Shift_JIS or UTF-16 SET.def as UTF-8.
         /// </summary>
         /// <remarks>
         /// Synchronous by design: the only caller is <see cref="GetSetDefLabelsByFile"/>, which
@@ -1348,7 +1361,8 @@ namespace DTXMania.Game.Lib.Song
 
             try
             {
-                // Try different encodings for Japanese text support (shared with ReadSetDefLines)
+                // Read with the shared encoding list (see BuildSetDefEncodings for why this is not
+                // a true fallback chain — UTF-8 always "wins" and repair happens in NormalizeSetDefLine).
                 var encodings = BuildSetDefEncodings();
 
                 string[]? lines = null;

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1344,8 +1344,13 @@ namespace DTXMania.Game.Lib.Song
             if (string.IsNullOrEmpty(directory))
                 return result;
 
-            var setDefPath = Path.Combine(directory, "set.def");
-            if (!File.Exists(setDefPath))
+            // The chart referenced by #LnFILE may live in a subdirectory (e.g. "#L1FILE
+            // charts/bas.dtx"), so the caller passes the chart's directory while set.def sits in
+            // the song-folder root one level up. Walk up from the chart's directory until set.def
+            // is found so subdirectory chart references resolve to the correct labels instead of
+            // returning an empty map (which would make the badge fall back to "Level N"/DTX).
+            var setDefPath = FindSetDefPath(directory);
+            if (setDefPath == null)
                 return result;
 
             var lines = ReadSetDefLines(setDefPath);
@@ -1366,6 +1371,29 @@ namespace DTXMania.Game.Lib.Song
                 }
             }
             return result;
+        }
+
+        /// <summary>
+        /// Searches <paramref name="directory"/> and its parent directories (bounded) for a
+        /// <c>set.def</c> file, returning the first match. This lets the database-load path
+        /// recover difficulty labels for charts that live in a subdirectory of the song folder.
+        /// Returns null when no set.def is found within the search depth.
+        /// </summary>
+        private static string? FindSetDefPath(string directory)
+        {
+            var current = directory;
+            for (int depth = 0; depth < 4 && !string.IsNullOrEmpty(current); depth++)
+            {
+                var candidate = Path.Combine(current, "set.def");
+                if (File.Exists(candidate))
+                    return candidate;
+
+                var parent = Path.GetDirectoryName(current);
+                if (parent == null || parent == current)
+                    break;
+                current = parent;
+            }
+            return null;
         }
 
         private async Task<List<SongListNode>> ParseSetDefinitionAsync(string setDefPath, SongListNode? parent, CancellationToken cancellationToken)

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1269,9 +1269,14 @@ namespace DTXMania.Game.Lib.Song
                         else if (command.StartsWith("L") &&
                                  (command.EndsWith("LABEL") || command.EndsWith("FILE")))
                         {
-                            // Extract level number (L1LABEL -> 1, L1FILE -> 1)
+                            // Extract level number (L1LABEL -> 1, L1FILE -> 1).
+                            // Guard the slice length: a malformed command such as "#LABEL"
+                            // (length 5, LABEL suffix 6) would otherwise pass a negative length to
+                            // Substring and crash enumeration with ArgumentOutOfRangeException.
                             int suffixLength = command.EndsWith("LABEL") ? 6 : 5;
-                            if (int.TryParse(command.Substring(1, command.Length - suffixLength), out int level))
+                            int levelTokenLength = command.Length - suffixLength;
+                            if (levelTokenLength > 0 &&
+                                int.TryParse(command.Substring(1, levelTokenLength), out int level))
                             {
                                 if (!difficulties.ContainsKey(level))
                                     difficulties[level] = ("", "");
@@ -1445,7 +1450,14 @@ namespace DTXMania.Game.Lib.Song
                                     // badge without re-reading the SET.def. Legacy databases stored an empty
                                     // label, so GetSetDefLabelsByFile recovers it from disk at load time.
                                     if (!string.IsNullOrEmpty(label))
-                                        diffChart.DifficultyLabel = label;
+                                    {
+                                        // SongChart.DifficultyLabel is [MaxLength(50)]; clamp the
+                                        // raw SET.def value so an unusually long label cannot violate
+                                        // the persisted column contract.
+                                        diffChart.DifficultyLabel = label.Length > 50
+                                            ? label.Substring(0, 50)
+                                            : label;
+                                    }
 
                                     // Add each difficulty to EF Core database if we have the database service
                                     if (_databaseService != null)

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -2635,7 +2635,11 @@ namespace DTXMania.Game.Lib.Song
                     // SET.def when the persisted chart label is empty, so the performance-stage difficulty
                     // badge selects the matching cell instead of always falling back to the DTX cell.
                     // Legacy databases stored an empty SongChart.DifficultyLabel.
-                    var setDefLabels = GetSetDefLabelsByFile(Path.GetDirectoryName(primaryChart.FilePath) ?? "");
+                    // Only hit disk when at least one chart is missing its label — avoids re-reading
+                    // SET.def for every multi-chart song on startup when labels are already persisted.
+                    var setDefLabels = charts.Any(c => string.IsNullOrWhiteSpace(c.DifficultyLabel))
+                        ? GetSetDefLabelsByFile(Path.GetDirectoryName(primaryChart.FilePath) ?? "")
+                        : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
                     int scoreIndex = 0;
                     foreach (var chart in charts.Take(5)) // Limit to 5 difficulties

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1196,6 +1196,130 @@ namespace DTXMania.Game.Lib.Song
             return $"#{parts[0]} {string.Join(" ", parts.Skip(1))}";
         }
 
+        /// <summary>
+        /// Reads a SET.def file, trying the same encodings as enumeration (UTF-8 first, then
+        /// the system default and Shift_JIS). Returns null when the file cannot be read with
+        /// any encoding. NormalizeSetDefLine repairs the BOM/null-byte/spaced artifacts that
+        /// result from reading a Shift_JIS or UTF-16 SET.def as UTF-8.
+        /// </summary>
+        private static string[]? ReadSetDefLines(string setDefPath)
+        {
+            var encodings = new List<Encoding> { Encoding.UTF8, Encoding.Default };
+            try
+            {
+                encodings.Add(Encoding.GetEncoding("Shift_JIS"));
+            }
+            catch (ArgumentException)
+            {
+                Debug.WriteLine("SongManager: Shift_JIS encoding not available for SET.def parsing");
+            }
+
+            foreach (var encoding in encodings)
+            {
+                try
+                {
+                    return File.ReadAllLines(setDefPath, encoding);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"SongManager: Failed to read SET.def with {encoding.EncodingName}: {ex.Message}");
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Parses the #TITLE and #Ln(LABEL|FILE) commands out of SET.def lines into the
+        /// title plus a per-difficulty (label, file) map keyed by the L-slot number. Shared by
+        /// enumeration (ParseSetDefinitionAsync) and the database-load path so the difficulty
+        /// badge can recover the authentic difficulty label from the SET.def.
+        /// </summary>
+        private (string title, Dictionary<int, (string label, string file)> difficulties) ParseSetDefContent(
+            string[] lines, CancellationToken cancellationToken)
+        {
+            string songTitle = "";
+            var difficulties = new Dictionary<int, (string label, string file)>();
+
+            foreach (var line in lines)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var trimmedLine = line.Trim();
+                if (string.IsNullOrEmpty(trimmedLine) || trimmedLine.StartsWith("//"))
+                    continue;
+
+                // Parse SET.def commands with robust parsing for corrupted/spaced text
+                if (trimmedLine.StartsWith("#") || trimmedLine.Contains("#"))
+                {
+                    // Handle both normal and spaced-out command formats
+                    string normalizedLine = NormalizeSetDefLine(trimmedLine);
+
+                    if (string.IsNullOrEmpty(normalizedLine)) continue;
+
+                    var parts = normalizedLine.Split(new char[] { ' ', '\t' }, 2, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2)
+                    {
+                        var command = parts[0].Substring(1).ToUpperInvariant(); // Remove # and convert to uppercase
+                        var value = parts[1].Trim();
+
+                        if (command == "TITLE")
+                        {
+                            songTitle = value;
+                        }
+                        else if (command.StartsWith("L") &&
+                                 (command.EndsWith("LABEL") || command.EndsWith("FILE")))
+                        {
+                            // Extract level number (L1LABEL -> 1, L1FILE -> 1)
+                            int suffixLength = command.EndsWith("LABEL") ? 6 : 5;
+                            if (int.TryParse(command.Substring(1, command.Length - suffixLength), out int level))
+                            {
+                                if (!difficulties.ContainsKey(level))
+                                    difficulties[level] = ("", "");
+
+                                if (command.EndsWith("LABEL"))
+                                    difficulties[level] = (value, difficulties[level].file);
+                                else
+                                    difficulties[level] = (difficulties[level].label, value);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return (songTitle, difficulties);
+        }
+
+        /// <summary>
+        /// Reads the SET.def in <paramref name="directory"/> (if any) and returns a map of
+        /// chart file name (e.g. "bas.dtx", case-insensitive) to its authentic #LnLABEL
+        /// (e.g. "BASIC"). The database-load path uses this to recover difficulty-tier labels
+        /// for the performance-stage difficulty badge when the persisted SongChart.DifficultyLabel
+        /// is empty (legacy databases never stored it). Returns an empty map when there is no
+        /// SET.def or it declares no labelled difficulties.
+        /// </summary>
+        internal Dictionary<string, string> GetSetDefLabelsByFile(string directory)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(directory))
+                return result;
+
+            var setDefPath = Path.Combine(directory, "set.def");
+            if (!File.Exists(setDefPath))
+                return result;
+
+            var lines = ReadSetDefLines(setDefPath);
+            if (lines == null)
+                return result;
+
+            var (_, difficulties) = ParseSetDefContent(lines, CancellationToken.None);
+            foreach (var (label, file) in difficulties.Values)
+            {
+                if (!string.IsNullOrEmpty(file) && !string.IsNullOrEmpty(label))
+                    result[file] = label;
+            }
+            return result;
+        }
+
         private async Task<List<SongListNode>> ParseSetDefinitionAsync(string setDefPath, SongListNode? parent, CancellationToken cancellationToken)
         {
             var results = new List<SongListNode>();
@@ -1242,54 +1366,7 @@ namespace DTXMania.Game.Lib.Song
                 }
 
                 SongListNode? currentSong = null;
-                string songTitle = "";
-                var difficulties = new Dictionary<int, (string label, string file)>();
-
-                foreach (var line in lines)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    var trimmedLine = line.Trim();
-                    if (string.IsNullOrEmpty(trimmedLine) || trimmedLine.StartsWith("//"))
-                        continue;
-
-                    // Parse SET.def commands with robust parsing for corrupted/spaced text
-                    if (trimmedLine.StartsWith("#") || trimmedLine.Contains("#"))
-                    {
-                        // Handle both normal and spaced-out command formats
-                        string normalizedLine = NormalizeSetDefLine(trimmedLine);
-                        
-                        if (string.IsNullOrEmpty(normalizedLine)) continue;
-                        
-                        var parts = normalizedLine.Split(new char[] { ' ', '\t' }, 2, StringSplitOptions.RemoveEmptyEntries);
-                        if (parts.Length >= 2)
-                        {
-                            var command = parts[0].Substring(1).ToUpperInvariant(); // Remove # and convert to uppercase
-                            var value = parts[1].Trim();
-
-                            if (command == "TITLE")
-                            {
-                                songTitle = value;
-                            }
-                            else if (command.StartsWith("L") &&
-                                     (command.EndsWith("LABEL") || command.EndsWith("FILE")))
-                            {
-                                // Extract level number (L1LABEL -> 1, L1FILE -> 1)
-                                int suffixLength = command.EndsWith("LABEL") ? 6 : 5;
-                                if (int.TryParse(command.Substring(1, command.Length - suffixLength), out int level))
-                                {
-                                    if (!difficulties.ContainsKey(level))
-                                        difficulties[level] = ("", "");
-                                    
-                                    if (command.EndsWith("LABEL"))
-                                        difficulties[level] = (value, difficulties[level].file);
-                                    else
-                                        difficulties[level] = (difficulties[level].label, value);
-                                }
-                            }
-                        }
-                    }
-                }
+                var (songTitle, difficulties) = ParseSetDefContent(lines, cancellationToken);
 
                 // Store the SET.def title (may be empty if parsing failed)
                 string setDefTitle = songTitle;
@@ -1362,6 +1439,13 @@ namespace DTXMania.Game.Lib.Song
 
                                     // Set the chart difficulty level from SET.def (L1, L2, L3, L5 etc.)
                                     diffChart.DifficultyLevel = level;
+
+                                    // Persist the SET.def difficulty label (BASIC/ADVANCED/EXTREME/...) on the
+                                    // chart so the database-load path can drive the performance-stage difficulty
+                                    // badge without re-reading the SET.def. Legacy databases stored an empty
+                                    // label, so GetSetDefLabelsByFile recovers it from disk at load time.
+                                    if (!string.IsNullOrEmpty(label))
+                                        diffChart.DifficultyLabel = label;
 
                                     // Add each difficulty to EF Core database if we have the database service
                                     if (_databaseService != null)
@@ -2519,6 +2603,12 @@ namespace DTXMania.Game.Lib.Song
                 // If there are multiple charts, populate the difficulties
                 if (charts.Length > 1)
                 {
+                    // Recover the authentic difficulty-tier labels (BASIC/ADVANCED/EXTREME/...) from the
+                    // SET.def when the persisted chart label is empty, so the performance-stage difficulty
+                    // badge selects the matching cell instead of always falling back to the DTX cell.
+                    // Legacy databases stored an empty SongChart.DifficultyLabel.
+                    var setDefLabels = GetSetDefLabelsByFile(Path.GetDirectoryName(primaryChart.FilePath) ?? "");
+
                     int scoreIndex = 0;
                     foreach (var chart in charts.Take(5)) // Limit to 5 difficulties
                     {
@@ -2544,15 +2634,17 @@ namespace DTXMania.Game.Lib.Song
                             difficultyLevel = chart.BassLevel;
                         }
 
+                        string difficultyLabelText = ResolveDifficultyLabel(chart, setDefLabels, scoreIndex);
+
                         songNode.Scores[scoreIndex] = new DTXMania.Game.Lib.Song.Entities.SongScore
                         {
                             ChartId = chart.Id,
                             Instrument = primaryInstrument,
                             DifficultyLevel = difficultyLevel,
-                            DifficultyLabel = $"Level {scoreIndex + 1}"
+                            DifficultyLabel = difficultyLabelText
                         };
 
-                        songNode.DifficultyLabels[scoreIndex] = $"Level {scoreIndex + 1}";
+                        songNode.DifficultyLabels[scoreIndex] = difficultyLabelText;
                         scoreIndex++;
                     }
                 }
@@ -2567,6 +2659,27 @@ namespace DTXMania.Game.Lib.Song
                 Debug.WriteLine($"SongManager: Error creating song node from database entities: {ex.Message}");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Resolves the difficulty-tier label shown by the performance-stage difficulty badge for a
+        /// chart. Prefers the persisted <see cref="SongChart.DifficultyLabel"/>, then the SET.def
+        /// #LnLABEL recovered by matching the chart's file name (e.g. "bas.dtx" -> "BASIC"), and
+        /// finally a synthetic "Level N" placeholder when no authentic label is available.
+        /// </summary>
+        internal static string ResolveDifficultyLabel(SongChart chart, IReadOnlyDictionary<string, string> setDefLabels, int scoreIndex)
+        {
+            if (!string.IsNullOrWhiteSpace(chart.DifficultyLabel))
+                return chart.DifficultyLabel;
+
+            if (setDefLabels != null && !string.IsNullOrEmpty(chart.FilePath))
+            {
+                var fileName = Path.GetFileName(chart.FilePath);
+                if (setDefLabels.TryGetValue(fileName, out var label) && !string.IsNullOrWhiteSpace(label))
+                    return label;
+            }
+
+            return $"Level {scoreIndex + 1}";
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1356,7 +1356,14 @@ namespace DTXMania.Game.Lib.Song
             foreach (var (label, file) in difficulties.Values)
             {
                 if (!string.IsNullOrEmpty(file) && !string.IsNullOrEmpty(label))
-                    result[file] = label;
+                {
+                    // Normalize to the bare file name. A legacy SET.def may reference a chart via a
+                    // relative path (e.g. "#L1FILE charts/bas.dtx"), but ResolveDifficultyLabel looks
+                    // up by Path.GetFileName(chart.FilePath) ("bas.dtx"). Storing the file name only
+                    // keeps the producer and consumer keys consistent so subdirectory references also
+                    // resolve; plain file names ("bas.dtx") are unaffected by GetFileName.
+                    result[Path.GetFileName(file)] = label;
+                }
             }
             return result;
         }
@@ -2657,7 +2664,18 @@ namespace DTXMania.Game.Lib.Song
                         : new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
                     int scoreIndex = 0;
-                    foreach (var chart in charts.Take(5)) // Limit to 5 difficulties
+                    // Order the charts by the same criteria SongChartHelper.GetCurrentDifficultyChart
+                    // uses to map a difficulty index to a chart (drum charts with a positive level,
+                    // ascending by DrumLevel), so DifficultyLabels[scoreIndex] corresponds to the chart
+                    // selected for that difficulty. Without this, an arbitrary database ordering could
+                    // place an EXTREME chart's label in slot 0 while difficulty 0 loads the BASIC chart,
+                    // making the performance-stage badge show the wrong difficulty cell. Non-drum charts
+                    // (DrumLevel == 0) sort after drum charts, matching the drum-first selection fallback.
+                    var orderedCharts = charts
+                        .OrderBy(c => (c.HasDrumChart && c.DrumLevel > 0) ? 0 : 1)
+                        .ThenBy(c => c.DrumLevel)
+                        .ToArray();
+                    foreach (var chart in orderedCharts.Take(5)) // Limit to 5 difficulties
                     {
                         if (scoreIndex >= songNode.Scores.Length) break;
 

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
@@ -95,9 +95,9 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// Retained for constructor-signature consistency with the sibling performance
         /// components (e.g. <see cref="ComboDisplay"/>, <see cref="GaugeDisplay"/>), which
         /// all accept an <see cref="IResourceManager"/>. This component builds its font
-        /// through the <see cref="ManagedFont"/> factory directly, so the manager is only
-        /// used here for the null-argument guard. Do not remove without updating every
-        /// performance-component constructor call site.
+        /// through the <see cref="ManagedFont"/> factory directly, but also loads the
+        /// <see cref="TexturePath.ScoreNumbers"/> bitmap font via the manager. Do not
+        /// remove without updating every performance-component constructor call site.
         /// </param>
         /// <param name="graphicsDevice">Graphics device used for font rendering.</param>
         public ScoreDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice)

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
@@ -17,8 +17,15 @@ namespace DTXMania.Game.Lib.Stage.Performance
         private readonly GraphicsDevice _graphicsDevice;
         private ManagedFont _scoreFont;
         private ManagedFont _titleFont;
+        private ITexture _scoreNumbersTexture;
         private readonly Vector2 _position;
         private const string TitleText = "SCORE";
+
+        // 7_score numbersGD.png layout (NX CActPerfDrumsScore): ten 36x50 digit cells on the top row,
+        // and the "SCORE" label sprite at (0,50,86,28).
+        private const int DigitCellWidth = 36;
+        private const int DigitCellHeight = 50;
+        private static readonly Rectangle LabelSourceRect = new Rectangle(0, 50, 86, 28);
         private int _currentScore = 0;
         private string _scoreText = "0000000";
         private Color _textColor = Color.White;
@@ -103,7 +110,19 @@ namespace DTXMania.Game.Lib.Stage.Performance
             // Initialize with default score
             Score = 0;
 
-            // Load font
+            // Preferred renderer: the DTXManiaNX 7_score numbersGD.png bitmap font, which places the
+            // digits and "SCORE" label at exact pixel positions. The system font is only a fallback.
+            try
+            {
+                _scoreNumbersTexture = resourceManager.LoadTexture(TexturePath.ScoreNumbers);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ScoreDisplay: Failed to load score numbers texture: {ex.Message}");
+                _scoreNumbersTexture = null;
+            }
+
+            // Load font (used as the fallback when the bitmap is unavailable).
             try
             {
                 LoadFont();
@@ -134,11 +153,22 @@ namespace DTXMania.Game.Lib.Stage.Performance
         /// <param name="spriteBatch">SpriteBatch for drawing</param>
         public void Draw(SpriteBatch spriteBatch)
         {
-            if (_disposed || spriteBatch == null || _scoreFont == null)
+            if (_disposed || spriteBatch == null)
                 return;
 
-            // Draw the "SCORE" title above the digits. The performance background is plain,
-            // so the label must be rendered here (its slot is PerformanceUILayout.Score.LabelPosition).
+            // Preferred: bitmap font, positioned exactly as DTXManiaNX (digits start at
+            // Score.FirstDigitPosition, advancing by DigitSpacing; label sprite at Score.LabelPosition).
+            if (_scoreNumbersTexture != null)
+            {
+                DrawBitmapScore(spriteBatch);
+                return;
+            }
+
+            if (_scoreFont == null)
+                return;
+
+            // Fallback: system font. Draw the "SCORE" title above the digits since the bitmap label
+            // sprite is unavailable here.
             _titleFont?.DrawStringWithShadow(
                 spriteBatch,
                 TitleText,
@@ -157,6 +187,28 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 _shadowColor,
                 _shadowOffset
             );
+        }
+
+        /// <summary>
+        /// Draws the score using the 7_score numbersGD.png bitmap, mirroring DTXManiaNX
+        /// CActPerfDrumsScore: the "SCORE" label sprite followed by seven 36x50 digit cells.
+        /// </summary>
+        private void DrawBitmapScore(SpriteBatch spriteBatch)
+        {
+            // "SCORE" label sprite.
+            _scoreNumbersTexture.Draw(spriteBatch, PerformanceUILayout.Score.LabelPosition, LabelSourceRect);
+
+            var digitPos = PerformanceUILayout.Score.FirstDigitPosition;
+            for (int i = 0; i < _scoreText.Length; i++)
+            {
+                char c = _scoreText[i];
+                if (c >= '0' && c <= '9')
+                {
+                    var source = new Rectangle((c - '0') * DigitCellWidth, 0, DigitCellWidth, DigitCellHeight);
+                    var position = new Vector2(digitPos.X + i * PerformanceUILayout.Score.DigitSpacing, digitPos.Y);
+                    _scoreNumbersTexture.Draw(spriteBatch, position, source);
+                }
+            }
         }
 
         #endregion
@@ -214,6 +266,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
                     _scoreFont = null;
                     _titleFont?.Dispose();
                     _titleFont = null;
+                    _scoreNumbersTexture?.RemoveReference();
+                    _scoreNumbersTexture = null;
                 }
 
                 _disposed = true;

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
@@ -227,22 +227,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
         {
             try
             {
-                // Create a font for score display
-                // Using a larger font size for visibility
-                _scoreFont = ManagedFont.CreateFont(
-                    _graphicsDevice,
-                    "NotoSerifJP",
-                    32,
-                    FontStyle.Bold
-                );
-
-                // Smaller font for the "SCORE" title that sits in the 86x28 label slot above the digits.
-                _titleFont = ManagedFont.CreateFont(
-                    _graphicsDevice,
-                    "NotoSerifJP",
-                    22,
-                    FontStyle.Bold
-                );
+                // Larger font for the score digits, and a smaller font for the "SCORE" title that
+                // sits in the 86x28 label slot above the digits.
+                _scoreFont = CreateScoreFont();
+                _titleFont = CreateTitleFont();
             }
             catch (Exception ex)
             {
@@ -257,6 +245,23 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 throw;
             }
         }
+
+        /// <summary>
+        /// Creates the large digit font. Virtual so tests can inject a controllable factory and
+        /// exercise the partial-initialization failure path of <see cref="LoadFont"/> (the case
+        /// where the score font loads but the title font then throws). Production behavior is
+        /// unchanged.
+        /// </summary>
+        protected virtual ManagedFont CreateScoreFont()
+            => ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 32, FontStyle.Bold);
+
+        /// <summary>
+        /// Creates the smaller "SCORE" label font. Virtual for the same reason as
+        /// <see cref="CreateScoreFont"/>; this is the call whose failure after a successful
+        /// <see cref="CreateScoreFont"/> exercises the leak-prevention dispose in <see cref="LoadFont"/>.
+        /// </summary>
+        protected virtual ManagedFont CreateTitleFont()
+            => ManagedFont.CreateFont(_graphicsDevice, "NotoSerifJP", 22, FontStyle.Bold);
 
         #endregion
 

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
@@ -247,7 +247,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"ScoreDisplay: Failed to load font: {ex.Message}");
+                // If _scoreFont was created before _titleFont threw, dispose it so the fallback
+                // font resource is not leaked on the font-failure path. _titleFont is disposed
+                // defensively too in case a future change assigns it before the failure point.
+                _scoreFont?.Dispose();
                 _scoreFont = null;
+                _titleFont?.Dispose();
                 _titleFont = null;
                 throw;
             }

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
@@ -16,7 +16,9 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         private readonly GraphicsDevice _graphicsDevice;
         private ManagedFont _scoreFont;
+        private ManagedFont _titleFont;
         private readonly Vector2 _position;
+        private const string TitleText = "SCORE";
         private int _currentScore = 0;
         private string _scoreText = "0000000";
         private Color _textColor = Color.White;
@@ -135,6 +137,17 @@ namespace DTXMania.Game.Lib.Stage.Performance
             if (_disposed || spriteBatch == null || _scoreFont == null)
                 return;
 
+            // Draw the "SCORE" title above the digits. The performance background is plain,
+            // so the label must be rendered here (its slot is PerformanceUILayout.Score.LabelPosition).
+            _titleFont?.DrawStringWithShadow(
+                spriteBatch,
+                TitleText,
+                PerformanceUILayout.Score.LabelPosition,
+                _textColor,
+                _shadowColor,
+                _shadowOffset
+            );
+
             // Draw score with shadow effect
             _scoreFont.DrawStringWithShadow(
                 spriteBatch,
@@ -162,11 +175,20 @@ namespace DTXMania.Game.Lib.Stage.Performance
                     32,
                     FontStyle.Bold
                 );
+
+                // Smaller font for the "SCORE" title that sits in the 86x28 label slot above the digits.
+                _titleFont = ManagedFont.CreateFont(
+                    _graphicsDevice,
+                    "NotoSerifJP",
+                    22,
+                    FontStyle.Bold
+                );
             }
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"ScoreDisplay: Failed to load font: {ex.Message}");
                 _scoreFont = null;
+                _titleFont = null;
                 throw;
             }
         }
@@ -190,6 +212,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
                     // Dispose managed resources
                     _scoreFont?.Dispose();
                     _scoreFont = null;
+                    _titleFont?.Dispose();
+                    _titleFont = null;
                 }
 
                 _disposed = true;

--- a/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/ScoreDisplay.cs
@@ -129,7 +129,15 @@ namespace DTXMania.Game.Lib.Stage.Performance
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException("ScoreDisplay could not be initialized because the font could not be loaded.", ex);
+                // The system font is only a fallback for the bitmap score sprite. When the bitmap
+                // loaded successfully the display can render without it, so treat the font as
+                // optional. Only abort construction when neither the bitmap nor the font is
+                // available (Draw() would otherwise have nothing to render).
+                if (_scoreNumbersTexture == null)
+                {
+                    throw new InvalidOperationException(
+                        "ScoreDisplay could not be initialized because the font could not be loaded.", ex);
+                }
             }
         }
 

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -67,9 +67,10 @@ namespace DTXMania.Game.Lib.Stage.Performance
             if (resourceManager == null) throw new ArgumentNullException(nameof(resourceManager));
             _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
             _chart           = chart;
-            // The DB-loaded chart carries no difficulty label (DifficultyLabel is never written and the
-            // DifficultyLabels dict is [NotMapped]), so the per-level badge name is supplied by the caller
-            // from SongListNode.DifficultyLabels[index]. Fall back to the chart's own label if present.
+            // The DB-loaded chart may carry a difficulty label recovered from SET.def by SongManager
+            // (see CreateSongNodeFromDatabaseEntities), but the DifficultyLabels dict is [NotMapped],
+            // so the per-level badge name is supplied by the caller from
+            // SongListNode.DifficultyLabels[index]. Fall back to the chart's own label if present.
             _difficultyLabel = !string.IsNullOrWhiteSpace(difficultyLabel) ? difficultyLabel : chart?.DifficultyLabel;
 
             try

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -67,10 +67,12 @@ namespace DTXMania.Game.Lib.Stage.Performance
             if (resourceManager == null) throw new ArgumentNullException(nameof(resourceManager));
             _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
             _chart           = chart;
-            // The DB-loaded chart may carry a difficulty label recovered from SET.def by SongManager
-            // (see CreateSongNodeFromDatabaseEntities), but the DifficultyLabels dict is [NotMapped],
-            // so the per-level badge name is supplied by the caller from
-            // SongListNode.DifficultyLabels[index]. Fall back to the chart's own label if present.
+            // The per-level badge name (BASIC/ADVANCED/EXTREME/...) lives on the song-select slot
+            // — SongListNode.DifficultyLabels[index], a slot-keyed string[5] — not on the chart
+            // entity. SongChart.DifficultyLabels is a *different*, instrument-keyed dict that is
+            // [NotMapped], so it is not the source here. The caller (PerformanceStage) reads the
+            // slot label and supplies it; see CreateSongNodeFromDatabaseEntities for how it is
+            // recovered from SET.def. Fall back to the chart's own DifficultyLabel if present.
             _difficultyLabel = !string.IsNullOrWhiteSpace(difficultyLabel) ? difficultyLabel : chart?.DifficultyLabel;
 
             try

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -21,6 +21,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         private readonly GraphicsDevice _graphicsDevice;
         private readonly SongChart? _chart;
+        private readonly string? _difficultyLabel;
         private ManagedFont? _font;
         private ITexture? _maxBadgeTexture;
         private ITexture? _smallRateNumbersTexture;
@@ -61,11 +62,15 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
         #region Constructor
 
-        public SkillPanelDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice, SongChart? chart)
+        public SkillPanelDisplay(IResourceManager resourceManager, GraphicsDevice graphicsDevice, SongChart? chart, string? difficultyLabel = null)
         {
             if (resourceManager == null) throw new ArgumentNullException(nameof(resourceManager));
             _graphicsDevice  = graphicsDevice  ?? throw new ArgumentNullException(nameof(graphicsDevice));
             _chart           = chart;
+            // The DB-loaded chart carries no difficulty label (DifficultyLabel is never written and the
+            // DifficultyLabels dict is [NotMapped]), so the per-level badge name is supplied by the caller
+            // from SongListNode.DifficultyLabels[index]. Fall back to the chart's own label if present.
+            _difficultyLabel = !string.IsNullOrWhiteSpace(difficultyLabel) ? difficultyLabel : chart?.DifficultyLabel;
 
             try
             {
@@ -152,7 +157,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 _difficultyPanelTexture.Draw(
                     spriteBatch,
                     new Vector2(iconBounds.X, iconBounds.Y),
-                    GetDifficultyPanelSourceRect(_chart?.DifficultyLabel));
+                    GetDifficultyPanelSourceRect(_difficultyLabel));
             }
 
             string levelText = FormatLevelText(level, levelDec);

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -170,6 +170,19 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 DrawFallbackText(spriteBatch, "%", PerformanceUILayout.SkillPanel.SkillPercent.PercentPosition);
             }
 
+            // Game skill ("曲別SKILL"): the level-weighted skill value NX draws near the bottom of
+            // the panel via tCalculateGameSkillFromPlayingSkill. Without this the panel's SKILL slot
+            // shows no number. Reuses the large rate-number sprite, mirroring NX t大文字表示.
+            string gameSkillText = FormatSkillText(SongScore.CalculateGameSkill(Skill, level, levelDec));
+            if (_largeRateNumbersTexture != null)
+            {
+                DrawLargeRateText(spriteBatch, gameSkillText, PerformanceUILayout.SkillPanel.GameSkill.NumbersPosition);
+            }
+            else
+            {
+                DrawFallbackText(spriteBatch, gameSkillText, PerformanceUILayout.SkillPanel.GameSkill.NumbersPosition);
+            }
+
             DrawJudgementCounts(spriteBatch);
 
             if (ShowMax && _maxBadgeTexture != null)

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.Xna.Framework;
@@ -72,8 +73,14 @@ namespace DTXMania.Game.Lib.Stage.Performance
             // entity. SongChart.DifficultyLabels is a *different*, instrument-keyed dict that is
             // [NotMapped], so it is not the source here. The caller (PerformanceStage) reads the
             // slot label and supplies it; see CreateSongNodeFromDatabaseEntities for how it is
-            // recovered from SET.def. Fall back to the chart's own DifficultyLabel if present.
-            _difficultyLabel = !string.IsNullOrWhiteSpace(difficultyLabel) ? difficultyLabel : chart?.DifficultyLabel;
+            // recovered from SET.def.
+            //
+            // A slot label is only authoritative when it names a real badge tier. For a
+            // single-chart song, SongListNode.CreateSongNode fills the slot with a synthetic
+            // display string ("DRUMS Lv.36") that GetDifficultyPanelSourceRect never matches,
+            // silently falling through to the default DTX cell. In that case prefer the chart's
+            // persisted DifficultyLabel (the authentic SET.def label), which selects the right cell.
+            _difficultyLabel = ResolveBadgeLabel(difficultyLabel, chart?.DifficultyLabel);
 
             try
             {
@@ -237,23 +244,57 @@ namespace DTXMania.Game.Lib.Stage.Performance
         public static Rectangle GetDifficultyPanelSourceRect(string? label)
         {
             const int cell = 60;
-            int row = (label ?? string.Empty).Trim().ToUpperInvariant() switch
-            {
-                "DTX" => 0,
-                "DEBUT" => 1,
-                "NOVICE" => 2,
-                "REGULAR" => 3,
-                "EXPERT" => 4,
-                "MASTER" => 5,
-                "BASIC" => 6,
-                "ADVANCED" => 7,
-                "EXTREME" => 8,
-                "RAW" => 9,
-                "RWS" => 10,
-                "REAL" => 11,
-                _ => 0
-            };
+            int row = DifficultyTierRows.TryGetValue((label ?? string.Empty).Trim(), out var r) ? r : 0;
             return new Rectangle(0, row * cell, cell, cell);
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="label"/> names a real difficulty-tier badge cell
+        /// (DTX, BASIC, ADVANCED, EXTREME, ...). Synthetic song-select labels such as
+        /// "DRUMS Lv.36" return false so the caller can fall back to the chart's persisted
+        /// DifficultyLabel instead of rendering the default DTX cell.
+        /// </summary>
+        public static bool IsKnownDifficultyTier(string? label)
+        {
+            return !string.IsNullOrWhiteSpace(label)
+                && DifficultyTierRows.ContainsKey(label.Trim());
+        }
+
+        /// <summary>
+        /// Shared, case-insensitive table of authentic difficulty-tier names to their row in
+        /// 7_Difficulty.png. Drives both <see cref="GetDifficultyPanelSourceRect"/> and
+        /// <see cref="IsKnownDifficultyTier"/> so a label is classified consistently.
+        /// </summary>
+        private static readonly Dictionary<string, int> DifficultyTierRows =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["DTX"] = 0,
+                ["DEBUT"] = 1,
+                ["NOVICE"] = 2,
+                ["REGULAR"] = 3,
+                ["EXPERT"] = 4,
+                ["MASTER"] = 5,
+                ["BASIC"] = 6,
+                ["ADVANCED"] = 7,
+                ["EXTREME"] = 8,
+                ["RAW"] = 9,
+                ["RWS"] = 10,
+                ["REAL"] = 11,
+            };
+
+        /// <summary>
+        /// Chooses the label that drives the performance-stage difficulty badge. Prefers a slot
+        /// label that names a real badge tier; otherwise falls back to the chart's persisted
+        /// DifficultyLabel (the authentic SET.def label). Keeps the slot label when neither is a
+        /// known tier so a non-empty display string is still rendered as the default DTX cell.
+        /// </summary>
+        private static string? ResolveBadgeLabel(string? slotLabel, string? chartLabel)
+        {
+            if (IsKnownDifficultyTier(slotLabel))
+                return slotLabel;
+            if (!string.IsNullOrWhiteSpace(chartLabel))
+                return chartLabel;
+            return slotLabel;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/SkillPanelDisplay.cs
@@ -27,6 +27,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
         private ITexture? _largeRateNumbersTexture;
         private ITexture? _levelNumbersTexture;
         private ITexture? _ratePercentTexture;
+        private ITexture? _difficultyPanelTexture;
         private bool _disposed;
 
         #endregion
@@ -90,6 +91,7 @@ namespace DTXMania.Game.Lib.Stage.Performance
             _largeRateNumbersTexture = TryLoadTexture(resourceManager, TexturePath.RateNumbersLarge, "large rate numbers");
             _levelNumbersTexture = TryLoadTexture(resourceManager, TexturePath.LevelNumbers, "level numbers");
             _ratePercentTexture = TryLoadTexture(resourceManager, TexturePath.RatePercent, "rate percent");
+            _difficultyPanelTexture = TryLoadTexture(resourceManager, TexturePath.PerformanceDifficultyPanel, "difficulty badge");
         }
 
         #endregion
@@ -140,6 +142,18 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
             int level    = _chart?.DrumLevel    ?? 0;
             int levelDec = _chart?.DrumLevelDec ?? 0;
+
+            // Difficulty badge (7_Difficulty.png). NX draws the 60x60 cell for the chart's difficulty
+            // label at (14 + n本体X, 266 + n本体Y), which equals DifficultyIcon.Bounds. The level number
+            // is drawn on top of it just below.
+            if (_difficultyPanelTexture != null)
+            {
+                var iconBounds = PerformanceUILayout.SkillPanel.DifficultyIcon.Bounds;
+                _difficultyPanelTexture.Draw(
+                    spriteBatch,
+                    new Vector2(iconBounds.X, iconBounds.Y),
+                    GetDifficultyPanelSourceRect(_chart?.DifficultyLabel));
+            }
 
             string levelText = FormatLevelText(level, levelDec);
             if (_levelNumbersTexture != null && CanRenderWithLevelTexture(levelText))
@@ -205,6 +219,33 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 ? level / 100.0
                 : (level / 10.0) + (levelDec / 100.0);
             return actual.ToString("0.00", System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Maps a difficulty label to its 60x60 source cell in 7_Difficulty.png (scene 7 of the
+        /// default Script/difficult.dtxs). All cells share X=0; the label selects the Y offset.
+        /// Unknown/empty labels fall back to the first cell ("DTX"), matching NX's default rect.
+        /// </summary>
+        public static Rectangle GetDifficultyPanelSourceRect(string? label)
+        {
+            const int cell = 60;
+            int row = (label ?? string.Empty).Trim().ToUpperInvariant() switch
+            {
+                "DTX" => 0,
+                "DEBUT" => 1,
+                "NOVICE" => 2,
+                "REGULAR" => 3,
+                "EXPERT" => 4,
+                "MASTER" => 5,
+                "BASIC" => 6,
+                "ADVANCED" => 7,
+                "EXTREME" => 8,
+                "RAW" => 9,
+                "RWS" => 10,
+                "REAL" => 11,
+                _ => 0
+            };
+            return new Rectangle(0, row * cell, cell, cell);
         }
 
         /// <summary>
@@ -405,6 +446,8 @@ namespace DTXMania.Game.Lib.Stage.Performance
                 _levelNumbersTexture = null;
                 _ratePercentTexture?.RemoveReference();
                 _ratePercentTexture = null;
+                _difficultyPanelTexture?.RemoveReference();
+                _difficultyPanelTexture = null;
             }
             _disposed = true;
         }

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -366,7 +366,15 @@ namespace DTXMania.Game.Lib.Stage
             // Skill displays (SkillManager itself is constructed in InitializeGameplayManagers
             // because it needs ComboManager + ChartManager.TotalNotes which arrive later)
             var skillChart = _selectedSong?.GetCurrentDifficultyChart(_selectedDifficulty);
-            _skillPanelDisplay = new SkillPanelDisplay(_resourceManager, graphicsDevice, skillChart);
+            // The difficulty badge name comes from the selected song-select slot (the chart entity has
+            // none once loaded from the DB). This is the same label the song-select panel shows.
+            string? difficultyLabel = null;
+            var labels = _selectedSong?.DifficultyLabels;
+            if (labels != null && _selectedDifficulty >= 0 && _selectedDifficulty < labels.Length)
+            {
+                difficultyLabel = labels[_selectedDifficulty];
+            }
+            _skillPanelDisplay = new SkillPanelDisplay(_resourceManager, graphicsDevice, skillChart, difficultyLabel);
             _skillMeterDisplay = new SkillMeterDisplay(_resourceManager, graphicsDevice);
 
             // Initialize Phase 2 components

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -355,7 +355,7 @@ namespace DTXMania.Game.Lib.UI.Layout
             }
             
             /// <summary>
-            /// Large skill percentage display
+            /// Large skill percentage display (達成率 / achievement rate)
             /// </summary>
             public static class SkillPercent
             {
@@ -363,6 +363,15 @@ namespace DTXMania.Game.Lib.UI.Layout
                 public static readonly Vector2 PercentPosition = new Vector2(239, 537);
                 public static readonly Vector2 MaxBadgePosition = new Vector2(149, 527);
                 public const int DigitWidth = 28;
+            }
+
+            /// <summary>
+            /// Game skill value (曲別SKILL) drawn near the bottom of the panel.
+            /// NX CActPerfDrumsStatusPanel: t大文字表示(88 + n本体X, 363 + n本体Y) with n本体X=22, n本体Y=250.
+            /// </summary>
+            public static class GameSkill
+            {
+                public static readonly Vector2 NumbersPosition = new Vector2(110, 613);
             }
             
             /// <summary>

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -94,6 +94,16 @@ namespace DTXMania.Game.Lib.UI.Layout
             public const int CellRankOffsetY = 25;   // Rank text offset from cell top edge
             public const int CellScoreOffsetY = 40;  // Score text offset from cell top edge
             public const int CellEmptyOffsetY = 10;  // Empty cell text offset from top edge
+
+            // NX-authentic pixel offsets for bitmap content within a difficulty cell.
+            // NX positions content as nBoxX + nPanelW - offset (from the right edge) and
+            // nBoxY + nPanelH - offset (from the bottom edge). These mirror the original
+            // tDrawDifficulty / tDrawAchievementRate coordinates in CActSelectStatus.
+            public const int LevelTextOffsetFromRight = 77;  // tDrawDifficulty X offset
+            public const int LevelTextOffsetFromBottom = 35; // tDrawDifficulty Y offset
+            public const int AchievementRateOffsetFromRight = 157; // tDrawAchievementRate X offset
+            public const int AchievementRateOffsetFromBottom = 27; // tDrawAchievementRate Y offset
+            public const int AchievementMaxOffsetFromRight = 142;  // tx達成率MAX X offset
             
             public static Vector2 BasePosition => new Vector2(BaseX, BaseY);
             public static Vector2 GridPosition => new Vector2(GridX, GridY);

--- a/DTXMania.Test/Song/AchievementRateRoundTripTests.cs
+++ b/DTXMania.Test/Song/AchievementRateRoundTripTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage.Performance;
+using DTXMania.Test.TestData;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Song;
+
+/// <summary>
+/// Integration tests verifying that BestAchievementRate survives the full DB load-back
+/// path: UpdateScoreAsync (PerformanceSummary) → BuildSongListFromDatabasePublicAsync
+/// → CreateSongNodeFromDatabaseEntities → PopulatePlayHistoryFromCharts
+/// → SongListNode.Scores[i].BestAchievementRate.
+/// </summary>
+[Collection("SongManager")]
+[Trait("Category", "Unit")]
+public class AchievementRateRoundTripTests : IDisposable
+{
+    private readonly SongManager _manager;
+    private readonly string _testRoot;
+    private readonly string _testDbPath;
+
+    public AchievementRateRoundTripTests()
+    {
+        SongManager.ResetInstanceForTesting();
+        _manager = SongManager.Instance;
+
+        _testRoot = Path.Combine(
+            Path.GetTempPath(),
+            "DTXManiaCX_Tests",
+            nameof(AchievementRateRoundTripTests),
+            Guid.NewGuid().ToString("N"));
+        _testDbPath = Path.Combine(_testRoot, "songs.db");
+
+        Directory.CreateDirectory(_testRoot);
+    }
+
+    [Fact]
+    public async Task BuildSongListFromDatabasePublicAsync_AfterPerformanceSummary_ShouldLoadBackBestAchievementRate()
+    {
+        // Arrange: create a multi-chart song (two .dtx files with the same title)
+        var songsRoot = Path.Combine(_testRoot, "Songs");
+        var songFolder = Path.Combine(songsRoot, "RoundTrip Song");
+        Directory.CreateDirectory(songFolder);
+
+        const string songTitle = "RoundTrip Song";
+        const string artist = "Test Bot";
+        const string genre = "RoundTrip";
+
+        await CreateDtxFileAsync(Path.Combine(songFolder, "basic.dtx"), songTitle, artist, genre, drumLevel: 30);
+        await CreateDtxFileAsync(Path.Combine(songFolder, "advanced.dtx"), songTitle, artist, genre, drumLevel: 65);
+
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        // Get the chart IDs from the database so we can record a performance
+        var songs = await _manager.DatabaseService!.GetSongsAsync();
+        var song = Assert.Single(songs);
+        Assert.Equal(2, song.Charts.Count);
+
+        var advancedChart = song.Charts.Single(c => c.DrumLevel == 65);
+        Assert.True(advancedChart.Id > 0, "Chart should have a database-assigned Id");
+
+        // Act: record a performance that sets BestAchievementRate via the PerformanceSummary overload.
+        // BestAchievementRate is only written when GameSkill > score.HighSkill (initial HighSkill = 0).
+        const double expectedAchievementRate = 87.53;
+        var summary = new PerformanceSummary
+        {
+            Score = 900_000,
+            PlayingSkill = expectedAchievementRate,
+            GameSkill = 45.0, // > 0 (initial HighSkill), triggers the BestAchievementRate write
+            ClearFlag = true,
+            PerfectCount = 80,
+            GreatCount = 15,
+            GoodCount = 3,
+            PoorCount = 1,
+            MissCount = 1,
+            MaxCombo = 80,
+            TotalNotes = 100
+        };
+
+        var updated = await _manager.UpdateScoreAsync(advancedChart.Id, EInstrumentPart.DRUMS, summary);
+        Assert.True(updated, "UpdateScoreAsync (PerformanceSummary) should succeed");
+
+        // Clear the in-memory song list and rebuild from the database
+        ClearRootSongs();
+        await _manager.BuildSongListFromDatabasePublicAsync(new[] { songsRoot });
+
+        // Assert: the loaded SongListNode should carry the persisted BestAchievementRate
+        var loadedSong = Assert.Single(_manager.RootSongs);
+        Assert.Equal(songTitle, loadedSong.Title);
+
+        // Find the score slot matching the advanced chart (DRUMS, difficulty 65)
+        var advancedScore = loadedSong.Scores.FirstOrDefault(s =>
+            s != null && s.Instrument == EInstrumentPart.DRUMS && s.DifficultyLevel == 65);
+        Assert.NotNull(advancedScore);
+        Assert.Equal(expectedAchievementRate, advancedScore!.BestAchievementRate);
+    }
+
+    [Fact]
+    public async Task BuildSongListFromDatabasePublicAsync_AfterLowerGameSkill_ShouldNotOverwriteBestAchievementRate()
+    {
+        // Arrange: multi-chart song
+        var songsRoot = Path.Combine(_testRoot, "Songs");
+        var songFolder = Path.Combine(songsRoot, "NoOverwrite Song");
+        Directory.CreateDirectory(songFolder);
+
+        const string songTitle = "NoOverwrite Song";
+        const string artist = "Test Bot";
+        const string genre = "NoOverwrite";
+
+        await CreateDtxFileAsync(Path.Combine(songFolder, "basic.dtx"), songTitle, artist, genre, drumLevel: 40);
+        await CreateDtxFileAsync(Path.Combine(songFolder, "advanced.dtx"), songTitle, artist, genre, drumLevel: 70);
+
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        var songs = await _manager.DatabaseService!.GetSongsAsync();
+        var song = Assert.Single(songs);
+        var advancedChart = song.Charts.Single(c => c.DrumLevel == 70);
+
+        // First play: high GameSkill sets BestAchievementRate
+        const double firstRate = 92.10;
+        await _manager.UpdateScoreAsync(advancedChart.Id, EInstrumentPart.DRUMS, new PerformanceSummary
+        {
+            Score = 950_000,
+            PlayingSkill = firstRate,
+            GameSkill = 60.0,
+            ClearFlag = true,
+            TotalNotes = 100
+        });
+
+        // Second play: lower GameSkill should NOT overwrite BestAchievementRate (NX-faithful gate)
+        await _manager.UpdateScoreAsync(advancedChart.Id, EInstrumentPart.DRUMS, new PerformanceSummary
+        {
+            Score = 800_000,
+            PlayingSkill = 50.0,
+            GameSkill = 30.0, // < 60.0 (current HighSkill), so BestAchievementRate stays
+            ClearFlag = true,
+            TotalNotes = 100
+        });
+
+        // Clear and reload from DB
+        ClearRootSongs();
+        await _manager.BuildSongListFromDatabasePublicAsync(new[] { songsRoot });
+
+        // Assert: BestAchievementRate should still be the first (higher) value
+        var loadedSong = Assert.Single(_manager.RootSongs);
+        var advancedScore = loadedSong.Scores.FirstOrDefault(s =>
+            s != null && s.Instrument == EInstrumentPart.DRUMS && s.DifficultyLevel == 70);
+        Assert.NotNull(advancedScore);
+        Assert.Equal(firstRate, advancedScore!.BestAchievementRate);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            SongManager.ResetInstanceForTesting();
+            if (Directory.Exists(_testRoot))
+            {
+                Directory.Delete(_testRoot, true);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup for temp test assets.
+        }
+    }
+
+    #region Helpers
+
+    private async Task InitializeAndEnumerateAsync(string songsRoot)
+    {
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+
+        var result = await _manager.EnumerateSongsAsync(new[] { songsRoot });
+        Assert.True(result >= 1);
+        Assert.NotNull(_manager.DatabaseService);
+    }
+
+    private async Task CreateDtxFileAsync(string path, string title, string artist, string genre, int drumLevel)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        await File.WriteAllTextAsync(path, $"""
+#TITLE: {title}
+#ARTIST: {artist}
+#GENRE: {genre}
+#BPM: 120
+#DLEVEL: {drumLevel}
+#00002:11111111
+#00011:01010101
+""");
+    }
+
+    private void ClearRootSongs()
+    {
+        var rootSongs = ReflectionHelpers.GetPrivateField<List<SongListNode>>(_manager, "_rootSongs");
+        Assert.NotNull(rootSongs);
+        rootSongs!.Clear();
+    }
+
+    #endregion
+}

--- a/DTXMania.Test/Song/SongDatabaseServiceHighSkillTests.cs
+++ b/DTXMania.Test/Song/SongDatabaseServiceHighSkillTests.cs
@@ -108,6 +108,72 @@ namespace DTXMania.Test.Song
             Assert.Equal(162.6, saved.LastSkillPoint, 4);
             Assert.Equal(800000, saved.LastScore);
             Assert.Equal(4, saved.PlayCount);
+            // On a new skill record the achievement rate (達成率 / playing skill) is persisted too,
+            // so the song-select panel shows the actual percentage instead of a stale value.
+            Assert.Equal(92.5, saved.BestAchievementRate, 4);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_NewSkillRecord_ShouldPersistBestAchievementRate()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                HighSkill = 100.0,
+                BestAchievementRate = 60.0,
+                PlayCount = 1
+            });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 850000,
+                ClearFlag = true,
+                PerfectCount = 95,
+                GreatCount = 5,
+                TotalNotes = 100,
+                MaxCombo = 100,
+                PlayingSkill = 96.25,  // new playing-skill best
+                GameSkill = 150.0,     // > stored HighSkill (100) → new skill record
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(150.0, saved.HighSkill, 4);
+            Assert.Equal(96.25, saved.BestAchievementRate, 4);
+        }
+
+        [Fact]
+        public async Task UpdateScoreAsync_GameSkillNotHigher_ShouldPreserveBestAchievementRate()
+        {
+            var chart = await SeedChartAsync();
+            await SeedScoreAsync(chart.Id, new SongScore
+            {
+                HighSkill = 180.0,
+                BestAchievementRate = 95.0,
+                PlayCount = 2
+            });
+
+            var summary = new PerformanceSummary
+            {
+                Score = 500000,
+                ClearFlag = false,
+                PerfectCount = 40,
+                MissCount = 60,
+                TotalNotes = 100,
+                PlayingSkill = 36.0,  // worse playing skill
+                GameSkill = 60.0,     // < stored HighSkill (180) → not a new skill record
+                ChartLevel = 78,
+                ChartLevelDec = 33
+            };
+
+            await _svc.UpdateScoreAsync(chart.Id, EInstrumentPart.DRUMS, summary);
+
+            var saved = await LoadSavedScoreAsync(chart.Id);
+            Assert.Equal(180.0, saved.HighSkill, 4);
+            Assert.Equal(95.0, saved.BestAchievementRate, 4); // preserved, not regressed
         }
 
         [Fact]

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game.Lib.Song;
@@ -557,6 +558,49 @@ public class SongManagerCoverageTests : IDisposable
         var results = await task!;
         
         Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task ParseSetDefinitionAsync_WithUtf16SetDef_ShouldRecoverLabelViaSharedEncodings()
+    {
+        // Both the async enumeration path (ParseSetDefinitionAsync) and the sync database-load
+        // path (ReadSetDefLines -> GetSetDefLabelsByFile) now share BuildSetDefEncodings.
+        // A UTF-16 SET.def read as UTF-8 appears as the spaced "# L 1 L A B E L ..." form that
+        // NormalizeSetDefLine must repair. This locks in the invariant that the async path uses
+        // the same encoding fallback chain as the sync path (which is covered separately in
+        // SongManagerDifficultyLabelTests.GetSetDefLabelsByFile_Utf16SpacedFormat).
+        var setFolder = Path.Combine(_testRoot, "Utf16Set");
+        var setDefPath = Path.Combine(setFolder, "set.def");
+        Directory.CreateDirectory(setFolder);
+
+        var setDefContent =
+            "#TITLE Utf16 Song\r\n" +
+            "#L1LABEL BASIC\r\n#L1FILE bas.dtx\r\n";
+        await File.WriteAllTextAsync(setDefPath, setDefContent, Encoding.Unicode);
+
+        await File.WriteAllTextAsync(Path.Combine(setFolder, "bas.dtx"), """
+#TITLE: Utf16 Song
+#BPM: 140
+#DLEVEL: 50
+#00002:11111111
+""");
+
+        await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+
+        var task = ReflectionHelpers.InvokePrivateMethod<Task<List<SongListNode>>>(
+            _manager,
+            "ParseSetDefinitionAsync",
+            setDefPath,
+            null!,
+            CancellationToken.None);
+
+        Assert.NotNull(task);
+        var results = await task!;
+
+        var node = Assert.Single(results);
+        // The recovered SET.def label proves the UTF-16 file was decoded through the shared
+        // encoding chain and repaired by NormalizeSetDefLine on the async path.
+        Assert.Equal("BASIC", node.DifficultyLabels[0]);
     }
 
     [Fact]

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -671,9 +671,12 @@ public class SongManagerCoverageTests : IDisposable
         var result = ReflectionHelpers.InvokePrivateMethod<SongListNode?>(_manager, "CreateSongNodeFromDatabaseEntities", song, charts);
 
         Assert.NotNull(result);
-        Assert.NotNull(result!.Scores[0]);
-        Assert.Equal(instrument, result.Scores[0]!.Instrument);
-        Assert.Equal(expectedLevel, result.Scores[0].DifficultyLevel);
+        // Charts are ordered drum-first (see CreateSongNodeFromDatabaseEntities), so the string-part
+        // chart sorts after the supporting drum chart. Locate its score by instrument rather than a
+        // fixed index to verify the requested part is still detected with its level.
+        var stringPartScore = result!.Scores.FirstOrDefault(s => s != null && s.Instrument == instrument);
+        Assert.NotNull(stringPartScore);
+        Assert.Equal(expectedLevel, stringPartScore!.DifficultyLevel);
     }
 
     [Fact]
@@ -698,6 +701,38 @@ public class SongManagerCoverageTests : IDisposable
         Assert.NotNull(result);
         Assert.Equal(5, result!.Scores.Count(s => s != null));
         Assert.Equal("Level 5", result.DifficultyLabels[4]);
+    }
+
+    [Fact]
+    public void CreateSongNodeFromDatabaseEntities_DrumChartsReturnedOutOfOrder_ShouldAssignSlotsByAscendingLevel()
+    {
+        // Regression: SongChartHelper.GetCurrentDifficultyChart selects the chart for a given
+        // difficulty by ordering drum charts ascending by DrumLevel. The score slots must be
+        // filled in the same order, otherwise DifficultyLabels[0] can hold the EXTREME chart's
+        // label while difficulty 0 loads the BASIC chart, making the performance-stage badge
+        // show the wrong difficulty cell. Here the database returns EXTREME first.
+        var song = new SongEntity
+        {
+            Title = "Out-of-order Song",
+            Artist = "Coverage Bot",
+            Genre = "Rock"
+        };
+
+        var charts = new[]
+        {
+            new SongChart { FilePath = Path.Combine(_testRoot, "ext.dtx"), HasDrumChart = true, DrumLevel = 90, DifficultyLabel = "" },
+            new SongChart { FilePath = Path.Combine(_testRoot, "bas.dtx"), HasDrumChart = true, DrumLevel = 30, DifficultyLabel = "" },
+            new SongChart { FilePath = Path.Combine(_testRoot, "adv.dtx"), HasDrumChart = true, DrumLevel = 60, DifficultyLabel = "" }
+        };
+
+        var result = ReflectionHelpers.InvokePrivateMethod<SongListNode?>(_manager, "CreateSongNodeFromDatabaseEntities", song, charts);
+
+        Assert.NotNull(result);
+        // Slot ordering must match GetCurrentDifficultyChart: ascending drum level.
+        Assert.Equal(30, result!.Scores[0]!.DifficultyLevel);
+        Assert.Equal(60, result.Scores[1]!.DifficultyLevel);
+        Assert.Equal(90, result.Scores[2]!.DifficultyLevel);
+        Assert.Equal(EInstrumentPart.DRUMS, result.Scores[0]!.Instrument);
     }
 
     [Fact]

--- a/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
+++ b/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Text;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Test.TestData;
 using Xunit;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 
 namespace DTXMania.Test.Song
 {
@@ -257,6 +259,43 @@ namespace DTXMania.Test.Song
             Assert.Equal("BASIC", SongManager.ResolveDifficultyLabel(chart, setDefLabels, 0));
         }
 
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_ChartInSubdirectory_ShouldFindSetDefInParentFolder()
+        {
+            // A legacy SET.def may reference charts in a subdirectory ("#L1FILE charts/bas.dtx").
+            // The DB-load path passes the chart's directory (".../song/charts") to this method, so
+            // it must walk up to the song-folder root to find set.def. Without the walk-up the
+            // label map is empty and the badge falls back to "Level N"/DTX even though SET.def
+            // declares the label.
+            var songDir = CreateTempDirectory();
+            var chartsDir = Path.Combine(songDir, "charts");
+            Directory.CreateDirectory(chartsDir);
+            var content =
+                "#TITLE Subdir song\n" +
+                "#L1LABEL BASIC\n#L1FILE charts/bas.dtx\n" +
+                "#L3LABEL EXTREME\n#L3FILE charts/ext.dtx\n";
+            File.WriteAllText(Path.Combine(songDir, "set.def"), content, Encoding.UTF8);
+
+            // Pass the chart's directory (charts/), not the song root.
+            var labels = _songManager.GetSetDefLabelsByFile(chartsDir);
+
+            Assert.Equal("BASIC", labels["bas.dtx"]);
+            Assert.Equal("EXTREME", labels["ext.dtx"]);
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_NoSetDefAnywhere_ShouldReturnEmpty()
+        {
+            var nestedDir = Path.Combine(CreateTempDirectory(), "deep", "charts");
+            Directory.CreateDirectory(nestedDir);
+
+            var labels = _songManager.GetSetDefLabelsByFile(nestedDir);
+
+            Assert.Empty(labels);
+        }
+
         #endregion
 
         #region Database-load path (normal launch)
@@ -390,6 +429,52 @@ namespace DTXMania.Test.Song
             Assert.NotNull(song);
             Assert.Equal("BASIC", song!.DifficultyLabels[0]);
             Assert.Equal("ADVANCED", song.DifficultyLabels[1]);
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void CreateSongNodeFromDatabaseEntities_ChartsInSubdirectoryWithEmptyLabels_ShouldRecoverFromParentSetDef()
+        {
+            // Reproduces the exact scenario from review: a multi-difficulty SET.def references
+            // charts in a subdirectory ("#L1FILE charts/bas.dtx"), and a legacy database stored
+            // an empty SongChart.DifficultyLabel. primaryChart.FilePath then points inside
+            // "charts/", so the DB-load path used to read "charts/set.def" (missing) instead of
+            // the song-folder "set.def". The directory walk-up must recover the authentic labels
+            // so the performance-stage badge shows BASIC/EXTREME rather than "Level N"/DTX.
+            var songDir = CreateTempDirectory();
+            var chartsDir = Path.Combine(songDir, "charts");
+            Directory.CreateDirectory(chartsDir);
+            var setDefContent =
+                "#TITLE Subdir song\n" +
+                "#L1LABEL BASIC\n#L1FILE charts/bas.dtx\n" +
+                "#L2LABEL EXTREME\n#L2FILE charts/ext.dtx\n";
+            File.WriteAllText(Path.Combine(songDir, "set.def"), setDefContent, Encoding.UTF8);
+
+            var song = new SongEntity { Title = "Subdir song" };
+            var charts = new[]
+            {
+                new SongChart
+                {
+                    FilePath = Path.Combine(chartsDir, "bas.dtx"),
+                    DifficultyLabel = "",   // legacy DB: empty persisted label
+                    HasDrumChart = true,
+                    DrumLevel = 36
+                },
+                new SongChart
+                {
+                    FilePath = Path.Combine(chartsDir, "ext.dtx"),
+                    DifficultyLabel = "",
+                    HasDrumChart = true,
+                    DrumLevel = 74
+                }
+            };
+
+            var result = ReflectionHelpers.InvokePrivateMethod<SongListNode?>(
+                _songManager, "CreateSongNodeFromDatabaseEntities", song, charts);
+
+            Assert.NotNull(result);
+            Assert.Equal("BASIC", result!.DifficultyLabels[0]);
+            Assert.Equal("EXTREME", result.DifficultyLabels[1]);
         }
 
         #endregion

--- a/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
+++ b/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
@@ -388,7 +388,7 @@ namespace DTXMania.Test.Song
 
         [Trait("Category", "Integration")]
         [Fact]
-        public async System.Threading.Tasks.Task BuildSongListFromDatabase_PersistedLabelsSurviveSetDefRemoval()
+        public async System.Threading.Tasks.Task BuildSongListFromDatabase_AfterSetDefRemoval_ShouldRetainPersistedLabels()
         {
             // Contract: once difficulty labels are persisted to the database, the DB-load path
             // (CreateSongNodeFromDatabaseEntities -> ResolveDifficultyLabel) surfaces them without

--- a/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
+++ b/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
@@ -308,6 +308,51 @@ namespace DTXMania.Test.Song
             Assert.Equal(50, persistedChart!.DifficultyLabel.Length);
         }
 
+        [Trait("Category", "Integration")]
+        [Fact]
+        public async System.Threading.Tasks.Task BuildSongListFromDatabase_PersistedLabelsSurviveSetDefRemoval()
+        {
+            // Contract: once difficulty labels are persisted to the database, the DB-load path
+            // (CreateSongNodeFromDatabaseEntities -> ResolveDifficultyLabel) surfaces them without
+            // needing SET.def on disk. This is the user-facing guarantee behind the skip optimization
+            // at SongManager.cs (only read SET.def when a chart label is missing).
+            //
+            // NOTE: this does NOT prove the disk read is skipped — that is a pure performance
+            // optimization that is unobservable behaviorally (the persisted label always wins in
+            // ResolveDifficultyLabel, verified by ResolveDifficultyLabel_PersistedLabelPresent).
+            // The skip is correct by inspection; this test locks in the contract it relies on.
+            var dir = CreateTempDirectory();
+            var setDefContent =
+                "#TITLE Persistence contract\n" +
+                "#L1LABEL BASIC\n#L1FILE bas.dtx\n" +
+                "#L2LABEL ADVANCED\n#L2FILE adv.dtx\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), setDefContent, Encoding.UTF8);
+            File.WriteAllText(Path.Combine(dir, "bas.dtx"), "#TITLE: Persistence contract\n#DLEVEL: 36", Encoding.UTF8);
+            File.WriteAllText(Path.Combine(dir, "adv.dtx"), "#TITLE: Persistence contract\n#DLEVEL: 60", Encoding.UTF8);
+
+            // First launch: enumerate, persisting the recovered labels to the database.
+            await _songManager.InitializeDatabaseServiceAsync(_testDbPath);
+            await _songManager.EnumerateSongsAsync(new[] { dir });
+
+            // Simulate a subsequent launch where SET.def is gone (renamed/moved) but the DB persists.
+            File.Delete(Path.Combine(dir, "set.def"));
+            await _songManager.BuildSongListFromDatabasePublicAsync(new[] { dir });
+
+            SongListNode? song = null;
+            foreach (var node in _songManager.RootSongs)
+            {
+                if (node.Type == NodeType.Score)
+                {
+                    song = node;
+                    break;
+                }
+            }
+
+            Assert.NotNull(song);
+            Assert.Equal("BASIC", song!.DifficultyLabels[0]);
+            Assert.Equal("ADVANCED", song.DifficultyLabels[1]);
+        }
+
         #endregion
     }
 }

--- a/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
+++ b/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
@@ -165,14 +165,16 @@ namespace DTXMania.Test.Song
             // DTXMania SET.def files are commonly UTF-16; read as UTF-8 they appear as the
             // spaced "# L 1 L A B E L   B A S I C" form. NormalizeSetDefLine must repair this so
             // the difficulty badge still resolves. This mirrors the real on-disk file that
-            // exposed the original bug.
+            // exposed the original bug. The L5 label is non-ASCII (Japanese) to verify the
+            // UTF-16 round-trip preserves multibyte characters, not just ASCII tier names.
             var dir = CreateTempDirectory();
             var content =
                 "#TITLE Soukyuu\r\n" +
                 "#L1LABEL BASIC\r\n#L1FILE bas.dtx\r\n" +
                 "#L2LABEL ADVANCED\r\n#L2FILE adv.dtx\r\n" +
                 "#L3LABEL EXTREME\r\n#L3FILE ext.dtx\r\n" +
-                "#L4LABEL MASTER\r\n#L4FILE mas.dtx\r\n";
+                "#L4LABEL MASTER\r\n#L4FILE mas.dtx\r\n" +
+                "#L5LABEL 初級\r\n#L5FILE haj.dtx\r\n";
             File.WriteAllText(Path.Combine(dir, "set.def"), content, Encoding.Unicode);
 
             var labels = _songManager.GetSetDefLabelsByFile(dir);
@@ -181,6 +183,7 @@ namespace DTXMania.Test.Song
             Assert.Equal("ADVANCED", labels["adv.dtx"]);
             Assert.Equal("EXTREME", labels["ext.dtx"]);
             Assert.Equal("MASTER", labels["mas.dtx"]);
+            Assert.Equal("初級", labels["haj.dtx"]);
         }
 
         [Trait("Category", "Unit")]
@@ -192,6 +195,27 @@ namespace DTXMania.Test.Song
             var labels = _songManager.GetSetDefLabelsByFile(dir);
 
             Assert.Empty(labels);
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_MalformedLCommand_ShouldNotThrow()
+        {
+            // A command like "#LABEL" starts with 'L' and ends with "LABEL" but is shorter than
+            // the 6-char LABEL suffix. The level-token slice length is therefore negative and must
+            // be guarded so Substring does not throw ArgumentOutOfRangeException during enumeration.
+            var dir = CreateTempDirectory();
+            var content =
+                "#TITLE Soukyuu\n" +
+                "#LABEL StrayLabel\n" +
+                "#LFILE OrphanFile\n" +
+                "#L1LABEL BASIC\n#L1FILE bas.dtx\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), content, Encoding.UTF8);
+
+            var labels = _songManager.GetSetDefLabelsByFile(dir);
+
+            // The malformed lines are skipped; the well-formed L1 pair still resolves.
+            Assert.Equal("BASIC", labels["bas.dtx"]);
         }
 
         #endregion
@@ -248,6 +272,40 @@ namespace DTXMania.Test.Song
             Assert.Equal("ADVANCED", song.DifficultyLabels[1]);
             Assert.Equal("EXTREME", song.DifficultyLabels[2]);
             Assert.Equal("MASTER", song.DifficultyLabels[3]);
+        }
+
+        [Trait("Category", "Integration")]
+        [Fact]
+        public async System.Threading.Tasks.Task BuildSongListFromDatabase_OverlongDifficultyLabel_ShouldBeClampedToMaxLength()
+        {
+            // SongChart.DifficultyLabel is [MaxLength(50)]. A raw SET.def label longer than that
+            // must be clamped before persistence so the column contract is never violated.
+            var dir = CreateTempDirectory();
+            var overlongLabel = new string('A', 60); // 60 chars > 50
+            var setDefContent =
+                "#TITLE Clamp test\n" +
+                "#L1LABEL " + overlongLabel + "\n#L1FILE bas.dtx\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), setDefContent, Encoding.UTF8);
+            File.WriteAllText(Path.Combine(dir, "bas.dtx"), "#TITLE: Clamp test\n#DLEVEL: 36", Encoding.UTF8);
+
+            await _songManager.InitializeDatabaseServiceAsync(_testDbPath);
+            await _songManager.EnumerateSongsAsync(new[] { dir });
+            await _songManager.BuildSongListFromDatabasePublicAsync(new[] { dir });
+
+            SongListNode? song = null;
+            foreach (var node in _songManager.RootSongs)
+            {
+                if (node.Type == NodeType.Score)
+                {
+                    song = node;
+                    break;
+                }
+            }
+            Assert.NotNull(song);
+
+            var persistedChart = song!.DatabaseChart ?? song.DatabaseSong?.Charts?.FirstOrDefault();
+            Assert.NotNull(persistedChart);
+            Assert.Equal(50, persistedChart!.DifficultyLabel.Length);
         }
 
         #endregion

--- a/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
+++ b/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
@@ -218,6 +218,45 @@ namespace DTXMania.Test.Song
             Assert.Equal("BASIC", labels["bas.dtx"]);
         }
 
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_RelativeSubdirectoryPath_ShouldNormalizeKeyToFileName()
+        {
+            // A legacy SET.def may reference a chart through a relative path such as
+            // "#L1FILE charts/bas.dtx". ResolveDifficultyLabel looks up by
+            // Path.GetFileName(chart.FilePath) ("bas.dtx"), so the label map must be keyed by
+            // the bare file name rather than the raw relative path, otherwise subdirectory
+            // references never match and the badge falls back to "Level N"/DTX.
+            var dir = CreateTempDirectory();
+            var content =
+                "#TITLE Subdir song\n" +
+                "#L1LABEL BASIC\n#L1FILE charts/bas.dtx\n" +
+                "#L3LABEL EXTREME\n#L3FILE charts/ext.dtx\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), content, Encoding.UTF8);
+
+            var labels = _songManager.GetSetDefLabelsByFile(dir);
+
+            Assert.Equal("BASIC", labels["bas.dtx"]);
+            Assert.Equal("EXTREME", labels["ext.dtx"]);
+            Assert.False(labels.ContainsKey("charts/bas.dtx"));
+            Assert.False(labels.ContainsKey("charts/ext.dtx"));
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void ResolveDifficultyLabel_SubDirectoryChartPath_ShouldRecoverByFileName()
+        {
+            // End-to-end: a chart whose FilePath includes a subdirectory ("charts/bas.dtx") must
+            // recover its label from the normalized (file-name-keyed) SET.def map.
+            var chart = new SongChart { FilePath = "/songs/song/charts/bas.dtx", DifficultyLabel = "" };
+            var setDefLabels = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["bas.dtx"] = "BASIC"
+            };
+
+            Assert.Equal("BASIC", SongManager.ResolveDifficultyLabel(chart, setDefLabels, 0));
+        }
+
         #endregion
 
         #region Database-load path (normal launch)

--- a/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
+++ b/DTXMania.Test/Song/SongManagerDifficultyLabelTests.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    /// <summary>
+    /// Verifies the difficulty-tier label resolution that drives the performance-stage difficulty
+    /// badge. Regression guard for the bug where a multi-difficulty song loaded from the database
+    /// showed only the fallback (DTX) badge because the per-difficulty label was synthesized as
+    /// "Level N" instead of the authentic SET.def #LnLABEL (BASIC/ADVANCED/EXTREME/MASTER/REAL).
+    /// </summary>
+    [Collection("SongManager")]
+    public class SongManagerDifficultyLabelTests : IDisposable
+    {
+        private readonly SongManager _songManager;
+        private readonly List<string> _tempDirs = new();
+        private readonly string _testDbPath;
+
+        public SongManagerDifficultyLabelTests()
+        {
+            SongManager.ResetInstanceForTesting();
+            _songManager = SongManager.Instance;
+            _testDbPath = Path.Combine(Path.GetTempPath(), $"test_difflabel_{Guid.NewGuid()}.db");
+        }
+
+        public void Dispose()
+        {
+            foreach (var dir in _tempDirs)
+            {
+                try
+                {
+                    if (Directory.Exists(dir))
+                        Directory.Delete(dir, true);
+                }
+                catch
+                {
+                    // Ignore cleanup errors
+                }
+            }
+            _songManager?.Clear();
+
+            try
+            {
+                if (File.Exists(_testDbPath))
+                    File.Delete(_testDbPath);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+
+        private string CreateTempDirectory()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+            _tempDirs.Add(tempDir);
+            return tempDir;
+        }
+
+        #region ResolveDifficultyLabel
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void ResolveDifficultyLabel_PersistedLabelPresent_ShouldReturnPersistedLabel()
+        {
+            var chart = new SongChart { FilePath = "/songs/song/bas.dtx", DifficultyLabel = "EXTREME" };
+            var setDefLabels = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["bas.dtx"] = "BASIC"
+            };
+
+            // The persisted chart label wins over the SET.def recovery so re-reading the disk is skipped.
+            Assert.Equal("EXTREME", SongManager.ResolveDifficultyLabel(chart, setDefLabels, 0));
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void ResolveDifficultyLabel_EmptyPersistedLabel_ShouldRecoverFromSetDefByFileName()
+        {
+            var chart = new SongChart { FilePath = "/songs/song/adv.dtx", DifficultyLabel = "" };
+            var setDefLabels = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["bas.dtx"] = "BASIC",
+                ["adv.dtx"] = "ADVANCED",
+                ["ext.dtx"] = "EXTREME"
+            };
+
+            // Legacy databases stored an empty label; recover the authentic name by chart file name.
+            Assert.Equal("ADVANCED", SongManager.ResolveDifficultyLabel(chart, setDefLabels, 1));
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void ResolveDifficultyLabel_FileNameCaseDiffers_ShouldRecoverCaseInsensitively()
+        {
+            var chart = new SongChart { FilePath = "/songs/song/MAS.DTX", DifficultyLabel = "   " };
+            var setDefLabels = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["mas.dtx"] = "MASTER"
+            };
+
+            Assert.Equal("MASTER", SongManager.ResolveDifficultyLabel(chart, setDefLabels, 3));
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void ResolveDifficultyLabel_NoMatchAndNoPersistedLabel_ShouldFallBackToLevelN()
+        {
+            var chart = new SongChart { FilePath = "/songs/song/unknown.dtx", DifficultyLabel = "" };
+            var setDefLabels = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["bas.dtx"] = "BASIC"
+            };
+
+            // scoreIndex 2 -> "Level 3" (one-based for display).
+            Assert.Equal("Level 3", SongManager.ResolveDifficultyLabel(chart, setDefLabels, 2));
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void ResolveDifficultyLabel_NullSetDefLabels_ShouldFallBackToLevelN()
+        {
+            var chart = new SongChart { FilePath = "/songs/song/bas.dtx", DifficultyLabel = "" };
+
+            Assert.Equal("Level 1", SongManager.ResolveDifficultyLabel(chart, null!, 0));
+        }
+
+        #endregion
+
+        #region GetSetDefLabelsByFile
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_StandardSetDef_ShouldMapFilesToLabels()
+        {
+            var dir = CreateTempDirectory();
+            var content =
+                "#TITLE Soukyuu e no shouka\n" +
+                "#L1LABEL BASIC\n#L1FILE bas.dtx\n" +
+                "#L2LABEL ADVANCED\n#L2FILE adv.dtx\n" +
+                "#L3LABEL EXTREME\n#L3FILE ext.dtx\n" +
+                "#L4LABEL MASTER\n#L4FILE mas.dtx\n" +
+                "#L5LABEL REAL\n#L5FILE real.dtx\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), content, Encoding.UTF8);
+
+            var labels = _songManager.GetSetDefLabelsByFile(dir);
+
+            Assert.Equal("BASIC", labels["bas.dtx"]);
+            Assert.Equal("ADVANCED", labels["adv.dtx"]);
+            Assert.Equal("EXTREME", labels["ext.dtx"]);
+            Assert.Equal("MASTER", labels["mas.dtx"]);
+            Assert.Equal("REAL", labels["real.dtx"]);
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_Utf16SpacedFormat_ShouldMapFilesToLabels()
+        {
+            // DTXMania SET.def files are commonly UTF-16; read as UTF-8 they appear as the
+            // spaced "# L 1 L A B E L   B A S I C" form. NormalizeSetDefLine must repair this so
+            // the difficulty badge still resolves. This mirrors the real on-disk file that
+            // exposed the original bug.
+            var dir = CreateTempDirectory();
+            var content =
+                "#TITLE Soukyuu\r\n" +
+                "#L1LABEL BASIC\r\n#L1FILE bas.dtx\r\n" +
+                "#L2LABEL ADVANCED\r\n#L2FILE adv.dtx\r\n" +
+                "#L3LABEL EXTREME\r\n#L3FILE ext.dtx\r\n" +
+                "#L4LABEL MASTER\r\n#L4FILE mas.dtx\r\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), content, Encoding.Unicode);
+
+            var labels = _songManager.GetSetDefLabelsByFile(dir);
+
+            Assert.Equal("BASIC", labels["bas.dtx"]);
+            Assert.Equal("ADVANCED", labels["adv.dtx"]);
+            Assert.Equal("EXTREME", labels["ext.dtx"]);
+            Assert.Equal("MASTER", labels["mas.dtx"]);
+        }
+
+        [Trait("Category", "Unit")]
+        [Fact]
+        public void GetSetDefLabelsByFile_NoSetDef_ShouldReturnEmpty()
+        {
+            var dir = CreateTempDirectory();
+
+            var labels = _songManager.GetSetDefLabelsByFile(dir);
+
+            Assert.Empty(labels);
+        }
+
+        #endregion
+
+        #region Database-load path (normal launch)
+
+        [Trait("Category", "Integration")]
+        [Fact]
+        public async System.Threading.Tasks.Task BuildSongListFromDatabase_MultiDifficultySetDef_ShouldExposeRealDifficultyLabels()
+        {
+            // Reproduces the user-facing scenario: a multi-difficulty SET.def song is enumerated,
+            // then re-loaded from the database on the next launch. The per-difficulty labels
+            // surfaced to the performance-stage difficulty badge must be the authentic SET.def
+            // names (BASIC/ADVANCED/EXTREME/MASTER), not the "Level N" placeholder that produced
+            // the always-fallback badge.
+            var dir = CreateTempDirectory();
+            var setDefContent =
+                "#TITLE Soukyuu e no shouka\n" +
+                "#L1LABEL BASIC\n#L1FILE bas.dtx\n" +
+                "#L2LABEL ADVANCED\n#L2FILE adv.dtx\n" +
+                "#L3LABEL EXTREME\n#L3FILE ext.dtx\n" +
+                "#L4LABEL MASTER\n#L4FILE mas.dtx\n";
+            File.WriteAllText(Path.Combine(dir, "set.def"), setDefContent, Encoding.UTF8);
+
+            var files = new[] { "bas", "adv", "ext", "mas" };
+            var levels = new[] { 36, 60, 74, 87 };
+            for (int i = 0; i < files.Length; i++)
+            {
+                File.WriteAllText(
+                    Path.Combine(dir, $"{files[i]}.dtx"),
+                    $"#TITLE: Soukyuu e no shouka\n#DLEVEL: {levels[i]}",
+                    Encoding.UTF8);
+            }
+
+            await _songManager.InitializeDatabaseServiceAsync(_testDbPath);
+            await _songManager.EnumerateSongsAsync(new[] { dir });
+
+            // Force the database-load path used on a normal launch (clears in-memory nodes and
+            // rebuilds them from persisted entities via CreateSongNodeFromDatabaseEntities).
+            await _songManager.BuildSongListFromDatabasePublicAsync(new[] { dir });
+
+            SongListNode? song = null;
+            foreach (var node in _songManager.RootSongs)
+            {
+                if (node.Type == NodeType.Score)
+                {
+                    song = node;
+                    break;
+                }
+            }
+
+            Assert.NotNull(song);
+            Assert.Equal("BASIC", song!.DifficultyLabels[0]);
+            Assert.Equal("ADVANCED", song.DifficultyLabels[1]);
+            Assert.Equal("EXTREME", song.DifficultyLabels[2]);
+            Assert.Equal("MASTER", song.DifficultyLabels[3]);
+        }
+
+        #endregion
+    }
+}

--- a/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
@@ -126,6 +126,29 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Null(GetPrivateField<ManagedFont?>(display, "_scoreFont"));
         }
 
+        [Fact]
+        public void ScoreDisplay_LoadFont_WhenFontFactoryFails_ShouldDisposePartiallyCreatedScoreFont()
+        {
+            // Regression: if _scoreFont exists when a later ManagedFont.CreateFont call throws,
+            // the catch in LoadFont must dispose it rather than only nulling the field, otherwise
+            // the fallback font resource leaks on the font-failure path. We pre-set _scoreFont to a
+            // disposal-tracking font and force the factory to throw on the first CreateFont call.
+            var display = CreateUninitialized<ScoreDisplay>();
+            var scoreFont = CreateTrackingManagedFont();
+            SetPrivateField(display, "_scoreFont", scoreFont);
+
+            WithManagedFontFactoryUnavailable(() =>
+            {
+                var invocation = Assert.Throws<TargetInvocationException>(() =>
+                    InvokePrivateMethod(display, "LoadFont"));
+                // The original font-load failure is wrapped; disposal must happen regardless.
+                Assert.NotNull(invocation.InnerException);
+            });
+
+            Assert.Equal(1, scoreFont.DisposeCount);
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_scoreFont"));
+        }
+
         #endregion
 
         #region ComboDisplay State Tests
@@ -717,6 +740,11 @@ namespace DTXMania.Test.Stage.Performance
             throw new InvalidOperationException($"Field '{fieldName}' not found on {target.GetType().Name}");
         }
 
+        private static void WithManagedFontFactoryUnavailable(Action action)
+        {
+            WithManagedFontFactoryUnavailable(() => { action(); return true; });
+        }
+
         private static T WithManagedFontFactoryUnavailable<T>(Func<T> action)
         {
             var managedFontType = typeof(ManagedFont);
@@ -765,6 +793,13 @@ namespace DTXMania.Test.Stage.Performance
                 type = type.BaseType;
             }
             throw new InvalidOperationException($"Field '{fieldName}' not found on {target.GetType().Name}");
+        }
+
+        private static void InvokePrivateMethod(object target, string methodName)
+        {
+            var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException($"Method '{methodName}' not found on {target.GetType().Name}");
+            method.Invoke(target, null);
         }
 
         private sealed class TrackingManagedFont : ManagedFont

--- a/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
@@ -127,26 +127,32 @@ namespace DTXMania.Test.Stage.Performance
         }
 
         [Fact]
-        public void ScoreDisplay_LoadFont_WhenFontFactoryFails_ShouldDisposePartiallyCreatedScoreFont()
+        public void ScoreDisplay_LoadFont_WhenTitleFontFactoryFails_ShouldDisposePartiallyCreatedScoreFont()
         {
-            // Regression: if _scoreFont exists when a later ManagedFont.CreateFont call throws,
-            // the catch in LoadFont must dispose it rather than only nulling the field, otherwise
-            // the fallback font resource leaks on the font-failure path. We pre-set _scoreFont to a
-            // disposal-tracking font and force the factory to throw on the first CreateFont call.
-            var display = CreateUninitialized<ScoreDisplay>();
+            // Regression for the partial-initialization leak in ScoreDisplay.LoadFont: when the
+            // score font loads but the title font then throws, the catch must dispose the already-
+            // created _scoreFont so the fallback font resource is not leaked. The static
+            // ManagedFont factory caches its SpriteFont and both LoadFont calls resolve to the same
+            // cached asset, so this path cannot be triggered by manipulating factory state; instead
+            // we inject a controllable factory through the protected CreateScoreFont/CreateTitleFont
+            // seams, returning a disposal-tracking font on the score path and throwing on the title
+            // path. Created via FormatterServices so the base constructor (needs a real
+            // GraphicsDevice) never runs.
             var scoreFont = CreateTrackingManagedFont();
-            SetPrivateField(display, "_scoreFont", scoreFont);
+            var display = CreateUninitialized<PartialInitScoreDisplay>();
+            display.ScoreFontToReturn = scoreFont;
 
-            WithManagedFontFactoryUnavailable(() =>
-            {
-                var invocation = Assert.Throws<TargetInvocationException>(() =>
-                    InvokePrivateMethod(display, "LoadFont"));
-                // The original font-load failure is wrapped; disposal must happen regardless.
-                Assert.NotNull(invocation.InnerException);
-            });
+            // LoadFont is private on the base ScoreDisplay; GetMethod on the derived
+            // PartialInitScoreDisplay won't see it (private members aren't inherited), so resolve
+            // it from the declaring type and invoke on the derived instance.
+            var loadFont = typeof(ScoreDisplay).GetMethod("LoadFont", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var invocation = Assert.Throws<TargetInvocationException>(() => loadFont.Invoke(display, null));
+            // The font-load failure is wrapped; disposal must happen regardless.
+            Assert.NotNull(invocation.InnerException);
 
             Assert.Equal(1, scoreFont.DisposeCount);
             Assert.Null(GetPrivateField<ManagedFont?>(display, "_scoreFont"));
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_titleFont"));
         }
 
         #endregion
@@ -830,6 +836,27 @@ namespace DTXMania.Test.Stage.Performance
                 WasDisposed = true;
                 DisposeCount++;
             }
+        }
+
+        /// <summary>
+        /// ScoreDisplay subclass that injects a controllable font factory so the partial-
+        /// initialization path of LoadFont (score font succeeds, title font throws) can be
+        /// exercised. Built via <see cref="CreateUninitialized{T}"/> so the base constructor
+        /// (which needs a real GraphicsDevice) never runs.
+        /// </summary>
+        private sealed class PartialInitScoreDisplay : ScoreDisplay
+        {
+            public TrackingManagedFont? ScoreFontToReturn;
+
+            // FormatterServices.GetUninitializedObject bypasses this ctor entirely, so the null
+            // base args never reach ScoreDisplay's null-checks. The declaration exists only to
+            // satisfy the compiler (the base has no parameterless ctor).
+            private PartialInitScoreDisplay() : base(null!, null!) { }
+
+            protected override ManagedFont CreateScoreFont() => ScoreFontToReturn!;
+
+            protected override ManagedFont CreateTitleFont()
+                => throw new InvalidOperationException("simulated _titleFont load failure");
         }
 
         #endregion

--- a/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
+++ b/DTXMania.Test/Stage/Performance/DisplayComponentStateTests.cs
@@ -108,6 +108,24 @@ namespace DTXMania.Test.Stage.Performance
             Assert.NotNull(ex.InnerException);
         }
 
+        [Fact]
+        public void ScoreDisplay_Constructor_WhenFontFailsButBitmapAvailable_ShouldNotThrow()
+        {
+            // The system font is only a fallback for the bitmap score sprite. When the bitmap
+            // loads successfully, a font-load failure must not abort construction because Draw()
+            // takes the bitmap render path and never touches the font.
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager
+                .Setup(r => r.LoadTexture(TexturePath.ScoreNumbers))
+                .Returns(new Mock<ITexture>().Object);
+
+            using var display = WithManagedFontFactoryUnavailable(() =>
+                new ScoreDisplay(resourceManager.Object, CreateGraphicsDeviceStub()));
+
+            Assert.NotNull(GetPrivateField<ITexture>(display, "_scoreNumbersTexture"));
+            Assert.Null(GetPrivateField<ManagedFont?>(display, "_scoreFont"));
+        }
+
         #endregion
 
         #region ComboDisplay State Tests

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
@@ -73,6 +73,48 @@ namespace DTXMania.Test.Stage.Performance
 
         #endregion
 
+        #region Difficulty Label Resolution
+
+        [Fact]
+        public void Constructor_ExplicitDifficultyLabel_ShouldBeUsedForBadge()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), null, "MASTER"));
+
+            Assert.Equal("MASTER", GetPrivateField<string?>(display, "_difficultyLabel"));
+            display.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_NoExplicitLabel_ShouldFallBackToChartLabel()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var chart = new SongChart { DifficultyLabel = "EXTREME" };
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), chart, null));
+
+            Assert.Equal("EXTREME", GetPrivateField<string?>(display, "_difficultyLabel"));
+            display.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_WhitespaceLabel_ShouldFallBackToChartLabel()
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var chart = new SongChart { DifficultyLabel = "BASIC" };
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), chart, "   "));
+
+            Assert.Equal("BASIC", GetPrivateField<string?>(display, "_difficultyLabel"));
+            display.Dispose();
+        }
+
+        #endregion
+
         #region Update Tests
 
         [Fact]

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayCoverageTests.cs
@@ -113,6 +113,39 @@ namespace DTXMania.Test.Stage.Performance
             display.Dispose();
         }
 
+        [Fact]
+        public void Constructor_SyntheticSlotLabel_ShouldPreferRealChartLabel()
+        {
+            // Regression: a single-chart SET.def song keeps the synthetic "DRUMS Lv.36" slot
+            // label produced by SongListNode.CreateSongNode. That string never matches a badge
+            // cell, so the badge must fall back to the chart's persisted DifficultyLabel
+            // (the authentic SET.def label) instead of rendering the default DTX cell.
+            var resourceManager = new Mock<IResourceManager>();
+            var chart = new SongChart { DifficultyLabel = "BASIC" };
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), chart, "DRUMS Lv.36"));
+
+            Assert.Equal("BASIC", GetPrivateField<string?>(display, "_difficultyLabel"));
+            display.Dispose();
+        }
+
+        [Fact]
+        public void Constructor_SyntheticSlotLabelAndEmptyChartLabel_ShouldKeepSlotLabel()
+        {
+            // When neither the slot label nor the chart label names a real tier, keep the slot
+            // label so a non-empty display string is still rendered as the default DTX cell
+            // rather than collapsing to null.
+            var resourceManager = new Mock<IResourceManager>();
+            var chart = new SongChart { DifficultyLabel = "" };
+
+            var display = WithManagedFontUnavailable(() =>
+                new SkillPanelDisplay(resourceManager.Object, CreateUninitialized<GraphicsDevice>(), chart, "DRUMS Lv.36"));
+
+            Assert.Equal("DRUMS Lv.36", GetPrivateField<string?>(display, "_difficultyLabel"));
+            display.Dispose();
+        }
+
         #endregion
 
         #region Update Tests

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
@@ -1,4 +1,5 @@
 using DTXMania.Game.Lib.Stage.Performance;
+using Microsoft.Xna.Framework;
 using Xunit;
 
 namespace DTXMania.Test.Stage.Performance
@@ -54,6 +55,40 @@ namespace DTXMania.Test.Stage.Performance
         public void FormatJudgementPercent_WithVariousInputs_ShouldReturnThreeColumnPercent(int count, int total, string expected)
         {
             Assert.Equal(expected, SkillPanelDisplay.FormatJudgementPercent(count, total));
+        }
+
+        // Difficulty badge cell selection mirrors Script/difficult.dtxs scene 7 (7_Difficulty.png is a
+        // 60x720 vertical strip of twelve 60x60 cells; all cells share X=0, the label picks the Y row).
+        [Theory]
+        [InlineData("DTX", 0)]
+        [InlineData("DEBUT", 60)]
+        [InlineData("NOVICE", 120)]
+        [InlineData("REGULAR", 180)]
+        [InlineData("EXPERT", 240)]
+        [InlineData("MASTER", 300)]
+        [InlineData("BASIC", 360)]
+        [InlineData("ADVANCED", 420)]
+        [InlineData("EXTREME", 480)]
+        [InlineData("RAW", 540)]
+        [InlineData("RWS", 600)]
+        [InlineData("REAL", 660)]
+        [InlineData("extreme", 480)]   // case-insensitive
+        [InlineData("  MASTER  ", 300)] // trimmed
+        public void GetDifficultyPanelSourceRect_KnownLabels_SelectExpectedCell(string label, int expectedY)
+        {
+            var rect = SkillPanelDisplay.GetDifficultyPanelSourceRect(label);
+            Assert.Equal(new Rectangle(0, expectedY, 60, 60), rect);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("Level 3")]
+        [InlineData("SPECIAL")]
+        public void GetDifficultyPanelSourceRect_UnknownLabel_FallsBackToFirstCell(string? label)
+        {
+            var rect = SkillPanelDisplay.GetDifficultyPanelSourceRect(label);
+            Assert.Equal(new Rectangle(0, 0, 60, 60), rect);
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/SkillPanelDisplayLogicTests.cs
@@ -91,6 +91,33 @@ namespace DTXMania.Test.Stage.Performance
             Assert.Equal(new Rectangle(0, 0, 60, 60), rect);
         }
 
+        [Theory]
+        [InlineData("DTX")]
+        [InlineData("BASIC")]
+        [InlineData("ADVANCED")]
+        [InlineData("EXTREME")]
+        [InlineData("MASTER")]
+        [InlineData("REAL")]
+        [InlineData("extreme")]      // case-insensitive
+        [InlineData("  BASIC  ")]    // trimmed
+        public void IsKnownDifficultyTier_AuthenticTierName_ShouldReturnTrue(string? label)
+        {
+            Assert.True(SkillPanelDisplay.IsKnownDifficultyTier(label));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("DRUMS Lv.36")]   // synthetic song-select display label, not a tier name
+        [InlineData("GUITAR Lv.50")]
+        [InlineData("Level 3")]
+        [InlineData("SPECIAL")]
+        public void IsKnownDifficultyTier_SyntheticOrUnknownLabel_ShouldReturnFalse(string? label)
+        {
+            Assert.False(SkillPanelDisplay.IsKnownDifficultyTier(label));
+        }
+
         [Fact]
         public void GetProcessedJudgementCount_ShouldSumJudgementCounts()
         {

--- a/DTXMania.Test/UI/SongStatusPanelAchievementRateTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelAchievementRateTests.cs
@@ -1,0 +1,68 @@
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    /// <summary>
+    /// Pure-logic tests for <see cref="SongStatusPanel.ClassifyAchievementRate"/>, extracted from
+    /// DrawAchievementRate so the boundary/source-field logic is verifiable without a graphics device.
+    /// Guards the regression this path fixes: the MAX badge must be driven by BestAchievementRate
+    /// (a 0-100 achievement percentage), not HighSkill (a level-weighted skill that routinely
+    /// exceeds 100 and would wrongly show MAX for non-perfect plays).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SongStatusPanelAchievementRateTests
+    {
+        private static SongScore Score(double bestAchievementRate, double highSkill = 0.0) =>
+            new SongScore { BestAchievementRate = bestAchievementRate, HighSkill = highSkill };
+
+        [Fact]
+        public void Classify_NullScore_ReturnsSkip()
+        {
+            Assert.Equal(SongStatusPanel.AchievementRateMode.Skip,
+                SongStatusPanel.ClassifyAchievementRate(null));
+        }
+
+        [Theory]
+        [InlineData(-5)]   // clamps to 0
+        [InlineData(0)]    // NX draws only when non-zero
+        public void Classify_NonPositiveRate_ReturnsSkip(double rate)
+        {
+            Assert.Equal(SongStatusPanel.AchievementRateMode.Skip,
+                SongStatusPanel.ClassifyAchievementRate(Score(rate)));
+        }
+
+        [Theory]
+        [InlineData(0.01)]
+        [InlineData(50.0)]
+        [InlineData(99.99)]
+        public void Classify_PartialRate_ReturnsDigits(double rate)
+        {
+            Assert.Equal(SongStatusPanel.AchievementRateMode.Digits,
+                SongStatusPanel.ClassifyAchievementRate(Score(rate)));
+        }
+
+        [Theory]
+        [InlineData(100.0)]
+        [InlineData(150.0)] // clamps to 100
+        public void Classify_PerfectOrAbove_ReturnsMax(double rate)
+        {
+            Assert.Equal(SongStatusPanel.AchievementRateMode.Max,
+                SongStatusPanel.ClassifyAchievementRate(Score(rate)));
+        }
+
+        [Fact]
+        public void Classify_Regression_SourceIsBestAchievementRateNotHighSkill()
+        {
+            // The bug this guards against: reading HighSkill (level-weighted, often > 100) would
+            // classify a non-perfect 85% play as MAX. With BestAchievementRate=85 the cell must show
+            // Digits even though HighSkill=120 would, if used, force the MAX badge.
+            var score = Score(bestAchievementRate: 85.0, highSkill: 120.0);
+
+            var mode = SongStatusPanel.ClassifyAchievementRate(score);
+
+            Assert.Equal(SongStatusPanel.AchievementRateMode.Digits, mode);
+        }
+    }
+}

--- a/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelLogicTests.cs
@@ -524,22 +524,25 @@ public class SongStatusPanelLogicTests
         var gbKnown = InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 1);
         var gbUnknown = InvokePrivate<Color>(panel, "GetGuitarBassLaneColor", 999);
 
-        Assert.Equal(Color.Orange, drumKnown);
+        // Drum bars reuse the authentic gameplay lane palette (PerformanceUILayout.LaneColors),
+        // so lane 5 (LP/Bass) is the gameplay orange (255,128,0) rather than XNA's Color.Orange.
+        Assert.Equal(new Color(255, 128, 0), drumKnown);
         Assert.Equal(Color.White, drumUnknown);
         Assert.Equal(Color.Green, gbKnown);
         Assert.Equal(Color.White, gbUnknown);
     }
 
     [Theory]
-    [InlineData(0, 128, 0, 128)]
-    [InlineData(1, 255, 255, 0)]
-    [InlineData(2, 128, 0, 128)]
-    [InlineData(3, 255, 0, 0)]
-    [InlineData(4, 0, 0, 255)]
-    [InlineData(5, 255, 165, 0)]
-    [InlineData(6, 0, 0, 255)]
-    [InlineData(7, 0, 128, 0)]
-    [InlineData(8, 0, 255, 255)]
+    [InlineData(0, 160, 64, 255)]   // LC - Purple
+    [InlineData(1, 255, 200, 0)]    // HH - Yellow
+    [InlineData(2, 255, 96, 255)]   // LP(missing) - Magenta
+    [InlineData(3, 255, 64, 64)]    // SD - Red
+    [InlineData(4, 0, 200, 255)]    // HT - Light Blue
+    [InlineData(5, 255, 128, 0)]    // LP (Bass) - Orange
+    [InlineData(6, 0, 128, 255)]    // LT - Blue
+    [InlineData(7, 0, 255, 128)]    // FT - Green
+    [InlineData(8, 255, 100, 200)]  // RC - Pink
+    [InlineData(9, 255, 100, 200)]  // RD - Pink (was White before reusing gameplay palette)
     public void GetDrumLaneColor_MapsCommonNamedLanes(int lane, byte r, byte g, byte b)
     {
         var panel = new SongStatusPanel();

--- a/DTXMania.Test/UI/SongStatusPanelNumberFontTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelNumberFontTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.UI.Layout;
 using Microsoft.Xna.Framework;
 using Xunit;
 
@@ -85,6 +86,36 @@ namespace DTXMania.Test.UI
         public void MeasureBpmNumberWidth_ReturnsTotalAdvanceWidth(string text, int expected)
         {
             Assert.Equal(expected, SongStatusPanel.MeasureBpmNumberWidth(text));
+        }
+
+        private static Color InvokeDrumLaneColor(int lane)
+        {
+            var panel = new SongStatusPanel();
+            var method = typeof(SongStatusPanel).GetMethod(
+                "GetDrumLaneColor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (Color)method!.Invoke(panel, new object[] { lane })!;
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(9)]
+        public void GetDrumLaneColor_MatchesAuthenticGameplayLaneColor(int lane)
+        {
+            // The distribution bars must be colored by lane type using the same palette as the
+            // performance stage (regression guard against the old ad-hoc color table).
+            Assert.Equal(PerformanceUILayout.GetLaneColor(lane), InvokeDrumLaneColor(lane));
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(10)]
+        public void GetDrumLaneColor_OutOfRange_ReturnsWhite(int lane)
+        {
+            Assert.Equal(Color.White, InvokeDrumLaneColor(lane));
         }
     }
 }

--- a/DTXMania.Test/UI/SongStatusPanelNumberFontTests.cs
+++ b/DTXMania.Test/UI/SongStatusPanelNumberFontTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using DTXMania.Game.Lib.Song.Components;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI
+{
+    /// <summary>
+    /// Verifies the DTXManiaNX bitmap-number sprite tables used by the song-select status panel.
+    /// The source rectangles must stay inside the texture bounds and match NX's CActSelectStatusPanel
+    /// layout so numbers render correctly (5_level number.png 250x28, 5_skill number.png 138x20,
+    /// 5_bpm font.png 132x20).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class SongStatusPanelNumberFontTests
+    {
+        private static Rectangle? InvokeRect(string methodName, char c)
+        {
+            var method = typeof(SongStatusPanel).GetMethod(
+                methodName, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (Rectangle?)method!.Invoke(null, new object[] { c });
+        }
+
+        [Theory]
+        [InlineData('0', 0, 20)]
+        [InlineData('9', 180, 20)]
+        [InlineData('.', 200, 10)]
+        [InlineData('-', 210, 20)]
+        [InlineData('?', 230, 20)]
+        public void GetDifficultyNumberRect_KnownChars_MatchNxLayout(char c, int expectedX, int expectedWidth)
+        {
+            var rect = InvokeRect("GetDifficultyNumberRect", c);
+            Assert.True(rect.HasValue);
+            Assert.Equal(expectedX, rect!.Value.X);
+            Assert.Equal(expectedWidth, rect.Value.Width);
+            Assert.Equal(28, rect.Value.Height);
+            Assert.True(rect.Value.Right <= 250, "5_level number.png is 250px wide");
+        }
+
+        [Theory]
+        [InlineData('0', 0, 12)]
+        [InlineData('9', 108, 12)]
+        [InlineData('.', 120, 6)]
+        [InlineData('%', 126, 12)]
+        public void GetAchievementNumberRect_KnownChars_MatchNxLayout(char c, int expectedX, int expectedWidth)
+        {
+            var rect = InvokeRect("GetAchievementNumberRect", c);
+            Assert.True(rect.HasValue);
+            Assert.Equal(expectedX, rect!.Value.X);
+            Assert.Equal(expectedWidth, rect.Value.Width);
+            Assert.Equal(20, rect.Value.Height);
+            Assert.True(rect.Value.Right <= 138, "5_skill number.png is 138px wide");
+        }
+
+        [Theory]
+        [InlineData('0', 0, 12)]
+        [InlineData('9', 108, 12)]
+        [InlineData(':', 123, 6)]
+        public void GetBpmNumberRect_KnownChars_MatchNxLayout(char c, int expectedX, int expectedWidth)
+        {
+            var rect = InvokeRect("GetBpmNumberRect", c);
+            Assert.True(rect.HasValue);
+            Assert.Equal(expectedX, rect!.Value.X);
+            Assert.Equal(expectedWidth, rect.Value.Width);
+            Assert.Equal(20, rect.Value.Height);
+            Assert.True(rect.Value.Right <= 132, "5_bpm font.png is 132px wide");
+        }
+
+        [Theory]
+        [InlineData('A')]
+        [InlineData(' ')]
+        public void GetRect_UnknownChar_ReturnsNull(char c)
+        {
+            Assert.False(InvokeRect("GetDifficultyNumberRect", c).HasValue);
+            Assert.False(InvokeRect("GetAchievementNumberRect", c).HasValue);
+            Assert.False(InvokeRect("GetBpmNumberRect", c).HasValue);
+        }
+
+        [Theory]
+        [InlineData("", 0)]
+        [InlineData("123", 36)]    // 3 digits x 12px
+        [InlineData("1:23", 42)]   // digit(12) + colon(6) + digit(12) + digit(12)
+        [InlineData(" 90", 36)]    // leading space advances 12px so the value right-aligns
+        public void MeasureBpmNumberWidth_ReturnsTotalAdvanceWidth(string text, int expected)
+        {
+            Assert.Equal(expected, SongStatusPanel.MeasureBpmNumberWidth(text));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds DTXManiaNX bitmap number font textures for the song-select status panel, replacing approximate system-font rendering with pixel-aligned sprites.
- Introduces achievement-rate number fonts, the MAX badge, and a BPM/length/total-notes font.
- Adds an NX score bitmap and difficulty badge for the performance stage, persisting the achievement rate so it can be displayed on the status panel.
- Fixes SET.def difficulty-label loading for the database badge and resolves the skill-panel difficulty badge from the selected song slot.

#### Test plan
- [x] Unit tests added for `SongStatusPanel` bitmap number fonts
- [x] `SongManager` difficulty label parsing covered
- [x] `SkillPanelDisplay` logic and coverage tests added
- [x] macOS test suite passes
- [ ] Windows test suite passes
- [ ] E2E smoke passes

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentic bitmap-number rendering across song-select and performance UI (difficulty, achievement rate/MAX, BPM, notes, and score), with pixel-aligned NX positioning.
  * Added a difficulty badge to the performance skill panel with label-aware 60×60 sprite selection and game-skill display.

* **Bug Fixes**
  * Improved difficulty tier label recovery from `set.def`, including more resilient parsing and correct subdirectory filename matching.
  * Ensured best achievement-rate is persisted correctly and not regressed across updates and reloads.
  * Refined panel rendering and lane color behavior for consistent visuals.

* **Tests**
  * Expanded unit/integration and UI coverage for label recovery, achievement-rate logic, bitmap layout, and rendering fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->