### PR TITLE
feat: rebuild config stage with NX master-detail layout

### DIFF
--- a/DTXMania.Game/Lib/Config/ConfigItems.cs
+++ b/DTXMania.Game/Lib/Config/ConfigItems.cs
@@ -9,6 +9,7 @@ namespace DTXMania.Game.Lib.Config
     public abstract class BaseConfigItem : IConfigItem
     {
         public string Name { get; protected set; }
+        public string Description { get; init; } = "";
 
         public event EventHandler ValueChanged;
 

--- a/DTXMania.Game/Lib/Config/IConfigItem.cs
+++ b/DTXMania.Game/Lib/Config/IConfigItem.cs
@@ -14,6 +14,11 @@ namespace DTXMania.Game.Lib.Config
         string Name { get; }
 
         /// <summary>
+        /// Optional one-line help text shown in the config description panel. Empty by default.
+        /// </summary>
+        string Description { get; }
+
+        /// <summary>
         /// Get the current display text for this config item (name + current value)
         /// </summary>
         /// <returns>Display text for the UI list</returns>

--- a/DTXMania.Game/Lib/Config/NavigationConfigItem.cs
+++ b/DTXMania.Game/Lib/Config/NavigationConfigItem.cs
@@ -3,8 +3,11 @@ using System;
 namespace DTXMania.Game.Lib.Config
 {
     /// <summary>
-    /// A config list item that navigates to a sub-panel when activated.
-    /// Left/right arrows and ToggleValue all invoke the same action.
+    /// A config list item that navigates to a sub-panel, a different stage, or runs an
+    /// action when activated. All three action methods (PreviousValue/NextValue/ToggleValue)
+    /// invoke the same callback so the item stays drop-in compatible with value-cycling
+    /// items; however, ConfigStage drives these items from the Activate path only — Left/Right
+    /// are value-adjust keys and must never trigger a stage change or an async import.
     /// </summary>
     public class NavigationConfigItem : BaseConfigItem
     {

--- a/DTXMania.Game/Lib/Config/NavigationConfigItem.cs
+++ b/DTXMania.Game/Lib/Config/NavigationConfigItem.cs
@@ -6,8 +6,11 @@ namespace DTXMania.Game.Lib.Config
     /// A config list item that navigates to a sub-panel, a different stage, or runs an
     /// action when activated. All three action methods (PreviousValue/NextValue/ToggleValue)
     /// invoke the same callback so the item stays drop-in compatible with value-cycling
-    /// items; however, ConfigStage drives these items from the Activate path only — Left/Right
-    /// are value-adjust keys and must never trigger a stage change or an async import.
+    /// items; however, ConfigStage drives these items from the Activate path only — see
+    /// <c>ConfigStage.HandleItemInput</c>, which restricts navigation items to Activate and
+    /// ignores Left/Right. Left/Right are value-adjust keys and must never trigger a stage
+    /// change or an async import. (This restriction lives in the stage, not in the item, so
+    /// it matters only if a second consumer of this item appears.)
     /// </summary>
     public class NavigationConfigItem : BaseConfigItem
     {

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -201,6 +201,36 @@ namespace DTXMania.Game.Lib.Resources
         /// </summary>
         public const string Scrollbar = "Graphics/5_scrollbar.png";
 
+        /// <summary>Config stage background (1280x720).</summary>
+        public const string ConfigBackground = "Graphics/4_background.png";
+
+        /// <summary>Config stage vertical divider between the menu and item columns (18x720, drawn at x=400).</summary>
+        public const string ConfigItemBar = "Graphics/4_item bar.png";
+
+        /// <summary>Config stage left category-menu panel (180x172, drawn at 245,140).</summary>
+        public const string ConfigMenuPanel = "Graphics/4_menu panel.png";
+
+        /// <summary>Config stage category-menu selection cursor.</summary>
+        public const string ConfigMenuCursor = "Graphics/4_menu cursor.png";
+
+        /// <summary>Config stage header panel (1280x105, drawn at 0,0).</summary>
+        public const string ConfigHeaderPanel = "Graphics/4_header panel.png";
+
+        /// <summary>Config stage footer panel (1280x30, drawn at 0,690).</summary>
+        public const string ConfigFooterPanel = "Graphics/4_footer panel.png";
+
+        /// <summary>Config stage normal item-row box.</summary>
+        public const string ConfigItemBox = "Graphics/4_itembox.png";
+
+        /// <summary>Config stage "other" item-row box (navigation/read-only items).</summary>
+        public const string ConfigItemBoxOther = "Graphics/4_itembox other.png";
+
+        /// <summary>Config stage item-row selection cursor.</summary>
+        public const string ConfigItemBoxCursor = "Graphics/4_itembox cursor.png";
+
+        /// <summary>Config stage description panel (280x360, drawn at 800,270).</summary>
+        public const string ConfigDescriptionPanel = "Graphics/4_Description Panel.png";
+
         #endregion
         
         #region Font Textures
@@ -592,7 +622,17 @@ namespace DTXMania.Game.Lib.Resources
                 ChipWave,
                 Bonus,
                 Bonus100,
-                HitFx
+                HitFx,
+                ConfigBackground,
+                ConfigItemBar,
+                ConfigMenuPanel,
+                ConfigMenuCursor,
+                ConfigHeaderPanel,
+                ConfigFooterPanel,
+                ConfigItemBox,
+                ConfigItemBoxOther,
+                ConfigItemBoxCursor,
+                ConfigDescriptionPanel
             };
         }
 
@@ -660,7 +700,16 @@ namespace DTXMania.Game.Lib.Resources
                 BarOther,
                 BarOtherSelected,
                 PreimagePanel,
-                Scrollbar
+                Scrollbar,
+                ConfigItemBar,
+                ConfigMenuPanel,
+                ConfigMenuCursor,
+                ConfigHeaderPanel,
+                ConfigFooterPanel,
+                ConfigItemBox,
+                ConfigItemBoxOther,
+                ConfigItemBoxCursor,
+                ConfigDescriptionPanel
             };
         }
 

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -5,6 +5,7 @@ using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -1155,7 +1156,7 @@ namespace DTXMania.Game.Lib.Song.Components
                 return;
 
             float maxTextWidth = SongSelectionUILayout.SongBars.ArtistNameAbsoluteRightEdge / Math.Max(textScale.X, 0.001f);
-            var displayArtistName = TruncateTextToWidth(artistName, maxTextWidth, _font);
+            var displayArtistName = TextHelper.TruncateToWidth(artistName, maxTextWidth, _font);
             var artistTextSize = _font.MeasureString(displayArtistName);
             var artistPos = CalculateArtistNamePosition(artistTextSize.X * textScale.X);
             var artistColor = Color.LightGray * 0.8f * opacityFactor;
@@ -1171,82 +1172,12 @@ namespace DTXMania.Game.Lib.Song.Components
             if (string.IsNullOrEmpty(artistName) || _managedFont == null)
                 return;
 
-            var displayArtistName = TruncateTextToWidth(artistName, SongSelectionUILayout.SongBars.ArtistNameAbsoluteRightEdge, _managedFont);
+            var displayArtistName = TextHelper.TruncateToWidth(artistName, SongSelectionUILayout.SongBars.ArtistNameAbsoluteRightEdge, _managedFont);
             var artistTextSize = _managedFont.MeasureString(displayArtistName);
             var artistPos = CalculateArtistNamePosition(artistTextSize.X);
             var artistColor = Color.LightGray * 0.8f * opacityFactor;
 
             _managedFont.DrawString(spriteBatch, displayArtistName, artistPos, artistColor);
-        }
-
-        /// <summary>
-        /// Truncate text to fit within specified width using binary search
-        /// </summary>
-        private string TruncateTextToWidth(string text, float maxWidth, SpriteFont font)
-        {
-            if (string.IsNullOrEmpty(text) || font == null)
-                return text;
-
-            if (font.MeasureString(text).X <= maxWidth)
-                return text;
-
-            int left = 0;
-            int right = text.Length;
-            string bestFit = "";
-
-            while (left <= right)
-            {
-                int mid = left + (right - left) / 2;
-                string candidate = text.Substring(0, mid) + "...";
-
-                if (font.MeasureString(candidate).X <= maxWidth)
-                {
-                    bestFit = candidate;
-                    left = mid + 1;
-                }
-                else
-                {
-                    right = mid - 1;
-                }
-            }
-
-            return bestFit;
-        }
-
-        /// <summary>
-        /// Truncate text to fit within specified width using binary search
-        /// </summary>
-        private string TruncateTextToWidth(string text, float maxWidth, IFont font)
-        {
-            if (string.IsNullOrEmpty(text) || font == null)
-                return text;
-
-            // If the full text fits, return it as-is
-            if (font.MeasureString(text).X <= maxWidth)
-                return text;
-
-            // Binary search for the longest text that fits within maxWidth
-            int left = 0;
-            int right = text.Length;
-            string bestFit = "";
-
-            while (left <= right)
-            {
-                int mid = left + (right - left) / 2;
-                string candidate = text.Substring(0, mid) + "...";
-                
-                if (font.MeasureString(candidate).X <= maxWidth)
-                {
-                    bestFit = candidate;
-                    left = mid + 1;
-                }
-                else
-                {
-                    right = mid - 1;
-                }
-            }
-
-            return bestFit;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs
+++ b/DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs
@@ -16,7 +16,20 @@ namespace DTXMania.Game.Lib.Stage.Config
         public string Name { get; }
         public string Description { get; }
         public IReadOnlyList<IConfigItem> Items { get; }
-        public int SelectedIndex { get; set; }
+
+        private int _selectedIndex;
+
+        /// <summary>
+        /// Index of the focused item within <see cref="Items"/>. Clamped on assignment so an
+        /// out-of-range value can never produce a phantom cursor row (the draw layer maps this
+        /// straight to a screen rectangle). Empty categories clamp to 0. <see cref="SelectedItem"/>
+        /// still bounds-checks defensively at read time.
+        /// </summary>
+        public int SelectedIndex
+        {
+            get => _selectedIndex;
+            set => _selectedIndex = Items.Count == 0 ? 0 : Math.Clamp(value, 0, Items.Count - 1);
+        }
 
         /// <summary>
         /// Creates a category. <paramref name="name"/> is the category's identity and must be

--- a/DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs
+++ b/DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs
@@ -1,0 +1,47 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
+
+namespace DTXMania.Game.Lib.Stage.Config
+{
+    /// <summary>
+    /// A left-column category in the NX Config stage: a labeled group of config items plus a
+    /// help description. The Exit category is simply a category with no items
+    /// (<see cref="HasItems"/> == false); no special flag is needed.
+    /// </summary>
+    public sealed class ConfigCategory
+    {
+        public string Name { get; }
+        public string Description { get; }
+        public IReadOnlyList<IConfigItem> Items { get; }
+        public int SelectedIndex { get; set; }
+
+        public ConfigCategory(string name, string description, IReadOnlyList<IConfigItem> items)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Description = description ?? string.Empty;
+            Items = items ?? throw new ArgumentNullException(nameof(items));
+        }
+
+        public bool HasItems => Items.Count > 0;
+
+        public IConfigItem? SelectedItem =>
+            HasItems && SelectedIndex >= 0 && SelectedIndex < Items.Count ? Items[SelectedIndex] : null;
+
+        public void MoveSelectionUp()
+        {
+            if (Items.Count == 0)
+                return;
+            SelectedIndex = (SelectedIndex - 1 + Items.Count) % Items.Count;
+        }
+
+        public void MoveSelectionDown()
+        {
+            if (Items.Count == 0)
+                return;
+            SelectedIndex = (SelectedIndex + 1) % Items.Count;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs
+++ b/DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs
@@ -18,6 +18,20 @@ namespace DTXMania.Game.Lib.Stage.Config
         public IReadOnlyList<IConfigItem> Items { get; }
         public int SelectedIndex { get; set; }
 
+        /// <summary>
+        /// Creates a category. <paramref name="name"/> is the category's identity and must be
+        /// non-null (it is shown in the menu and never blank), so a null name throws. A null
+        /// <paramref name="description"/> is coerced to <see cref="string.Empty"/> instead — the
+        /// description is optional help text, and an empty string degrades gracefully (the panel
+        /// still renders) rather than crashing the caller.
+        /// </summary>
+        /// <param name="name">Category label (required, non-null).</param>
+        /// <param name="description">Help text shown when the category is selected (optional;
+        /// null becomes empty).</param>
+        /// <param name="items">The config items in this category (required, non-null; may be
+        /// empty for an action-only category such as Exit).</param>
+        /// <exception cref="ArgumentNullException"><paramref name="name"/> or
+        /// <paramref name="items"/> is null.</exception>
         public ConfigCategory(string name, string description, IReadOnlyList<IConfigItem> items)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -628,7 +628,7 @@ namespace DTXMania.Game.Lib.Stage
 
         #region Drawing (NX master-detail)
 
-        private void DrawConfigBackground()
+        protected virtual void DrawConfigBackground()
         {
             var viewport = GetViewport();
             var full = new Rectangle(0, 0, viewport.Width, viewport.Height);
@@ -639,7 +639,7 @@ namespace DTXMania.Game.Lib.Stage
                 DrawFilledRectangle(full, FallbackBackgroundColor);
         }
 
-        private void DrawItemBar()
+        protected virtual void DrawItemBar()
         {
             if (_itemBarTexture?.Texture != null)
                 _spriteBatch.Draw(_itemBarTexture.Texture, ConfigUILayout.ItemBarRect, Color.White);
@@ -647,7 +647,7 @@ namespace DTXMania.Game.Lib.Stage
                 DrawFilledRectangle(ConfigUILayout.ItemBarRect, PanelFallbackColor);
         }
 
-        private void DrawCategoryMenu()
+        protected virtual void DrawCategoryMenu()
         {
             if (_categories.Count == 0)
                 return;
@@ -683,7 +683,7 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
-        private void DrawItemList()
+        protected virtual void DrawItemList()
         {
             if (_categories.Count == 0)
                 return;
@@ -732,6 +732,14 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        // Extracts the value portion for the two-column item list by stripping the
+        // "{Name}: " prefix that GetDisplayText() prepends. This is coupled to every
+        // concrete item type's GetDisplayText() format (Dropdown/Toggle/Integer/
+        // ReadOnly all use "$"{Name}: {value}""); a future item type that omits the
+        // prefix would render an empty value here. Adding a GetValueText() to
+        // IConfigItem would decouple this, but that value-semantics change is an
+        // explicit non-goal of the NX layout revamp — so the coupling is documented
+        // here instead.
         private static string GetItemValueText(IConfigItem item)
         {
             if (item is NavigationConfigItem)
@@ -744,7 +752,7 @@ namespace DTXMania.Game.Lib.Stage
                 : string.Empty;
         }
 
-        private void DrawDescriptionPanel()
+        protected virtual void DrawDescriptionPanel()
         {
             if (_categories.Count == 0)
                 return;
@@ -797,7 +805,7 @@ namespace DTXMania.Game.Lib.Stage
                 yield return line.ToString();
         }
 
-        private void DrawHeaderFooter()
+        protected virtual void DrawHeaderFooter()
         {
             if (_headerPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_headerPanelTexture.Texture, ConfigUILayout.HeaderRect, Color.White);

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -4,71 +4,79 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
 using DTXMania.Game.Lib.Stage.KeyAssign;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using DTXMania.Game.Lib.Utilities;
-
 
 namespace DTXMania.Game.Lib.Stage
 {
     /// <summary>
-    /// Configuration stage with basic settings management.
-    /// Reads <see cref="IConfigManager.Config"/> as the single source of truth; every edit
-    /// applies immediately through the typed setters (which live-apply to the runtime via the
-    /// Phase 2 events and mark a deferred save dirty). The Back command (Esc) or the Exit
-    /// button flushes the pending save and leaves — there is no working copy, no
-    /// discard/rollback. Follows DTXMania patterns for config item handling.
+    /// NX-style master-detail configuration stage: a left category menu (System / Drums / Exit),
+    /// a right per-category item list, a description panel, and header/footer panels. Reads
+    /// <see cref="IConfigManager.Config"/> as the single source of truth; every edit applies
+    /// immediately through the typed setters and marks a deferred save dirty. Back/Exit flushes
+    /// the pending save and leaves — there is no working copy. Two focus states mirror the NX
+    /// bFocusIsOnMenu pattern.
     /// </summary>
     public class ConfigStage : BaseStage
     {
         #region Private Fields
 
         private IConfigManager _configManager;
-        private List<IConfigItem> _configItems;
-        private int _selectedIndex = 0;
+        private List<ConfigCategory> _categories = new();
+        private int _currentCategoryIndex = 0;
+        private bool _focusOnMenu = true;
 
-        // Input handling
         private KeyboardState _previousKeyboardState;
         private KeyboardState _currentKeyboardState;
 
-        // Key-assign sub-panels
         private SystemKeyAssignPanel? _systemPanel;
         private IKeyAssignPanel? _activePanel;
 
-        // Graphics resources
         private SpriteBatch _spriteBatch;
         private Texture2D _whitePixel;
         private IFont _font;
         private IFont _boldFont;
         private IResourceManager _resourceManager;
+
         private ITexture? _backgroundTexture;
+        private ITexture? _itemBarTexture;
+        private ITexture? _menuPanelTexture;
+        private ITexture? _menuCursorTexture;
+        private ITexture? _headerPanelTexture;
+        private ITexture? _footerPanelTexture;
+        private ITexture? _itemBoxTexture;
+        private ITexture? _itemBoxOtherTexture;
+        private ITexture? _itemBoxCursorTexture;
+        private ITexture? _descriptionPanelTexture;
 
-        // Dark UI text, for legibility on the bright background image.
-        private static readonly Color DarkText = new(26, 30, 46);
+        // Light text reads on the dark NX config background.
+        private static readonly Color LightText = new(235, 238, 248);
+        private static readonly Color SelectedText = Color.Yellow;
+        private static readonly Color ValueText = new(255, 226, 150);
+        private static readonly Color MenuCursorFallback = new(64, 96, 160, 180);
+        private static readonly Color ItemCursorFallback = new(96, 96, 160, 180);
+        private static readonly Color ImportStatusColor = new(180, 220, 255);
 
-        // Light fallback used when the startup background texture is missing/unavailable, so the
-        // dark UI text stays readable instead of going dark-on-dark.
-        private static readonly Color FallbackBackgroundColor = new(220, 222, 230);
+        // Dark fill behind the UI when the background art is unavailable, so the light text stays
+        // legible (light-on-light was the failure mode to avoid).
+        private static readonly Color FallbackBackgroundColor = new(18, 20, 34);
 
-        // NX score import status
         private volatile string _importStatus = "";
         private volatile bool _importRunning;
         private CancellationTokenSource? _importCts;
-
-        // DTXMania-style constants
-        private const int MenuX = 100;
-        private const int MenuY = 100;
-        private const int MenuItemHeight = 40;
-        private const int MenuItemWidth = 600;
 
         #endregion
 
@@ -90,11 +98,11 @@ namespace DTXMania.Game.Lib.Stage
             System.Diagnostics.Debug.WriteLine("Activating Config Stage");
 
             InitializeGraphics();
-
-            // Config is the single source of truth; reads pull directly from ConfigManager.Config
-            // and the runtime (which mirrors Config). There is no working copy to (re)load.
             SetupConfigItems();
             InitializePanels();
+
+            _currentCategoryIndex = 0;
+            _focusOnMenu = true;
 
             _previousKeyboardState = Keyboard.GetState();
             _currentKeyboardState = Keyboard.GetState();
@@ -121,14 +129,14 @@ namespace DTXMania.Game.Lib.Stage
 
             BeginDrawFrame();
 
-            DrawBackground();
-            DrawTitle();
-            DrawConfigItems();
-            DrawButtons();
+            DrawConfigBackground();
+            DrawItemBar();
+            DrawCategoryMenu();
+            DrawItemList();
+            DrawDescriptionPanel();
+            DrawHeaderFooter();
             DrawImportStatus();
-            DrawInstructions();
 
-            // Draw active panel as overlay within the same sprite batch
             if (_activePanel?.IsActive == true)
             {
                 var vp = GetViewport();
@@ -142,24 +150,18 @@ namespace DTXMania.Game.Lib.Stage
         {
             System.Diagnostics.Debug.WriteLine("Deactivating Config Stage");
 
-            // Persist-on-edit safety net: flush any pending deferred save when leaving the stage.
-            // Back/Exit already flushes; this covers other deactivation paths so an edited Config
-            // is never left dirty in memory only.
             FlushPendingSaveSafely();
 
-            // Cancel any in-flight NX score import so it doesn't continue on a deactivated stage.
             _importCts?.Cancel();
 
             _activePanel?.Deactivate();
             _activePanel = null;
 
-            // Release font references (re-acquired in InitializeGraphics on re-activation)
             _font?.RemoveReference();
             _font = null;
             _boldFont?.RemoveReference();
             _boldFont = null;
-            _backgroundTexture?.RemoveReference();
-            _backgroundTexture = null;
+            ReleaseTextures();
 
             _previousKeyboardState = default;
             _currentKeyboardState = default;
@@ -171,26 +173,22 @@ namespace DTXMania.Game.Lib.Stage
             {
                 System.Diagnostics.Debug.WriteLine("Disposing Config Stage resources");
 
-                // Cancel and dispose import cancellation token
                 _importCts?.Cancel();
                 _importCts?.Dispose();
                 _importCts = null;
 
-                // Cleanup MonoGame resources
                 _whitePixel?.Dispose();
                 _spriteBatch?.Dispose();
 
-                // Release font references if still held (e.g. stage disposed without deactivation)
                 _font?.RemoveReference();
                 _boldFont?.RemoveReference();
-                _backgroundTexture?.RemoveReference();
+                ReleaseTextures();
 
                 _whitePixel = null;
                 _spriteBatch = null;
                 _font = null;
                 _boldFont = null;
-                _backgroundTexture = null;
-                _resourceManager = null; // Do NOT dispose — shared game-wide instance
+                _resourceManager = null; // shared game-wide instance; do NOT dispose
             }
 
             base.Dispose(disposing);
@@ -208,7 +206,6 @@ namespace DTXMania.Game.Lib.Stage
             _whitePixel = new Texture2D(graphicsDevice, 1, 1);
             _whitePixel.SetData(new[] { Color.White });
 
-            // Initialize ResourceManager
             _resourceManager = _game.ResourceManager;
 
             try
@@ -229,23 +226,57 @@ namespace DTXMania.Game.Lib.Stage
                 throw;
             }
 
-            // Background: the bright startup artwork (best-effort; DrawBackground falls back to a
-            // dark fill if it is unavailable).
+            // All skin art is best-effort; every draw is null-guarded with a fill/text fallback.
+            _backgroundTexture = TryLoadTexture(TexturePath.ConfigBackground);
+            _itemBarTexture = TryLoadTexture(TexturePath.ConfigItemBar);
+            _menuPanelTexture = TryLoadTexture(TexturePath.ConfigMenuPanel);
+            _menuCursorTexture = TryLoadTexture(TexturePath.ConfigMenuCursor);
+            _headerPanelTexture = TryLoadTexture(TexturePath.ConfigHeaderPanel);
+            _footerPanelTexture = TryLoadTexture(TexturePath.ConfigFooterPanel);
+            _itemBoxTexture = TryLoadTexture(TexturePath.ConfigItemBox);
+            _itemBoxOtherTexture = TryLoadTexture(TexturePath.ConfigItemBoxOther);
+            _itemBoxCursorTexture = TryLoadTexture(TexturePath.ConfigItemBoxCursor);
+            _descriptionPanelTexture = TryLoadTexture(TexturePath.ConfigDescriptionPanel);
+        }
+
+        private ITexture? TryLoadTexture(string path)
+        {
             try
             {
-                _backgroundTexture = _resourceManager.LoadTexture(TexturePath.StartupBackground);
+                return _resourceManager.LoadTexture(path);
             }
             catch
             {
-                _backgroundTexture = null;
+                return null;
             }
+        }
+
+        private void ReleaseTextures()
+        {
+            _backgroundTexture?.RemoveReference();
+            _backgroundTexture = null;
+            _itemBarTexture?.RemoveReference();
+            _itemBarTexture = null;
+            _menuPanelTexture?.RemoveReference();
+            _menuPanelTexture = null;
+            _menuCursorTexture?.RemoveReference();
+            _menuCursorTexture = null;
+            _headerPanelTexture?.RemoveReference();
+            _headerPanelTexture = null;
+            _footerPanelTexture?.RemoveReference();
+            _footerPanelTexture = null;
+            _itemBoxTexture?.RemoveReference();
+            _itemBoxTexture = null;
+            _itemBoxOtherTexture?.RemoveReference();
+            _itemBoxOtherTexture = null;
+            _itemBoxCursorTexture?.RemoveReference();
+            _itemBoxCursorTexture = null;
+            _descriptionPanelTexture?.RemoveReference();
+            _descriptionPanelTexture = null;
         }
 
         private void SetupConfigItems()
         {
-            _configItems = new List<IConfigItem>();
-
-            // Screen Resolution dropdown
             var resolutionItem = new DropdownConfigItem(
                 "Screen Resolution",
                 () => $"{_configManager.Config.ScreenWidth}x{_configManager.Config.ScreenHeight}",
@@ -256,104 +287,97 @@ namespace DTXMania.Game.Lib.Stage
                     if (parts.Length == 2 && int.TryParse(parts[0], out var width) && int.TryParse(parts[1], out var height))
                     {
                         _configManager.SetResolution(width, height);
-                        System.Diagnostics.Debug.WriteLine($"Resolution changed to {width}x{height}");
                     }
-                }
-            );
+                })
+            { Description = "Sets the game window resolution." };
 
-            // Fullscreen checkbox
             var fullscreenItem = new ToggleConfigItem(
                 "Fullscreen",
                 () => _configManager.Config.FullScreen,
-                value =>
-                {
-                    _configManager.SetFullscreen(value);
-                    System.Diagnostics.Debug.WriteLine($"Fullscreen changed to {value}");
-                }
-            );
+                value => _configManager.SetFullscreen(value))
+            { Description = "Toggles fullscreen display mode." };
 
-            // VSync toggle
             var vsyncItem = new ToggleConfigItem(
                 "VSync Wait",
                 () => _configManager.Config.VSyncWait,
-                value =>
-                {
-                    _configManager.SetVSync(value);
-                    System.Diagnostics.Debug.WriteLine($"VSync changed to {value}");
-                });
-
-            // NoFail toggle
-            var noFailItem = new ToggleConfigItem(
-                "No Fail",
-                () => _configManager.Config.NoFail,
-                value =>
-                {
-                    _configManager.SetNoFail(value);
-                    System.Diagnostics.Debug.WriteLine($"NoFail changed to {value}");
-                });
-
-            // AutoPlay toggle
-            var autoPlayItem = new ToggleConfigItem(
-                "Auto Play",
-                () => _configManager.Config.AutoPlay,
-                value =>
-                {
-                    _configManager.SetAutoPlay(value);
-                    System.Diagnostics.Debug.WriteLine($"AutoPlay changed to {value}");
-                });
-
-            var scrollSpeedItem = new IntegerConfigItem(
-                "Scroll Speed",
-                () => _configManager.Config.ScrollSpeed,
-                value =>
-                {
-                    // SetScrollSpeed snaps+clamps internally and raises ScrollSpeedChanged (which
-                    // the runtime mirrors), so the live-apply that ConfigStage previously bypassed
-                    // now happens here.
-                    _configManager.SetScrollSpeed(AppPaths.GetConfigFilePath(), value);
-                },
-                minValue: ScrollSpeedRange.Min,
-                maxValue: ScrollSpeedRange.Max,
-                step: ScrollSpeedRange.Step,
-                valueFormatter: ScrollSpeedRange.Format);
+                value => _configManager.SetVSync(value))
+            { Description = "Syncs drawing to the monitor refresh rate to reduce tearing." };
 
             var audioLatencyItem = new IntegerConfigItem(
                 "Audio Latency Offset",
                 () => _configManager.Config.AudioLatencyOffsetMs,
-                value =>
-                {
-                    _configManager.SetAudioLatency(value);
-                },
+                value => _configManager.SetAudioLatency(value),
                 minValue: 0,
                 maxValue: 500,
                 step: 10,
-                valueFormatter: v => $"{v} ms");
+                valueFormatter: v => $"{v} ms")
+            { Description = "Shifts audio timing to compensate for output latency." };
 
             var dtxFolderItem = new ReadOnlyConfigItem(
                 "DTX Folder",
-                () => _configManager.Config.DTXPath);
+                () => _configManager.Config.DTXPath)
+            { Description = "Folder scanned for songs and charts (read-only)." };
 
-            _configItems.Add(resolutionItem);
-            _configItems.Add(fullscreenItem);
-            _configItems.Add(vsyncItem);
-            _configItems.Add(noFailItem);
-            _configItems.Add(autoPlayItem);
-            _configItems.Add(scrollSpeedItem);
-            _configItems.Add(audioLatencyItem);
-            _configItems.Add(dtxFolderItem);
+            var systemKeyItem = new NavigationConfigItem("System Key Mapping",
+                () => OpenPanel(_systemPanel))
+            { Description = "Assign keys for menu and system commands." };
 
-            // Drum and system key mapping navigation items
-            _configItems.Add(new NavigationConfigItem("Drum Key Mapping",
-                () => NavigateToDrumConfig()));
-            _configItems.Add(new NavigationConfigItem("System Key Mapping",
-                () => OpenPanel(_systemPanel)));
+            var importItem = new NavigationConfigItem("Import NX Scores",
+                () => StartNxScoreImport())
+            { Description = "Import play counts and scores from a DTXManiaNX database." };
 
-            // NX score import (idempotent best/delta counters; history merged top-5)
-            _configItems.Add(new NavigationConfigItem("Import NX Scores",
-                () => StartNxScoreImport()));
+            var scrollSpeedItem = new IntegerConfigItem(
+                "Scroll Speed",
+                () => _configManager.Config.ScrollSpeed,
+                value => _configManager.SetScrollSpeed(AppPaths.GetConfigFilePath(), value),
+                minValue: ScrollSpeedRange.Min,
+                maxValue: ScrollSpeedRange.Max,
+                step: ScrollSpeedRange.Step,
+                valueFormatter: ScrollSpeedRange.Format)
+            { Description = "Sets how fast notes scroll down the lanes." };
 
-            if (_configItems.Count > 0)
-                _selectedIndex = 0;
+            var autoPlayItem = new ToggleConfigItem(
+                "Auto Play",
+                () => _configManager.Config.AutoPlay,
+                value => _configManager.SetAutoPlay(value))
+            { Description = "Plays the chart automatically without input." };
+
+            var noFailItem = new ToggleConfigItem(
+                "No Fail",
+                () => _configManager.Config.NoFail,
+                value => _configManager.SetNoFail(value))
+            { Description = "Continue playing even when the life gauge is empty." };
+
+            var drumKeyItem = new NavigationConfigItem("Drum Key Mapping",
+                () => NavigateToDrumConfig())
+            { Description = "Assign keys for each drum lane." };
+
+            var systemItems = new List<IConfigItem>
+            {
+                resolutionItem, fullscreenItem, vsyncItem, audioLatencyItem,
+                dtxFolderItem, systemKeyItem, importItem
+            };
+
+            var drumItems = new List<IConfigItem>
+            {
+                scrollSpeedItem, autoPlayItem, noFailItem, drumKeyItem
+            };
+
+            _categories = new List<ConfigCategory>
+            {
+                new ConfigCategory("System",
+                    "System settings: display, audio, file paths, and system key bindings.",
+                    systemItems),
+                new ConfigCategory("Drums",
+                    "Drum gameplay settings and drum pad key bindings.",
+                    drumItems),
+                new ConfigCategory("Exit",
+                    "Save changes and return to the title screen.",
+                    new List<IConfigItem>())
+            };
+
+            _currentCategoryIndex = 0;
+            _focusOnMenu = true;
         }
 
         private void InitializePanels()
@@ -362,9 +386,6 @@ namespace DTXMania.Game.Lib.Stage
                 ?? throw new InvalidOperationException("InputManager not available");
 
             _systemPanel = new SystemKeyAssignPanel(inputManagerCompat);
-            // Providers read the RUNTIME, which always mirrors Config via the Phase 2 events
-            // (ConfigManager.KeyBindingsChanged/SystemKeyBindingsChanged -> InputManagerCompat
-            // reloads). Config is truth, so there is no working copy to read.
             _systemPanel._workingMappingProvider =
                 () => new Dictionary<Keys, InputCommandType>(inputManagerCompat.GetKeyMappingSnapshot());
             _systemPanel._liveDrumBindingsProvider =
@@ -383,11 +404,6 @@ namespace DTXMania.Game.Lib.Stage
             _activePanel.Activate();
         }
 
-        /// <summary>
-        /// Navigates to DrumConfigStage. DrumConfigStage reads ConfigManager as its single source of
-        /// truth (the runtime mirrors Config via the Phase 2 events), so there is no pending handoff
-        /// to forward.
-        /// </summary>
         private void NavigateToDrumConfig()
         {
             ChangeStage(StageType.DrumConfig, new InstantTransition());
@@ -395,9 +411,6 @@ namespace DTXMania.Game.Lib.Stage
 
         private void OnPanelSaved(object? sender, EventArgs e)
         {
-            // Persist-on-edit: the panel's working snapshot is written to Config immediately via the
-            // typed setter, which live-applies to the runtime (SystemKeyBindingsChanged) and marks a
-            // deferred save dirty. Flushed on stage exit.
             if (sender == _systemPanel)
             {
                 _configManager.SetSystemKeyBindings(_systemPanel.GetWorkingMappingSnapshot());
@@ -409,12 +422,6 @@ namespace DTXMania.Game.Lib.Stage
             _activePanel = null;
         }
 
-        /// <summary>
-        /// Starts the NX score import asynchronously. Guarded against re-entry; updates
-        /// <see cref="_importStatus"/> for the live status line. Best scores and counters
-        /// use idempotent max/delta merges (safe to re-run); performance history is merged
-        /// and deduplicated (top 5 kept). No confirmation prompt needed.
-        /// </summary>
         private void StartNxScoreImport()
         {
             if (_importRunning)
@@ -422,16 +429,11 @@ namespace DTXMania.Game.Lib.Stage
             _importRunning = true;
             _importStatus = "Importing NX scores...";
 
-            // Cancel any previous import (e.g. if stage was re-activated).
             _importCts?.Cancel();
             _importCts?.Dispose();
             _importCts = new CancellationTokenSource();
             var token = _importCts.Token;
 
-            // Use a synchronous IProgress<T> so the callback runs inline on the thread
-            // that calls Report(). Progress<T> would post asynchronously to the ThreadPool
-            // (no SynchronizationContext in MonoGame's loop), allowing a stale queued
-            // callback to overwrite the final status after the task completes.
             IProgress<NxImportProgress> progress = new InlineProgress<NxImportProgress>(p =>
             {
                 _importStatus = $"Importing... {p.Imported} imported / {p.Scanned} scanned";
@@ -447,8 +449,6 @@ namespace DTXMania.Game.Lib.Stage
                         : $"Imported {result.Imported} scores ({result.Scanned} charts scanned" +
                           (result.Errors > 0 ? $", {result.Errors} errors)" : ")");
 
-                    // Refresh the in-memory song list so SongSelectionStage sees the
-                    // updated play counts, ranks, etc. without requiring a restart.
                     if (result.Imported > 0)
                     {
                         token.ThrowIfCancellationRequested();
@@ -458,8 +458,6 @@ namespace DTXMania.Game.Lib.Stage
                         }
                         catch (System.Exception ex)
                         {
-                            // Import succeeded; refresh failure is non-fatal — the user
-                            // can restart or re-enter song select to trigger a rebuild.
                             System.Diagnostics.Debug.WriteLine(
                                 $"ConfigStage: NX import succeeded but song list refresh failed: {ex}");
                         }
@@ -488,56 +486,82 @@ namespace DTXMania.Game.Lib.Stage
 
         private void HandleInput()
         {
+            if (_focusOnMenu)
+                HandleMenuInput();
+            else
+                HandleItemInput();
+        }
+
+        private void HandleMenuInput()
+        {
             if (IsConfigNavigationCommandPressed(InputCommandType.Back))
             {
-                // Back = exit: edits are already live+dirty, so flush the pending save and leave.
-                System.Diagnostics.Debug.WriteLine("Config: Returning to Title stage");
-                FlushPendingSaveSafely();
-                ChangeStage(StageType.Title, new CrossfadeTransition(0.3));
+                ExitToTitle();
                 return;
             }
 
-            // Handle navigation
             if (IsConfigNavigationCommandPressed(InputCommandType.MoveUp))
             {
-                _selectedIndex = (_selectedIndex - 1 + _configItems.Count + 1) % (_configItems.Count + 1); // +1 for Exit button
+                _currentCategoryIndex = (_currentCategoryIndex - 1 + _categories.Count) % _categories.Count;
             }
             else if (IsConfigNavigationCommandPressed(InputCommandType.MoveDown))
             {
-                _selectedIndex = (_selectedIndex + 1) % (_configItems.Count + 1); // +1 for Exit button
+                _currentCategoryIndex = (_currentCategoryIndex + 1) % _categories.Count;
             }
 
-            // Handle config item value editing (only for config items, not buttons)
-            if (_selectedIndex < _configItems.Count)
+            if (IsConfigNavigationCommandPressed(InputCommandType.Activate) ||
+                IsConfigNavigationCommandPressed(InputCommandType.MoveRight))
             {
-                var selectedItem = _configItems[_selectedIndex];
+                var category = _categories[_currentCategoryIndex];
+                if (category.HasItems)
+                    _focusOnMenu = false;
+                else
+                    ExitToTitle();
+            }
+        }
 
-                // Left/Right arrows for value editing
-                if (IsConfigNavigationCommandPressed(InputCommandType.MoveLeft))
-                {
-                    selectedItem.PreviousValue();
-                }
-                else if (IsConfigNavigationCommandPressed(InputCommandType.MoveRight))
-                {
-                    selectedItem.NextValue();
-                }
-                else if (IsConfigNavigationCommandPressed(InputCommandType.Activate))
-                {
-                    selectedItem.ToggleValue();
-                }
-            }
-            else
+        private void HandleItemInput()
+        {
+            var category = _categories[_currentCategoryIndex];
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.Back))
             {
-                // Handle button selection (the only button is Exit at buttonIndex 0)
-                if (IsConfigNavigationCommandPressed(InputCommandType.Activate))
-                {
-                    int buttonIndex = _selectedIndex - _configItems.Count;
-                    if (buttonIndex == 0) // Exit button
-                    {
-                        OnExitButtonClicked(null, EventArgs.Empty);
-                    }
-                }
+                _focusOnMenu = true;
+                return;
             }
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.MoveUp))
+            {
+                category.MoveSelectionUp();
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.MoveDown))
+            {
+                category.MoveSelectionDown();
+            }
+
+            var item = category.SelectedItem;
+            if (item == null)
+                return;
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.MoveLeft))
+            {
+                item.PreviousValue();
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.MoveRight))
+            {
+                item.NextValue();
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.Activate))
+            {
+                item.ToggleValue();
+            }
+        }
+
+        private void ExitToTitle()
+        {
+            System.Diagnostics.Debug.WriteLine("Config: Returning to Title stage");
+            FlushPendingSaveSafely();
+            ChangeStage(StageType.Title, new CrossfadeTransition(0.3));
         }
 
         private bool IsConfigNavigationCommandPressed(InputCommandType command)
@@ -545,8 +569,6 @@ namespace DTXMania.Game.Lib.Stage
             if (_game.InputManager?.IsCommandPressed(command) == true)
                 return true;
 
-            // Read the runtime system map (= Config truth; the runtime mirrors Config via the
-            // Phase 2 events). There is no separate navigation snapshot.
             var systemMap = _game.InputManager?.GetKeyMappingSnapshot();
             return systemMap != null && systemMap.Any(kvp =>
                 kvp.Value == command &&
@@ -567,22 +589,6 @@ namespace DTXMania.Game.Lib.Stage
 
         #region Event Handlers
 
-        private void OnExitButtonClicked(object sender, EventArgs e)
-        {
-            // Edits are already live+dirty; Exit just flushes to disk and leaves.
-            System.Diagnostics.Debug.WriteLine("Exit button clicked - returning to Title stage");
-            FlushPendingSaveSafely();
-            ChangeStage(StageType.Title, new CrossfadeTransition(0.3));
-        }
-
-        /// <summary>
-        /// Flushes the pending deferred save, swallowing disk failures so a save error can never
-        /// trap the user on the config screen. Under persist-on-edit (Decision A), a flush failure
-        /// is logged and the dirty flag is retained for retry on the next flush; the stage always
-        /// proceeds to leave. <see cref="ConfigManager.FlushPendingSave"/> already swallows
-        /// internally, but this guards against a custom <see cref="IConfigManager"/> whose
-        /// FlushPendingSave propagates.
-        /// </summary>
         private void FlushPendingSaveSafely()
         {
             try
@@ -597,107 +603,183 @@ namespace DTXMania.Game.Lib.Stage
 
         #endregion
 
-        #region Drawing (DTXMania Style)
+        #region Drawing (NX master-detail)
 
-        private void DrawBackground()
+        private void DrawConfigBackground()
         {
             var viewport = GetViewport();
             var full = new Rectangle(0, 0, viewport.Width, viewport.Height);
 
-            // Bright startup artwork, calmed by a translucent light scrim so the dark text reads;
-            // a light fill covers the case where the texture could not be loaded, keeping DarkText
-            // legible instead of going dark-on-dark.
             if (_backgroundTexture?.Texture != null)
-            {
                 _spriteBatch.Draw(_backgroundTexture.Texture, full, Color.White);
-                // Premultiplied light scrim (Color.White * a scales RGB and alpha together) so it
-                // reads as a ~25% white wash under the default premultiplied AlphaBlend, not a wipe.
-                _spriteBatch.Draw(_whitePixel, full, Color.White * 0.25f);
-            }
             else
-            {
                 DrawFilledRectangle(full, FallbackBackgroundColor);
-            }
         }
 
-        private void DrawTitle()
+        private void DrawItemBar()
         {
-            const string titleText = "CONFIGURATION";
-            int x = MenuX;
-            int y = 50;
+            if (_itemBarTexture?.Texture != null)
+                _spriteBatch.Draw(_itemBarTexture.Texture, ConfigUILayout.ItemBarRect, Color.White);
+        }
 
-            if (_font != null)
+        private void DrawCategoryMenu()
+        {
+            if (_menuPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_menuPanelTexture.Texture, ConfigUILayout.MenuPanelRect, Color.White);
+
+            var cursorRect = ConfigUILayout.MenuCursorRect(_currentCategoryIndex);
+            if (_menuCursorTexture?.Texture != null)
             {
-                // Center the title
-                var textSize = _font.MeasureString(titleText);
-                x = (1280 - (int)textSize.X) / 2; // Assume 1280 width for centering
-                _font.DrawString(_spriteBatch, titleText, new Vector2(x, y), DarkText);
+                var tint = _focusOnMenu ? Color.White : new Color(255, 255, 255, 128);
+                _spriteBatch.Draw(_menuCursorTexture.Texture, cursorRect, tint);
             }
             else
             {
-                // Fallback to rectangle
-                DrawTextRect(x, y, titleText.Length * 12, 20, DarkText);
+                DrawFilledRectangle(cursorRect, MenuCursorFallback);
+            }
+
+            if (_font == null || _boldFont == null)
+                return;
+
+            for (int i = 0; i < _categories.Count; i++)
+            {
+                bool selected = i == _currentCategoryIndex;
+                var font = selected ? _boldFont : _font;
+                var color = selected ? SelectedText : LightText;
+                var label = _categories[i].Name;
+                var size = font.MeasureString(label);
+                var pos = new Vector2(ConfigUILayout.MenuLabelCenterX - size.X / 2f, ConfigUILayout.MenuRowY(i));
+                font.DrawString(_spriteBatch, label, pos, color);
             }
         }
 
-        private void DrawConfigItems()
+        private void DrawItemList()
         {
-            int x = MenuX;
-            int y = MenuY;
+            if (_categories.Count == 0)
+                return;
 
-            for (int i = 0; i < _configItems.Count; i++)
+            var category = _categories[_currentCategoryIndex];
+            var items = category.Items;
+
+            for (int row = 0; row < items.Count; row++)
             {
-                var item = _configItems[i];
-                var displayText = item.GetDisplayText();
-                bool isSelected = (i == _selectedIndex);
+                var box = (items[row] is NavigationConfigItem || items[row] is ReadOnlyConfigItem)
+                    ? _itemBoxOtherTexture
+                    : _itemBoxTexture;
+                if (box?.Texture != null)
+                    _spriteBatch.Draw(box.Texture, ConfigUILayout.ItemRowRect(row), Color.White);
+            }
 
-                // Draw selection background
-                if (isSelected)
+            if (!_focusOnMenu && category.HasItems)
+            {
+                var cursorRect = ConfigUILayout.ItemCursorRect(category.SelectedIndex);
+                if (_itemBoxCursorTexture?.Texture != null)
+                    _spriteBatch.Draw(_itemBoxCursorTexture.Texture, cursorRect, Color.White);
+                else
+                    DrawFilledRectangle(cursorRect, ItemCursorFallback);
+            }
+
+            if (_font == null || _boldFont == null)
+                return;
+
+            for (int row = 0; row < items.Count; row++)
+            {
+                var item = items[row];
+                bool selected = !_focusOnMenu && row == category.SelectedIndex;
+                var font = selected ? _boldFont : _font;
+
+                font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(row),
+                    selected ? SelectedText : LightText);
+
+                var value = GetItemValueText(item);
+                if (!string.IsNullOrEmpty(value))
                 {
-                    DrawTextRect(x - 5, y - 2, MenuItemWidth + 10, MenuItemHeight, new Color(64, 64, 128, 150));
+                    font.DrawString(_spriteBatch, value, ConfigUILayout.ItemValuePos(row),
+                        selected ? SelectedText : ValueText);
                 }
+            }
+        }
 
-                // Draw text
-                if (_font != null)
+        private static string GetItemValueText(IConfigItem item)
+        {
+            if (item is NavigationConfigItem)
+                return ">";
+
+            var text = item.GetDisplayText();
+            var prefix = item.Name + ": ";
+            return text.StartsWith(prefix, StringComparison.Ordinal)
+                ? text.Substring(prefix.Length)
+                : string.Empty;
+        }
+
+        private void DrawDescriptionPanel()
+        {
+            if (_categories.Count == 0)
+                return;
+
+            var category = _categories[_currentCategoryIndex];
+            string text = _focusOnMenu
+                ? category.Description
+                : (category.SelectedItem?.Description ?? string.Empty);
+
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            if (_descriptionPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_descriptionPanelTexture.Texture, ConfigUILayout.DescriptionPanelRect, Color.White);
+
+            if (_font == null)
+                return;
+
+            var pos = ConfigUILayout.DescriptionTextPos;
+            foreach (var line in WrapText(_font, text, ConfigUILayout.DescriptionWrapWidth))
+            {
+                _font.DrawString(_spriteBatch, line, pos, LightText);
+                pos.Y += ConfigUILayout.DescriptionLineHeight;
+            }
+        }
+
+        private static IEnumerable<string> WrapText(IFont font, string text, int maxWidth)
+        {
+            var line = new StringBuilder();
+            foreach (var word in text.Split(' '))
+            {
+                var candidate = line.Length == 0 ? word : line + " " + word;
+                if (line.Length > 0 && font.MeasureString(candidate).X > maxWidth)
                 {
-                    var textColor = isSelected ? Color.Yellow : DarkText;
-                    var font = isSelected ? _boldFont : _font;
-                    font.DrawString(_spriteBatch, displayText, new Vector2(x, y + 10), textColor);
+                    yield return line.ToString();
+                    line.Clear();
+                    line.Append(word);
                 }
                 else
                 {
-                    // Fallback to rectangle
-                    var color = isSelected ? Color.Yellow : DarkText;
-                    DrawTextRect(x, y + 10, displayText.Length * 8, 16, color);
+                    if (line.Length > 0)
+                        line.Append(' ');
+                    line.Append(word);
                 }
-
-                y += MenuItemHeight;
             }
+            if (line.Length > 0)
+                yield return line.ToString();
         }
 
-        private void DrawButtons()
+        private void DrawHeaderFooter()
         {
-            int x = MenuX;
-            int y = MenuY + (_configItems.Count * MenuItemHeight) + 20;
-
-            // Exit button (the sole action button; persist-on-edit removed the save/discard split)
-            bool exitSelected = (_selectedIndex == _configItems.Count);
-            if (exitSelected)
-            {
-                DrawTextRect(x - 5, y - 2, 120, 30, new Color(64, 96, 64, 150));
-            }
+            if (_headerPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_headerPanelTexture.Texture, ConfigUILayout.HeaderRect, Color.White);
 
             if (_font != null)
             {
-                var textColor = exitSelected ? Color.Yellow : DarkText;
-                var font = exitSelected ? _boldFont : _font;
-                font.DrawString(_spriteBatch, "EXIT", new Vector2(x, y + 5), textColor);
+                const string title = "CONFIGURATION";
+                var size = _font.MeasureString(title);
+                var pos = new Vector2((ConfigUILayout.ScreenWidth - size.X) / 2f, ConfigUILayout.TitleY);
+                _font.DrawString(_spriteBatch, title, pos, LightText);
             }
-            else
-            {
-                var color = exitSelected ? Color.Yellow : Color.Green;
-                DrawTextRect(x, y + 5, 32, 16, color);
-            }
+
+            if (_footerPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_footerPanelTexture.Texture, ConfigUILayout.FooterRect, Color.White);
+
+            if (_font != null)
+                _font.DrawString(_spriteBatch, ConfigUILayout.InstructionsText, ConfigUILayout.InstructionsPos, LightText);
         }
 
         private void DrawImportStatus()
@@ -705,37 +787,7 @@ namespace DTXMania.Game.Lib.Stage
             if (string.IsNullOrEmpty(_importStatus) || _font == null)
                 return;
 
-            int x = MenuX;
-            int y = MenuY + (_configItems.Count * MenuItemHeight) + 60;
-            _font.DrawString(_spriteBatch, _importStatus, new Vector2(x, y), new Color(18, 64, 132));
-        }
-
-        private void DrawInstructions()
-        {
-            // Persist-on-edit: changes are applied live and saved automatically, so ESC exits
-            // (flushing any pending save) rather than discarding edits. Saying "cancel" here would
-            // mislead users into expecting their changes to be reverted on exit.
-            const string instructions = "Use UP/DOWN to navigate, LEFT/RIGHT to change values, ENTER to select, ESC to exit (changes save automatically)";
-            int x = 10;
-            int y = 720 - 30; // Bottom of screen
-
-            if (_font != null)
-            {
-                _font.DrawString(_spriteBatch, instructions, new Vector2(x, y), DarkText);
-            }
-            else
-            {
-                // Fallback to rectangle
-                DrawTextRect(x, y, instructions.Length * 6, 12, DarkText);
-            }
-        }
-
-        private void DrawTextRect(int x, int y, int width, int height, Color color)
-        {
-            if (_whitePixel != null)
-            {
-                DrawFilledRectangle(new Rectangle(x, y, width, height), color);
-            }
+            _font.DrawString(_spriteBatch, _importStatus, ConfigUILayout.ImportStatusPos, ImportStatusColor);
         }
 
         [ExcludeFromCodeCoverage]
@@ -768,10 +820,8 @@ namespace DTXMania.Game.Lib.Stage
         #endregion
 
         /// <summary>
-        /// Synchronous <see cref="IProgress{T}"/> that invokes the callback inline
-        /// on the thread calling <see cref="Report"/>. Unlike <see cref="System.Progress{T}"/>,
-        /// this does not post asynchronously to the synchronization context, preventing
-        /// stale progress callbacks from overwriting the final import status.
+        /// Synchronous <see cref="IProgress{T}"/> that invokes the callback inline on the calling
+        /// thread, preventing stale queued progress from overwriting the final import status.
         /// </summary>
         private sealed class InlineProgress<T> : IProgress<T>
         {

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -543,6 +543,18 @@ namespace DTXMania.Game.Lib.Stage
             if (item == null)
                 return;
 
+            // Navigation items (sub-panel openers, stage transitions, async imports) have no
+            // cyclic value to adjust. Left/Right are the value-adjust keys, so letting them
+            // trigger navigation would surprise the player — e.g. an instant ChangeStage to
+            // DrumConfig or kicking off a long NX import from a stray keypress. Restrict them
+            // to the Activate path only (mirrors HandleMenuInput, where Left never activates).
+            if (item is NavigationConfigItem)
+            {
+                if (IsConfigNavigationCommandPressed(InputCommandType.Activate))
+                    item.ToggleValue();
+                return;
+            }
+
             if (IsConfigNavigationCommandPressed(InputCommandType.MoveLeft))
             {
                 item.PreviousValue();

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -776,11 +776,17 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     // Right-align the value at the box's right inner edge (ItemValueRightX) so it
                     // never overflows the box and never runs under the description panel drawn next.
-                    // Clamp the value to ItemValueMaxWidth first: a value wider than the gap between
-                    // the name's left edge and the value's right anchor (e.g. a deep macOS DTXPath)
-                    // would otherwise push valuePos.X left of the name and, drawn after the name,
-                    // overwrite it. Ellipsizing keeps the right-aligned anchor meaningful.
-                    var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
+                    // Reserve the measured name width plus ItemValueNameGap when deriving the value's
+                    // max width: truncating only to the static ItemValueMaxWidth lets the value's left
+                    // edge reach the name's left edge (namePos.X), which still overlaps the name
+                    // because the value is drawn after it (e.g. a deep macOS DTXPath overwriting the
+                    // "DTX Folder" label). The name-relative max width keeps the value strictly right
+                    // of the name's right edge plus a visual gap before right-aligning.
+                    var namePos = ConfigUILayout.ItemNamePos(row);
+                    var nameWidth = font.MeasureString(item.Name).X;
+                    var valueMaxWidth = Math.Max(0f,
+                        ConfigUILayout.ItemValueRightX - (namePos.X + nameWidth + ConfigUILayout.ItemValueNameGap));
+                    var displayValue = TextHelper.TruncateToWidth(value, valueMaxWidth, font);
                     var valueWidth = font.MeasureString(displayValue).X;
                     var valuePos = new Vector2(ConfigUILayout.ItemValueRightX - valueWidth,
                         ConfigUILayout.ItemRowY(row) + ConfigUILayout.ItemTextInsetY);

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -74,6 +74,11 @@ namespace DTXMania.Game.Lib.Stage
         // legible (light-on-light was the failure mode to avoid).
         private static readonly Color FallbackBackgroundColor = new(18, 20, 34);
 
+        // Semi-transparent panel stand-ins drawn when the NX skin art is missing, so each panel
+        // region stays visually delimited and text remains legible without the texture.
+        private static readonly Color PanelFallbackColor = new(28, 32, 54, 220);
+        private static readonly Color ItemBoxFallbackColor = new(34, 40, 68, 200);
+
         private volatile string _importStatus = "";
         private volatile bool _importRunning;
         private CancellationTokenSource? _importCts;
@@ -632,12 +637,19 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (_itemBarTexture?.Texture != null)
                 _spriteBatch.Draw(_itemBarTexture.Texture, ConfigUILayout.ItemBarRect, Color.White);
+            else
+                DrawFilledRectangle(ConfigUILayout.ItemBarRect, PanelFallbackColor);
         }
 
         private void DrawCategoryMenu()
         {
+            if (_categories.Count == 0)
+                return;
+
             if (_menuPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_menuPanelTexture.Texture, ConfigUILayout.MenuPanelRect, Color.White);
+            else
+                DrawFilledRectangle(ConfigUILayout.MenuPanelRect, PanelFallbackColor);
 
             var cursorRect = ConfigUILayout.MenuCursorRect(_currentCategoryIndex);
             if (_menuCursorTexture?.Texture != null)
@@ -680,6 +692,8 @@ namespace DTXMania.Game.Lib.Stage
                     : _itemBoxTexture;
                 if (box?.Texture != null)
                     _spriteBatch.Draw(box.Texture, ConfigUILayout.ItemRowRect(row), Color.White);
+                else
+                    DrawFilledRectangle(ConfigUILayout.ItemRowRect(row), ItemBoxFallbackColor);
             }
 
             if (!_focusOnMenu && category.HasItems)
@@ -739,6 +753,8 @@ namespace DTXMania.Game.Lib.Stage
 
             if (_descriptionPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_descriptionPanelTexture.Texture, ConfigUILayout.DescriptionPanelRect, Color.White);
+            else
+                DrawFilledRectangle(ConfigUILayout.DescriptionPanelRect, PanelFallbackColor);
 
             if (_font == null)
                 return;
@@ -778,6 +794,8 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (_headerPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_headerPanelTexture.Texture, ConfigUILayout.HeaderRect, Color.White);
+            else
+                DrawFilledRectangle(ConfigUILayout.HeaderRect, PanelFallbackColor);
 
             if (_font != null)
             {
@@ -789,6 +807,8 @@ namespace DTXMania.Game.Lib.Stage
 
             if (_footerPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_footerPanelTexture.Texture, ConfigUILayout.FooterRect, Color.White);
+            else
+                DrawFilledRectangle(ConfigUILayout.FooterRect, PanelFallbackColor);
 
             if (_font != null)
                 _font.DrawString(_spriteBatch, ConfigUILayout.InstructionsText, ConfigUILayout.InstructionsPos, LightText);

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -774,7 +774,12 @@ namespace DTXMania.Game.Lib.Stage
                 var value = GetItemValueText(item);
                 if (!string.IsNullOrEmpty(value))
                 {
-                    font.DrawString(_spriteBatch, value, ConfigUILayout.ItemValuePos(row),
+                    // Right-align the value at the box's right inner edge (ItemValueRightX) so it
+                    // never overflows the box and never runs under the description panel drawn next.
+                    var valueWidth = font.MeasureString(value).X;
+                    var valuePos = new Vector2(ConfigUILayout.ItemValueRightX - valueWidth,
+                        ConfigUILayout.ItemRowY(row) + ConfigUILayout.ItemTextInsetY);
+                    font.DrawString(_spriteBatch, value, valuePos,
                         selected ? SelectedText : ValueText);
                 }
             }

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -776,10 +776,15 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     // Right-align the value at the box's right inner edge (ItemValueRightX) so it
                     // never overflows the box and never runs under the description panel drawn next.
-                    var valueWidth = font.MeasureString(value).X;
+                    // Clamp the value to ItemValueMaxWidth first: a value wider than the gap between
+                    // the name's left edge and the value's right anchor (e.g. a deep macOS DTXPath)
+                    // would otherwise push valuePos.X left of the name and, drawn after the name,
+                    // overwrite it. Ellipsizing keeps the right-aligned anchor meaningful.
+                    var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
+                    var valueWidth = font.MeasureString(displayValue).X;
                     var valuePos = new Vector2(ConfigUILayout.ItemValueRightX - valueWidth,
                         ConfigUILayout.ItemRowY(row) + ConfigUILayout.ItemTextInsetY);
-                    font.DrawString(_spriteBatch, value, valuePos,
+                    font.DrawString(_spriteBatch, displayValue, valuePos,
                         selected ? SelectedText : ValueText);
                 }
             }

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -19,6 +19,8 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using DTXMania.Game.Lib.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DTXMania.Game.Lib.Stage
 {
@@ -33,6 +35,12 @@ namespace DTXMania.Game.Lib.Stage
     public class ConfigStage : BaseStage
     {
         #region Private Fields
+
+        // NullLogger until OnActivate swaps in the game's factory. Lets reflection-based tests
+        // (which skip OnActivate) exercise the helpers without NullReferenceException, while real
+        // runtime gets structured logging that survives Release builds (Debug.WriteLine is
+        // [Conditional("DEBUG")] and compiles out in Release).
+        private ILogger<ConfigStage> _logger = NullLogger<ConfigStage>.Instance;
 
         private IConfigManager _configManager;
         private List<ConfigCategory> _categories = new();
@@ -100,7 +108,8 @@ namespace DTXMania.Game.Lib.Stage
 
         protected override void OnActivate()
         {
-            System.Diagnostics.Debug.WriteLine("Activating Config Stage");
+            _logger = _game.LoggerFactory?.CreateLogger<ConfigStage>() ?? _logger;
+            _logger.LogDebug("Activating Config Stage");
 
             InitializeGraphics();
             SetupConfigItems();
@@ -108,6 +117,13 @@ namespace DTXMania.Game.Lib.Stage
 
             _currentCategoryIndex = 0;
             _focusOnMenu = true;
+
+            // Clear any import status left over from a previous visit. StageManager reuses this
+            // instance, so without this a stale "Imported N scores" / "cancelled" message would
+            // survive leaving and re-entering Config. (_importRunning is intentionally NOT reset
+            // here: the background task clears it in its finally, and the StartNxScoreImport guard
+            // correctly serializes a still-draining task.)
+            _importStatus = "";
 
             _previousKeyboardState = Keyboard.GetState();
             _currentKeyboardState = Keyboard.GetState();
@@ -153,7 +169,7 @@ namespace DTXMania.Game.Lib.Stage
 
         protected override void OnDeactivate()
         {
-            System.Diagnostics.Debug.WriteLine("Deactivating Config Stage");
+            _logger.LogDebug("Deactivating Config Stage");
 
             FlushPendingSaveSafely();
 
@@ -168,6 +184,15 @@ namespace DTXMania.Game.Lib.Stage
             _boldFont = null;
             ReleaseTextures();
 
+            // OnActivate allocates a fresh SpriteBatch/white-pixel each entry. Dispose them here
+            // (symmetric with InitializeGraphics and the DrumConfigStage sibling) so a
+            // Title→Config→Title round-trip doesn't leak one of each on every visit, since
+            // StageManager reuses this instance.
+            _spriteBatch?.Dispose();
+            _spriteBatch = null!;
+            _whitePixel?.Dispose();
+            _whitePixel = null!;
+
             _previousKeyboardState = default;
             _currentKeyboardState = default;
         }
@@ -176,7 +201,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             if (disposing)
             {
-                System.Diagnostics.Debug.WriteLine("Disposing Config Stage resources");
+                _logger.LogDebug("Disposing Config Stage resources");
 
                 _importCts?.Cancel();
                 _importCts?.Dispose();
@@ -244,16 +269,28 @@ namespace DTXMania.Game.Lib.Stage
             _descriptionPanelTexture = TryLoadTexture(TexturePath.ConfigDescriptionPanel);
         }
 
+        /// <summary>
+        /// Load an optional skin texture, returning null when the asset is absent. ResourceManager
+        /// never throws for a missing/invalid texture — it returns a 1x1 white fallback (see
+        /// <see cref="ResourceManager.CreateFallbackTexture"/>), which would stretch a single texel
+        /// over the panel and wash the screen white. A real asset is always larger than 1x1, so a
+        /// 1x1 result is treated as "not present": its reference is released and null is returned so
+        /// each draw method takes its documented fallback-fill branch.
+        /// </summary>
         private ITexture? TryLoadTexture(string path)
         {
-            try
+            ITexture? texture = null;
+            try { texture = _resourceManager.LoadTexture(path); }
+            catch (Exception ex) { _logger.LogDebug(ex, "optional texture unavailable: {Path}", path); return null; }
+
+            if (texture == null || texture.Width <= 1 || texture.Height <= 1)
             {
-                return _resourceManager.LoadTexture(path);
-            }
-            catch
-            {
+                _logger.LogDebug("optional texture unavailable (asset missing or 1x1 fallback): {Path}", path);
+                texture?.RemoveReference();
                 return null;
             }
+
+            return texture;
         }
 
         private void ReleaseTextures()
@@ -446,9 +483,10 @@ namespace DTXMania.Game.Lib.Stage
 
             _ = System.Threading.Tasks.Task.Run(async () =>
             {
+                NxImportResult? result = null;
                 try
                 {
-                    var result = await SongManager.Instance.ImportNxScoresAsync(progress, token);
+                    result = await SongManager.Instance.ImportNxScoresAsync(progress, token);
                     _importStatus = result.DbUnavailable
                         ? "NX import unavailable (no database)"
                         : $"Imported {result.Imported} scores ({result.Scanned} charts scanned" +
@@ -463,20 +501,30 @@ namespace DTXMania.Game.Lib.Stage
                         }
                         catch (System.Exception ex)
                         {
-                            System.Diagnostics.Debug.WriteLine(
-                                $"ConfigStage: NX import succeeded but song list refresh failed: {ex}");
+                            // Scores were written, but the live song list didn't refresh. Surface the
+                            // partial failure so the user isn't left looking at a stale list with no
+                            // explanation (a restart will pick up the imported scores).
+                            _importStatus = $"Imported {result.Imported} scores, but the song list didn't " +
+                                $"refresh (restart to see them). {ex.GetBaseException().Message}";
+                            _logger.LogWarning(ex, "ConfigStage: NX import succeeded but song list refresh failed");
                         }
                     }
                 }
                 catch (System.OperationCanceledException)
                 {
-                    _importStatus = "NX import cancelled";
+                    // If cancellation landed AFTER a successful import (between the write and the
+                    // song-list refresh, at the ThrowIfCancellationRequested above), scores ARE on
+                    // disk — report partial success instead of a bare "cancelled" that hides the
+                    // write. Mid-import cancellation (result null / nothing imported) is a real cancel.
+                    _importStatus = (result != null && result.Imported > 0)
+                        ? $"Imported {result.Imported} scores (cancelled before the song list could refresh)"
+                        : "NX import cancelled";
                 }
                 catch (System.Exception ex)
                 {
                     var detail = ex.GetBaseException().Message;
                     _importStatus = $"NX import failed: {detail}";
-                    System.Diagnostics.Debug.WriteLine($"ConfigStage: NX import failed: {ex}");
+                    _logger.LogError(ex, "ConfigStage: NX import failed");
                 }
                 finally
                 {
@@ -582,7 +630,7 @@ namespace DTXMania.Game.Lib.Stage
 
         private void ExitToTitle()
         {
-            System.Diagnostics.Debug.WriteLine("Config: Returning to Title stage");
+            _logger.LogDebug("Config: Returning to Title stage");
             FlushPendingSaveSafely();
             ChangeStage(StageType.Title, new CrossfadeTransition(0.3));
         }
@@ -620,7 +668,7 @@ namespace DTXMania.Game.Lib.Stage
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"ConfigStage: failed to flush pending save: {ex}");
+                _logger.LogWarning(ex, "ConfigStage: failed to flush pending save");
             }
         }
 

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -491,6 +491,12 @@ namespace DTXMania.Game.Lib.Stage
 
         private void HandleInput()
         {
+            // Defensive: SetupConfigItems (called from OnActivate) always populates _categories,
+            // so this is never empty during normal play. Guard mirrors the draw methods and keeps
+            // the modular-arithmetic / index access below safe if the invariant ever breaks.
+            if (_categories.Count == 0)
+                return;
+
             if (_focusOnMenu)
                 HandleMenuInput();
             else
@@ -743,20 +749,21 @@ namespace DTXMania.Game.Lib.Stage
             if (_categories.Count == 0)
                 return;
 
-            var category = _categories[_currentCategoryIndex];
-            string text = _focusOnMenu
-                ? category.Description
-                : (category.SelectedItem?.Description ?? string.Empty);
-
-            if (string.IsNullOrEmpty(text))
-                return;
-
+            // The panel is a fixed UI region; always render its background (texture or fallback
+            // fill) so the layout stays consistent. Only the wrapped text is gated on content —
+            // every category/item has a description today (enforced by test), but decoupling the
+            // panel from the text avoids a surprise blank gap if that invariant ever changes.
             if (_descriptionPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_descriptionPanelTexture.Texture, ConfigUILayout.DescriptionPanelRect, Color.White);
             else
                 DrawFilledRectangle(ConfigUILayout.DescriptionPanelRect, PanelFallbackColor);
 
-            if (_font == null)
+            var category = _categories[_currentCategoryIndex];
+            string text = _focusOnMenu
+                ? category.Description
+                : (category.SelectedItem?.Description ?? string.Empty);
+
+            if (string.IsNullOrEmpty(text) || _font == null)
                 return;
 
             var pos = ConfigUILayout.DescriptionTextPos;

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -16,11 +16,11 @@ namespace DTXMania.Game.Lib.UI.Layout
 
         // Background + vertical divider.
         public static Rectangle BackgroundRect => new(0, 0, ScreenWidth, ScreenHeight);
-        public static Rectangle ItemBarRect => new(400, 0, 18, 720);
+        public static Rectangle ItemBarRect => new(400, 0, 18, ScreenHeight);
 
         // Header / footer / title / instructions / import status.
-        public static Rectangle HeaderRect => new(0, 0, 1280, 105);
-        public static Rectangle FooterRect => new(0, 690, 1280, 30);
+        public static Rectangle HeaderRect => new(0, 0, ScreenWidth, 105);
+        public static Rectangle FooterRect => new(0, 690, ScreenWidth, 30);
         public const int TitleY = 40;
         public const string InstructionsText =
             "UP/DOWN select   LEFT/RIGHT change   ENTER choose   ESC back (saves automatically)";

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -60,9 +60,18 @@ namespace DTXMania.Game.Lib.UI.Layout
         // Right anchor for value text; the draw layer subtracts the measured string width so the
         // value's right edge sits here (inside the box, clear of the description panel).
         public static int ItemValueRightX => ItemListX + ItemBoxWidth - ItemValueRightInset;
-        // Maximum width a right-aligned value may occupy before its left edge would cross the
-        // item name (drawn at ItemNamePos). The draw layer ellipsizes values to this width so a
-        // long value (e.g. a deep macOS DTXPath) never overwrites the name it sits beside.
+        // Minimum horizontal gap kept between a measured item name and the right-aligned value
+        // drawn beside it. The draw layer subtracts the measured name width plus this gap from
+        // ItemValueRightX to derive the value's per-row max width before ellipsizing, so a long
+        // value (e.g. a deep macOS DTXPath) never touches or overwrites the name. This is required
+        // because the value is drawn after the name; reserving only the name's left edge (as
+        // ItemValueMaxWidth does below) lets the value's left edge sit exactly on that edge and
+        // still overlap the name's glyph run.
+        public const int ItemValueNameGap = 16;
+        // Theoretical maximum value width assuming a zero-width name: the full gap from the name
+        // column's left edge to the value's right anchor. Used only as an upper-bound ceiling
+        // (e.g. layout sanity assertions); the draw layer uses the per-row name-relative width
+        // derived via ItemValueNameGap instead, which is always <= this value for a real name.
         public static int ItemValueMaxWidth => ItemBoxWidth - ItemValueRightInset - ItemNameInsetX;
 
         // Description panel.

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -60,6 +60,10 @@ namespace DTXMania.Game.Lib.UI.Layout
         // Right anchor for value text; the draw layer subtracts the measured string width so the
         // value's right edge sits here (inside the box, clear of the description panel).
         public static int ItemValueRightX => ItemListX + ItemBoxWidth - ItemValueRightInset;
+        // Maximum width a right-aligned value may occupy before its left edge would cross the
+        // item name (drawn at ItemNamePos). The draw layer ellipsizes values to this width so a
+        // long value (e.g. a deep macOS DTXPath) never overwrites the name it sits beside.
+        public static int ItemValueMaxWidth => ItemBoxWidth - ItemValueRightInset - ItemNameInsetX;
 
         // Description panel.
         public static Rectangle DescriptionPanelRect => new(800, 270, 280, 360);

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -1,0 +1,66 @@
+#nullable enable
+
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.UI.Layout
+{
+    /// <summary>
+    /// Coordinate/size constants and index→position helpers for the NX-style master-detail
+    /// Config stage, in the 1280x720 virtual space ported from DTXManiaNX CStageConfig /
+    /// CActConfigList. Pure (no GraphicsDevice) so it is fully unit-testable.
+    /// </summary>
+    public static class ConfigUILayout
+    {
+        public const int ScreenWidth = 1280;
+        public const int ScreenHeight = 720;
+
+        // Background + vertical divider.
+        public static Rectangle BackgroundRect => new(0, 0, ScreenWidth, ScreenHeight);
+        public static Rectangle ItemBarRect => new(400, 0, 18, 720);
+
+        // Header / footer / title / instructions / import status.
+        public static Rectangle HeaderRect => new(0, 0, 1280, 105);
+        public static Rectangle FooterRect => new(0, 690, 1280, 30);
+        public const int TitleY = 40;
+        public const string InstructionsText =
+            "UP/DOWN select   LEFT/RIGHT change   ENTER choose   ESC back (saves automatically)";
+        public static Vector2 InstructionsPos => new(16, 696);
+        public static Vector2 ImportStatusPos => new(430, 600);
+
+        // Left category menu.
+        public static Rectangle MenuPanelRect => new(245, 140, 180, 172);
+        public const int MenuFirstRowY = 156;
+        public const int MenuRowStride = 34;
+        public const int MenuLabelCenterX = 335;
+        public const int MenuCursorWidth = 150;
+        public const int MenuCursorHeight = 30;
+        public static int MenuRowY(int index) => MenuFirstRowY + index * MenuRowStride;
+        public static Rectangle MenuCursorRect(int index) =>
+            new(250, MenuRowY(index) - 3, MenuCursorWidth, MenuCursorHeight);
+
+        // Right item list.
+        public const int ItemListX = 430;
+        public const int ItemFirstRowY = 150;
+        public const int ItemRowStride = 60;
+        public const int ItemBoxWidth = 360;
+        public const int ItemBoxHeight = 54;
+        public const int ItemNameInsetX = 24;
+        public const int ItemValueInsetX = 330;
+        public const int ItemTextInsetY = 14;
+        public static int ItemRowY(int row) => ItemFirstRowY + row * ItemRowStride;
+        public static Rectangle ItemRowRect(int row) =>
+            new(ItemListX, ItemRowY(row), ItemBoxWidth, ItemBoxHeight);
+        public static Rectangle ItemCursorRect(int row) =>
+            new(ItemListX - 4, ItemRowY(row) - 3, ItemBoxWidth + 8, ItemRowStride);
+        public static Vector2 ItemNamePos(int row) =>
+            new(ItemListX + ItemNameInsetX, ItemRowY(row) + ItemTextInsetY);
+        public static Vector2 ItemValuePos(int row) =>
+            new(ItemListX + ItemValueInsetX, ItemRowY(row) + ItemTextInsetY);
+
+        // Description panel.
+        public static Rectangle DescriptionPanelRect => new(800, 270, 280, 360);
+        public static Vector2 DescriptionTextPos => new(818, 288);
+        public const int DescriptionWrapWidth = 248;
+        public const int DescriptionLineHeight = 22;
+    }
+}

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -45,7 +45,10 @@ namespace DTXMania.Game.Lib.UI.Layout
         public const int ItemBoxWidth = 360;
         public const int ItemBoxHeight = 54;
         public const int ItemNameInsetX = 24;
-        public const int ItemValueInsetX = 330;
+        // Right-aligned value column: values anchor at the box's right inner edge so they never
+        // overflow the box and never run under the description panel (drawn afterward at x=800).
+        // A fixed left-aligned column left wide values stretching into the panel region.
+        public const int ItemValueRightInset = ItemNameInsetX; // symmetric with the name's left inset
         public const int ItemTextInsetY = 14;
         public static int ItemRowY(int row) => ItemFirstRowY + row * ItemRowStride;
         public static Rectangle ItemRowRect(int row) =>
@@ -54,8 +57,9 @@ namespace DTXMania.Game.Lib.UI.Layout
             new(ItemListX - 4, ItemRowY(row) - 3, ItemBoxWidth + 8, ItemRowStride);
         public static Vector2 ItemNamePos(int row) =>
             new(ItemListX + ItemNameInsetX, ItemRowY(row) + ItemTextInsetY);
-        public static Vector2 ItemValuePos(int row) =>
-            new(ItemListX + ItemValueInsetX, ItemRowY(row) + ItemTextInsetY);
+        // Right anchor for value text; the draw layer subtracts the measured string width so the
+        // value's right edge sits here (inside the box, clear of the description panel).
+        public static int ItemValueRightX => ItemListX + ItemBoxWidth - ItemValueRightInset;
 
         // Description panel.
         public static Rectangle DescriptionPanelRect => new(800, 270, 280, 360);

--- a/DTXMania.Game/Lib/Utilities/TextHelper.cs
+++ b/DTXMania.Game/Lib/Utilities/TextHelper.cs
@@ -1,0 +1,94 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using DTXMania.Game.Lib.Resources;
+
+namespace DTXMania.Game.Lib.Utilities
+{
+    /// <summary>
+    /// Text layout helpers shared across rendering components. Consolidates the binary-search
+    /// ellipsis truncation that was previously duplicated in SongListDisplay (artist names) and
+    /// ConfigStage (right-aligned item values).
+    /// </summary>
+    public static class TextHelper
+    {
+        /// <summary>
+        /// Truncate text to fit within <paramref name="maxWidth"/> using binary search, appending
+        /// an ellipsis ("...") when truncation is needed. Returns the original text unchanged when
+        /// it already fits or when the inputs are null/empty.
+        /// </summary>
+        /// <param name="text">Text to truncate.</param>
+        /// <param name="maxWidth">Maximum rendered width in pixels.</param>
+        /// <param name="font">MonoGame SpriteFont used to measure the text.</param>
+        /// <returns>The original text if it fits, otherwise the longest prefix + "..." that fits.</returns>
+        public static string TruncateToWidth(string text, float maxWidth, SpriteFont font)
+        {
+            if (string.IsNullOrEmpty(text) || font == null)
+                return text;
+
+            if (font.MeasureString(text).X <= maxWidth)
+                return text;
+
+            int left = 0;
+            int right = text.Length;
+            string bestFit = string.Empty;
+
+            while (left <= right)
+            {
+                int mid = left + (right - left) / 2;
+                string candidate = text.Substring(0, mid) + "...";
+
+                if (font.MeasureString(candidate).X <= maxWidth)
+                {
+                    bestFit = candidate;
+                    left = mid + 1;
+                }
+                else
+                {
+                    right = mid - 1;
+                }
+            }
+
+            return bestFit;
+        }
+
+        /// <summary>
+        /// Truncate text to fit within <paramref name="maxWidth"/> using binary search, appending
+        /// an ellipsis ("...") when truncation is needed. Returns the original text unchanged when
+        /// it already fits or when the inputs are null/empty.
+        /// </summary>
+        /// <param name="text">Text to truncate.</param>
+        /// <param name="maxWidth">Maximum rendered width in pixels.</param>
+        /// <param name="font">IFont used to measure the text.</param>
+        /// <returns>The original text if it fits, otherwise the longest prefix + "..." that fits.</returns>
+        public static string TruncateToWidth(string text, float maxWidth, IFont font)
+        {
+            if (string.IsNullOrEmpty(text) || font == null)
+                return text;
+
+            if (font.MeasureString(text).X <= maxWidth)
+                return text;
+
+            int left = 0;
+            int right = text.Length;
+            string bestFit = string.Empty;
+
+            while (left <= right)
+            {
+                int mid = left + (right - left) / 2;
+                string candidate = text.Substring(0, mid) + "...";
+
+                if (font.MeasureString(candidate).X <= maxWidth)
+                {
+                    bestFit = candidate;
+                    left = mid + 1;
+                }
+                else
+                {
+                    right = mid - 1;
+                }
+            }
+
+            return bestFit;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Utilities/TextHelper.cs
+++ b/DTXMania.Game/Lib/Utilities/TextHelper.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using DTXMania.Game.Lib.Resources;
@@ -28,14 +29,17 @@ namespace DTXMania.Game.Lib.Utilities
             if (font.MeasureString(text).X <= maxWidth)
                 return text;
 
+            int[] elementStarts = StringInfo.ParseCombiningCharacters(text);
+            int elementCount = elementStarts.Length;
             int left = 0;
-            int right = text.Length;
+            int right = elementCount;
             string bestFit = string.Empty;
 
             while (left <= right)
             {
                 int mid = left + (right - left) / 2;
-                string candidate = text.Substring(0, mid) + "...";
+                int charIndex = mid < elementCount ? elementStarts[mid] : text.Length;
+                string candidate = text.Substring(0, charIndex) + "...";
 
                 if (font.MeasureString(candidate).X <= maxWidth)
                 {
@@ -68,14 +72,17 @@ namespace DTXMania.Game.Lib.Utilities
             if (font.MeasureString(text).X <= maxWidth)
                 return text;
 
+            int[] elementStarts = StringInfo.ParseCombiningCharacters(text);
+            int elementCount = elementStarts.Length;
             int left = 0;
-            int right = text.Length;
+            int right = elementCount;
             string bestFit = string.Empty;
 
             while (left <= right)
             {
                 int mid = left + (right - left) / 2;
-                string candidate = text.Substring(0, mid) + "...";
+                int charIndex = mid < elementCount ? elementStarts[mid] : text.Length;
+                string candidate = text.Substring(0, charIndex) + "...";
 
                 if (font.MeasureString(candidate).X <= maxWidth)
                 {

--- a/DTXMania.Test/Config/ConfigCategoryTests.cs
+++ b/DTXMania.Test/Config/ConfigCategoryTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public class ConfigCategoryTests
+{
+    private static IConfigItem Toggle(string name) =>
+        new ToggleConfigItem(name, () => false, _ => { });
+
+    [Fact]
+    public void Constructor_ShouldExposeNameDescriptionAndItems()
+    {
+        var items = new List<IConfigItem> { Toggle("A"), Toggle("B") };
+
+        var category = new ConfigCategory("Drums", "Drum settings.", items);
+
+        Assert.Equal("Drums", category.Name);
+        Assert.Equal("Drum settings.", category.Description);
+        Assert.Equal(2, category.Items.Count);
+        Assert.True(category.HasItems);
+        Assert.Same(items[0], category.SelectedItem);
+    }
+
+    [Fact]
+    public void MoveSelectionDown_ShouldWrapAround()
+    {
+        var category = new ConfigCategory("Drums", "", new List<IConfigItem> { Toggle("A"), Toggle("B") });
+
+        category.MoveSelectionDown();
+        Assert.Equal(1, category.SelectedIndex);
+
+        category.MoveSelectionDown();
+        Assert.Equal(0, category.SelectedIndex);
+    }
+
+    [Fact]
+    public void MoveSelectionUp_FromFirst_ShouldWrapToLast()
+    {
+        var category = new ConfigCategory("Drums", "", new List<IConfigItem> { Toggle("A"), Toggle("B"), Toggle("C") });
+
+        category.MoveSelectionUp();
+
+        Assert.Equal(2, category.SelectedIndex);
+    }
+
+    [Fact]
+    public void EmptyCategory_ShouldHaveNoItemsAndNoOpMoves()
+    {
+        var category = new ConfigCategory("Exit", "Leave.", new List<IConfigItem>());
+
+        Assert.False(category.HasItems);
+        Assert.Null(category.SelectedItem);
+
+        category.MoveSelectionDown();
+        category.MoveSelectionUp();
+
+        Assert.Equal(0, category.SelectedIndex);
+    }
+}

--- a/DTXMania.Test/Config/ConfigCategoryTests.cs
+++ b/DTXMania.Test/Config/ConfigCategoryTests.cs
@@ -60,4 +60,37 @@ public class ConfigCategoryTests
 
         Assert.Equal(0, category.SelectedIndex);
     }
+
+    [Fact]
+    public void SelectedIndex_AboveRange_ShouldClampToLastItem()
+    {
+        // The setter is self-enforcing so an out-of-range value can never drive a phantom cursor
+        // row in the draw layer (which maps SelectedIndex straight to a screen rectangle).
+        var category = new ConfigCategory("Drums", "", new List<IConfigItem> { Toggle("A"), Toggle("B") });
+
+        category.SelectedIndex = 99;
+
+        Assert.Equal(1, category.SelectedIndex);
+    }
+
+    [Fact]
+    public void SelectedIndex_BelowRange_ShouldClampToFirstItem()
+    {
+        var category = new ConfigCategory("Drums", "", new List<IConfigItem> { Toggle("A"), Toggle("B") });
+
+        category.SelectedIndex = -5;
+
+        Assert.Equal(0, category.SelectedIndex);
+    }
+
+    [Fact]
+    public void SelectedIndex_OnEmptyCategory_ShouldStayAtZero()
+    {
+        var category = new ConfigCategory("Exit", "", new List<IConfigItem>());
+
+        category.SelectedIndex = 7;
+
+        Assert.Equal(0, category.SelectedIndex);
+        Assert.Null(category.SelectedItem);
+    }
 }

--- a/DTXMania.Test/Config/ConfigItemTests.cs
+++ b/DTXMania.Test/Config/ConfigItemTests.cs
@@ -288,6 +288,29 @@ namespace DTXMania.Test.Config
         }
 
         #endregion
+
+        #region Description Tests
+
+        [Fact]
+        public void Description_WhenNotSet_ShouldDefaultToEmptyString()
+        {
+            var item = new ToggleConfigItem("Fullscreen", () => false, _ => { });
+
+            Assert.Equal(string.Empty, item.Description);
+        }
+
+        [Fact]
+        public void Description_WhenSetViaInitializer_ShouldRoundTrip()
+        {
+            var item = new ToggleConfigItem("Fullscreen", () => false, _ => { })
+            {
+                Description = "Toggles fullscreen display mode."
+            };
+
+            Assert.Equal("Toggles fullscreen display mode.", item.Description);
+        }
+
+        #endregion
     }
 
     [Trait("Category", "Unit")]

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1328,6 +1328,19 @@ public class ConfigStageLogicTests
             Assert.EndsWith("...", pathDraw.Text);
             Assert.True(font.Object.MeasureString(pathDraw.Text).X <= ConfigUILayout.ItemValueMaxWidth + 0.01f,
                 $"ellipsized value width must fit ItemValueMaxWidth ({ConfigUILayout.ItemValueMaxWidth})");
+
+            // The value is drawn after the name, so its left edge must sit strictly right of the
+            // name's right edge plus the reserved gap. Reserving only the name's left edge (the
+            // static ItemValueMaxWidth) lets the value's left edge reach that same X and overwrite
+            // the name's glyphs (e.g. a deep macOS DTXPath overwriting the "DTX Folder" label).
+            // Per-character mock font: "DTX Folder" (10 chars) measures 80px -> right edge at 534.
+            var folderNameDraw = draws.Single(d => d.Text == "DTX Folder");
+            var folderNameRightEdge = folderNameDraw.Position.X
+                + font.Object.MeasureString("DTX Folder").X;
+            var expectedValueLeftFloor = folderNameRightEdge + ConfigUILayout.ItemValueNameGap;
+            Assert.True(pathDraw.Position.X >= expectedValueLeftFloor - 0.01f,
+                $"value drawn at x={pathDraw.Position.X} overlaps the name (right edge {folderNameRightEdge}) "
+                + $"+ gap ({ConfigUILayout.ItemValueNameGap}); expected >= {expectedValueLeftFloor}");
         }
     }
 

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
 using DTXMania.Game.Lib.Stage.KeyAssign;
+using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Utilities;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
@@ -30,33 +33,6 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void SetupConfigItems_ShouldCreateExpectedItemsAndSelectFirstItem()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            Assert.NotNull(configItems);
-            Assert.Equal(11, configItems!.Count);
-            Assert.Collection(configItems,
-                item => Assert.Equal("Screen Resolution", item.Name),
-                item => Assert.Equal("Fullscreen", item.Name),
-                item => Assert.Equal("VSync Wait", item.Name),
-                item => Assert.Equal("No Fail", item.Name),
-                item => Assert.Equal("Auto Play", item.Name),
-                item => Assert.Equal("Scroll Speed", item.Name),
-                item => Assert.Equal("Audio Latency Offset", item.Name),
-                item => Assert.Equal("DTX Folder", item.Name),
-                item => Assert.Equal("Drum Key Mapping", item.Name),
-                item => Assert.Equal("System Key Mapping", item.Name),
-                item => Assert.Equal("Import NX Scores", item.Name));
-            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
-        }
-    }
-
-    [Fact]
     public void SetupConfigItems_ShouldShowConfiguredDtxFolder()
     {
         var (stage, configManager, inputManager) = CreateStage();
@@ -65,8 +41,8 @@ public class ConfigStageLogicTests
             configManager.Config.DTXPath = "/tmp/custom dtx";
             InitializeStageMenu(stage, includePanels: false);
 
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            var item = Assert.Single(configItems!, item => item.Name == "DTX Folder");
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            var item = categories!.SelectMany(c => c.Items).Single(i => i.Name == "DTX Folder");
 
             Assert.Equal("DTX Folder: /tmp/custom dtx", item.GetDisplayText());
         }
@@ -80,48 +56,13 @@ public class ConfigStageLogicTests
         {
             configManager.Config.DTXPath = "/tmp/custom dtx";
             InitializeStageMenu(stage, includePanels: false);
-            var dtxFolderIndex = GetConfigItemIndex(stage, "DTX Folder");
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", dtxFolderIndex);
+            SelectItemForEditing(stage, "DTX Folder");
             SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
             // DTX Folder is read-only; Config must be unchanged.
             Assert.Equal("/tmp/custom dtx", configManager.Config.DTXPath);
-        }
-    }
-
-    [Fact]
-    public void MoveUpPressedAtFirstItem_ShouldWrapToExitButton()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
-            SetKeyboardStates(stage, new KeyboardState(Keys.Up), new KeyboardState());
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
-
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            Assert.Equal(configItems!.Count, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
-        }
-    }
-
-    [Fact]
-    public void MoveDownPressedAtExitButton_ShouldWrapToFirstItem()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count);
-            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
-
-            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
         }
     }
 
@@ -134,7 +75,7 @@ public class ConfigStageLogicTests
             configManager.Config.ScreenWidth = 1280;
             configManager.Config.ScreenHeight = 720;
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
+            SelectItemForEditing(stage, "Screen Resolution");
             SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -153,7 +94,7 @@ public class ConfigStageLogicTests
             configManager.Config.ScreenWidth = 1920;
             configManager.Config.ScreenHeight = 1080;
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
+            SelectItemForEditing(stage, "Screen Resolution");
             SetKeyboardStates(stage, new KeyboardState(Keys.Left), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -171,7 +112,7 @@ public class ConfigStageLogicTests
         {
             configManager.Config.FullScreen = false;
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 1);
+            SelectItemForEditing(stage, "Fullscreen");
             SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -190,7 +131,7 @@ public class ConfigStageLogicTests
             var stageManager = new Moq.Mock<IStageManager>();
             stage.StageManager = stageManager.Object;
 
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", GetConfigItemIndex(stage, "Drum Key Mapping"));
+            SelectItemForEditing(stage, "Drum Key Mapping");
             SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -255,7 +196,7 @@ public class ConfigStageLogicTests
             InitializeStageMenu(stage, includePanels: false);
             var stageManager = new Moq.Mock<IStageManager>();
             stage.StageManager = stageManager.Object;
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 7);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
             SetKeyboardStates(stage, new KeyboardState(Keys.Escape), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -266,78 +207,6 @@ public class ConfigStageLogicTests
                     Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
                 Moq.Times.Once);
         }
-    }
-
-    [Fact]
-    public void ActivatePressedOnExitButton_ShouldReturnToTitleStage()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var stageManager = new Moq.Mock<IStageManager>();
-            stage.StageManager = stageManager.Object;
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count);
-            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
-
-            stageManager.Verify(
-                manager => manager.ChangeStage(
-                    StageType.Title,
-                    Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
-                Moq.Times.Once);
-        }
-    }
-
-    [Fact]
-    public void ExitButton_ShouldCallFlushPendingSaveAndTransitionToTitle()
-    {
-        // Spy on FlushPendingSave via a Mock<IConfigManager> to PROVE the exit path flushes,
-        // independent of internal ConfigManager state (the call must happen regardless).
-        using var inputManager = new InputManagerCompat(new ConfigManager());
-        var (stage, mockConfig) = CreateStageWithMockConfig(inputManager);
-        InitializeStageMenu(stage, includePanels: false);
-        var stageManager = new Moq.Mock<IStageManager>();
-        stage.StageManager = stageManager.Object;
-        var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-        ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count); // Exit button
-        SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
-
-        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
-
-        // EXIT must flush the pending save (persist-on-edit) and leave for Title.
-        mockConfig.Verify(c => c.FlushPendingSave(), Moq.Times.Once);
-        stageManager.Verify(
-            manager => manager.ChangeStage(
-                StageType.Title,
-                Moq.It.Is<IStageTransition>(transition => transition is CrossfadeTransition)),
-            Moq.Times.Once);
-    }
-
-    [Fact]
-    public void ExitButton_WhenFlushThrows_ShouldStillTransitionToTitle()
-    {
-        // Persist-on-edit contract: a flush failure must not trap the user on the config screen.
-        // The stage logs the failure, keeps the dirty flag for retry, and still transitions.
-        using var inputManager = new InputManagerCompat(new ConfigManager());
-        var (stage, mockConfig) = CreateStageWithMockConfig(inputManager);
-        mockConfig.Setup(c => c.FlushPendingSave()).Throws(new IOException("disk full"));
-        InitializeStageMenu(stage, includePanels: false);
-        var stageManager = new Moq.Mock<IStageManager>();
-        stage.StageManager = stageManager.Object;
-        var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-        ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count); // Exit button
-        SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
-
-        var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput"));
-
-        Assert.Null(exception);
-        mockConfig.Verify(c => c.FlushPendingSave(), Moq.Times.Once);
-        stageManager.Verify(
-            manager => manager.ChangeStage(StageType.Title, Moq.It.IsAny<IStageTransition>()),
-            Moq.Times.Once);
     }
 
     [Fact]
@@ -371,13 +240,13 @@ public class ConfigStageLogicTests
             InitializeStageMenu(stage, includePanels: false);
             var activePanel = new TrackingKeyAssignPanel { IsActive = true };
             ReflectionHelpers.SetPrivateField(stage, "_activePanel", activePanel);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 4);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 1);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "OnUpdate", 0.25);
 
             Assert.Equal(1, activePanel.UpdateCallCount);
             Assert.Equal(0.25, activePanel.LastDeltaTime, 3);
-            Assert.Equal(4, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
         }
     }
 
@@ -393,11 +262,12 @@ public class ConfigStageLogicTests
 
         InitializeStageMenu(stage, includePanels: false);
         ReflectionHelpers.SetPrivateField(stage, "_activePanel", (IKeyAssignPanel?)null);
-        ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
+        ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+        ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
 
         ReflectionHelpers.InvokePrivateMethod(stage, "OnUpdate", 0.25);
 
-        Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
+        Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
     }
 
     [Fact]
@@ -414,17 +284,17 @@ public class ConfigStageLogicTests
 
             ReflectionHelpers.InvokePrivateMethod(stage, "OnActivate");
 
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
 
             // Config is the single source of truth; getters read it directly.
             Assert.NotNull(ReflectionHelpers.GetPrivateField<SpriteBatch>(stage, "_spriteBatch"));
             Assert.NotNull(ReflectionHelpers.GetPrivateField<Texture2D>(stage, "_whitePixel"));
-            Assert.NotNull(configItems);
-            Assert.Equal(11, configItems!.Count);
+            Assert.NotNull(categories);
+            Assert.Equal(3, categories!.Count);
             Assert.NotNull(ReflectionHelpers.GetPrivateField<SystemKeyAssignPanel>(stage, "_systemPanel"));
 
             // The resolution item reflects Config (truth).
-            Assert.Equal("Screen Resolution: 1920x1080", configItems[0].GetDisplayText());
+            Assert.Equal("Screen Resolution: 1920x1080", categories[0].Items[0].GetDisplayText());
         }
     }
 
@@ -468,31 +338,13 @@ public class ConfigStageLogicTests
         {
             stage.InitializeDrawingState();
 
-            _ = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawBackground"));
+            _ = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawConfigBackground"));
 
             var drawCall = Assert.Single(stage.RectangleDrawCalls);
             Assert.Equal(new Rectangle(0, 0, viewport.Width, viewport.Height), drawCall.Rectangle);
-            // Must match ConfigStage.FallbackBackgroundColor: a light fill keeps DarkText legible
-            // when the background texture is unavailable (dark-on-dark was the old failure mode).
-            Assert.Equal(new Color(220, 222, 230), drawCall.Color);
-        }
-    }
-
-    [Fact]
-    public void DrawTitle_WhenFontMissing_ShouldFallbackToRectangleDrawing()
-    {
-        var (stage, inputManager) = CreateRenderSpyStage(new Viewport(0, 0, 1280, 720));
-        using (inputManager)
-        {
-            stage.InitializeDrawingState();
-            ReflectionHelpers.SetPrivateField(stage, "_font", null);
-            ReflectionHelpers.SetPrivateField(stage, "_boldFont", null);
-
-            _ = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawTitle"));
-
-            var drawCall = Assert.Single(stage.RectangleDrawCalls);
-            Assert.Equal(new Rectangle(100, 50, "CONFIGURATION".Length * 12, 20), drawCall.Rectangle);
-            Assert.Equal(new Color(26, 30, 46), drawCall.Color);
+            // Must match ConfigStage.FallbackBackgroundColor: dark fill keeps LightText legible
+            // when the background texture is unavailable (light-on-dark is the NX aesthetic).
+            Assert.Equal(new Color(18, 20, 34), drawCall.Color);
         }
     }
 
@@ -504,12 +356,13 @@ public class ConfigStageLogicTests
         {
             InitializeStageMenu(stage, includePanels: false);
             ReflectionHelpers.SetPrivateField(stage, "_activePanel", (IKeyAssignPanel?)null);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
             SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
-            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
         }
     }
 
@@ -521,8 +374,7 @@ public class ConfigStageLogicTests
         {
             InitializeStageMenu(stage, includePanels: false);
             // Drum Key Mapping is a NavigationConfigItem; Left should not change config values.
-            var drumIndex = GetConfigItemIndex(stage, "Drum Key Mapping");
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", drumIndex);
+            SelectItemForEditing(stage, "Drum Key Mapping");
             var autoPlayBefore = configManager.Config.AutoPlay;
             SetKeyboardStates(stage, new KeyboardState(Keys.Left), new KeyboardState());
 
@@ -540,34 +392,13 @@ public class ConfigStageLogicTests
         {
             InitializeStageMenu(stage, includePanels: false);
             // System Key Mapping is a NavigationConfigItem; Right should not change config values.
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", GetConfigItemIndex(stage, "System Key Mapping"));
+            SelectItemForEditing(stage, "System Key Mapping");
             var autoPlayBefore = configManager.Config.AutoPlay;
             SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
             Assert.Equal(autoPlayBefore, configManager.Config.AutoPlay);
-        }
-    }
-
-    [Fact]
-    public void HandleInput_ActivateOnExitButton_ShouldInvokeExitButtonClicked()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            var stageManager = new Moq.Mock<IStageManager>();
-            stage.StageManager = stageManager.Object;
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count);
-            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
-
-            stageManager.Verify(
-                manager => manager.ChangeStage(StageType.Title, Moq.It.IsAny<IStageTransition>()),
-                Moq.Times.Once);
         }
     }
 
@@ -724,8 +555,7 @@ public class ConfigStageLogicTests
             InitializeStageMenu(stage, includePanels: true);
             var systemPanel = ReflectionHelpers.GetPrivateField<SystemKeyAssignPanel>(stage, "_systemPanel");
             Assert.NotNull(systemPanel);
-            var systemKeyMappingIndex = GetConfigItemIndex(stage, "System Key Mapping");
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", systemKeyMappingIndex);
+            SelectItemForEditing(stage, "System Key Mapping");
             ReflectionHelpers.InvokePrivateMethod(stage, "OpenPanel", systemPanel!);
             var before = inputManager.GetKeyMappingSnapshot().Count;
 
@@ -733,7 +563,10 @@ public class ConfigStageLogicTests
 
             Assert.False(systemPanel.IsActive);
             Assert.Null(ReflectionHelpers.GetPrivateField<IKeyAssignPanel>(stage, "_activePanel"));
-            Assert.Equal(systemKeyMappingIndex, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedIndex"));
+            // Still in System category with System Key Mapping selected (index 5 in System items).
+            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            Assert.Equal(5, categories![0].SelectedIndex);
             // Cancel (Back) does not persist; system bindings unchanged.
             Assert.Equal(before, inputManager.GetKeyMappingSnapshot().Count);
         }
@@ -821,10 +654,10 @@ public class ConfigStageLogicTests
     }
 
     [Theory]
-    [InlineData(2, nameof(ConfigData.VSyncWait))]
-    [InlineData(3, nameof(ConfigData.NoFail))]
-    [InlineData(4, nameof(ConfigData.AutoPlay))]
-    public void ActivatePressedOnToggle_ShouldMutateConfigViaSetter(int selectedIndex, string propertyName)
+    [InlineData("VSync Wait", nameof(ConfigData.VSyncWait))]
+    [InlineData("No Fail", nameof(ConfigData.NoFail))]
+    [InlineData("Auto Play", nameof(ConfigData.AutoPlay))]
+    public void ActivatePressedOnToggle_ShouldMutateConfigViaSetter(string itemName, string propertyName)
     {
         var (stage, configManager, inputManager) = CreateStage();
         using (inputManager)
@@ -833,7 +666,7 @@ public class ConfigStageLogicTests
             Assert.NotNull(property);
             property!.SetValue(configManager.Config, false);
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", selectedIndex);
+            SelectItemForEditing(stage, itemName);
             SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
@@ -851,8 +684,7 @@ public class ConfigStageLogicTests
             configManager.Config.AudioLatencyOffsetMs = 200;
             InitializeStageMenu(stage, includePanels: false);
 
-            // Audio Latency Offset is at index 6 (after Resolution, Fullscreen, VSync, NoFail, AutoPlay, ScrollSpeed)
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 6);
+            SelectItemForEditing(stage, "Audio Latency Offset");
             SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
@@ -869,7 +701,7 @@ public class ConfigStageLogicTests
             configManager.Config.AudioLatencyOffsetMs = 0;
             InitializeStageMenu(stage, includePanels: false);
 
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 6);
+            SelectItemForEditing(stage, "Audio Latency Offset");
             SetKeyboardStates(stage, new KeyboardState(Keys.Left), new KeyboardState());
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
@@ -886,7 +718,7 @@ public class ConfigStageLogicTests
             configManager.Config.AudioLatencyOffsetMs = 500;
             InitializeStageMenu(stage, includePanels: false);
 
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 6);
+            SelectItemForEditing(stage, "Audio Latency Offset");
             SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
@@ -942,6 +774,190 @@ public class ConfigStageLogicTests
         reloaded.LoadConfig(configPath);
         return reloaded.Config.AutoPlay;
     }
+
+    // ---- New NX master-detail behavior tests (Task 5) ----
+
+    [Fact]
+    public void SetupConfigItems_ShouldBuildSystemDrumsExitCategories()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+
+            Assert.Collection(categories!,
+                c => Assert.Equal("System", c.Name),
+                c => Assert.Equal("Drums", c.Name),
+                c => Assert.Equal("Exit", c.Name));
+
+            Assert.Collection(categories![0].Items,
+                i => Assert.Equal("Screen Resolution", i.Name),
+                i => Assert.Equal("Fullscreen", i.Name),
+                i => Assert.Equal("VSync Wait", i.Name),
+                i => Assert.Equal("Audio Latency Offset", i.Name),
+                i => Assert.Equal("DTX Folder", i.Name),
+                i => Assert.Equal("System Key Mapping", i.Name),
+                i => Assert.Equal("Import NX Scores", i.Name));
+
+            Assert.Collection(categories[1].Items,
+                i => Assert.Equal("Scroll Speed", i.Name),
+                i => Assert.Equal("Auto Play", i.Name),
+                i => Assert.Equal("No Fail", i.Name),
+                i => Assert.Equal("Drum Key Mapping", i.Name));
+
+            Assert.False(categories[2].HasItems);
+        }
+    }
+
+    [Fact]
+    public void EveryConfigCategoryAndItem_ShouldHaveNonEmptyDescription()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+
+            foreach (var category in categories!)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(category.Description));
+                foreach (var item in category.Items)
+                    Assert.False(string.IsNullOrWhiteSpace(item.Description), $"{item.Name} needs a description");
+            }
+        }
+    }
+
+    [Fact]
+    public void MenuActivateOnSettingsCategory_ShouldMoveFocusToItems()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+        }
+    }
+
+    [Fact]
+    public void MenuActivateOnExitCategory_ShouldFlushAndTransitionToTitle()
+    {
+        using var inputManager = new InputManagerCompat(new ConfigManager());
+        var (stage, mockConfig) = CreateStageWithMockConfig(inputManager);
+        InitializeStageMenu(stage, includePanels: false);
+        var stageManager = new Moq.Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 2); // Exit
+        ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+        SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        mockConfig.Verify(c => c.FlushPendingSave(), Moq.Times.Once);
+        stageManager.Verify(
+            m => m.ChangeStage(StageType.Title, Moq.It.Is<IStageTransition>(t => t is CrossfadeTransition)),
+            Moq.Times.Once);
+    }
+
+    [Fact]
+    public void ItemsBackCommand_ShouldReturnFocusToMenu_WithoutLeavingStage()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Moq.Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Escape), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+            stageManager.Verify(
+                m => m.ChangeStage(Moq.It.IsAny<StageType>(), Moq.It.IsAny<IStageTransition>()),
+                Moq.Times.Never);
+        }
+    }
+
+    [Fact]
+    public void MenuMoveDown_ShouldWrapAcrossCategories()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 2); // Exit (last)
+            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+        }
+    }
+
+    [Fact]
+    public void DrawCategoryMenu_ShouldHighlightCurrentCategory()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 1);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawCategoryMenu");
+
+            Assert.Contains(stage.RectangleDrawCalls, c => c.Rectangle == ConfigUILayout.MenuCursorRect(1));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WhenFocusOnItems_ShouldDrawItemCursorAtSelectedRow()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            categories![0].SelectedIndex = 2;
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            Assert.Contains(stage.RectangleDrawCalls, c => c.Rectangle == ConfigUILayout.ItemCursorRect(2));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WhenFocusOnMenu_ShouldNotDrawItemCursor()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            Assert.DoesNotContain(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.ItemCursorRect(0));
+        }
+    }
+
+    // ---- End of new NX master-detail behavior tests ----
 
     private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
     {
@@ -1020,13 +1036,29 @@ public class ConfigStageLogicTests
         cm.SetSystemKeyBindings(bindings);
     }
 
-    private static int GetConfigItemIndex(ConfigStage stage, string itemName)
+    /// <summary>
+    /// Finds (categoryIndex, itemIndex) for a named item across all categories, sets the stage's
+    /// current category + that category's SelectedIndex, and switches focus to the item list so a
+    /// subsequent HandleInput acts on the item. Mirrors the new master-detail navigation.
+    /// </summary>
+    private static void SelectItemForEditing(ConfigStage stage, string itemName)
     {
-        var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-        Assert.NotNull(configItems);
-        var index = configItems!.FindIndex(item => item.Name == itemName);
-        Assert.True(index >= 0, $"Config item '{itemName}' should exist.");
-        return index;
+        var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+        Assert.NotNull(categories);
+        for (int c = 0; c < categories!.Count; c++)
+        {
+            for (int i = 0; i < categories[c].Items.Count; i++)
+            {
+                if (categories[c].Items[i].Name == itemName)
+                {
+                    ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", c);
+                    categories[c].SelectedIndex = i;
+                    ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+                    return;
+                }
+            }
+        }
+        Assert.Fail($"Config item '{itemName}' should exist.");
     }
 
     private static void SetKeyboardStates(ConfigStage stage, KeyboardState current, KeyboardState previous)

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1253,6 +1253,38 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void DrawItemList_ShouldRightAlignValuesWithinTheBox()
+    {
+        // Values anchor at the box's right inner edge (ItemValueRightX) so they never overflow the
+        // box and never run under the description panel drawn afterward at x=800. A fixed-width
+        // mock font lets us assert the exact right-aligned x position.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            const float measuredWidth = 80f;
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(measuredWidth, 14f));
+            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", font.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            // Value x = right anchor (766) minus measured width (80) = 686. Names are drawn at the
+            // fixed ItemNamePos (x=454), so only the right-aligned values land at 686.
+            var expectedValueX = ConfigUILayout.ItemValueRightX - measuredWidth;
+            font.Verify(f => f.DrawString(It.IsAny<SpriteBatch>(), It.IsAny<string>(),
+                It.Is<Vector2>(p => Math.Abs(p.X - expectedValueX) < 0.01f), It.IsAny<Color>()),
+                Times.AtLeastOnce,
+                "value text should be right-aligned within the item box");
+        }
+    }
+
+    [Fact]
     public void DrawHeaderFooter_WhenTexturesMissing_ShouldFallbackToPanelFills()
     {
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1179,6 +1179,126 @@ public class ConfigStageLogicTests
         }
     }
 
+    // ---- Integration flow + defensive-guard tests (code review follow-up) ----
+
+    [Fact]
+    public void HandleInput_FullMenuItemsEditBackExitFlow_ShouldTransitionThroughAllFocusStates()
+    {
+        // Integration-style: drives the complete focus-state machine end-to-end through HandleInput
+        // (Menu -> enter Items -> edit a toggle -> Back to Menu -> navigate to Exit -> activate Exit).
+        // Each step asserts the state carried over from the previous one, catching interaction
+        // bugs that the per-transition unit tests above can miss in isolation.
+        var (stage, configManager, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+            var stageManager = new Moq.Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            var fullscreenBefore = configManager.Config.FullScreen;
+
+            // Start: System category, focus on menu.
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+
+            // 1. Menu: Activate -> enter System items (SelectedIndex starts at 0).
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+
+            // 2. Items: MoveDown -> select Fullscreen (index 1).
+            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            Assert.Equal(1, categories![0].SelectedIndex);
+
+            // 3. Items: Activate -> toggle Fullscreen via the typed setter.
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            Assert.NotEqual(fullscreenBefore, configManager.Config.FullScreen);
+
+            // 4. Items: Back -> return focus to menu WITHOUT leaving the stage.
+            SetKeyboardStates(stage, new KeyboardState(Keys.Escape), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+            stageManager.Verify(m => m.ChangeStage(
+                Moq.It.IsAny<StageType>(), Moq.It.IsAny<IStageTransition>()), Moq.Times.Never);
+
+            // 5. Menu: MoveDown -> Drums.
+            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+
+            // 6. Menu: MoveDown -> Exit.
+            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            Assert.Equal(2, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+
+            // 7. Menu: Activate on Exit (no items) -> flush + transition to Title.
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+            stageManager.Verify(m => m.ChangeStage(
+                StageType.Title, Moq.It.Is<IStageTransition>(t => t is CrossfadeTransition)), Moq.Times.Once);
+        }
+    }
+
+    [Fact]
+    public void HandleInput_WithEmptyCategories_ShouldNotThrowInEitherFocusState()
+    {
+        // Defensive guard: SetupConfigItems always populates _categories, but if that invariant
+        // ever breaks the modular-arithmetic (% Count) and index access in the handlers would
+        // throw DivideByZero/ArgumentOutOfRange. The HandleInput guard must swallow both.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            SetupRuntimeSystemBindings(inputManager, new Dictionary<Keys, InputCommandType>
+            {
+                [Keys.Down] = InputCommandType.MoveDown,
+                [Keys.Enter] = InputCommandType.Activate,
+                [Keys.Escape] = InputCommandType.Back
+            });
+            ReflectionHelpers.SetPrivateField(stage, "_categories", new List<ConfigCategory>());
+
+            // Menu focus: would hit % _categories.Count == 0 (DivideByZero) without the guard.
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
+            Assert.Null(Record.Exception(() =>
+                ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput")));
+
+            // Item focus: would hit _categories[_currentCategoryIndex] (ArgumentOutOfRange).
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+            Assert.Null(Record.Exception(() =>
+                ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput")));
+        }
+    }
+
+    [Fact]
+    public void DrawDescriptionPanel_WithEmptyDescription_ShouldStillRenderPanelBackground()
+    {
+        // The description panel is a fixed UI region; its background must render even when the
+        // selected item's description is empty, so the layout never shows a surprise blank gap.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            var emptyDescItem = new ReadOnlyConfigItem("X", () => "v") { Description = "" };
+            var category = new ConfigCategory("Cat", "category desc",
+                new List<IConfigItem> { emptyDescItem });
+            category.SelectedIndex = 0;
+            ReflectionHelpers.SetPrivateField(stage, "_categories",
+                new List<ConfigCategory> { category });
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false); // item desc path (empty)
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
+
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.DescriptionPanelRect && c.Color == new Color(28, 32, 54, 220));
+        }
+    }
+
     private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
     {
         configManager ??= new ConfigManager();

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -403,6 +403,70 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void HandleInput_MoveLeftOnNavigationItem_ShouldNotChangeStage()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+            var stageManager = new Moq.Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+
+            // Drum Key Mapping navigates to DrumConfig via an InstantTransition. Left is a
+            // value-adjust key and must never trigger that stage change.
+            SelectItemForEditing(stage, "Drum Key Mapping");
+            SetKeyboardStates(stage, new KeyboardState(Keys.Left), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            stageManager.Verify(
+                manager => manager.ChangeStage(
+                    Moq.It.IsAny<StageType>(),
+                    Moq.It.IsAny<IStageTransition>()),
+                Moq.Times.Never);
+        }
+    }
+
+    [Fact]
+    public void HandleInput_MoveRightOnNavigationItem_ShouldNotOpenPanel()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+
+            // System Key Mapping opens the key-assign panel. Right is a value-adjust key and
+            // must never pop that overlay open.
+            SelectItemForEditing(stage, "System Key Mapping");
+            SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            var activePanel = ReflectionHelpers.GetPrivateField<IKeyAssignPanel>(stage, "_activePanel");
+            Assert.Null(activePanel);
+        }
+    }
+
+    [Fact]
+    public void HandleInput_ActivateOnSystemKeyMapping_ShouldOpenPanel()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+
+            // Activate is the supported path for navigation items; it must still open the panel.
+            SelectItemForEditing(stage, "System Key Mapping");
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            var activePanel = ReflectionHelpers.GetPrivateField<IKeyAssignPanel>(stage, "_activePanel");
+            Assert.NotNull(activePanel);
+        }
+    }
+
+    [Fact]
     public void IsConfigNavigationCommandPressed_RuntimeBindingPressed_ShouldReturnTrue()
     {
         var (stage, _, inputManager) = CreateStage();

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1023,6 +1023,162 @@ public class ConfigStageLogicTests
 
     // ---- End of new NX master-detail behavior tests ----
 
+    // ---- Coverage gaps flagged in code review ----
+
+    [Fact]
+    public void SelectedIndex_ShouldBeRememberedAcrossCategorySwitches()
+    {
+        // Spec-required: the item selection within each category must persist when the player
+        // navigates away and returns. Each ConfigCategory owns its own SelectedIndex which is
+        // never reset on focus/category changes.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+
+            // Enter System items, move selection down twice (index 0 -> 2).
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+            categories![0].MoveSelectionDown();
+            categories[0].MoveSelectionDown();
+            Assert.Equal(2, categories[0].SelectedIndex);
+
+            // Switch focus back to menu, move to Drums category.
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 1);
+
+            // Navigate back to System category.
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+
+            // The System category must still remember index 2.
+            Assert.Equal(2, categories[0].SelectedIndex);
+        }
+    }
+
+    [Fact]
+    public void MenuMoveRightOnSettingsCategory_ShouldMoveFocusToItems()
+    {
+        // HandleMenuInput accepts both Activate and MoveRight to enter the item list.
+        // Activate is covered above; this verifies the MoveRight path.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+        }
+    }
+
+    [Fact]
+    public void MenuMoveUp_ShouldWrapAcrossCategories()
+    {
+        // MoveDown wrap is covered above; this verifies MoveUp wraps from first to last.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System (first)
+            SetKeyboardStates(stage, new KeyboardState(Keys.Up), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.Equal(2, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+        }
+    }
+
+    [Fact]
+    public void DrawItemBar_WhenTextureMissing_ShouldFallbackToPanelFill()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemBar");
+
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.ItemBarRect && c.Color == new Color(28, 32, 54, 220));
+        }
+    }
+
+    [Fact]
+    public void DrawHeaderFooter_WhenTexturesMissing_ShouldFallbackToPanelFills()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawHeaderFooter");
+
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.HeaderRect && c.Color == new Color(28, 32, 54, 220));
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.FooterRect && c.Color == new Color(28, 32, 54, 220));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WhenItemBoxTexturesMissing_ShouldFallbackToItemBoxFill()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System has 7 items
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            // Every item row should get a fallback fill when its box texture is unavailable.
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.ItemRowRect(0) && c.Color == new Color(34, 40, 68, 200));
+        }
+    }
+
+    [Fact]
+    public void DrawCategoryMenu_WhenPanelTextureMissing_ShouldFallbackToPanelFill()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 1);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawCategoryMenu");
+
+            // Menu panel fallback fill plus the cursor fallback fill.
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.MenuPanelRect && c.Color == new Color(28, 32, 54, 220));
+        }
+    }
+
+    [Fact]
+    public void DrawDescriptionPanel_WhenTextureMissing_ShouldFallbackToPanelFill()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
+
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.DescriptionPanelRect && c.Color == new Color(28, 32, 54, 220));
+        }
+    }
+
     private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
     {
         configManager ??= new ConfigManager();

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1285,6 +1285,53 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void DrawItemList_WhenValueExceedsAvailableWidth_ShouldEllipsizeBeforeRightAligning()
+    {
+        // A value wider than the gap between the name's left edge and the value's right anchor
+        // (ItemValueMaxWidth) must be ellipsized before the right-aligned position is computed.
+        // Otherwise valuePos.X = ItemValueRightX - fullWidth moves left of the name and, since the
+        // value is drawn after the name, overwrites it (e.g. the default macOS DTXPath under
+        // ~/Library/Application Support/...). The per-character mock font makes the overflow
+        // deterministic: 8px/char means a 56-char path measures 448px > 312px available.
+        var longPath = "/Users/testuser/Library/Application Support/DTXManiaCX/DTXFiles";
+        var configManager = new ConfigManager { Config = { DTXPath = longPath } };
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice(configManager);
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            const float charWidth = 8f;
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * charWidth, 14f));
+            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", font.Object);
+
+            var draws = new List<(string Text, Vector2 Position)>();
+            font.Setup(f => f.DrawString(It.IsAny<SpriteBatch>(), It.IsAny<string>(),
+                    It.IsAny<Vector2>(), It.IsAny<Color>()))
+                .Callback<SpriteBatch, string, Vector2, Color>((_, text, pos, _) => draws.Add((text, pos)));
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            // No text may start left of the name column: names sit at ItemNamePos.X (454) and
+            // right-aligned values must not cross that boundary.
+            var nameLeftX = ConfigUILayout.ItemNamePos(0).X;
+            Assert.All(draws, d => Assert.True(d.Position.X >= nameLeftX - 0.01f,
+                $"text \"{d.Text}\" drawn at x={d.Position.X} crosses left of the name column at x={nameLeftX}"));
+
+            // The long DTX path value must be ellipsized (ends with "...") and fit the available width.
+            var pathDraw = draws.Single(d => d.Text.StartsWith("/Users/", StringComparison.Ordinal));
+            Assert.EndsWith("...", pathDraw.Text);
+            Assert.True(font.Object.MeasureString(pathDraw.Text).X <= ConfigUILayout.ItemValueMaxWidth + 0.01f,
+                $"ellipsized value width must fit ItemValueMaxWidth ({ConfigUILayout.ItemValueMaxWidth})");
+        }
+    }
+
+    [Fact]
     public void DrawHeaderFooter_WhenTexturesMissing_ShouldFallbackToPanelFills()
     {
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -16,6 +16,7 @@ using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using Moq;
 
 namespace DTXMania.Test.Config;
 
@@ -295,6 +296,23 @@ public class ConfigStageLogicTests
 
             // The resolution item reflects Config (truth).
             Assert.Equal("Screen Resolution: 1920x1080", categories[0].Items[0].GetDisplayText());
+        }
+    }
+
+    [Fact]
+    public void OnActivate_ShouldClearStaleImportStatus()
+    {
+        // StageManager reuses this instance, so an import status left by a previous visit must be
+        // cleared on re-entry (otherwise a stale "Imported N scores" survives leaving/re-entering).
+        var configManager = new ConfigManager();
+        var (stage, inputManager) = CreateLifecycleStage(configManager);
+        using (inputManager)
+        {
+            ReflectionHelpers.SetPrivateField(stage, "_importStatus", "Imported 5 scores");
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OnActivate");
+
+            Assert.Equal("", ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
         }
     }
 
@@ -819,6 +837,12 @@ public class ConfigStageLogicTests
                 configManager.SetAutoPlay(true);
                 Assert.False(ReadAutoPlayFromDisk(configPath));
 
+                // Graphics fields are uninitialized stand-ins (no real GraphicsDevice in headless
+                // tests); null them so OnDeactivate's dispose path is a no-op, mirroring the
+                // DrumConfigStage lifecycle test.
+                ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", null);
+                ReflectionHelpers.SetPrivateField(stage, "_whitePixel", null);
+
                 // OnDeactivate must flush the dirty edit to disk.
                 ReflectionHelpers.InvokePrivateMethod(stage, "OnDeactivate");
             }
@@ -1106,6 +1130,126 @@ public class ConfigStageLogicTests
             Assert.Contains(stage.RectangleDrawCalls,
                 c => c.Rectangle == ConfigUILayout.ItemBarRect && c.Color == new Color(28, 32, 54, 220));
         }
+    }
+
+    // ---- TryLoadTexture regression: the 1×1 white-fallback must be treated as "missing" ----
+    // ResourceManager.LoadTexture never throws for an absent file — it returns a 1×1 white
+    // fallback (see ResourceManager.CreateFallbackTexture). The old TryLoadTexture only caught
+    // exceptions, so it returned that 1×1 texture, every draw took its texture branch, and a
+    // single white texel was stretched across every panel (white-box rendering). The fix rejects
+    // Width/Height <= 1, releases the throwaway fallback's reference, and returns null so the
+    // documented fallback fills engage.
+
+    [Fact]
+    public void TryLoadTexture_WhenResourceManagerReturns1x1Fallback_ShouldReturnNullAndReleaseReference()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+
+            var fallbackTexture = new Mock<ITexture>();
+            fallbackTexture.SetupGet(t => t.Width).Returns(1);
+            fallbackTexture.SetupGet(t => t.Height).Returns(1);
+
+            var mockResources = new Mock<IResourceManager>();
+            mockResources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(fallbackTexture.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", mockResources.Object);
+
+            var result = ReflectionHelpers.InvokePrivateMethod<ITexture>(stage, "TryLoadTexture", TexturePath.ConfigBackground);
+
+            Assert.Null(result);
+            // The 1×1 fallback's reference must be released so it isn't leaked.
+            fallbackTexture.Verify(t => t.RemoveReference(), Times.Once);
+        }
+    }
+
+    [Fact]
+    public void TryLoadTexture_WhenAssetIsValid_ShouldReturnTextureWithoutReleasing()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+
+            var realTexture = new Mock<ITexture>();
+            realTexture.SetupGet(t => t.Width).Returns(256);
+            realTexture.SetupGet(t => t.Height).Returns(128);
+
+            var mockResources = new Mock<IResourceManager>();
+            mockResources.Setup(r => r.LoadTexture(It.IsAny<string>())).Returns(realTexture.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", mockResources.Object);
+
+            var result = ReflectionHelpers.InvokePrivateMethod<ITexture>(stage, "TryLoadTexture", TexturePath.ConfigBackground);
+
+            Assert.Same(realTexture.Object, result);
+            realTexture.Verify(t => t.RemoveReference(), Times.Never);
+        }
+    }
+
+    [Fact]
+    public void TryLoadTexture_WhenLoadTextureThrows_ShouldReturnNull()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+
+            var mockResources = new Mock<IResourceManager>();
+            mockResources.Setup(r => r.LoadTexture(It.IsAny<string>()))
+                .Throws(new InvalidOperationException("boom"));
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", mockResources.Object);
+
+            var result = ReflectionHelpers.InvokePrivateMethod<ITexture>(stage, "TryLoadTexture", TexturePath.ConfigBackground);
+
+            Assert.Null(result);
+        }
+    }
+
+    // ---- GetItemValueText: value-column extraction (private static, reached via reflection) ----
+
+    [Fact]
+    public void GetItemValueText_ForValueItem_ShouldStripNamePrefix()
+    {
+        var item = new DropdownConfigItem("Volume", () => "75", new[] { "75", "100" }, _ => { });
+
+        Assert.Equal("75", InvokeGetItemValueText(item));
+    }
+
+    [Fact]
+    public void GetItemValueText_ForReadOnlyItem_ShouldStripNamePrefix()
+    {
+        var item = new ReadOnlyConfigItem("DTX Folder", () => "/songs");
+
+        Assert.Equal("/songs", InvokeGetItemValueText(item));
+    }
+
+    [Fact]
+    public void GetItemValueText_ForNavigationItem_ShouldReturnArrowIndicator()
+    {
+        var item = new NavigationConfigItem("Drum Mapping", () => { });
+
+        Assert.Equal(">", InvokeGetItemValueText(item));
+    }
+
+    [Fact]
+    public void GetItemValueText_WhenDisplayTextDoesNotStartWithPrefix_ShouldReturnEmpty()
+    {
+        // Defensive: a future item type whose GetDisplayText omits the "{Name}: " prefix renders
+        // an empty value column rather than echoing the whole display string into the value slot.
+        var item = new Mock<IConfigItem>();
+        item.SetupGet(i => i.Name).Returns("X");
+        item.Setup(i => i.GetDisplayText()).Returns("no prefix here");
+
+        Assert.Equal(string.Empty, InvokeGetItemValueText(item.Object));
+    }
+
+    private static string InvokeGetItemValueText(IConfigItem item)
+    {
+        var method = typeof(ConfigStage).GetMethod("GetItemValueText",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (string)method!.Invoke(null, new object[] { item })!;
     }
 
     [Fact]

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1299,6 +1299,66 @@ public class ConfigStageLogicTests
         }
     }
 
+    [Fact]
+    public void DrawDescriptionPanel_WhenFocusOnMenu_ShouldDrawCategoryDescription()
+    {
+        // Spec requirement: while focus = Menu, the description panel shows the focused
+        // category's Description. The render spy nulls the font, so this injects a mock
+        // font to capture the DrawString text content — the one spec assertion the
+        // fallback-rect tests can't cover.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            var mockFont = new Moq.Mock<IFont>();
+            mockFont.Setup(f => f.MeasureString(Moq.It.IsAny<string>())).Returns(new Vector2(1, 1));
+            ReflectionHelpers.SetPrivateField(stage, "_font", mockFont.Object);
+
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
+
+            var expected = categories![0].Description;
+            mockFont.Verify(
+                f => f.DrawString(Moq.It.IsAny<SpriteBatch>(), expected,
+                    Moq.It.IsAny<Vector2>(), Moq.It.IsAny<Color>()),
+                Moq.Times.Once);
+        }
+    }
+
+    [Fact]
+    public void DrawDescriptionPanel_WhenFocusOnItems_ShouldDrawSelectedItemDescription()
+    {
+        // Spec requirement: while focus = Items, the description panel shows the focused
+        // item's Description (not the category's). Paired with the Menu-focus test above
+        // to prove the focus-driven text switch.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            categories![0].SelectedIndex = 0; // Screen Resolution
+            var mockFont = new Moq.Mock<IFont>();
+            mockFont.Setup(f => f.MeasureString(Moq.It.IsAny<string>())).Returns(new Vector2(1, 1));
+            ReflectionHelpers.SetPrivateField(stage, "_font", mockFont.Object);
+
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
+
+            var expected = categories[0].SelectedItem!.Description;
+            mockFont.Verify(
+                f => f.DrawString(Moq.It.IsAny<SpriteBatch>(), expected,
+                    Moq.It.IsAny<Vector2>(), Moq.It.IsAny<Color>()),
+                Moq.Times.Once);
+        }
+    }
+
     private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
     {
         configManager ??= new ConfigManager();

--- a/DTXMania.Test/Resources/TexturePathTests.cs
+++ b/DTXMania.Test/Resources/TexturePathTests.cs
@@ -433,5 +433,42 @@ namespace DTXMania.Test.Resources
         }
 
         #endregion
+
+        #region Config Stage Texture Constants
+
+        [Fact]
+        public void ConfigTexturePaths_ShouldUseExpectedSkinFiles()
+        {
+            Assert.Equal("Graphics/4_background.png", TexturePath.ConfigBackground);
+            Assert.Equal("Graphics/4_item bar.png", TexturePath.ConfigItemBar);
+            Assert.Equal("Graphics/4_menu panel.png", TexturePath.ConfigMenuPanel);
+            Assert.Equal("Graphics/4_menu cursor.png", TexturePath.ConfigMenuCursor);
+            Assert.Equal("Graphics/4_header panel.png", TexturePath.ConfigHeaderPanel);
+            Assert.Equal("Graphics/4_footer panel.png", TexturePath.ConfigFooterPanel);
+            Assert.Equal("Graphics/4_itembox.png", TexturePath.ConfigItemBox);
+            Assert.Equal("Graphics/4_itembox other.png", TexturePath.ConfigItemBoxOther);
+            Assert.Equal("Graphics/4_itembox cursor.png", TexturePath.ConfigItemBoxCursor);
+            Assert.Equal("Graphics/4_Description Panel.png", TexturePath.ConfigDescriptionPanel);
+        }
+
+        [Fact]
+        public void GetAllTexturePaths_ShouldContainConfigPaths()
+        {
+            var paths = TexturePath.GetAllTexturePaths();
+            Assert.Contains(TexturePath.ConfigBackground, paths);
+            Assert.Contains(TexturePath.ConfigMenuPanel, paths);
+            Assert.Contains(TexturePath.ConfigDescriptionPanel, paths);
+        }
+
+        [Fact]
+        public void GetPanelTextures_ShouldContainConfigPanels_ButNotBackground()
+        {
+            var paths = TexturePath.GetPanelTextures();
+            Assert.Contains(TexturePath.ConfigMenuPanel, paths);
+            Assert.Contains(TexturePath.ConfigItemBox, paths);
+            Assert.DoesNotContain(TexturePath.ConfigBackground, paths);
+        }
+
+        #endregion
     }
 }

--- a/DTXMania.Test/Stage/ConfigStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageCoverageTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
@@ -10,8 +9,6 @@ using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Stage.KeyAssign;
 using DTXMania.Test.TestData;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using Moq;
 
@@ -28,16 +25,6 @@ public class ConfigStageCoverageTests
         ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
         ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
         return (new ConfigStage(game), configManager, inputManager);
-    }
-
-    private static (RenderSpyConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateRenderSpyStage(ConfigManager? configManager = null)
-    {
-        configManager ??= new ConfigManager();
-        var inputManager = new InputManagerCompat(configManager);
-        var game = ReflectionHelpers.CreateGame();
-        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
-        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
-        return (new RenderSpyConfigStage(game), configManager, inputManager);
     }
 
     private static void InitializeStageMenu(ConfigStage stage, bool includePanels)
@@ -157,50 +144,9 @@ public class ConfigStageCoverageTests
         }
     }
 
-    private static void SetFallbackDrawingState(ConfigStage stage)
-    {
-        ReflectionHelpers.SetPrivateField(stage, "_font", null);
-        ReflectionHelpers.SetPrivateField(stage, "_boldFont", null);
-        ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", CreateUninitializedSpriteBatch());
-        ReflectionHelpers.SetPrivateField(stage, "_whitePixel", CreateUninitializedTexture());
-    }
-
-    private static SpriteBatch CreateUninitializedSpriteBatch()
-    {
-#pragma warning disable SYSLIB0050
-        var sb = (SpriteBatch)FormatterServices.GetUninitializedObject(typeof(SpriteBatch));
-#pragma warning restore SYSLIB0050
-        GC.SuppressFinalize(sb);
-        return sb;
-    }
-
-    private static Texture2D CreateUninitializedTexture()
-    {
-#pragma warning disable SYSLIB0050
-        var texture = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
-#pragma warning restore SYSLIB0050
-        GC.SuppressFinalize(texture);
-        return texture;
-    }
-
     private static void SetPrivateField(object target, string fieldName, object? value)
         => ReflectionHelpers.SetPrivateField(target, fieldName, value);
 
     private static T? GetPrivateField<T>(object target, string fieldName)
         => ReflectionHelpers.GetPrivateField<T>(target, fieldName);
-
-    private sealed class RenderSpyConfigStage : ConfigStage
-    {
-        public RenderSpyConfigStage(BaseGame game)
-            : base(game)
-        {
-        }
-
-        public List<(Rectangle Rectangle, Color Color)> RectangleDrawCalls { get; } = [];
-
-        protected override void DrawFilledRectangle(Rectangle destinationRectangle, Color color)
-        {
-            RectangleDrawCalls.Add((destinationRectangle, color));
-        }
-    }
 }

--- a/DTXMania.Test/Stage/ConfigStageCoverageTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageCoverageTests.cs
@@ -65,26 +65,6 @@ public class ConfigStageCoverageTests
     }
 
     [Fact]
-    public void OnExitButtonClicked_ShouldChangeStage()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var stageManager = new Mock<IStageManager>();
-            stage.StageManager = stageManager.Object;
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "OnExitButtonClicked", null, EventArgs.Empty);
-
-            stageManager.Verify(
-                m => m.ChangeStage(
-                    StageType.Title,
-                    It.Is<IStageTransition>(t => t is CrossfadeTransition)),
-                Times.Once);
-        }
-    }
-
-    [Fact]
     public void HandleInput_WhenBackCommandPressed_ShouldChangeStage()
     {
         var (stage, _, inputManager) = CreateStage();
@@ -152,173 +132,7 @@ public class ConfigStageCoverageTests
     }
 
     [Fact]
-    public void DrawTitle_WhenFontExists_ShouldUseMeasureStringAndDrawString()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            var font = new Mock<IFont>();
-            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(200, 20));
-            var spriteBatch = CreateUninitializedSpriteBatch();
-            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", spriteBatch);
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "DrawTitle");
-
-            font.Verify(f => f.MeasureString("CONFIGURATION"), Times.Once);
-            font.Verify(f => f.DrawString(spriteBatch, "CONFIGURATION", new Vector2(540, 50), new Color(26, 30, 46)), Times.Once);
-        }
-    }
-
-    [Fact]
-    public void DrawTitle_WhenFontNull_ShouldNotThrow()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            ReflectionHelpers.SetPrivateField(stage, "_font", null);
-
-            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawTitle"));
-
-            Assert.Null(exception);
-        }
-    }
-
-    [Fact]
-    public void DrawConfigItems_WhenSelected_ShouldUseBoldFont()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var font = new Mock<IFont>();
-            var boldFont = new Mock<IFont>();
-            var spriteBatch = CreateUninitializedSpriteBatch();
-            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_boldFont", boldFont.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", spriteBatch);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "DrawConfigItems");
-
-            boldFont.Verify(f => f.DrawString(spriteBatch, It.IsAny<string>(), It.IsAny<Vector2>(), Color.Yellow), Times.AtLeastOnce);
-        }
-    }
-
-    [Fact]
-    public void DrawConfigItems_WhenFontIsNull_ShouldUseRectangleFallbackWithoutThrowing()
-    {
-        var (stage, _, inputManager) = CreateRenderSpyStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            Assert.NotNull(configItems);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count);
-            SetFallbackDrawingState(stage);
-
-            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawConfigItems"));
-
-            Assert.Null(exception);
-            var expectedWidths = configItems
-                .ConvertAll(item => item.GetDisplayText().Length * 8)
-                .OrderBy(width => width)
-                .ToArray();
-            var actualWidths = stage.RectangleDrawCalls
-                .FindAll(call => call.Rectangle.Height == 16 && call.Color == new Color(26, 30, 46))
-                .ConvertAll(call => call.Rectangle.Width)
-                .OrderBy(width => width)
-                .ToArray();
-            Assert.Equal(expectedWidths, actualWidths);
-        }
-    }
-
-    [Fact]
-    public void DrawButtons_WhenFontIsNull_ShouldUseRectangleFallbackWithoutThrowing()
-    {
-        var (stage, _, inputManager) = CreateRenderSpyStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", 0);
-            SetFallbackDrawingState(stage);
-
-            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawButtons"));
-
-            Assert.Null(exception);
-            var actualButtonRects = stage.RectangleDrawCalls
-                .FindAll(call => call.Rectangle.Height == 16)
-                .ConvertAll(call => (Width: call.Rectangle.Width, call.Color))
-                .OrderBy(call => call.Width)
-                .ToArray();
-            var expectedButtonRects = new[]
-            {
-                (Width: "EXIT".Length * 8, Color: Color.Green)
-            }
-            .OrderBy(call => call.Width)
-            .ToArray();
-            Assert.Equal(expectedButtonRects, actualButtonRects);
-        }
-    }
-
-    [Fact]
-    public void DrawInstructions_WhenFontIsNull_ShouldUseRectangleFallbackWithoutThrowing()
-    {
-        var (stage, _, inputManager) = CreateRenderSpyStage();
-        using (inputManager)
-        {
-            SetFallbackDrawingState(stage);
-
-            var exception = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawInstructions"));
-
-            Assert.Null(exception);
-            Assert.Contains(
-                stage.RectangleDrawCalls,
-                call => call.Rectangle.Height == 12 && call.Rectangle.Width > 0 && call.Color == new Color(26, 30, 46));
-        }
-    }
-
-    [Fact]
-    public void DrawButtons_WhenExitSelectedAndFontPresent_ShouldUseBoldFont()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var configItems = ReflectionHelpers.GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            Assert.NotNull(configItems);
-            var boldFont = new Mock<IFont>();
-            var spriteBatch = CreateUninitializedSpriteBatch();
-            ReflectionHelpers.SetPrivateField(stage, "_font", new Mock<IFont>().Object);
-            ReflectionHelpers.SetPrivateField(stage, "_boldFont", boldFont.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", spriteBatch);
-            ReflectionHelpers.SetPrivateField(stage, "_selectedIndex", configItems!.Count);
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "DrawButtons");
-
-            boldFont.Verify(f => f.DrawString(spriteBatch, "EXIT", It.IsAny<Vector2>(), Color.Yellow), Times.Once);
-        }
-    }
-
-    [Fact]
-    public void DrawInstructions_WhenFontPresent_ShouldDrawText()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            var font = new Mock<IFont>();
-            var spriteBatch = CreateUninitializedSpriteBatch();
-            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_spriteBatch", spriteBatch);
-
-            ReflectionHelpers.InvokePrivateMethod(stage, "DrawInstructions");
-
-            font.Verify(f => f.DrawString(spriteBatch, It.Is<string>(s => s.Contains("UP/DOWN")), It.IsAny<Vector2>(), new Color(26, 30, 46)), Times.Once);
-        }
-    }
-
-    [Fact]
-    public void HandleInput_WhenMoveDownPressed_ShouldIncrementSelectedIndex()
+    public void HandleInput_WhenMoveDownPressed_ShouldIncrementCategoryIndex()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
@@ -333,12 +147,13 @@ public class ConfigStageCoverageTests
                 [Keys.Left] = InputCommandType.MoveLeft,
                 [Keys.Right] = InputCommandType.MoveRight,
             });
-            SetPrivateField(stage, "_selectedIndex", 0);
+            SetPrivateField(stage, "_focusOnMenu", true);
+            SetPrivateField(stage, "_currentCategoryIndex", 0);
             SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
-            Assert.Equal(1, GetPrivateField<int>(stage, "_selectedIndex"));
+            Assert.Equal(1, GetPrivateField<int>(stage, "_currentCategoryIndex"));
         }
     }
 

--- a/DTXMania.Test/Stage/ConfigStageInputCoverageTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageInputCoverageTests.cs
@@ -5,6 +5,7 @@ using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
 using DTXMania.Game.Lib.Stage.KeyAssign;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework.Input;
@@ -64,37 +65,63 @@ public class ConfigStageInputCoverageTests
         [Keys.Right] = InputCommandType.MoveRight,
     };
 
+    /// <summary>
+    /// Finds (categoryIndex, itemIndex) for a named item across all categories, sets the stage's
+    /// current category + that category's SelectedIndex, and switches focus to the item list.
+    /// </summary>
+    private static void SelectItemForEditing(ConfigStage stage, string itemName)
+    {
+        var categories = GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+        Xunit.Assert.NotNull(categories);
+        for (int c = 0; c < categories!.Count; c++)
+        {
+            for (int i = 0; i < categories[c].Items.Count; i++)
+            {
+                if (categories[c].Items[i].Name == itemName)
+                {
+                    SetPrivateField(stage, "_currentCategoryIndex", c);
+                    categories[c].SelectedIndex = i;
+                    SetPrivateField(stage, "_focusOnMenu", false);
+                    return;
+                }
+            }
+        }
+        Xunit.Assert.Fail($"Config item '{itemName}' should exist.");
+    }
+
     [Fact]
-    public void HandleInput_WhenMoveDownPressed_ShouldIncrementSelectedIndex()
+    public void HandleInput_WhenMoveDownPressed_ShouldIncrementCategoryIndex()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
             SetupRuntimeSystemBindings(inputManager, DefaultNavBindings());
-            SetPrivateField(stage, "_selectedIndex", 0);
+            SetPrivateField(stage, "_focusOnMenu", true);
+            SetPrivateField(stage, "_currentCategoryIndex", 0);
             SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
 
             InvokePrivateMethod(stage, "HandleInput");
 
-            Assert.Equal(1, GetPrivateField<int>(stage, "_selectedIndex"));
+            Assert.Equal(1, GetPrivateField<int>(stage, "_currentCategoryIndex"));
         }
     }
 
     [Fact]
-    public void HandleInput_WhenMoveUpPressed_ShouldDecrementSelectedIndex()
+    public void HandleInput_WhenMoveUpPressed_ShouldDecrementCategoryIndex()
     {
         var (stage, _, inputManager) = CreateStage();
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
             SetupRuntimeSystemBindings(inputManager, DefaultNavBindings());
-            SetPrivateField(stage, "_selectedIndex", 2);
+            SetPrivateField(stage, "_focusOnMenu", true);
+            SetPrivateField(stage, "_currentCategoryIndex", 2);
             SetKeyboardStates(stage, new KeyboardState(Keys.Up), new KeyboardState());
 
             InvokePrivateMethod(stage, "HandleInput");
 
-            Assert.Equal(1, GetPrivateField<int>(stage, "_selectedIndex"));
+            Assert.Equal(1, GetPrivateField<int>(stage, "_currentCategoryIndex"));
         }
     }
 
@@ -106,11 +133,7 @@ public class ConfigStageInputCoverageTests
         {
             InitializeStageMenu(stage, includePanels: false);
             SetupRuntimeSystemBindings(inputManager, DefaultNavBindings());
-            SetPrivateField(stage, "_selectedIndex", 1); // Fullscreen toggle
-
-            var configItems = GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            Assert.NotNull(configItems);
-            Assert.True(configItems!.Count > 1);
+            SelectItemForEditing(stage, "Fullscreen");
 
             var fullscreenBefore = configManager.Config.FullScreen;
 
@@ -122,34 +145,6 @@ public class ConfigStageInputCoverageTests
     }
 
     [Fact]
-    public void HandleInput_WhenActivatePressedOnExitButton_ShouldCallOnExitButtonClicked()
-    {
-        var (stage, _, inputManager) = CreateStage();
-        using (inputManager)
-        {
-            InitializeStageMenu(stage, includePanels: false);
-            var stageManager = new Mock<IStageManager>();
-            stage.StageManager = stageManager.Object;
-            SetupRuntimeSystemBindings(inputManager, DefaultNavBindings());
-
-            var configItems = GetPrivateField<List<IConfigItem>>(stage, "_configItems");
-            Assert.NotNull(configItems);
-            // Exit is the sole action button, at index == configItems.Count.
-            var exitButtonIndex = configItems!.Count;
-            SetPrivateField(stage, "_selectedIndex", exitButtonIndex);
-
-            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
-            InvokePrivateMethod(stage, "HandleInput");
-
-            stageManager.Verify(
-                m => m.ChangeStage(
-                    StageType.Title,
-                    It.Is<IStageTransition>(t => t is CrossfadeTransition)),
-                Times.Once);
-        }
-    }
-
-    [Fact]
     public void HandleInput_WhenMoveLeftPressed_ShouldPreviousValue()
     {
         var (stage, configManager, inputManager) = CreateStage();
@@ -157,7 +152,7 @@ public class ConfigStageInputCoverageTests
         {
             InitializeStageMenu(stage, includePanels: false);
             SetupRuntimeSystemBindings(inputManager, DefaultNavBindings());
-            SetPrivateField(stage, "_selectedIndex", 5); // Scroll Speed
+            SelectItemForEditing(stage, "Scroll Speed");
 
             var scrollSpeedBefore = configManager.Config.ScrollSpeed;
 
@@ -177,7 +172,7 @@ public class ConfigStageInputCoverageTests
         {
             InitializeStageMenu(stage, includePanels: false);
             SetupRuntimeSystemBindings(inputManager, DefaultNavBindings());
-            SetPrivateField(stage, "_selectedIndex", 5); // Scroll Speed
+            SelectItemForEditing(stage, "Scroll Speed");
 
             var scrollSpeedBefore = configManager.Config.ScrollSpeed;
 

--- a/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
@@ -164,6 +164,27 @@ public class ConfigStageNxImportTests : IDisposable
     }
 
     [Fact]
+    public async Task StartNxScoreImport_WhenDatabaseUnavailable_ShouldSetUnavailableStatus()
+    {
+        // No InitializeDatabaseServiceAsync call: _databaseService stays null, so
+        // ImportNxScoresAsync returns DbUnavailable=true (no throw). The status must reflect this
+        // most common real-world path rather than reporting a misleading success/error.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
+
+            var completed = await WaitUntilImportCompletesAsync(stage, timeoutMs: 5000);
+            Assert.True(completed, "Import did not complete within timeout");
+
+            Assert.Equal("NX import unavailable (no database)",
+                ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
+        }
+    }
+
+    [Fact]
     public void DrawImportStatus_WhenStatusPresent_ShouldDrawString()
     {
         var (stage, _, inputManager) = CreateStage();

--- a/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
@@ -178,7 +178,7 @@ public class ConfigStageNxImportTests : IDisposable
 
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawImportStatus");
 
-            font.Verify(f => f.DrawString(spriteBatch, "Importing... 1 / 5", It.IsAny<Microsoft.Xna.Framework.Vector2>(), new Microsoft.Xna.Framework.Color(18, 64, 132)), Times.Once);
+            font.Verify(f => f.DrawString(spriteBatch, "Importing... 1 / 5", It.IsAny<Microsoft.Xna.Framework.Vector2>(), new Microsoft.Xna.Framework.Color(180, 220, 255)), Times.Once);
         }
     }
 

--- a/DTXMania.Test/UI/ConfigUILayoutTests.cs
+++ b/DTXMania.Test/UI/ConfigUILayoutTests.cs
@@ -1,0 +1,65 @@
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI;
+
+[Trait("Category", "Unit")]
+public class ConfigUILayoutTests
+{
+    [Fact]
+    public void Panels_ShouldMatchNxCoordinates()
+    {
+        Assert.Equal(new Rectangle(0, 0, 1280, 720), ConfigUILayout.BackgroundRect);
+        Assert.Equal(new Rectangle(400, 0, 18, 720), ConfigUILayout.ItemBarRect);
+        Assert.Equal(new Rectangle(0, 0, 1280, 105), ConfigUILayout.HeaderRect);
+        Assert.Equal(new Rectangle(0, 690, 1280, 30), ConfigUILayout.FooterRect);
+        Assert.Equal(new Rectangle(245, 140, 180, 172), ConfigUILayout.MenuPanelRect);
+        Assert.Equal(new Rectangle(800, 270, 280, 360), ConfigUILayout.DescriptionPanelRect);
+    }
+
+    [Theory]
+    [InlineData(0, 156)]
+    [InlineData(1, 190)]
+    [InlineData(2, 224)]
+    public void MenuRowY_ShouldStepBy34(int index, int expected)
+    {
+        Assert.Equal(expected, ConfigUILayout.MenuRowY(index));
+    }
+
+    [Fact]
+    public void MenuCursorRect_ShouldSitOnSelectedRow()
+    {
+        Assert.Equal(new Rectangle(250, 153, 150, 30), ConfigUILayout.MenuCursorRect(0));
+        Assert.Equal(new Rectangle(250, 221, 150, 30), ConfigUILayout.MenuCursorRect(2));
+    }
+
+    [Fact]
+    public void ItemRowRect_ShouldStepBy60()
+    {
+        Assert.Equal(new Rectangle(430, 150, 360, 54), ConfigUILayout.ItemRowRect(0));
+        Assert.Equal(new Rectangle(430, 210, 360, 54), ConfigUILayout.ItemRowRect(1));
+    }
+
+    [Fact]
+    public void ItemCursorRect_ShouldFrameTheRow()
+    {
+        Assert.Equal(new Rectangle(426, 147, 368, 60), ConfigUILayout.ItemCursorRect(0));
+        Assert.Equal(new Rectangle(426, 207, 368, 60), ConfigUILayout.ItemCursorRect(1));
+    }
+
+    [Fact]
+    public void ItemTextPositions_ShouldOffsetFromRow()
+    {
+        Assert.Equal(new Vector2(454, 164), ConfigUILayout.ItemNamePos(0));
+        Assert.Equal(new Vector2(760, 164), ConfigUILayout.ItemValuePos(0));
+        Assert.Equal(new Vector2(454, 224), ConfigUILayout.ItemNamePos(1));
+    }
+
+    [Fact]
+    public void DescriptionText_ShouldStartInsidePanel()
+    {
+        Assert.Equal(new Vector2(818, 288), ConfigUILayout.DescriptionTextPos);
+        Assert.Equal(248, ConfigUILayout.DescriptionWrapWidth);
+    }
+}

--- a/DTXMania.Test/UI/ConfigUILayoutTests.cs
+++ b/DTXMania.Test/UI/ConfigUILayoutTests.cs
@@ -52,8 +52,16 @@ public class ConfigUILayoutTests
     public void ItemTextPositions_ShouldOffsetFromRow()
     {
         Assert.Equal(new Vector2(454, 164), ConfigUILayout.ItemNamePos(0));
-        Assert.Equal(new Vector2(760, 164), ConfigUILayout.ItemValuePos(0));
         Assert.Equal(new Vector2(454, 224), ConfigUILayout.ItemNamePos(1));
+    }
+
+    [Fact]
+    public void ItemValueRightX_ShouldSitInsideTheBoxClearOfTheDescriptionPanel()
+    {
+        // Value right anchor = box right edge (430 + 360 = 790) minus the symmetric inset (24).
+        // Values end at <= 790, so they never reach the description panel (x = 800).
+        Assert.Equal(766, ConfigUILayout.ItemValueRightX);
+        Assert.True(ConfigUILayout.ItemValueRightX < ConfigUILayout.DescriptionPanelRect.X);
     }
 
     [Fact]

--- a/DTXMania.Test/UI/SongListDisplayLogicTests.cs
+++ b/DTXMania.Test/UI/SongListDisplayLogicTests.cs
@@ -48,12 +48,11 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_ShouldReturnOriginalOrTruncated()
     {
-        var display = new SongListDisplay();
         var font = new Mock<IFont>();
         font.Setup(x => x.MeasureString(It.IsAny<string>())).Returns((string s) => new Vector2(s.Length * 10, 10));
 
-        var original = InvokePrivate<string>(display, "TruncateTextToWidth", "ABC", 100f, font.Object);
-        var truncated = InvokePrivate<string>(display, "TruncateTextToWidth", "ABCDEFGHIJ", 40f, font.Object);
+        var original = TextHelper.TruncateToWidth("ABC", 100f, font.Object);
+        var truncated = TextHelper.TruncateToWidth("ABCDEFGHIJ", 40f, font.Object);
 
         Assert.Equal("ABC", original);
         Assert.EndsWith("...", truncated);
@@ -63,11 +62,10 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_WhenSpriteFontTextIsTooLong_ShouldReturnFittingEllipsis()
     {
-        var display = new SongListDisplay();
         var font = CreateSpriteFont(
             [(' ', 4), ('.', 4), ('A', 10), ('B', 10), ('C', 10), ('D', 10), ('E', 10), ('F', 10), ('G', 10), ('H', 10)]);
 
-        var truncated = InvokePrivate<string>(display, "TruncateTextToWidth", "ABCDEFGH", 44f, font);
+        var truncated = TextHelper.TruncateToWidth("ABCDEFGH", 44f, font);
 
         Assert.EndsWith("...", truncated);
         Assert.True(font.MeasureString(truncated).X <= 44f);
@@ -1090,10 +1088,9 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_WhenTextIsNull_ShouldReturnNull()
     {
-        var display = new SongListDisplay();
         var font = new Mock<IFont>();
 
-        var result = InvokePrivate<string>(display, "TruncateTextToWidth", null, 100f, font.Object);
+        var result = TextHelper.TruncateToWidth(null, 100f, font.Object);
 
         Assert.Null(result);
     }
@@ -1101,10 +1098,9 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_WhenTextIsEmpty_ShouldReturnEmpty()
     {
-        var display = new SongListDisplay();
         var font = new Mock<IFont>();
 
-        var result = InvokePrivate<string>(display, "TruncateTextToWidth", "", 100f, font.Object);
+        var result = TextHelper.TruncateToWidth("", 100f, font.Object);
 
         Assert.Equal("", result);
     }
@@ -1112,9 +1108,7 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_WhenFontIsNull_ShouldReturnOriginalText()
     {
-        var display = new SongListDisplay();
-
-        var result = InvokePrivate<string>(display, "TruncateTextToWidth", "test", 100f, (IFont)null);
+        var result = TextHelper.TruncateToWidth("test", 100f, (IFont)null);
 
         Assert.Equal("test", result);
     }
@@ -1122,11 +1116,10 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_WhenTextFitsExactly_ShouldReturnOriginal()
     {
-        var display = new SongListDisplay();
         var font = new Mock<IFont>();
         font.Setup(x => x.MeasureString("exact")).Returns(new Vector2(100f, 10f));
 
-        var result = InvokePrivate<string>(display, "TruncateTextToWidth", "exact", 100f, font.Object);
+        var result = TextHelper.TruncateToWidth("exact", 100f, font.Object);
 
         Assert.Equal("exact", result);
     }
@@ -1134,12 +1127,11 @@ public class SongListDisplayLogicTests
     [Fact]
     public void TruncateTextToWidth_WhenVeryLongText_ShouldTruncateWithEllipsis()
     {
-        var display = new SongListDisplay();
         var font = new Mock<IFont>();
         font.Setup(x => x.MeasureString(It.IsAny<string>())).Returns((string s) => new Vector2(s.Length * 10, 10));
 
         var longText = new string('A', 100);
-        var result = InvokePrivate<string>(display, "TruncateTextToWidth", longText, 50f, font.Object);
+        var result = TextHelper.TruncateToWidth(longText, 50f, font.Object);
 
         Assert.EndsWith("...", result);
         Assert.True(result.Length < longText.Length);

--- a/DTXMania.Test/Utilities/TextHelperTests.cs
+++ b/DTXMania.Test/Utilities/TextHelperTests.cs
@@ -109,5 +109,43 @@ namespace DTXMania.Test.Utilities
             Assert.Equal("abcde...", result);
             Assert.True(font.Object.MeasureString(result).X <= 40f + 0.01f);
         }
+
+        [Fact]
+        public void TruncateToWidth_WhenTextContainsSurrogatePair_ShouldNotSplitSurrogate()
+        {
+            // "abc" + U+1F600 (grinning face, a surrogate pair) + "XYZZZ" => 10 raw chars, 9 text elements.
+            // Per-char mock font: 10px/char. Full text = 100px (does not fit maxWidth=75).
+            // The naive raw-index cut at char 4 splits the surrogate pair: "abc\uD83D..." = 7 chars =
+            // 70px (fits). The grapheme-aligned cut at the emoji boundary is "abc😀..." = 8 chars = 80px
+            // (does not fit). The previous implementation returned "abc\uD83D..." (a malformed string
+            // with an unpaired high surrogate). The grapheme-aware cut must back off to "abc...".
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 10f, 14f));
+
+            var text = "abc\uD83D\uDE00XYZZZ";
+            var result = TextHelper.TruncateToWidth(text, 75f, font.Object);
+
+            Assert.Equal("abc...", result);
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenTextContainsCombiningMark_ShouldNotDetachFromBaseChar()
+        {
+            // "e" + U+0301 (combining acute) + "xyz" => 5 raw chars, 4 text elements ("é", "x", "y", "z").
+            // Per-char mock font: 10px/char. maxWidth=45 makes the naive raw-index cut at index 1
+            // ("e" + "..." = 4 chars = 40px) fit, while the grapheme-aligned cut ("é" + "..." = 5 chars
+            // = 50px) does not. The previous implementation returned "e..." which silently drops the
+            // combining mark and displays a different character ("e" instead of "é"). The grapheme-aware
+            // cut must back off to the ellipsis only, never detaching a combining mark from its base.
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 10f, 14f));
+
+            var text = "e\u0301xyz";
+            var result = TextHelper.TruncateToWidth(text, 45f, font.Object);
+
+            Assert.Equal("...", result);
+        }
     }
 }

--- a/DTXMania.Test/Utilities/TextHelperTests.cs
+++ b/DTXMania.Test/Utilities/TextHelperTests.cs
@@ -1,0 +1,113 @@
+using System;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Utilities;
+using Microsoft.Xna.Framework;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Utilities
+{
+    /// <summary>
+    /// Unit tests for <see cref="TextHelper.TruncateToWidth(string, float, IFont)"/>. The
+    /// <see cref="Microsoft.Xna.Framework.Graphics.SpriteFont"/> overload shares the identical
+    /// algorithm body but needs a GraphicsDevice to instantiate; it is covered by the Windows-only
+    /// SongListDisplay rendering tests instead of here (Mac test project excludes graphics tests).
+    /// </summary>
+    [Trait("Category", "Unit")]
+    public class TextHelperTests
+    {
+        [Fact]
+        public void TruncateToWidth_WhenTextIsNull_ShouldReturnNull()
+        {
+            var font = new Mock<IFont>().Object;
+
+            Assert.Null(TextHelper.TruncateToWidth(null!, 100f, font));
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenTextIsEmpty_ShouldReturnEmpty()
+        {
+            var font = new Mock<IFont>().Object;
+
+            Assert.Equal(string.Empty, TextHelper.TruncateToWidth(string.Empty, 100f, font));
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenFontIsNull_ShouldReturnTextUnchanged()
+        {
+            Assert.Equal("hello", TextHelper.TruncateToWidth("hello", 1f, (IFont)null!));
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenTextFits_ShouldReturnTextUnchanged()
+        {
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 5f, 14f));
+
+            var result = TextHelper.TruncateToWidth("short", 100f, font.Object);
+
+            Assert.Equal("short", result);
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenTextExceedsWidth_ShouldEllipsizeToFit()
+        {
+            // Per-character mock font: 8px/char. "longtextthatwontfit" = 19 chars = 152px.
+            // With maxWidth=50, the ellipsis "..." (3 chars = 24px) alone fits; each extra char
+            // adds 8px. 50/8 = 6.25, so the longest prefix + "..." that fits is 3 chars + "..."
+            // = 6 chars = 48px. Binary search must converge on "lon...".
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 8f, 14f));
+
+            var result = TextHelper.TruncateToWidth("longtextthatwontfit", 50f, font.Object);
+
+            Assert.EndsWith("...", result);
+            Assert.True(font.Object.MeasureString(result).X <= 50f + 0.01f,
+                $"truncated result \"{result}\" must fit maxWidth");
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenOnlyEllipsisFits_ShouldReturnEllipsis()
+        {
+            // 8px/char, maxWidth=24 -> exactly the ellipsis width. No prefix char fits.
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 8f, 14f));
+
+            var result = TextHelper.TruncateToWidth("longtextthatwontfit", 24f, font.Object);
+
+            Assert.Equal("...", result);
+        }
+
+        [Fact]
+        public void TruncateToWidth_WhenNothingFits_ShouldReturnEmptyString()
+        {
+            // 8px/char, maxWidth=16 -> even "..." (24px) doesn't fit. bestFit stays "".
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 8f, 14f));
+
+            var result = TextHelper.TruncateToWidth("longtextthatwontfit", 16f, font.Object);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void TruncateToWidth_ShouldReturnLongestPrefixThatFits()
+        {
+            // 5px/char. "abcdefghij" = 10 chars = 50px. maxWidth=40.
+            // "..." = 15px. Each prefix char adds 5px. 40 - 15 = 25 -> 5 chars prefix.
+            // "abcde..." = 8 chars = 40px. Exactly fits. Binary search must find it.
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>()))
+                .Returns<string>(s => new Vector2(s.Length * 5f, 14f));
+
+            var result = TextHelper.TruncateToWidth("abcdefghij", 40f, font.Object);
+
+            Assert.Equal("abcde...", result);
+            Assert.True(font.Object.MeasureString(result).X <= 40f + 0.01f);
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-06-25-config-stage-nx-layout.md
+++ b/docs/superpowers/plans/2026-06-25-config-stage-nx-layout.md
@@ -1,0 +1,1863 @@
+# Config Stage NX Layout Revamp Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild `ConfigStage` from a single flat list into the DTXManiaNX two-column master-detail layout (left category menu, right per-category item list, description panel, header/footer).
+
+**Architecture:** Extract pure, fully-testable helpers — `ConfigUILayout` (coordinate math) and `ConfigCategory` (model) — and render the NX layout *in-stage* through `ConfigStage`'s existing overridable draw seam (`BeginDrawFrame`/`EndDrawFrame`/`DrawFilledRectangle`/`GetViewport` + null-guarded texture draws), so all tests stay Mac-safe with no GraphicsDevice. Categories are System / Drums / Exit; key mapping reuses the existing `DrumConfigStage` and `SystemKeyAssignPanel`; persist-on-edit is unchanged.
+
+**Tech Stack:** .NET 8, MonoGame 3.8 (`Microsoft.Xna.Framework`), xUnit + Moq, existing `ReflectionHelpers` test utilities.
+
+## Global Constraints
+
+- Virtual layout space is **1280×720**; all coordinates are in that space.
+- Code conventions: 4-space indent, LF, UTF-8; PascalCase types, `_camelCase` private fields.
+- Use `TexturePath` constants, never hardcoded texture path strings.
+- Every texture load is **best-effort** (try/catch → null) and every texture draw is **null-guarded**; missing art must never throw and must fall back to fills/text.
+- Persist-on-edit is preserved: `ConfigManager.Config` is the single source of truth; edits apply live and a deferred save is flushed on exit. No working copy, no discard.
+- Mac build/test: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj` and `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`. No new files may require a GraphicsDevice on Mac.
+- Categories are exactly **System**, **Drums**, **Exit** (no Guitar/Bass). Exit is a category with zero items.
+- Commit after each task with a Conventional Commit subject under 72 chars.
+
+---
+
+## File Structure
+
+**Create:**
+- `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs` — pure coordinate constants + index→Rectangle/Vector2 helpers.
+- `DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs` — pure category model.
+- `DTXMania.Test/UI/ConfigUILayoutTests.cs` — layout math tests (Mac-safe).
+- `DTXMania.Test/Config/ConfigCategoryTests.cs` — model tests (Mac-safe).
+
+**Modify:**
+- `DTXMania.Game/Lib/Config/IConfigItem.cs` — add `string Description { get; }`.
+- `DTXMania.Game/Lib/Config/ConfigItems.cs` — implement `Description` on `BaseConfigItem`.
+- `DTXMania.Game/Lib/Resources/TexturePath.cs` — add 10 config constants + register in arrays.
+- `DTXMania.Game/Lib/Stage/ConfigStage.cs` — full rewrite to categories + focus model + NX rendering.
+- `DTXMania.Test/Resources/TexturePathTests.cs` — membership assertions for new constants.
+- `DTXMania.Test/Config/ConfigStageLogicTests.cs` — add the new category/focus/render tests **and** migrate the flat-list tests (the new tests reuse this file's existing helpers: `CreateStage`, `CreateRenderSpyStageWithGraphicsDevice`, `CreateStageWithMockConfig`, `SetKeyboardStates`, `RenderSpyConfigStage`).
+- `DTXMania.Test/Config/ConfigItemTests.cs` — `Description` default + round-trip.
+
+**Established test patterns to reuse (already in `ConfigStageLogicTests.cs`):**
+- `CreateStage()` → `(ConfigStage, ConfigManager, InputManagerCompat)`; wires the game via `SetProperty(game, nameof(BaseGame.ConfigManager/InputManager), …)`.
+- `InitializeStageMenu(stage, includePanels)` → invokes `SetupConfigItems` (+ `InitializePanels`).
+- Drive input with `SetKeyboardStates(stage, new KeyboardState(Keys.X), new KeyboardState())` then `InvokePrivateMethod(stage, "HandleInput")`; default map: `Escape`→Back, `Enter`→Activate, `Up/Down/Left/Right`→Move*.
+- Verify a stage change with `stage.StageManager = new Moq.Mock<IStageManager>().Object` then `stageManager.Verify(m => m.ChangeStage(StageType.Title, It.Is<IStageTransition>(t => t is CrossfadeTransition)), Times.Once)`.
+- Verify a save flush with `CreateStageWithMockConfig(inputManager)` → `mockConfig.Verify(c => c.FlushPendingSave(), Times.Once)`.
+- Render assertions: `CreateRenderSpyStageWithGraphicsDevice()` → `RenderSpyConfigStage` with `RectangleDrawCalls` and `InitializeDrawingState()` (textures + fonts null, so fallback `DrawFilledRectangle` rects are captured).
+
+No `DTXMania.Test.Mac.csproj` change is required (no GraphicsDevice-dependent new files).
+
+---
+
+### Task 1: Add `Description` to config items
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Config/IConfigItem.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigItems.cs:9-29` (`BaseConfigItem`)
+- Test: `DTXMania.Test/Config/ConfigItemTests.cs`
+
+**Interfaces:**
+- Produces: `string IConfigItem.Description { get; }`; `BaseConfigItem.Description` is `{ get; init; }` defaulting to `""`, settable via object initializer. Inherited unchanged by `ReadOnlyConfigItem`, `DropdownConfigItem`, `ToggleConfigItem`, `IntegerConfigItem`, `NavigationConfigItem`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `DTXMania.Test/Config/ConfigItemTests.cs` (inside the existing test class):
+
+```csharp
+[Fact]
+public void Description_WhenNotSet_ShouldDefaultToEmptyString()
+{
+    var item = new ToggleConfigItem("Fullscreen", () => false, _ => { });
+
+    Assert.Equal(string.Empty, item.Description);
+}
+
+[Fact]
+public void Description_WhenSetViaInitializer_ShouldRoundTrip()
+{
+    var item = new ToggleConfigItem("Fullscreen", () => false, _ => { })
+    {
+        Description = "Toggles fullscreen display mode."
+    };
+
+    Assert.Equal("Toggles fullscreen display mode.", item.Description);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigItemTests.Description"`
+Expected: FAIL — `'ToggleConfigItem' does not contain a definition for 'Description'`.
+
+- [ ] **Step 3: Add `Description` to the interface**
+
+In `DTXMania.Game/Lib/Config/IConfigItem.cs`, add inside the interface (after `string Name { get; }`):
+
+```csharp
+        /// <summary>
+        /// Optional one-line help text shown in the config description panel. Empty by default.
+        /// </summary>
+        string Description { get; }
+```
+
+- [ ] **Step 4: Implement `Description` on `BaseConfigItem`**
+
+In `DTXMania.Game/Lib/Config/ConfigItems.cs`, add to `BaseConfigItem` (after the `Name` property at line 11):
+
+```csharp
+        public string Description { get; init; } = "";
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigItemTests.Description"`
+Expected: PASS (2 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Config/IConfigItem.cs DTXMania.Game/Lib/Config/ConfigItems.cs DTXMania.Test/Config/ConfigItemTests.cs
+git commit -m "feat: add optional Description to config items"
+```
+
+---
+
+### Task 2: Add config `TexturePath` constants
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Resources/TexturePath.cs` (constants in the `UI Panel Textures` region near line 126; arrays `GetAllTexturePaths` line 500, `GetPanelTextures` line 636)
+- Test: `DTXMania.Test/Resources/TexturePathTests.cs`
+
+**Interfaces:**
+- Produces constants: `TexturePath.ConfigBackground`, `ConfigItemBar`, `ConfigMenuPanel`, `ConfigMenuCursor`, `ConfigHeaderPanel`, `ConfigFooterPanel`, `ConfigItemBox`, `ConfigItemBoxOther`, `ConfigItemBoxCursor`, `ConfigDescriptionPanel`. All ten are in `GetAllTexturePaths()`; all except `ConfigBackground` are also in `GetPanelTextures()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `DTXMania.Test/Resources/TexturePathTests.cs` (inside the test class):
+
+```csharp
+[Fact]
+public void ConfigTexturePaths_ShouldUseExpectedSkinFiles()
+{
+    Assert.Equal("Graphics/4_background.png", TexturePath.ConfigBackground);
+    Assert.Equal("Graphics/4_item bar.png", TexturePath.ConfigItemBar);
+    Assert.Equal("Graphics/4_menu panel.png", TexturePath.ConfigMenuPanel);
+    Assert.Equal("Graphics/4_menu cursor.png", TexturePath.ConfigMenuCursor);
+    Assert.Equal("Graphics/4_header panel.png", TexturePath.ConfigHeaderPanel);
+    Assert.Equal("Graphics/4_footer panel.png", TexturePath.ConfigFooterPanel);
+    Assert.Equal("Graphics/4_itembox.png", TexturePath.ConfigItemBox);
+    Assert.Equal("Graphics/4_itembox other.png", TexturePath.ConfigItemBoxOther);
+    Assert.Equal("Graphics/4_itembox cursor.png", TexturePath.ConfigItemBoxCursor);
+    Assert.Equal("Graphics/4_Description Panel.png", TexturePath.ConfigDescriptionPanel);
+}
+
+[Fact]
+public void GetAllTexturePaths_ShouldContainConfigPaths()
+{
+    var paths = TexturePath.GetAllTexturePaths();
+    Assert.Contains(TexturePath.ConfigBackground, paths);
+    Assert.Contains(TexturePath.ConfigMenuPanel, paths);
+    Assert.Contains(TexturePath.ConfigDescriptionPanel, paths);
+}
+
+[Fact]
+public void GetPanelTextures_ShouldContainConfigPanels_ButNotBackground()
+{
+    var paths = TexturePath.GetPanelTextures();
+    Assert.Contains(TexturePath.ConfigMenuPanel, paths);
+    Assert.Contains(TexturePath.ConfigItemBox, paths);
+    Assert.DoesNotContain(TexturePath.ConfigBackground, paths);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~TexturePathTests.ConfigTexturePaths_ShouldUseExpectedSkinFiles"`
+Expected: FAIL — `'TexturePath' does not contain a definition for 'ConfigBackground'`.
+
+- [ ] **Step 3: Add the constants**
+
+In `DTXMania.Game/Lib/Resources/TexturePath.cs`, inside the `#region UI Panel Textures` block (e.g. after `SongStatusPanel` near line 115), add:
+
+```csharp
+        /// <summary>Config stage background (1280x720).</summary>
+        public const string ConfigBackground = "Graphics/4_background.png";
+
+        /// <summary>Config stage vertical divider between the menu and item columns (18x720, drawn at x=400).</summary>
+        public const string ConfigItemBar = "Graphics/4_item bar.png";
+
+        /// <summary>Config stage left category-menu panel (180x172, drawn at 245,140).</summary>
+        public const string ConfigMenuPanel = "Graphics/4_menu panel.png";
+
+        /// <summary>Config stage category-menu selection cursor.</summary>
+        public const string ConfigMenuCursor = "Graphics/4_menu cursor.png";
+
+        /// <summary>Config stage header panel (1280x105, drawn at 0,0).</summary>
+        public const string ConfigHeaderPanel = "Graphics/4_header panel.png";
+
+        /// <summary>Config stage footer panel (1280x30, drawn at 0,690).</summary>
+        public const string ConfigFooterPanel = "Graphics/4_footer panel.png";
+
+        /// <summary>Config stage normal item-row box.</summary>
+        public const string ConfigItemBox = "Graphics/4_itembox.png";
+
+        /// <summary>Config stage "other" item-row box (navigation/read-only items).</summary>
+        public const string ConfigItemBoxOther = "Graphics/4_itembox other.png";
+
+        /// <summary>Config stage item-row selection cursor.</summary>
+        public const string ConfigItemBoxCursor = "Graphics/4_itembox cursor.png";
+
+        /// <summary>Config stage description panel (280x360, drawn at 800,270).</summary>
+        public const string ConfigDescriptionPanel = "Graphics/4_Description Panel.png";
+```
+
+- [ ] **Step 4: Register in `GetAllTexturePaths`**
+
+In `GetAllTexturePaths()` (line ~500), add these entries before the closing `};` (after `HitFx`):
+
+```csharp
+                ,ConfigBackground,
+                ConfigItemBar,
+                ConfigMenuPanel,
+                ConfigMenuCursor,
+                ConfigHeaderPanel,
+                ConfigFooterPanel,
+                ConfigItemBox,
+                ConfigItemBoxOther,
+                ConfigItemBoxCursor,
+                ConfigDescriptionPanel
+```
+
+(Note: the existing last entry `HitFx` has no trailing comma; the leading `,` above attaches cleanly. If `HitFx` already ends with a comma, drop the leading comma.)
+
+- [ ] **Step 5: Register the panels in `GetPanelTextures`**
+
+In `GetPanelTextures()` (line ~636), add before its closing `};`:
+
+```csharp
+                ,ConfigItemBar,
+                ConfigMenuPanel,
+                ConfigMenuCursor,
+                ConfigHeaderPanel,
+                ConfigFooterPanel,
+                ConfigItemBox,
+                ConfigItemBoxOther,
+                ConfigItemBoxCursor,
+                ConfigDescriptionPanel
+```
+
+(Same comma caveat as Step 4 — match the existing final entry's punctuation.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~TexturePathTests"`
+Expected: PASS — including the existing `GetAllTexturePaths_AllEntriesShouldStartWithGraphics`, `GetAllTexturePaths_ShouldNotDuplicateAnyPaths`, and `GetPanelTextures_AllEntriesShouldStartWithGraphics` guards.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Resources/TexturePath.cs DTXMania.Test/Resources/TexturePathTests.cs
+git commit -m "feat: add config stage NX skin texture paths"
+```
+
+---
+
+### Task 3: Add `ConfigUILayout`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs`
+- Test: `DTXMania.Test/UI/ConfigUILayoutTests.cs`
+
+**Interfaces:**
+- Produces (all `public static`, in namespace `DTXMania.Game.Lib.UI.Layout`):
+  - consts `int ScreenWidth=1280`, `ScreenHeight=720`, `TitleY=40`, `MenuFirstRowY=156`, `MenuRowStride=34`, `MenuLabelCenterX=335`, `MenuCursorWidth=150`, `MenuCursorHeight=30`, `ItemListX=430`, `ItemFirstRowY=150`, `ItemRowStride=60`, `ItemBoxWidth=360`, `ItemBoxHeight=54`, `ItemNameInsetX=24`, `ItemValueInsetX=330`, `ItemTextInsetY=14`, `DescriptionWrapWidth=248`, `DescriptionLineHeight=22`, `string InstructionsText`.
+  - props `Rectangle BackgroundRect/ItemBarRect/HeaderRect/FooterRect/MenuPanelRect/DescriptionPanelRect`, `Vector2 InstructionsPos/ImportStatusPos/DescriptionTextPos`.
+  - helpers `int MenuRowY(int)`, `Rectangle MenuCursorRect(int)`, `int ItemRowY(int)`, `Rectangle ItemRowRect(int)`, `Rectangle ItemCursorRect(int)`, `Vector2 ItemNamePos(int)`, `Vector2 ItemValuePos(int)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/UI/ConfigUILayoutTests.cs`:
+
+```csharp
+using DTXMania.Game.Lib.UI.Layout;
+using Microsoft.Xna.Framework;
+using Xunit;
+
+namespace DTXMania.Test.UI;
+
+[Trait("Category", "Unit")]
+public class ConfigUILayoutTests
+{
+    [Fact]
+    public void Panels_ShouldMatchNxCoordinates()
+    {
+        Assert.Equal(new Rectangle(0, 0, 1280, 720), ConfigUILayout.BackgroundRect);
+        Assert.Equal(new Rectangle(400, 0, 18, 720), ConfigUILayout.ItemBarRect);
+        Assert.Equal(new Rectangle(0, 0, 1280, 105), ConfigUILayout.HeaderRect);
+        Assert.Equal(new Rectangle(0, 690, 1280, 30), ConfigUILayout.FooterRect);
+        Assert.Equal(new Rectangle(245, 140, 180, 172), ConfigUILayout.MenuPanelRect);
+        Assert.Equal(new Rectangle(800, 270, 280, 360), ConfigUILayout.DescriptionPanelRect);
+    }
+
+    [Theory]
+    [InlineData(0, 156)]
+    [InlineData(1, 190)]
+    [InlineData(2, 224)]
+    public void MenuRowY_ShouldStepBy34(int index, int expected)
+    {
+        Assert.Equal(expected, ConfigUILayout.MenuRowY(index));
+    }
+
+    [Fact]
+    public void MenuCursorRect_ShouldSitOnSelectedRow()
+    {
+        Assert.Equal(new Rectangle(250, 153, 150, 30), ConfigUILayout.MenuCursorRect(0));
+        Assert.Equal(new Rectangle(250, 221, 150, 30), ConfigUILayout.MenuCursorRect(2));
+    }
+
+    [Fact]
+    public void ItemRowRect_ShouldStepBy60()
+    {
+        Assert.Equal(new Rectangle(430, 150, 360, 54), ConfigUILayout.ItemRowRect(0));
+        Assert.Equal(new Rectangle(430, 210, 360, 54), ConfigUILayout.ItemRowRect(1));
+    }
+
+    [Fact]
+    public void ItemCursorRect_ShouldFrameTheRow()
+    {
+        Assert.Equal(new Rectangle(426, 147, 368, 60), ConfigUILayout.ItemCursorRect(0));
+        Assert.Equal(new Rectangle(426, 207, 368, 60), ConfigUILayout.ItemCursorRect(1));
+    }
+
+    [Fact]
+    public void ItemTextPositions_ShouldOffsetFromRow()
+    {
+        Assert.Equal(new Vector2(454, 164), ConfigUILayout.ItemNamePos(0));
+        Assert.Equal(new Vector2(760, 164), ConfigUILayout.ItemValuePos(0));
+        Assert.Equal(new Vector2(454, 224), ConfigUILayout.ItemNamePos(1));
+    }
+
+    [Fact]
+    public void DescriptionText_ShouldStartInsidePanel()
+    {
+        Assert.Equal(new Vector2(818, 288), ConfigUILayout.DescriptionTextPos);
+        Assert.Equal(248, ConfigUILayout.DescriptionWrapWidth);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: FAIL — `The type or namespace name 'ConfigUILayout' does not exist`.
+
+- [ ] **Step 3: Create the layout class**
+
+Create `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs`:
+
+```csharp
+#nullable enable
+
+using Microsoft.Xna.Framework;
+
+namespace DTXMania.Game.Lib.UI.Layout
+{
+    /// <summary>
+    /// Coordinate/size constants and index→position helpers for the NX-style master-detail
+    /// Config stage, in the 1280x720 virtual space ported from DTXManiaNX CStageConfig /
+    /// CActConfigList. Pure (no GraphicsDevice) so it is fully unit-testable.
+    /// </summary>
+    public static class ConfigUILayout
+    {
+        public const int ScreenWidth = 1280;
+        public const int ScreenHeight = 720;
+
+        // Background + vertical divider.
+        public static Rectangle BackgroundRect => new(0, 0, ScreenWidth, ScreenHeight);
+        public static Rectangle ItemBarRect => new(400, 0, 18, 720);
+
+        // Header / footer / title / instructions / import status.
+        public static Rectangle HeaderRect => new(0, 0, 1280, 105);
+        public static Rectangle FooterRect => new(0, 690, 1280, 30);
+        public const int TitleY = 40;
+        public const string InstructionsText =
+            "UP/DOWN select   LEFT/RIGHT change   ENTER choose   ESC back (saves automatically)";
+        public static Vector2 InstructionsPos => new(16, 696);
+        public static Vector2 ImportStatusPos => new(430, 600);
+
+        // Left category menu.
+        public static Rectangle MenuPanelRect => new(245, 140, 180, 172);
+        public const int MenuFirstRowY = 156;
+        public const int MenuRowStride = 34;
+        public const int MenuLabelCenterX = 335;
+        public const int MenuCursorWidth = 150;
+        public const int MenuCursorHeight = 30;
+        public static int MenuRowY(int index) => MenuFirstRowY + index * MenuRowStride;
+        public static Rectangle MenuCursorRect(int index) =>
+            new(250, MenuRowY(index) - 3, MenuCursorWidth, MenuCursorHeight);
+
+        // Right item list.
+        public const int ItemListX = 430;
+        public const int ItemFirstRowY = 150;
+        public const int ItemRowStride = 60;
+        public const int ItemBoxWidth = 360;
+        public const int ItemBoxHeight = 54;
+        public const int ItemNameInsetX = 24;
+        public const int ItemValueInsetX = 330;
+        public const int ItemTextInsetY = 14;
+        public static int ItemRowY(int row) => ItemFirstRowY + row * ItemRowStride;
+        public static Rectangle ItemRowRect(int row) =>
+            new(ItemListX, ItemRowY(row), ItemBoxWidth, ItemBoxHeight);
+        public static Rectangle ItemCursorRect(int row) =>
+            new(ItemListX - 4, ItemRowY(row) - 3, ItemBoxWidth + 8, ItemRowStride);
+        public static Vector2 ItemNamePos(int row) =>
+            new(ItemListX + ItemNameInsetX, ItemRowY(row) + ItemTextInsetY);
+        public static Vector2 ItemValuePos(int row) =>
+            new(ItemListX + ItemValueInsetX, ItemRowY(row) + ItemTextInsetY);
+
+        // Description panel.
+        public static Rectangle DescriptionPanelRect => new(800, 270, 280, 360);
+        public static Vector2 DescriptionTextPos => new(818, 288);
+        public const int DescriptionWrapWidth = 248;
+        public const int DescriptionLineHeight = 22;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs DTXMania.Test/UI/ConfigUILayoutTests.cs
+git commit -m "feat: add ConfigUILayout coordinate helpers"
+```
+
+---
+
+### Task 4: Add `ConfigCategory`
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs`
+- Test: `DTXMania.Test/Config/ConfigCategoryTests.cs`
+
+**Interfaces:**
+- Produces `public sealed class ConfigCategory` in namespace `DTXMania.Game.Lib.Stage.Config`:
+  - ctor `ConfigCategory(string name, string description, IReadOnlyList<IConfigItem> items)`
+  - `string Name { get; }`, `string Description { get; }`, `IReadOnlyList<IConfigItem> Items { get; }`, `int SelectedIndex { get; set; }`
+  - `bool HasItems { get; }`, `IConfigItem? SelectedItem { get; }`
+  - `void MoveSelectionUp()`, `void MoveSelectionDown()` (wrap; no-op when empty)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `DTXMania.Test/Config/ConfigCategoryTests.cs`:
+
+```csharp
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public class ConfigCategoryTests
+{
+    private static IConfigItem Toggle(string name) =>
+        new ToggleConfigItem(name, () => false, _ => { });
+
+    [Fact]
+    public void Constructor_ShouldExposeNameDescriptionAndItems()
+    {
+        var items = new List<IConfigItem> { Toggle("A"), Toggle("B") };
+
+        var category = new ConfigCategory("Drums", "Drum settings.", items);
+
+        Assert.Equal("Drums", category.Name);
+        Assert.Equal("Drum settings.", category.Description);
+        Assert.Equal(2, category.Items.Count);
+        Assert.True(category.HasItems);
+        Assert.Same(items[0], category.SelectedItem);
+    }
+
+    [Fact]
+    public void MoveSelectionDown_ShouldWrapAround()
+    {
+        var category = new ConfigCategory("Drums", "", new List<IConfigItem> { Toggle("A"), Toggle("B") });
+
+        category.MoveSelectionDown();
+        Assert.Equal(1, category.SelectedIndex);
+
+        category.MoveSelectionDown();
+        Assert.Equal(0, category.SelectedIndex);
+    }
+
+    [Fact]
+    public void MoveSelectionUp_FromFirst_ShouldWrapToLast()
+    {
+        var category = new ConfigCategory("Drums", "", new List<IConfigItem> { Toggle("A"), Toggle("B"), Toggle("C") });
+
+        category.MoveSelectionUp();
+
+        Assert.Equal(2, category.SelectedIndex);
+    }
+
+    [Fact]
+    public void EmptyCategory_ShouldHaveNoItemsAndNoOpMoves()
+    {
+        var category = new ConfigCategory("Exit", "Leave.", new List<IConfigItem>());
+
+        Assert.False(category.HasItems);
+        Assert.Null(category.SelectedItem);
+
+        category.MoveSelectionDown();
+        category.MoveSelectionUp();
+
+        Assert.Equal(0, category.SelectedIndex);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigCategoryTests"`
+Expected: FAIL — `The type or namespace name 'ConfigCategory' does not exist`.
+
+- [ ] **Step 3: Create the model**
+
+Create `DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs`:
+
+```csharp
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
+
+namespace DTXMania.Game.Lib.Stage.Config
+{
+    /// <summary>
+    /// A left-column category in the NX Config stage: a labeled group of config items plus a
+    /// help description. The Exit category is simply a category with no items
+    /// (<see cref="HasItems"/> == false); no special flag is needed.
+    /// </summary>
+    public sealed class ConfigCategory
+    {
+        public string Name { get; }
+        public string Description { get; }
+        public IReadOnlyList<IConfigItem> Items { get; }
+        public int SelectedIndex { get; set; }
+
+        public ConfigCategory(string name, string description, IReadOnlyList<IConfigItem> items)
+        {
+            Name = name ?? throw new ArgumentNullException(nameof(name));
+            Description = description ?? string.Empty;
+            Items = items ?? throw new ArgumentNullException(nameof(items));
+        }
+
+        public bool HasItems => Items.Count > 0;
+
+        public IConfigItem? SelectedItem =>
+            HasItems && SelectedIndex >= 0 && SelectedIndex < Items.Count ? Items[SelectedIndex] : null;
+
+        public void MoveSelectionUp()
+        {
+            if (Items.Count == 0)
+                return;
+            SelectedIndex = (SelectedIndex - 1 + Items.Count) % Items.Count;
+        }
+
+        public void MoveSelectionDown()
+        {
+            if (Items.Count == 0)
+                return;
+            SelectedIndex = (SelectedIndex + 1) % Items.Count;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigCategoryTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Config/ConfigCategory.cs DTXMania.Test/Config/ConfigCategoryTests.cs
+git commit -m "feat: add ConfigCategory model for master-detail config"
+```
+
+---
+
+### Task 5: Rewrite `ConfigStage` to NX master-detail
+
+This is the load-bearing task: it replaces the flat-list state, input, and rendering with the category + two-focus model and NX layout, and migrates the existing tests. Production and tests are in one task because the rewrite changes private fields the existing tests reference — the whole solution must build green at the end.
+
+**Files:**
+- Modify (full rewrite): `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- Modify: `DTXMania.Test/Config/ConfigStageLogicTests.cs` (add the new tests + migrate the flat-list tests, reusing existing helpers)
+
+**Interfaces:**
+- Consumes: `ConfigUILayout` (Task 3), `ConfigCategory` (Task 4), `IConfigItem.Description` (Task 1), `TexturePath.Config*` (Task 2).
+- Produces (private, reflection-accessed by tests): fields `_categories : List<ConfigCategory>`, `_currentCategoryIndex : int`, `_focusOnMenu : bool`; methods `SetupConfigItems()`, `HandleInput()`, `DrawCategoryMenu()`, `DrawItemList()`, `DrawConfigBackground()`; the render seam (`BeginDrawFrame`/`EndDrawFrame`/`DrawFilledRectangle`/`GetViewport`) is unchanged so `RenderSpyConfigStage` keeps working. `ChangeStage`/`StageManager` and `FlushPendingSave` paths are unchanged, so the existing `Moq.Mock<IStageManager>` / `CreateStageWithMockConfig` verification patterns keep working.
+
+- [ ] **Step 1: Write the new behavior tests (failing)**
+
+Add these tests **inside the existing `ConfigStageLogicTests` class** in `DTXMania.Test/Config/ConfigStageLogicTests.cs` (they reuse that file's helpers — do not duplicate helpers). First add `using DTXMania.Game.Lib.Stage.Config;` to the file's usings if absent.
+
+```csharp
+    [Fact]
+    public void SetupConfigItems_ShouldBuildSystemDrumsExitCategories()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+
+            Assert.Collection(categories!,
+                c => Assert.Equal("System", c.Name),
+                c => Assert.Equal("Drums", c.Name),
+                c => Assert.Equal("Exit", c.Name));
+
+            Assert.Collection(categories![0].Items,
+                i => Assert.Equal("Screen Resolution", i.Name),
+                i => Assert.Equal("Fullscreen", i.Name),
+                i => Assert.Equal("VSync Wait", i.Name),
+                i => Assert.Equal("Audio Latency Offset", i.Name),
+                i => Assert.Equal("DTX Folder", i.Name),
+                i => Assert.Equal("System Key Mapping", i.Name),
+                i => Assert.Equal("Import NX Scores", i.Name));
+
+            Assert.Collection(categories[1].Items,
+                i => Assert.Equal("Scroll Speed", i.Name),
+                i => Assert.Equal("Auto Play", i.Name),
+                i => Assert.Equal("No Fail", i.Name),
+                i => Assert.Equal("Drum Key Mapping", i.Name));
+
+            Assert.False(categories[2].HasItems);
+        }
+    }
+
+    [Fact]
+    public void EveryConfigCategoryAndItem_ShouldHaveNonEmptyDescription()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+
+            foreach (var category in categories!)
+            {
+                Assert.False(string.IsNullOrWhiteSpace(category.Description));
+                foreach (var item in category.Items)
+                    Assert.False(string.IsNullOrWhiteSpace(item.Description), $"{item.Name} needs a description");
+            }
+        }
+    }
+
+    [Fact]
+    public void MenuActivateOnSettingsCategory_ShouldMoveFocusToItems()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.False(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+        }
+    }
+
+    [Fact]
+    public void MenuActivateOnExitCategory_ShouldFlushAndTransitionToTitle()
+    {
+        using var inputManager = new InputManagerCompat(new ConfigManager());
+        var (stage, mockConfig) = CreateStageWithMockConfig(inputManager);
+        InitializeStageMenu(stage, includePanels: false);
+        var stageManager = new Moq.Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 2); // Exit
+        ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+        SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        mockConfig.Verify(c => c.FlushPendingSave(), Moq.Times.Once);
+        stageManager.Verify(
+            m => m.ChangeStage(StageType.Title, Moq.It.Is<IStageTransition>(t => t is CrossfadeTransition)),
+            Moq.Times.Once);
+    }
+
+    [Fact]
+    public void ItemsBackCommand_ShouldReturnFocusToMenu_WithoutLeavingStage()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var stageManager = new Moq.Mock<IStageManager>();
+            stage.StageManager = stageManager.Object;
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+            SetKeyboardStates(stage, new KeyboardState(Keys.Escape), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_focusOnMenu"));
+            stageManager.Verify(
+                m => m.ChangeStage(Moq.It.IsAny<StageType>(), Moq.It.IsAny<IStageTransition>()),
+                Moq.Times.Never);
+        }
+    }
+
+    [Fact]
+    public void MenuMoveDown_ShouldWrapAcrossCategories()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 2); // Exit (last)
+            SetKeyboardStates(stage, new KeyboardState(Keys.Down), new KeyboardState());
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+        }
+    }
+
+    [Fact]
+    public void DrawCategoryMenu_ShouldHighlightCurrentCategory()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 1);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawCategoryMenu");
+
+            Assert.Contains(stage.RectangleDrawCalls, c => c.Rectangle == ConfigUILayout.MenuCursorRect(1));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WhenFocusOnItems_ShouldDrawItemCursorAtSelectedRow()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            categories![0].SelectedIndex = 2;
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            Assert.Contains(stage.RectangleDrawCalls, c => c.Rectangle == ConfigUILayout.ItemCursorRect(2));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WhenFocusOnMenu_ShouldNotDrawItemCursor()
+    {
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            Assert.DoesNotContain(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.ItemCursorRect(0));
+        }
+    }
+```
+
+Add `using DTXMania.Game.Lib.UI.Layout;` for `ConfigUILayout`. The render tests require `RenderSpyConfigStage` to expose `InitializeDrawingState()` (it already does, per the existing `DrawTitle_WhenFontMissing...` test) and not to load real textures (it doesn't — `_resourceManager` is unset and the texture fields stay null, so draws fall through to `DrawFilledRectangle`).
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigStageLogicTests.SetupConfigItems_ShouldBuildSystemDrumsExitCategories"`
+Expected: FAIL to compile — `ConfigCategory` / `_categories` do not exist in the (pre-rewrite) stage yet.
+
+- [ ] **Step 3: Rewrite `ConfigStage.cs`**
+
+Replace the entire contents of `DTXMania.Game/Lib/Stage/ConfigStage.cs` with:
+
+```csharp
+#nullable enable
+
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Game.Lib.Stage.KeyAssign;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.UI.Layout;
+using DTXMania.Game;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using DTXMania.Game.Lib.Utilities;
+
+namespace DTXMania.Game.Lib.Stage
+{
+    /// <summary>
+    /// NX-style master-detail configuration stage: a left category menu (System / Drums / Exit),
+    /// a right per-category item list, a description panel, and header/footer panels. Reads
+    /// <see cref="IConfigManager.Config"/> as the single source of truth; every edit applies
+    /// immediately through the typed setters and marks a deferred save dirty. Back/Exit flushes
+    /// the pending save and leaves — there is no working copy. Two focus states mirror the NX
+    /// bFocusIsOnMenu pattern.
+    /// </summary>
+    public class ConfigStage : BaseStage
+    {
+        #region Private Fields
+
+        private IConfigManager _configManager;
+        private List<ConfigCategory> _categories = new();
+        private int _currentCategoryIndex = 0;
+        private bool _focusOnMenu = true;
+
+        private KeyboardState _previousKeyboardState;
+        private KeyboardState _currentKeyboardState;
+
+        private SystemKeyAssignPanel? _systemPanel;
+        private IKeyAssignPanel? _activePanel;
+
+        private SpriteBatch _spriteBatch;
+        private Texture2D _whitePixel;
+        private IFont _font;
+        private IFont _boldFont;
+        private IResourceManager _resourceManager;
+
+        private ITexture? _backgroundTexture;
+        private ITexture? _itemBarTexture;
+        private ITexture? _menuPanelTexture;
+        private ITexture? _menuCursorTexture;
+        private ITexture? _headerPanelTexture;
+        private ITexture? _footerPanelTexture;
+        private ITexture? _itemBoxTexture;
+        private ITexture? _itemBoxOtherTexture;
+        private ITexture? _itemBoxCursorTexture;
+        private ITexture? _descriptionPanelTexture;
+
+        // Light text reads on the dark NX config background.
+        private static readonly Color LightText = new(235, 238, 248);
+        private static readonly Color SelectedText = Color.Yellow;
+        private static readonly Color ValueText = new(255, 226, 150);
+        private static readonly Color MenuCursorFallback = new(64, 96, 160, 180);
+        private static readonly Color ItemCursorFallback = new(96, 96, 160, 180);
+        private static readonly Color ImportStatusColor = new(180, 220, 255);
+
+        // Dark fill behind the UI when the background art is unavailable, so the light text stays
+        // legible (light-on-light was the failure mode to avoid).
+        private static readonly Color FallbackBackgroundColor = new(18, 20, 34);
+
+        private volatile string _importStatus = "";
+        private volatile bool _importRunning;
+        private CancellationTokenSource? _importCts;
+
+        #endregion
+
+        #region Constructor
+
+        public override StageType Type => StageType.Config;
+
+        public ConfigStage(BaseGame game) : base(game)
+        {
+            _configManager = game.ConfigManager ?? throw new InvalidOperationException("ConfigManager not found");
+        }
+
+        #endregion
+
+        #region Stage Lifecycle
+
+        protected override void OnActivate()
+        {
+            System.Diagnostics.Debug.WriteLine("Activating Config Stage");
+
+            InitializeGraphics();
+            SetupConfigItems();
+            InitializePanels();
+
+            _currentCategoryIndex = 0;
+            _focusOnMenu = true;
+
+            _previousKeyboardState = Keyboard.GetState();
+            _currentKeyboardState = Keyboard.GetState();
+        }
+
+        protected override void OnUpdate(double deltaTime)
+        {
+            _previousKeyboardState = _currentKeyboardState;
+            _currentKeyboardState = Keyboard.GetState();
+
+            if (_activePanel?.IsActive == true)
+            {
+                _activePanel.Update(deltaTime, _currentKeyboardState, _previousKeyboardState);
+                return;
+            }
+
+            HandleInput();
+        }
+
+        protected override void OnDraw(double deltaTime)
+        {
+            if (_spriteBatch == null)
+                return;
+
+            BeginDrawFrame();
+
+            DrawConfigBackground();
+            DrawItemBar();
+            DrawCategoryMenu();
+            DrawItemList();
+            DrawDescriptionPanel();
+            DrawHeaderFooter();
+            DrawImportStatus();
+
+            if (_activePanel?.IsActive == true)
+            {
+                var vp = GetViewport();
+                _activePanel.Draw(_spriteBatch, _font, _boldFont, _whitePixel, vp.Width, vp.Height);
+            }
+
+            EndDrawFrame();
+        }
+
+        protected override void OnDeactivate()
+        {
+            System.Diagnostics.Debug.WriteLine("Deactivating Config Stage");
+
+            FlushPendingSaveSafely();
+
+            _importCts?.Cancel();
+
+            _activePanel?.Deactivate();
+            _activePanel = null;
+
+            _font?.RemoveReference();
+            _font = null;
+            _boldFont?.RemoveReference();
+            _boldFont = null;
+            ReleaseTextures();
+
+            _previousKeyboardState = default;
+            _currentKeyboardState = default;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                System.Diagnostics.Debug.WriteLine("Disposing Config Stage resources");
+
+                _importCts?.Cancel();
+                _importCts?.Dispose();
+                _importCts = null;
+
+                _whitePixel?.Dispose();
+                _spriteBatch?.Dispose();
+
+                _font?.RemoveReference();
+                _boldFont?.RemoveReference();
+                ReleaseTextures();
+
+                _whitePixel = null;
+                _spriteBatch = null;
+                _font = null;
+                _boldFont = null;
+                _resourceManager = null; // shared game-wide instance; do NOT dispose
+            }
+
+            base.Dispose(disposing);
+        }
+
+        #endregion
+
+        #region Initialization
+
+        protected virtual void InitializeGraphics()
+        {
+            var graphicsDevice = _game.GraphicsDevice;
+            _spriteBatch = new SpriteBatch(graphicsDevice);
+
+            _whitePixel = new Texture2D(graphicsDevice, 1, 1);
+            _whitePixel.SetData(new[] { Color.White });
+
+            _resourceManager = _game.ResourceManager;
+
+            try
+            {
+                _font = _resourceManager.LoadFont("NotoSerifJP", 14);
+                _boldFont = _resourceManager.LoadFont("NotoSerifJP", 14, FontStyle.Bold);
+            }
+            catch
+            {
+                _font?.RemoveReference();
+                _font = null;
+                _boldFont?.RemoveReference();
+                _boldFont = null;
+                _whitePixel?.Dispose();
+                _whitePixel = null;
+                _spriteBatch?.Dispose();
+                _spriteBatch = null;
+                throw;
+            }
+
+            // All skin art is best-effort; every draw is null-guarded with a fill/text fallback.
+            _backgroundTexture = TryLoadTexture(TexturePath.ConfigBackground);
+            _itemBarTexture = TryLoadTexture(TexturePath.ConfigItemBar);
+            _menuPanelTexture = TryLoadTexture(TexturePath.ConfigMenuPanel);
+            _menuCursorTexture = TryLoadTexture(TexturePath.ConfigMenuCursor);
+            _headerPanelTexture = TryLoadTexture(TexturePath.ConfigHeaderPanel);
+            _footerPanelTexture = TryLoadTexture(TexturePath.ConfigFooterPanel);
+            _itemBoxTexture = TryLoadTexture(TexturePath.ConfigItemBox);
+            _itemBoxOtherTexture = TryLoadTexture(TexturePath.ConfigItemBoxOther);
+            _itemBoxCursorTexture = TryLoadTexture(TexturePath.ConfigItemBoxCursor);
+            _descriptionPanelTexture = TryLoadTexture(TexturePath.ConfigDescriptionPanel);
+        }
+
+        private ITexture? TryLoadTexture(string path)
+        {
+            try
+            {
+                return _resourceManager.LoadTexture(path);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private void ReleaseTextures()
+        {
+            _backgroundTexture?.RemoveReference();
+            _backgroundTexture = null;
+            _itemBarTexture?.RemoveReference();
+            _itemBarTexture = null;
+            _menuPanelTexture?.RemoveReference();
+            _menuPanelTexture = null;
+            _menuCursorTexture?.RemoveReference();
+            _menuCursorTexture = null;
+            _headerPanelTexture?.RemoveReference();
+            _headerPanelTexture = null;
+            _footerPanelTexture?.RemoveReference();
+            _footerPanelTexture = null;
+            _itemBoxTexture?.RemoveReference();
+            _itemBoxTexture = null;
+            _itemBoxOtherTexture?.RemoveReference();
+            _itemBoxOtherTexture = null;
+            _itemBoxCursorTexture?.RemoveReference();
+            _itemBoxCursorTexture = null;
+            _descriptionPanelTexture?.RemoveReference();
+            _descriptionPanelTexture = null;
+        }
+
+        private void SetupConfigItems()
+        {
+            var resolutionItem = new DropdownConfigItem(
+                "Screen Resolution",
+                () => $"{_configManager.Config.ScreenWidth}x{_configManager.Config.ScreenHeight}",
+                new[] { "1280x720", "1920x1080", "2560x1440", "3840x2160" },
+                value =>
+                {
+                    var parts = value.Split('x');
+                    if (parts.Length == 2 && int.TryParse(parts[0], out var width) && int.TryParse(parts[1], out var height))
+                    {
+                        _configManager.SetResolution(width, height);
+                    }
+                })
+            { Description = "Sets the game window resolution." };
+
+            var fullscreenItem = new ToggleConfigItem(
+                "Fullscreen",
+                () => _configManager.Config.FullScreen,
+                value => _configManager.SetFullscreen(value))
+            { Description = "Toggles fullscreen display mode." };
+
+            var vsyncItem = new ToggleConfigItem(
+                "VSync Wait",
+                () => _configManager.Config.VSyncWait,
+                value => _configManager.SetVSync(value))
+            { Description = "Syncs drawing to the monitor refresh rate to reduce tearing." };
+
+            var audioLatencyItem = new IntegerConfigItem(
+                "Audio Latency Offset",
+                () => _configManager.Config.AudioLatencyOffsetMs,
+                value => _configManager.SetAudioLatency(value),
+                minValue: 0,
+                maxValue: 500,
+                step: 10,
+                valueFormatter: v => $"{v} ms")
+            { Description = "Shifts audio timing to compensate for output latency." };
+
+            var dtxFolderItem = new ReadOnlyConfigItem(
+                "DTX Folder",
+                () => _configManager.Config.DTXPath)
+            { Description = "Folder scanned for songs and charts (read-only)." };
+
+            var systemKeyItem = new NavigationConfigItem("System Key Mapping",
+                () => OpenPanel(_systemPanel))
+            { Description = "Assign keys for menu and system commands." };
+
+            var importItem = new NavigationConfigItem("Import NX Scores",
+                () => StartNxScoreImport())
+            { Description = "Import play counts and scores from a DTXManiaNX database." };
+
+            var scrollSpeedItem = new IntegerConfigItem(
+                "Scroll Speed",
+                () => _configManager.Config.ScrollSpeed,
+                value => _configManager.SetScrollSpeed(AppPaths.GetConfigFilePath(), value),
+                minValue: ScrollSpeedRange.Min,
+                maxValue: ScrollSpeedRange.Max,
+                step: ScrollSpeedRange.Step,
+                valueFormatter: ScrollSpeedRange.Format)
+            { Description = "Sets how fast notes scroll down the lanes." };
+
+            var autoPlayItem = new ToggleConfigItem(
+                "Auto Play",
+                () => _configManager.Config.AutoPlay,
+                value => _configManager.SetAutoPlay(value))
+            { Description = "Plays the chart automatically without input." };
+
+            var noFailItem = new ToggleConfigItem(
+                "No Fail",
+                () => _configManager.Config.NoFail,
+                value => _configManager.SetNoFail(value))
+            { Description = "Continue playing even when the life gauge is empty." };
+
+            var drumKeyItem = new NavigationConfigItem("Drum Key Mapping",
+                () => NavigateToDrumConfig())
+            { Description = "Assign keys for each drum lane." };
+
+            var systemItems = new List<IConfigItem>
+            {
+                resolutionItem, fullscreenItem, vsyncItem, audioLatencyItem,
+                dtxFolderItem, systemKeyItem, importItem
+            };
+
+            var drumItems = new List<IConfigItem>
+            {
+                scrollSpeedItem, autoPlayItem, noFailItem, drumKeyItem
+            };
+
+            _categories = new List<ConfigCategory>
+            {
+                new ConfigCategory("System",
+                    "System settings: display, audio, file paths, and system key bindings.",
+                    systemItems),
+                new ConfigCategory("Drums",
+                    "Drum gameplay settings and drum pad key bindings.",
+                    drumItems),
+                new ConfigCategory("Exit",
+                    "Save changes and return to the title screen.",
+                    new List<IConfigItem>())
+            };
+
+            _currentCategoryIndex = 0;
+            _focusOnMenu = true;
+        }
+
+        private void InitializePanels()
+        {
+            var inputManagerCompat = _game.InputManager
+                ?? throw new InvalidOperationException("InputManager not available");
+
+            _systemPanel = new SystemKeyAssignPanel(inputManagerCompat);
+            _systemPanel._workingMappingProvider =
+                () => new Dictionary<Keys, InputCommandType>(inputManagerCompat.GetKeyMappingSnapshot());
+            _systemPanel._liveDrumBindingsProvider =
+                () => new Dictionary<string, int>(inputManagerCompat.ModularInputManager.KeyBindings.ButtonToLane);
+            _systemPanel._navigationMappingProvider =
+                () => new Dictionary<Keys, InputCommandType>(inputManagerCompat.GetKeyMappingSnapshot());
+            _systemPanel._commandPressedProvider = IsPanelCommandPressed;
+            _systemPanel.Saved += OnPanelSaved;
+            _systemPanel.Closed += OnPanelClosed;
+        }
+
+        private void OpenPanel(IKeyAssignPanel? panel)
+        {
+            if (panel == null) return;
+            _activePanel = panel;
+            _activePanel.Activate();
+        }
+
+        private void NavigateToDrumConfig()
+        {
+            ChangeStage(StageType.DrumConfig, new InstantTransition());
+        }
+
+        private void OnPanelSaved(object? sender, EventArgs e)
+        {
+            if (sender == _systemPanel)
+            {
+                _configManager.SetSystemKeyBindings(_systemPanel.GetWorkingMappingSnapshot());
+            }
+        }
+
+        private void OnPanelClosed(object? sender, EventArgs e)
+        {
+            _activePanel = null;
+        }
+
+        private void StartNxScoreImport()
+        {
+            if (_importRunning)
+                return;
+            _importRunning = true;
+            _importStatus = "Importing NX scores...";
+
+            _importCts?.Cancel();
+            _importCts?.Dispose();
+            _importCts = new CancellationTokenSource();
+            var token = _importCts.Token;
+
+            IProgress<NxImportProgress> progress = new InlineProgress<NxImportProgress>(p =>
+            {
+                _importStatus = $"Importing... {p.Imported} imported / {p.Scanned} scanned";
+            });
+
+            _ = System.Threading.Tasks.Task.Run(async () =>
+            {
+                try
+                {
+                    var result = await SongManager.Instance.ImportNxScoresAsync(progress, token);
+                    _importStatus = result.DbUnavailable
+                        ? "NX import unavailable (no database)"
+                        : $"Imported {result.Imported} scores ({result.Scanned} charts scanned" +
+                          (result.Errors > 0 ? $", {result.Errors} errors)" : ")");
+
+                    if (result.Imported > 0)
+                    {
+                        token.ThrowIfCancellationRequested();
+                        try
+                        {
+                            await SongManager.Instance.RefreshSongListFromDatabaseAsync();
+                        }
+                        catch (System.Exception ex)
+                        {
+                            System.Diagnostics.Debug.WriteLine(
+                                $"ConfigStage: NX import succeeded but song list refresh failed: {ex}");
+                        }
+                    }
+                }
+                catch (System.OperationCanceledException)
+                {
+                    _importStatus = "NX import cancelled";
+                }
+                catch (System.Exception ex)
+                {
+                    var detail = ex.GetBaseException().Message;
+                    _importStatus = $"NX import failed: {detail}";
+                    System.Diagnostics.Debug.WriteLine($"ConfigStage: NX import failed: {ex}");
+                }
+                finally
+                {
+                    _importRunning = false;
+                }
+            });
+        }
+
+        #endregion
+
+        #region Input Handling
+
+        private void HandleInput()
+        {
+            if (_focusOnMenu)
+                HandleMenuInput();
+            else
+                HandleItemInput();
+        }
+
+        private void HandleMenuInput()
+        {
+            if (IsConfigNavigationCommandPressed(InputCommandType.Back))
+            {
+                ExitToTitle();
+                return;
+            }
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.MoveUp))
+            {
+                _currentCategoryIndex = (_currentCategoryIndex - 1 + _categories.Count) % _categories.Count;
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.MoveDown))
+            {
+                _currentCategoryIndex = (_currentCategoryIndex + 1) % _categories.Count;
+            }
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.Activate) ||
+                IsConfigNavigationCommandPressed(InputCommandType.MoveRight))
+            {
+                var category = _categories[_currentCategoryIndex];
+                if (category.HasItems)
+                    _focusOnMenu = false;
+                else
+                    ExitToTitle();
+            }
+        }
+
+        private void HandleItemInput()
+        {
+            var category = _categories[_currentCategoryIndex];
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.Back))
+            {
+                _focusOnMenu = true;
+                return;
+            }
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.MoveUp))
+            {
+                category.MoveSelectionUp();
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.MoveDown))
+            {
+                category.MoveSelectionDown();
+            }
+
+            var item = category.SelectedItem;
+            if (item == null)
+                return;
+
+            if (IsConfigNavigationCommandPressed(InputCommandType.MoveLeft))
+            {
+                item.PreviousValue();
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.MoveRight))
+            {
+                item.NextValue();
+            }
+            else if (IsConfigNavigationCommandPressed(InputCommandType.Activate))
+            {
+                item.ToggleValue();
+            }
+        }
+
+        private void ExitToTitle()
+        {
+            System.Diagnostics.Debug.WriteLine("Config: Returning to Title stage");
+            FlushPendingSaveSafely();
+            ChangeStage(StageType.Title, new CrossfadeTransition(0.3));
+        }
+
+        private bool IsConfigNavigationCommandPressed(InputCommandType command)
+        {
+            if (_game.InputManager?.IsCommandPressed(command) == true)
+                return true;
+
+            var systemMap = _game.InputManager?.GetKeyMappingSnapshot();
+            return systemMap != null && systemMap.Any(kvp =>
+                kvp.Value == command &&
+                _currentKeyboardState.IsKeyDown(kvp.Key) &&
+                !_previousKeyboardState.IsKeyDown(kvp.Key));
+        }
+
+        private bool IsPanelCommandPressed(InputCommandType command)
+        {
+            var systemMap = _game.InputManager?.GetKeyMappingSnapshot();
+            return systemMap != null && systemMap.Any(kvp =>
+                kvp.Value == command &&
+                ((_game.InputManager?.IsKeyPressed((int)kvp.Key) == true)
+                 || (_currentKeyboardState.IsKeyDown(kvp.Key) && !_previousKeyboardState.IsKeyDown(kvp.Key))));
+        }
+
+        #endregion
+
+        #region Event Handlers
+
+        private void FlushPendingSaveSafely()
+        {
+            try
+            {
+                _configManager.FlushPendingSave();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"ConfigStage: failed to flush pending save: {ex}");
+            }
+        }
+
+        #endregion
+
+        #region Drawing (NX master-detail)
+
+        private void DrawConfigBackground()
+        {
+            var viewport = GetViewport();
+            var full = new Rectangle(0, 0, viewport.Width, viewport.Height);
+
+            if (_backgroundTexture?.Texture != null)
+                _spriteBatch.Draw(_backgroundTexture.Texture, full, Color.White);
+            else
+                DrawFilledRectangle(full, FallbackBackgroundColor);
+        }
+
+        private void DrawItemBar()
+        {
+            if (_itemBarTexture?.Texture != null)
+                _spriteBatch.Draw(_itemBarTexture.Texture, ConfigUILayout.ItemBarRect, Color.White);
+        }
+
+        private void DrawCategoryMenu()
+        {
+            if (_menuPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_menuPanelTexture.Texture, ConfigUILayout.MenuPanelRect, Color.White);
+
+            var cursorRect = ConfigUILayout.MenuCursorRect(_currentCategoryIndex);
+            if (_menuCursorTexture?.Texture != null)
+            {
+                var tint = _focusOnMenu ? Color.White : new Color(255, 255, 255, 128);
+                _spriteBatch.Draw(_menuCursorTexture.Texture, cursorRect, tint);
+            }
+            else
+            {
+                DrawFilledRectangle(cursorRect, MenuCursorFallback);
+            }
+
+            if (_font == null || _boldFont == null)
+                return;
+
+            for (int i = 0; i < _categories.Count; i++)
+            {
+                bool selected = i == _currentCategoryIndex;
+                var font = selected ? _boldFont : _font;
+                var color = selected ? SelectedText : LightText;
+                var label = _categories[i].Name;
+                var size = font.MeasureString(label);
+                var pos = new Vector2(ConfigUILayout.MenuLabelCenterX - size.X / 2f, ConfigUILayout.MenuRowY(i));
+                font.DrawString(_spriteBatch, label, pos, color);
+            }
+        }
+
+        private void DrawItemList()
+        {
+            if (_categories.Count == 0)
+                return;
+
+            var category = _categories[_currentCategoryIndex];
+            var items = category.Items;
+
+            for (int row = 0; row < items.Count; row++)
+            {
+                var box = (items[row] is NavigationConfigItem || items[row] is ReadOnlyConfigItem)
+                    ? _itemBoxOtherTexture
+                    : _itemBoxTexture;
+                if (box?.Texture != null)
+                    _spriteBatch.Draw(box.Texture, ConfigUILayout.ItemRowRect(row), Color.White);
+            }
+
+            if (!_focusOnMenu && category.HasItems)
+            {
+                var cursorRect = ConfigUILayout.ItemCursorRect(category.SelectedIndex);
+                if (_itemBoxCursorTexture?.Texture != null)
+                    _spriteBatch.Draw(_itemBoxCursorTexture.Texture, cursorRect, Color.White);
+                else
+                    DrawFilledRectangle(cursorRect, ItemCursorFallback);
+            }
+
+            if (_font == null || _boldFont == null)
+                return;
+
+            for (int row = 0; row < items.Count; row++)
+            {
+                var item = items[row];
+                bool selected = !_focusOnMenu && row == category.SelectedIndex;
+                var font = selected ? _boldFont : _font;
+
+                font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(row),
+                    selected ? SelectedText : LightText);
+
+                var value = GetItemValueText(item);
+                if (!string.IsNullOrEmpty(value))
+                {
+                    font.DrawString(_spriteBatch, value, ConfigUILayout.ItemValuePos(row),
+                        selected ? SelectedText : ValueText);
+                }
+            }
+        }
+
+        private static string GetItemValueText(IConfigItem item)
+        {
+            if (item is NavigationConfigItem)
+                return ">";
+
+            var text = item.GetDisplayText();
+            var prefix = item.Name + ": ";
+            return text.StartsWith(prefix, StringComparison.Ordinal)
+                ? text.Substring(prefix.Length)
+                : string.Empty;
+        }
+
+        private void DrawDescriptionPanel()
+        {
+            if (_categories.Count == 0)
+                return;
+
+            var category = _categories[_currentCategoryIndex];
+            string text = _focusOnMenu
+                ? category.Description
+                : (category.SelectedItem?.Description ?? string.Empty);
+
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            if (_descriptionPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_descriptionPanelTexture.Texture, ConfigUILayout.DescriptionPanelRect, Color.White);
+
+            if (_font == null)
+                return;
+
+            var pos = ConfigUILayout.DescriptionTextPos;
+            foreach (var line in WrapText(_font, text, ConfigUILayout.DescriptionWrapWidth))
+            {
+                _font.DrawString(_spriteBatch, line, pos, LightText);
+                pos.Y += ConfigUILayout.DescriptionLineHeight;
+            }
+        }
+
+        private static IEnumerable<string> WrapText(IFont font, string text, int maxWidth)
+        {
+            var line = new StringBuilder();
+            foreach (var word in text.Split(' '))
+            {
+                var candidate = line.Length == 0 ? word : line + " " + word;
+                if (line.Length > 0 && font.MeasureString(candidate).X > maxWidth)
+                {
+                    yield return line.ToString();
+                    line.Clear();
+                    line.Append(word);
+                }
+                else
+                {
+                    if (line.Length > 0)
+                        line.Append(' ');
+                    line.Append(word);
+                }
+            }
+            if (line.Length > 0)
+                yield return line.ToString();
+        }
+
+        private void DrawHeaderFooter()
+        {
+            if (_headerPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_headerPanelTexture.Texture, ConfigUILayout.HeaderRect, Color.White);
+
+            if (_font != null)
+            {
+                const string title = "CONFIGURATION";
+                var size = _font.MeasureString(title);
+                var pos = new Vector2((ConfigUILayout.ScreenWidth - size.X) / 2f, ConfigUILayout.TitleY);
+                _font.DrawString(_spriteBatch, title, pos, LightText);
+            }
+
+            if (_footerPanelTexture?.Texture != null)
+                _spriteBatch.Draw(_footerPanelTexture.Texture, ConfigUILayout.FooterRect, Color.White);
+
+            if (_font != null)
+                _font.DrawString(_spriteBatch, ConfigUILayout.InstructionsText, ConfigUILayout.InstructionsPos, LightText);
+        }
+
+        private void DrawImportStatus()
+        {
+            if (string.IsNullOrEmpty(_importStatus) || _font == null)
+                return;
+
+            _font.DrawString(_spriteBatch, _importStatus, ConfigUILayout.ImportStatusPos, ImportStatusColor);
+        }
+
+        [ExcludeFromCodeCoverage]
+        protected virtual void BeginDrawFrame()
+        {
+            _spriteBatch.Begin();
+        }
+
+        [ExcludeFromCodeCoverage]
+        protected virtual void EndDrawFrame()
+        {
+            _spriteBatch.End();
+        }
+
+        [ExcludeFromCodeCoverage]
+        protected virtual void DrawFilledRectangle(Rectangle destinationRectangle, Color color)
+        {
+            if (_whitePixel == null)
+                return;
+
+            _spriteBatch.Draw(_whitePixel, destinationRectangle, color);
+        }
+
+        [ExcludeFromCodeCoverage]
+        protected virtual Viewport GetViewport()
+        {
+            return _game.GraphicsDevice.Viewport;
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Synchronous <see cref="IProgress{T}"/> that invokes the callback inline on the calling
+        /// thread, preventing stale queued progress from overwriting the final import status.
+        /// </summary>
+        private sealed class InlineProgress<T> : IProgress<T>
+        {
+            private readonly Action<T> _callback;
+            public InlineProgress(Action<T> callback) => _callback = callback;
+            public void Report(T value) => _callback(value);
+        }
+    }
+}
+```
+
+> **Transition/flush verification uses the existing seams unchanged:** the new tests verify `ChangeStage` via a `Moq.Mock<IStageManager>` on `stage.StageManager` and verify the save flush via `CreateStageWithMockConfig` — exactly like the existing `BackCommandPressed_*` and `ExitButton_*` tests. The rewrite keeps `ExitToTitle()` calling `ChangeStage(StageType.Title, new CrossfadeTransition(0.3))` and `FlushPendingSaveSafely()` calling `_configManager.FlushPendingSave()`, so those seams continue to work.
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigStageLogicTests.SetupConfigItems_ShouldBuildSystemDrumsExitCategories|FullyQualifiedName~ConfigStageLogicTests.DrawCategoryMenu_ShouldHighlightCurrentCategory|FullyQualifiedName~ConfigStageLogicTests.MenuActivateOnExitCategory"`
+Expected: PASS. If a rendering assertion fails, confirm the render-spy left every texture field null so the fallback `DrawFilledRectangle` path runs.
+
+- [ ] **Step 5: Migrate the existing `ConfigStageLogicTests.cs`**
+
+The existing flat-list tests reference removed members (`_configItems`, `_selectedIndex`, `GetConfigItemIndex`, `DrawTitle`, the Exit pseudo-button). Apply these changes in `DTXMania.Test/Config/ConfigStageLogicTests.cs`:
+
+**(a) Delete** these now-obsolete tests (their behavior is replaced by `ConfigStageNxLayoutTests`):
+- `SetupConfigItems_ShouldCreateExpectedItemsAndSelectFirstItem` (asserts 11 flat items)
+- `MoveUpPressedAtFirstItem_ShouldWrapToExitButton`
+- `MoveDownPressedAtExitButton_ShouldWrapToFirstItem`
+- `ActivatePressedOnExitButton_ShouldReturnToTitleStage`
+- `ExitButton_ShouldCallFlushPendingSaveAndTransitionToTitle`
+- `ExitButton_WhenFlushThrows_ShouldStillTransitionToTitle`
+- `HandleInput_ActivateOnExitButton_ShouldInvokeExitButtonClicked`
+- `DrawTitle_WhenFontMissing_ShouldFallbackToRectangleDrawing` (DrawTitle is gone; title now drawn in `DrawHeaderFooter`)
+- `OnDraw_WithActivePanel_ShouldDrawOverlayBeforeCompletingFrame` only if it asserts a removed draw method; keep it if it only checks the overlay path (it should still pass — verify).
+
+**(b) Rewrite** the helper `GetConfigItemIndex` and the per-item tests to drive a category + selection instead of a flat index. Replace the `GetConfigItemIndex` helper (around line 1023) with:
+
+```csharp
+    /// <summary>
+    /// Finds (categoryIndex, itemIndex) for a named item across all categories, sets the stage's
+    /// current category + that category's SelectedIndex, and switches focus to the item list so a
+    /// subsequent HandleInput acts on the item. Mirrors the new master-detail navigation.
+    /// </summary>
+    private static void SelectItemForEditing(ConfigStage stage, string itemName)
+    {
+        var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+        Assert.NotNull(categories);
+        for (int c = 0; c < categories!.Count; c++)
+        {
+            for (int i = 0; i < categories[c].Items.Count; i++)
+            {
+                if (categories[c].Items[i].Name == itemName)
+                {
+                    ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", c);
+                    categories[c].SelectedIndex = i;
+                    ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+                    return;
+                }
+            }
+        }
+        Assert.Fail($"Config item '{itemName}' should exist.");
+    }
+```
+
+Add `using DTXMania.Game.Lib.Stage.Config;` to the file's usings.
+
+**(c) For each remaining test** that did `SetPrivateField(stage, "_selectedIndex", GetConfigItemIndex(stage, "X"))` (or a literal index) and then invoked input/edit, replace those two lines with `SelectItemForEditing(stage, "X");`. The affected tests and their item names:
+
+| Test | Item to select |
+| --- | --- |
+| `DtxFolderItem_WhenActivated_ShouldNotMutateConfig` | `DTX Folder` |
+| `MoveRightPressedOnResolution_ShouldMutateConfigViaSetter` | `Screen Resolution` |
+| `MoveLeftPressedOnResolution_ShouldMutateConfigViaSetter` | `Screen Resolution` |
+| `ActivatePressedOnToggleItem_ShouldMutateConfigViaSetter` | `Fullscreen` |
+| `ActivatePressedOnDrumKeyMapping_ShouldChangeToDrumConfigStage` | `Drum Key Mapping` |
+| `HandleInput_MoveLeftOnNavigationItem_ShouldNotMutateConfig` | `Drum Key Mapping` |
+| `HandleInput_MoveRightOnNavigationItem_ShouldNotMutateConfig` | `System Key Mapping` |
+| `SystemPanelBackCommand_ShouldClosePanelWithoutMutatingSystemBindings` | `System Key Mapping` |
+| `AudioLatencyConfigItem_ShouldIncrementBy10Ms` | `Audio Latency Offset` |
+| `AudioLatencyConfigItem_AtZero_ShouldNotDecrementBelowMin` | `Audio Latency Offset` |
+| `AudioLatencyConfigItem_At500_ShouldNotIncrementAboveMax` | `Audio Latency Offset` |
+| `ActivatePressedOnToggle_ShouldMutateConfigViaSetter` (Theory) | map each `selectedIndex` row to its name: replace the `[InlineData(...)]` selectedIndex column with the item name and select by name — `No Fail`, `Auto Play` (Drums), `Fullscreen`, `VSync Wait` (System) as the original data intended; verify against the original `propertyName` column and keep the property assertion unchanged. |
+
+Worked example — `MoveRightPressedOnResolution_ShouldMutateConfigViaSetter` becomes:
+
+```csharp
+[Fact]
+public void MoveRightPressedOnResolution_ShouldMutateConfigViaSetter()
+{
+    var (stage, configManager, inputManager) = CreateStage();
+    using (inputManager)
+    {
+        InitializeStageMenu(stage, includePanels: true);
+        SelectItemForEditing(stage, "Screen Resolution");
+        SetKeyboardStates(stage, new KeyboardState(Keys.Right), new KeyboardState());
+
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        // (keep the original assertion comparing configManager.Config resolution to the expected next value)
+    }
+}
+```
+
+**(d) Migrate focus-dependent navigation tests.** Tests that previously asserted up/down moved `_selectedIndex` within the flat list (`OnUpdate_WithoutActivePanel_ShouldHandleMenuInput`, `HandleInput_WithNullActivePanel_ShouldHandleInputNormally`, `OnUpdate_WithActivePanel_ShouldForwardKeyboardStatesToPanelAndSkipMenuHandling`) now operate on category navigation while `_focusOnMenu == true`. For the two that assert a `Down` press advances selection, set `_focusOnMenu` appropriately:
+- If testing **category** movement: keep `_focusOnMenu = true` and assert `_currentCategoryIndex` advanced.
+- If testing **item** movement: `SetPrivateField(stage, "_focusOnMenu", false)`, set the category, press Down, and assert the category's `SelectedIndex` advanced.
+
+Worked example — `OnUpdate_WithoutActivePanel_ShouldHandleMenuInput` (category movement). Preserve the original's `ForcedCommandInputManager(MoveDown)` + manual game wiring + `OnUpdate(0.25)`; only swap `_selectedIndex` for the category fields and assertion:
+
+```csharp
+[Fact]
+public void OnUpdate_WithoutActivePanel_ShouldHandleMenuInput()
+{
+    var configManager = new ConfigManager();
+    using var inputManager = new ForcedCommandInputManager(configManager, InputCommandType.MoveDown);
+    var game = ReflectionHelpers.CreateGame();
+    ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+    ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+    var stage = new ConfigStage(game);
+
+    InitializeStageMenu(stage, includePanels: false);
+    ReflectionHelpers.SetPrivateField(stage, "_activePanel", (IKeyAssignPanel?)null);
+    ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+    ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+
+    ReflectionHelpers.InvokePrivateMethod(stage, "OnUpdate", 0.25);
+
+    Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_currentCategoryIndex"));
+}
+```
+
+(The same `_selectedIndex` → `_currentCategoryIndex`/`_focusOnMenu` swap applies to `HandleInput_WithNullActivePanel_ShouldHandleInputNormally` and `OnUpdate_WithActivePanel_ShouldForwardKeyboardStatesToPanelAndSkipMenuHandling` — keep each test's original input mechanism and only change the field it reads/asserts.)
+
+**(e) Fix `OnActivate_ShouldInitializeConfigItemsAndPanels`** (line ~404): replace its `_configItems` assertion with a `_categories` assertion:
+
+```csharp
+var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+Assert.NotNull(categories);
+Assert.Equal(3, categories!.Count);
+```
+
+**(f) Keep unchanged** (they don't touch removed members): `Constructor_WithoutConfigManager...`, `SetupConfigItems_ShouldShowConfiguredDtxFolder` (but change its `_configItems` lookup to search `_categories[0].Items` for `DTX Folder`), `BackCommandPressed_*`, `IsConfigNavigationCommandPressed_*`, `IsPanelCommandPressed_*`, `OnPanelSaved_*`, `OnPanelClosed_*`, `OpenPanel_WithNullPanel...`, `OnDeactivate_ShouldFlushDirtyConfigToDisk`, `DrawBackground_ShouldFillViewportWithBackgroundColor` (update its expected fallback color to `new Color(18, 20, 34)` and its invoked method name to `DrawConfigBackground`), `OnDraw_WhenSpriteBatchMissing...`.
+
+For `SetupConfigItems_ShouldShowConfiguredDtxFolder`, change the lookup to:
+
+```csharp
+var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+var item = categories!.SelectMany(c => c.Items).Single(i => i.Name == "DTX Folder");
+Assert.Equal("DTX Folder: /tmp/custom dtx", item.GetDisplayText());
+```
+
+(add `using System.Linq;` if not present).
+
+- [ ] **Step 6: Build and run the full Mac suite**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeds, no warnings about unreachable old members.
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~Config"`
+Expected: PASS — `ConfigStageNxLayoutTests`, migrated `ConfigStageLogicTests`, `ConfigCategoryTests`, `ConfigItemTests`, `ConfigUILayoutTests`.
+
+- [ ] **Step 7: Run the entire Mac test suite to catch collateral**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: PASS. Fix any remaining references to removed `ConfigStage` members surfaced by the compiler.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ConfigStage.cs DTXMania.Test/Config/ConfigStageLogicTests.cs
+git commit -m "feat: rebuild config stage with NX master-detail layout"
+```
+
+---
+
+### Task 6: Visual & end-to-end verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build and launch the game (Mac)**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: success.
+
+- [ ] **Step 2: Drive to the Config stage and screenshot**
+
+Launch the game and navigate Title → Config (the game exposes the JSON-RPC/MCP control surface described in CLAUDE.md). Capture a screenshot of the Config stage. Confirm visually:
+- Left menu shows **System / Drums / Exit** with the current category highlighted.
+- Right column shows the current category's items in NX item-box rows with values right-aligned.
+- The description panel shows the focused category/item help text.
+- Header (CONFIGURATION) and footer (instructions) panels render.
+
+If running headless, instead set a breakpoint-free smoke check: confirm `OnDraw` runs without exceptions by launching and entering Config, then exiting.
+
+- [ ] **Step 3: Manual interaction check**
+
+Verify by keyboard:
+- Up/Down on the menu cycles System ↔ Drums ↔ Exit.
+- Enter on System/Drums moves focus to the item list; Esc returns to the menu.
+- Left/Right changes a value (e.g. Scroll Speed) and it persists after leaving Config.
+- Enter on Exit (or Esc on the menu) returns to Title and the edited value is saved in `Config.ini`.
+- Drum Key Mapping opens `DrumConfigStage`; System Key Mapping opens the key panel overlay.
+
+- [ ] **Step 4: Final full test pass**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: PASS.
+
+- [ ] **Step 5: Commit any verification fixes**
+
+```bash
+git add -A
+git commit -m "fix: config stage NX layout verification adjustments"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Two-column NX layout → Tasks 3 (coordinates) + 5 (rendering). ✓
+- System/Drums/Exit categories + item mapping → Task 5 `SetupConfigItems` + `SetupConfigItems_ShouldBuildSystemDrumsExitCategories`. ✓
+- English per-category + per-item descriptions → Task 1 (`Description`) + Task 5 (strings) + `EveryConfigCategoryAndItem_ShouldHaveNonEmptyDescription`. ✓
+- Two-focus navigation (menu ↔ items; Exit/Esc behavior; remembered selection) → Task 5 `HandleMenuInput`/`HandleItemInput` + focus tests. ✓
+- Reuse existing key UIs → Task 5 keeps `NavigateToDrumConfig` + `OpenPanel(_systemPanel)`. ✓
+- Skin assets + best-effort fallback → Task 2 (paths) + Task 5 null-guarded draws + `DrawConfigBackground` fallback. ✓
+- No new Mac exclusions; all Mac-testable → Tasks 3/4 pure, Task 5 reuses `RenderSpyConfigStage`. ✓
+- Persist-on-edit preserved → Task 5 keeps `FlushPendingSaveSafely`/typed setters. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. The Step 5 test-migration table is a mechanical per-test mapping (each row names the exact item to select), not a placeholder.
+
+**Type consistency:** `ConfigCategory` members (`HasItems`, `SelectedItem`, `MoveSelectionUp/Down`, `SelectedIndex`) are used identically in Tasks 4 and 5. `ConfigUILayout` helper names (`MenuCursorRect`, `ItemCursorRect`, `ItemRowRect`, `ItemNamePos`, `ItemValuePos`, `MenuRowY`) match between Tasks 3 and 5 and the render tests. `IConfigItem.Description` (Task 1) is consumed by `SetupConfigItems` (Task 5) and asserted in Task 5 tests. Private field names (`_categories`, `_currentCategoryIndex`, `_focusOnMenu`, `_font`, `_boldFont`, `_spriteBatch`, `_whitePixel`) are consistent between the rewrite and the reflection-based tests.

--- a/docs/superpowers/specs/2026-06-25-config-stage-nx-layout-design.md
+++ b/docs/superpowers/specs/2026-06-25-config-stage-nx-layout-design.md
@@ -1,0 +1,214 @@
+# Config Stage NX Layout Revamp — Design
+
+**Date:** 2026-06-25
+**Status:** Approved (brainstorming), ready for implementation planning
+
+## Summary
+
+Rebuild `ConfigStage`'s UI from a single flat vertical list into the DTXManiaNX
+two-column **master-detail** layout: a left category menu, a right per-category
+item list, a description panel, and header/footer panels over the config
+background. The behaviour model (persist-on-edit, single source of truth =
+`ConfigManager.Config`) is unchanged — only the layout, navigation model, and
+item grouping change.
+
+All required skin assets (`4_*.png`) already exist in `System/Graphics/`. The
+existing visual `DrumConfigStage` and `SystemKeyAssignPanel` are reused as-is.
+
+## Goals
+
+- Two-column master-detail layout matching the NX config screen structure.
+- Left menu with three categories: **System**, **Drums**, **Exit**.
+- Right item list per category, rendered with NX item-box skin art.
+- Description panel showing English help text for the focused category/item.
+- NX-style two-focus navigation (focus on menu ↔ focus on item list).
+- Reuse the existing key-mapping UIs (no inline NX key list).
+- Graceful fallback to solid fills + text when skin art is missing.
+
+## Non-Goals (explicitly out of scope)
+
+- **Guitar / Bass categories.** This is a drum-only port; NX's Guitar/Bass menu
+  entries are dropped, not stubbed.
+- **Inline NX key-assignment list (`CActConfigKeyAssign`).** Key mapping keeps the
+  existing richer UIs: Drum Key Mapping → `DrumConfigStage`; System Key Mapping →
+  `SystemKeyAssignPanel` overlay.
+- **NX's animated 14-slot centered scroll carousel.** Replaced by a simpler
+  top-anchored item-box list (each category has ≤7 items, so no scrolling is
+  needed). Same NX look, minus the wheel animation.
+- **Bilingual (JP/EN) description text.** English-only.
+- Changes to `ConfigManager`, the persist-on-edit model, the `IConfigItem` value
+  semantics, or the NX-import logic. Those are preserved as-is.
+
+## Decisions (from brainstorming)
+
+| Topic | Decision |
+| --- | --- |
+| Layout fidelity | Full NX master-detail (two-column + description + header/footer). |
+| Categories | System / Drums / Exit (Guitar & Bass dropped). |
+| Descriptions | English-only, per category **and** per item. |
+| Key mapping | Reuse existing UIs (`DrumConfigStage`, `SystemKeyAssignPanel`). |
+| Right column | Simple top-anchored item-box list, not the animated carousel. |
+| Per-category selection | Remember the selected item index per category. |
+
+## Visual Layout (1280×720, NX coordinates)
+
+```
+┌──────────────────────────────────────────────────────────────┐  4_header panel.png (0,0)
+│  CONFIGURATION                                                 │
+├───────────────┬──────────────────────────────────────────────┤
+│ ▸ System      │  ┌────────────────────────────────────────┐  │  item-box rows, x=420
+│   Drums       │  │ Screen Resolution           1920x1080  │◀ │  4_itembox.png /
+│   Exit        │  │ Fullscreen                       OFF   │  │  4_itembox other.png
+│               │  │ VSync Wait                        ON   │  │  cursor 4_itembox cursor.png
+│ menu panel    │  │ Audio Latency Offset            30 ms  │  │  name x+20, value x+260
+│ (245,140)     │  │ DTX Folder            …/path/to/dtx    │  │
+│ cursor        │  │ System Key Mapping                ▸    │  │
+│ 4_menu        │  │ Import NX Scores                  ▸    │  │
+│ cursor.png    │  └────────────────────────────────────────┘  │
+│               │                  ┌────────────────────────┐   │  4_Description Panel.png
+│ │ item bar    │                  │ Sets the display       │   │  (800,270)
+│ │ (x=400)     │                  │ resolution.            │   │
+├───────────────┴──────────────────────────────────────────────┤
+│  ↑↓ navigate   ←→ change   Enter select   Esc back            │  4_footer panel.png (bottom)
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Draw order (back to front):** `4_background.png` (0,0) → `4_item bar.png`
+(400,0) → left `4_menu panel.png` (245,140) + `4_menu cursor.png`
+(x=250, y=146+idx·32, ~170 wide) + category labels (centered ≈x=340, y start 144,
+step 32) → right item-box rows (x=420) + item cursor + name (x+20) / value (x+260)
+text → `4_Description Panel.png` (800,270) + wrapped text → `4_header panel.png`
+(top) → `4_footer panel.png` (bottom).
+
+These coordinates are ported directly from `CStageConfig.OnUpdateAndDraw` and
+`CActConfigList` (item panel at x=420, name at +20, value at +260). All values are
+centralized in `ConfigUILayout` rather than inlined.
+
+**Fallbacks:** each texture load is best-effort (try/catch, null-check on draw).
+Missing background → existing light `FallbackBackgroundColor` fill; missing panel
+art → solid-rectangle stand-ins so text stays legible. Config remains fully usable
+without the skin (mirrors the current `ConfigStage` and `DrumConfigStage` pattern).
+
+## Categories & Item Mapping
+
+| Category | Items (in order) | Notes |
+| --- | --- | --- |
+| **System** | Screen Resolution · Fullscreen · VSync Wait · Audio Latency Offset · DTX Folder · System Key Mapping · Import NX Scores | DTX Folder is read-only; System Key Mapping opens the overlay; Import NX Scores starts the async import. |
+| **Drums** | Scroll Speed · Auto Play · No Fail · Drum Key Mapping | Drum Key Mapping navigates to `DrumConfigStage`. |
+| **Exit** | _(none — the category itself is the action)_ | Activating Exit flushes the pending save and returns to Title. |
+
+Every existing `IConfigItem` instance from today's `SetupConfigItems()` is reused;
+only its grouping and an added `Description` change. No item is dropped.
+
+## Navigation / Focus Model (NX two-focus)
+
+Two focus states mirror NX's `bFocusIsOnMenu`:
+
+**Focus = Menu (left column), the entry state:**
+- ↑ / ↓ — change category (wraps); updates the right list and shows the
+  category-level description.
+- Enter / → on a settings category (System, Drums) — move focus into the right
+  item list (focus = Items).
+- Enter / → on **Exit** — flush pending save, `ChangeStage(Title)`.
+- Esc / Back — flush pending save, `ChangeStage(Title)`.
+
+**Focus = Items (right column):**
+- ↑ / ↓ — move the selected item (wraps within the category).
+- ← / → — change the focused item's value (`PreviousValue` / `NextValue`).
+- Enter / Activate — `ToggleValue` for toggles; trigger nav items (DrumConfig
+  navigation, System Key panel, NX import).
+- Esc / Back — return focus to the **menu** (does NOT exit).
+
+**Description panel:** shows the focused item's `Description` while focus = Items;
+shows the focused category's `Description` while focus = Menu.
+
+**Remembered selection:** each category keeps its own selected-item index, restored
+when the user re-enters that category.
+
+Input plumbing reuses the existing `IsConfigNavigationCommandPressed` /
+`IsPanelCommandPressed` helpers and `InputCommandType` mapping unchanged.
+
+## Component Architecture
+
+Follows the existing `DrumConfig/` subfolder + `*UILayout` conventions.
+
+- **`Lib/UI/Layout/ConfigUILayout.cs`** *(new)* — all coordinate/size constants:
+  panel origins, menu cursor step, item-row origin/stride, name/value offsets,
+  description panel origin and text inset, header/footer placement. Renderers carry
+  no magic numbers.
+
+- **`Lib/Stage/Config/`** *(new subfolder)*:
+  - `ConfigCategory.cs` — model: `string Name`, `string Description`,
+    `IReadOnlyList<IConfigItem> Items`, plus the remembered selected index.
+  - `ConfigMenuRenderer.cs` — draws menu panel, menu cursor, category labels;
+    highlights the current category and dims when focus = Items.
+  - `ConfigItemListRenderer.cs` — draws item-box rows (`4_itembox.png` /
+    `4_itembox other.png`), the item cursor, and name/value text; highlights the
+    focused row, dims the whole list when focus = Menu.
+  - `ConfigDescriptionRenderer.cs` — draws the description panel and word-wrapped
+    text (simple greedy wrap to the panel's inner width).
+
+- **`Lib/Resources/TexturePath.cs`** — add constants and register them in the
+  existing path arrays: `ConfigBackground` (`Graphics/4_background.png`),
+  `ConfigItemBar` (`4_item bar.png`), `ConfigMenuPanel` (`4_menu panel.png`),
+  `ConfigMenuCursor` (`4_menu cursor.png`), `ConfigHeaderPanel`
+  (`4_header panel.png`), `ConfigFooterPanel` (`4_footer panel.png`),
+  `ConfigItemBox` (`4_itembox.png`), `ConfigItemBoxOther` (`4_itembox other.png`),
+  `ConfigItemBoxCursor` (`4_itembox cursor.png`), `ConfigDescriptionPanel`
+  (`4_Description Panel.png`).
+
+- **`Lib/Config/IConfigItem.cs` + `ConfigItems.cs`** — add `string Description { get; }`
+  to `IConfigItem`, default `""` on `BaseConfigItem`, settable via an optional ctor
+  argument / object initializer. `NavigationConfigItem` and `ReadOnlyConfigItem`
+  inherit it. No value-semantics change.
+
+- **`Lib/Stage/ConfigStage.cs`** — refactor:
+  - `SetupConfigItems()` → builds the three `ConfigCategory` objects (reusing the
+    existing item instances, now with descriptions).
+  - Replace flat-list `HandleInput()` / `DrawConfigItems()` / `DrawButtons()` with
+    the focus-state machine + the three renderers.
+  - `InitializeGraphics()` loads the new textures (best-effort) and disposes them in
+    `OnDeactivate` / `Dispose`, matching the current font/background lifecycle.
+  - Preserve unchanged: NX-import (`StartNxScoreImport` and its `InlineProgress`),
+    key-panel wiring (`InitializePanels`, `OpenPanel`, `OnPanelSaved`/`Closed`),
+    `FlushPendingSaveSafely`, and the persist-on-edit contract.
+
+## Error Handling & Edge Cases
+
+- **Missing skin textures** — best-effort load; null-checked draw with
+  solid-rectangle / fallback-color stand-ins. Never throws; config stays usable.
+- **Font load failure** — keep the current behaviour in `InitializeGraphics`:
+  dispose the partially-acquired graphics resources and rethrow.
+- **Empty category** — Exit has no items; guard item navigation against a
+  zero-length list (no modulo-by-zero). Settings categories always have ≥1 item.
+- **Description word-wrap** — greedy wrap to the panel inner width; over-long single
+  tokens are drawn as-is (no crash), truncation acceptable.
+- **Active key panel overlay** — when `_activePanel.IsActive`, it draws over the new
+  layout and swallows input, exactly as today.
+
+## Testing
+
+- **Excluded from `DTXMania.Test.Mac.csproj`** (GraphicsDevice-dependent, like
+  `SongBarRenderer*`): `ConfigMenuRenderer`, `ConfigItemListRenderer`,
+  `ConfigDescriptionRenderer` tests. Add the new test files to the Mac project's
+  explicit-exclude list.
+- **Mac-safe logic tests** (no GraphicsDevice):
+  - Category construction and item-to-category mapping (System has 7 items in
+    order, Drums has 4, Exit has 0).
+  - Focus-state transitions: Menu→Items on Enter over a settings category;
+    Items→Menu on Esc; Exit/Esc on menu triggers flush + Title.
+  - Category index wraps; per-category item index wraps and is remembered across
+    category switches.
+  - Each item exposes a non-empty `Description`; each category has a `Description`.
+- **Update existing `ConfigStage` tests** to the category structure (current tests
+  assume a flat `_configItems` list + Exit pseudo-button).
+- Where focus/navigation logic needs to be exercised without a GraphicsDevice,
+  follow the existing `ConfigStageLogicTests` pattern (subclass `ConfigStage`,
+  override `InitializeGraphics`, drive state via `ReflectionHelpers` and the
+  fallback-drawing paths, skipping real `OnActivate`).
+
+## Out-of-Scope Follow-ups (noted, not built)
+
+- NX's animated centered scroll carousel for the item list.
+- Future Guitar/Bass categories if non-drum instruments are ever added.
+- Bilingual description text.

--- a/docs/superpowers/specs/2026-06-25-config-stage-nx-layout-design.md
+++ b/docs/superpowers/specs/2026-06-25-config-stage-nx-layout-design.md
@@ -130,48 +130,61 @@ Input plumbing reuses the existing `IsConfigNavigationCommandPressed` /
 
 ## Component Architecture
 
-Follows the existing `DrumConfig/` subfolder + `*UILayout` conventions.
+Follows the existing `*UILayout` convention and `ConfigStage`'s established
+render-spy seam. **Rendering decision:** `ConfigStage` already routes its
+primitive drawing through overridable `protected virtual` seams
+(`BeginDrawFrame` / `EndDrawFrame` / `DrawFilledRectangle` / `GetViewport`) and
+guards every texture draw with a null check, which lets `RenderSpyConfigStage`
+exercise the draw logic on Mac with no GraphicsDevice. We therefore keep the NX
+rendering **in-stage** through that same seam rather than introducing separate
+GraphicsDevice-dependent renderer classes (which would force Mac-excluded tests).
+Only the pure, fully-testable pieces are extracted into focused files.
 
-- **`Lib/UI/Layout/ConfigUILayout.cs`** *(new)* — all coordinate/size constants:
-  panel origins, menu cursor step, item-row origin/stride, name/value offsets,
-  description panel origin and text inset, header/footer placement. Renderers carry
-  no magic numbers.
+- **`Lib/UI/Layout/ConfigUILayout.cs`** *(new, pure / no graphics)* — every
+  coordinate, size, and helper that maps an index to a `Rectangle` / `Vector2`:
+  panel origins, menu row stride, menu cursor rect, item-row rect, item name/value
+  positions, description panel rect + text inset/wrap width, header/footer/title
+  placement. The stage carries no magic numbers. Fully Mac-testable.
 
-- **`Lib/Stage/Config/`** *(new subfolder)*:
-  - `ConfigCategory.cs` — model: `string Name`, `string Description`,
-    `IReadOnlyList<IConfigItem> Items`, plus the remembered selected index.
-  - `ConfigMenuRenderer.cs` — draws menu panel, menu cursor, category labels;
-    highlights the current category and dims when focus = Items.
-  - `ConfigItemListRenderer.cs` — draws item-box rows (`4_itembox.png` /
-    `4_itembox other.png`), the item cursor, and name/value text; highlights the
-    focused row, dims the whole list when focus = Menu.
-  - `ConfigDescriptionRenderer.cs` — draws the description panel and word-wrapped
-    text (simple greedy wrap to the panel's inner width).
+- **`Lib/Stage/Config/ConfigCategory.cs`** *(new, pure / no graphics)* — model:
+  `string Name`, `string Description`, `IReadOnlyList<IConfigItem> Items`, mutable
+  `int SelectedIndex`, `bool HasItems`, `IConfigItem? SelectedItem`, and
+  `MoveSelectionUp()` / `MoveSelectionDown()` (wrap, no-op when empty). The **Exit**
+  category is simply a category with zero items (`HasItems == false`); no special
+  flag. Fully Mac-testable.
 
-- **`Lib/Resources/TexturePath.cs`** — add constants and register them in the
-  existing path arrays: `ConfigBackground` (`Graphics/4_background.png`),
-  `ConfigItemBar` (`4_item bar.png`), `ConfigMenuPanel` (`4_menu panel.png`),
-  `ConfigMenuCursor` (`4_menu cursor.png`), `ConfigHeaderPanel`
-  (`4_header panel.png`), `ConfigFooterPanel` (`4_footer panel.png`),
-  `ConfigItemBox` (`4_itembox.png`), `ConfigItemBoxOther` (`4_itembox other.png`),
-  `ConfigItemBoxCursor` (`4_itembox cursor.png`), `ConfigDescriptionPanel`
-  (`4_Description Panel.png`).
+- **`Lib/Resources/TexturePath.cs`** — add constants and register them in
+  `GetAllTexturePaths()` (all ten) and `GetPanelTextures()` (the nine panel/art
+  ones, i.e. all except `ConfigBackground`): `ConfigBackground`
+  (`Graphics/4_background.png`), `ConfigItemBar` (`4_item bar.png`),
+  `ConfigMenuPanel` (`4_menu panel.png`), `ConfigMenuCursor` (`4_menu cursor.png`),
+  `ConfigHeaderPanel` (`4_header panel.png`), `ConfigFooterPanel`
+  (`4_footer panel.png`), `ConfigItemBox` (`4_itembox.png`), `ConfigItemBoxOther`
+  (`4_itembox other.png`), `ConfigItemBoxCursor` (`4_itembox cursor.png`),
+  `ConfigDescriptionPanel` (`4_Description Panel.png`).
 
 - **`Lib/Config/IConfigItem.cs` + `ConfigItems.cs`** — add `string Description { get; }`
-  to `IConfigItem`, default `""` on `BaseConfigItem`, settable via an optional ctor
-  argument / object initializer. `NavigationConfigItem` and `ReadOnlyConfigItem`
-  inherit it. No value-semantics change.
+  to `IConfigItem`; `BaseConfigItem` implements it as `{ get; init; } = ""`, set via
+  object initializer at item-construction. `NavigationConfigItem` and
+  `ReadOnlyConfigItem` inherit it. No value-semantics change.
 
-- **`Lib/Stage/ConfigStage.cs`** — refactor:
+- **`Lib/Stage/ConfigStage.cs`** — refactor (single file, reusing its render seam):
+  - State: replace `_configItems` / `_selectedIndex` with `_categories`
+    (`List<ConfigCategory>`), `_currentCategoryIndex`, and `_focusOnMenu`.
   - `SetupConfigItems()` → builds the three `ConfigCategory` objects (reusing the
-    existing item instances, now with descriptions).
-  - Replace flat-list `HandleInput()` / `DrawConfigItems()` / `DrawButtons()` with
-    the focus-state machine + the three renderers.
-  - `InitializeGraphics()` loads the new textures (best-effort) and disposes them in
-    `OnDeactivate` / `Dispose`, matching the current font/background lifecycle.
-  - Preserve unchanged: NX-import (`StartNxScoreImport` and its `InlineProgress`),
+    existing item instances, now with `Description` set).
+  - `HandleInput()` → the two-focus state machine (Menu ↔ Items).
+  - Replace `DrawTitle` / `DrawConfigItems` / `DrawButtons` / `DrawInstructions`
+    with new `protected virtual` draw methods consuming `ConfigUILayout`:
+    `DrawConfigBackground`, `DrawItemBar`, `DrawCategoryMenu`, `DrawItemList`,
+    `DrawDescriptionPanel`, `DrawHeaderFooter`. Selection highlights draw a texture
+    when present, else a `DrawFilledRectangle` fallback (the assertable seam).
+  - `InitializeGraphics()` loads the new textures best-effort; `OnDeactivate` /
+    `Dispose` release them, matching the current font/background lifecycle.
+  - Preserve unchanged: NX-import (`StartNxScoreImport` + `InlineProgress`),
     key-panel wiring (`InitializePanels`, `OpenPanel`, `OnPanelSaved`/`Closed`),
-    `FlushPendingSaveSafely`, and the persist-on-edit contract.
+    `DrawImportStatus`, `FlushPendingSaveSafely`, persist-on-edit contract, and the
+    `IsConfigNavigationCommandPressed` / `IsPanelCommandPressed` input readers.
 
 ## Error Handling & Edge Cases
 
@@ -188,24 +201,37 @@ Follows the existing `DrumConfig/` subfolder + `*UILayout` conventions.
 
 ## Testing
 
-- **Excluded from `DTXMania.Test.Mac.csproj`** (GraphicsDevice-dependent, like
-  `SongBarRenderer*`): `ConfigMenuRenderer`, `ConfigItemListRenderer`,
-  `ConfigDescriptionRenderer` tests. Add the new test files to the Mac project's
-  explicit-exclude list.
-- **Mac-safe logic tests** (no GraphicsDevice):
-  - Category construction and item-to-category mapping (System has 7 items in
-    order, Drums has 4, Exit has 0).
-  - Focus-state transitions: Menu→Items on Enter over a settings category;
-    Items→Menu on Esc; Exit/Esc on menu triggers flush + Title.
-  - Category index wraps; per-category item index wraps and is remembered across
-    category switches.
-  - Each item exposes a non-empty `Description`; each category has a `Description`.
-- **Update existing `ConfigStage` tests** to the category structure (current tests
-  assume a flat `_configItems` list + Exit pseudo-button).
-- Where focus/navigation logic needs to be exercised without a GraphicsDevice,
-  follow the existing `ConfigStageLogicTests` pattern (subclass `ConfigStage`,
-  override `InitializeGraphics`, drive state via `ReflectionHelpers` and the
-  fallback-drawing paths, skipping real `OnActivate`).
+Everything is Mac-testable — **no new `DTXMania.Test.Mac.csproj` exclusions** —
+because rendering stays on `ConfigStage`'s render-spy seam and the new helpers are
+pure.
+
+- **`ConfigUILayout`** (pure): assert each helper returns the documented NX
+  rectangle/position for given indices.
+- **`ConfigCategory`** (pure): construction; `SelectedIndex` wrap on
+  up/down; empty category (`HasItems == false`, `SelectedItem == null`, moves are
+  no-ops).
+- **Config item `Description`**: default `""`; round-trips through the object
+  initializer.
+- **`ConfigStage` logic** (existing reflection / `ForcedCommandInputManager`
+  pattern, Mac-safe):
+  - `SetupConfigItems` builds 3 categories — System (7 items, in order), Drums
+    (4 items), Exit (0 items) — each with a non-empty `Description`, and each item
+    with a non-empty `Description`.
+  - Focus transitions: Menu→Items on Activate over System/Drums; Activate over Exit
+    flushes + returns to Title; Esc in Items returns to Menu; Esc in Menu flushes +
+    returns to Title.
+  - Category index wraps on up/down; per-category item index wraps and is remembered
+    across category switches.
+- **`ConfigStage` rendering** (existing `RenderSpyConfigStage` pattern, Mac-safe,
+  textures + fonts null): `DrawCategoryMenu` emits a highlight rect at
+  `ConfigUILayout.MenuCursorRect(currentCategoryIndex)`; `DrawItemList` emits an
+  item-cursor rect at `ItemCursorRect(selectedIndex)` only when `_focusOnMenu ==
+  false`; `DrawConfigBackground` falls back to the light fill when the texture is
+  absent.
+- **Update existing `ConfigStageLogicTests` / `ConfigStageTests`** that assume the
+  flat `_configItems` / `_selectedIndex` / Exit-pseudo-button model: delete the
+  obsolete `DrawConfigItems` / `DrawButtons` / flat-list-navigation tests, add the
+  category-structure and focus-model replacements above.
 
 ## Out-of-Scope Follow-ups (noted, not built)
 


### PR DESCRIPTION
## Summary
- Rebuild the config stage to use an NX-style master-detail layout with category list on the left and item list on the right
- Introduce `ConfigCategory` model and `ConfigUILayout` coordinate helpers for consistent layout
- Add NX skin texture paths for config stage rendering
- Add optional `Description` property to config items for richer UI
- Update all relevant tests to cover new layout logic and input handling
- Add design spec and implementation plan documentation

## Test plan
- [x] `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj` passes (5750 tests)

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The configuration screen now uses a category-based layout with a left menu, item list, and description panel for easier navigation.
  * Config items can display short, optional help text, with selection constrained and wrap-around navigation within categories.
  * Added support for additional config-screen visual elements and consistent layout positioning.

* **Bug Fixes**
  * Improved robustness when visual assets are missing, including safer texture fallbacks and more informative import status messaging.
  * Artist names in the song list now use shared truncation logic for consistent ellipsis behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->