### PR TITLE
feat: align config stage with NX layout and fixed virtual resolution rendering

### DIFF
--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -423,6 +423,14 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
     /// </summary>
     internal static Rectangle CalculateLetterboxDestination(Rectangle viewport, int virtualWidth, int virtualHeight)
     {
+        // Guard against degenerate inputs (zero/negative viewport or virtual dims) that would
+        // produce division by zero or negative destination sizes. Not reachable in normal
+        // operation (the render target and back buffer always have positive dims), but the
+        // guard makes the contract explicit and prevents NaN/negative rects if a future caller
+        // passes a zero-sized viewport (e.g. a minimized window on some platforms).
+        if (virtualWidth <= 0 || virtualHeight <= 0 || viewport.Width <= 0 || viewport.Height <= 0)
+            return Rectangle.Empty;
+
         float scale = Math.Min(viewport.Width / (float)virtualWidth, viewport.Height / (float)virtualHeight);
         int destWidth = (int)Math.Round(virtualWidth * scale);
         int destHeight = (int)Math.Round(virtualHeight * scale);

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -135,6 +135,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         _logger = _loggerFactory.CreateLogger<BaseGame>();
     }
 
+    [ExcludeFromCodeCoverage]
     protected override void Initialize()
     {
         // Initialize managers
@@ -471,11 +472,24 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         // against design-space rects still works instead of crashing.
         if (_graphicsManager == null)
             return windowPoint;
-        var graphicsDevice = GraphicsDevice;
-        if (graphicsDevice == null)
+        var viewport = TryGetViewportBounds();
+        if (viewport == null)
             return windowPoint;
-        return WindowToVirtualCoordinates(windowPoint, graphicsDevice.Viewport.Bounds,
+        return WindowToVirtualCoordinates(windowPoint, viewport.Value,
             GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight);
+    }
+
+    /// <summary>
+    /// Returns the current back-buffer viewport bounds (used by <see cref="MapMouseToVirtual"/>),
+    /// or null when no <see cref="GraphicsDevice"/> is available (headless tests / pre-Initialize).
+    /// Extracted as a seam so headless tests can override it with a known rectangle instead of
+    /// requiring a live GraphicsDevice.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    protected virtual Rectangle? TryGetViewportBounds()
+    {
+        var graphicsDevice = GraphicsDevice;
+        return graphicsDevice == null ? null : graphicsDevice.Viewport.Bounds;
     }
 
     [ExcludeFromCodeCoverage]

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -173,13 +173,18 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
 
         _logger.LogInformation("Graphics Manager initialized with settings: {Settings}", _graphicsManager.Settings);
 
-        // Create main render target using the graphics manager
+        // Create the main render target at the fixed virtual resolution (NOT the configured
+        // screen resolution). Every stage draws its 1280x720-authored layout 1:1 into this
+        // target; Draw() then letterbox-scales it once to fill the physical window. Sizing the
+        // target to the configured resolution instead would leave stages that draw 1:1 stranded
+        // in the top-left corner of a larger target.
         _renderTarget = _graphicsManager.RenderTargetManager.GetOrCreateRenderTarget(
             "MainRenderTarget",
-            config.ScreenWidth,
-            config.ScreenHeight);
+            GameConstants.Display.VirtualWidth,
+            GameConstants.Display.VirtualHeight);
 
-        _logger.LogInformation("Main render target created: {Width}x{Height}", config.ScreenWidth, config.ScreenHeight);
+        _logger.LogInformation("Main render target created: {Width}x{Height}",
+            GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight);
     }
 
     protected override void LoadContent()
@@ -338,11 +343,10 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         // Ensure render target is valid before using it
         if (_renderTarget == null || _renderTarget.IsDisposed)
         {
-            var config = ConfigManager.Config;
             _renderTarget = _graphicsManager.RenderTargetManager.GetOrCreateRenderTarget(
                 "MainRenderTarget",
-                config.ScreenWidth,
-                config.ScreenHeight);
+                GameConstants.Display.VirtualWidth,
+                GameConstants.Display.VirtualHeight);
         }
 
         // Draw to render target first
@@ -399,9 +403,31 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
     [ExcludeFromCodeCoverage]
     internal virtual void DrawRenderTargetToBackBuffer(RenderTarget2D renderTarget)
     {
+        // Scale the virtual-resolution render target up to fill the physical window while
+        // preserving 16:9 aspect (adds black bars if the window is a different aspect ratio),
+        // rather than stretching to the raw viewport bounds.
+        var destination = CalculateLetterboxDestination(
+            GraphicsDevice.Viewport.Bounds, renderTarget.Width, renderTarget.Height);
+
         _spriteBatch.Begin(samplerState: SamplerState.LinearClamp);
-        _spriteBatch.Draw(renderTarget, GraphicsDevice.Viewport.Bounds, Color.White);
+        _spriteBatch.Draw(renderTarget, destination, Color.White);
         _spriteBatch.End();
+    }
+
+    /// <summary>
+    /// Computes the aspect-preserving, centered destination rectangle for blitting a
+    /// <paramref name="virtualWidth"/>x<paramref name="virtualHeight"/> render target into
+    /// <paramref name="viewport"/>. The result fills the viewport on the fitting axis and is
+    /// centered (letterboxed/pillarboxed) on the other.
+    /// </summary>
+    internal static Rectangle CalculateLetterboxDestination(Rectangle viewport, int virtualWidth, int virtualHeight)
+    {
+        float scale = Math.Min(viewport.Width / (float)virtualWidth, viewport.Height / (float)virtualHeight);
+        int destWidth = (int)Math.Round(virtualWidth * scale);
+        int destHeight = (int)Math.Round(virtualHeight * scale);
+        int destX = viewport.X + (viewport.Width - destWidth) / 2;
+        int destY = viewport.Y + (viewport.Height - destHeight) / 2;
+        return new Rectangle(destX, destY, destWidth, destHeight);
     }
 
     [ExcludeFromCodeCoverage]
@@ -438,13 +464,15 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
                 _renderTarget.Dispose();
             }
 
-            // Create new render target with current settings
+            // Recreate at the fixed virtual resolution. The render target is decoupled from the
+            // display resolution; the new physical size only affects the letterbox blit in Draw().
             _renderTarget = _graphicsManager.RenderTargetManager.GetOrCreateRenderTarget(
                 "MainRenderTarget",
-                e.NewSettings.Width,
-                e.NewSettings.Height);
+                GameConstants.Display.VirtualWidth,
+                GameConstants.Display.VirtualHeight);
 
-            _logger.LogInformation("Render target recreated: {Width}x{Height}", e.NewSettings.Width, e.NewSettings.Height);
+            _logger.LogInformation("Render target recreated: {Width}x{Height}",
+                GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight);
         }
         catch (Exception ex)
         {
@@ -484,11 +512,10 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         // Ensure our main render target is recreated after device reset
         try
         {
-            var config = ConfigManager.Config;
             _renderTarget = _graphicsManager.RenderTargetManager.GetOrCreateRenderTarget(
                 "MainRenderTarget",
-                config.ScreenWidth,
-                config.ScreenHeight);
+                GameConstants.Display.VirtualWidth,
+                GameConstants.Display.VirtualHeight);
 
             _logger.LogInformation("Main render target recreated after device reset");
         }

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -430,6 +430,54 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext
         return new Rectangle(destX, destY, destWidth, destHeight);
     }
 
+    /// <summary>
+    /// Inverse of <see cref="CalculateLetterboxDestination"/>: maps a mouse position given in
+    /// physical window/client pixels into the fixed <paramref name="virtualWidth"/>x
+    /// <paramref name="virtualHeight"/> design space the stages author against. Returns null when
+    /// the point falls outside the letterboxed destination (i.e. on the black bars), so callers
+    /// can treat it as "no hit". Stages draw into the 1280x720 render target and read
+    /// <see cref="GraphicsDevice.Viewport"/> during Update (which is the back buffer = window
+    /// size, NOT the 1280x720 target), so raw mouse coords must be routed through this before
+    /// hit-testing against design-space rectangles.
+    /// </summary>
+    internal static Point? WindowToVirtualCoordinates(Point windowPoint, Rectangle viewport, int virtualWidth, int virtualHeight)
+    {
+        var dest = CalculateLetterboxDestination(viewport, virtualWidth, virtualHeight);
+        if (windowPoint.X < dest.X || windowPoint.X >= dest.Right ||
+            windowPoint.Y < dest.Y || windowPoint.Y >= dest.Bottom)
+            return null;
+
+        int vx = (int)Math.Round((windowPoint.X - dest.X) * virtualWidth / (float)dest.Width);
+        int vy = (int)Math.Round((windowPoint.Y - dest.Y) * virtualHeight / (float)dest.Height);
+        // Clamp to virtual bounds to guard against rounding at the right/bottom edge.
+        if (vx < 0) vx = 0;
+        if (vy < 0) vy = 0;
+        if (vx >= virtualWidth) vx = virtualWidth - 1;
+        if (vy >= virtualHeight) vy = virtualHeight - 1;
+        return new Point(vx, vy);
+    }
+
+    /// <summary>
+    /// Instance wrapper around <see cref="WindowToVirtualCoordinates"/> using the current
+    /// <see cref="GraphicsDevice.Viewport"/> (the back buffer during Update) and the fixed
+    /// virtual resolution from <see cref="GameConstants.Display"/>. Stages call this during
+    /// hit-testing to convert raw window mouse coords into the 1280x720 design space their
+    /// rectangles are authored in.
+    /// </summary>
+    internal Point? MapMouseToVirtual(Point windowPoint)
+    {
+        // If no graphics device is available (e.g. headless tests with an uninitialized game, or
+        // before Initialize completes), assume a 1:1 window->virtual mapping so hit-testing
+        // against design-space rects still works instead of crashing.
+        if (_graphicsManager == null)
+            return windowPoint;
+        var graphicsDevice = GraphicsDevice;
+        if (graphicsDevice == null)
+            return windowPoint;
+        return WindowToVirtualCoordinates(windowPoint, graphicsDevice.Viewport.Bounds,
+            GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight);
+    }
+
     [ExcludeFromCodeCoverage]
     internal virtual void CompleteBaseDraw(GameTime gameTime)
     {

--- a/DTXMania.Game/Lib/Config/GameConstants.cs
+++ b/DTXMania.Game/Lib/Config/GameConstants.cs
@@ -6,6 +6,24 @@ namespace DTXMania.Game.Lib.Config
     public static class GameConstants
     {
         /// <summary>
+        /// Display constants. All stage layouts are authored in a fixed virtual resolution;
+        /// the game renders every stage into a render target of this size and then
+        /// letterbox-scales that target once to fill the physical window (see BaseGame.Draw).
+        /// </summary>
+        public static class Display
+        {
+            /// <summary>
+            /// Virtual render width every stage is authored against (matches DTXManiaNX 1280x720).
+            /// </summary>
+            public const int VirtualWidth = 1280;
+
+            /// <summary>
+            /// Virtual render height every stage is authored against (matches DTXManiaNX 1280x720).
+            /// </summary>
+            public const int VirtualHeight = 720;
+        }
+
+        /// <summary>
         /// Stage transition timing constants
         /// </summary>
         public static class StageTransition

--- a/DTXMania.Game/Lib/Resources/TexturePath.cs
+++ b/DTXMania.Game/Lib/Resources/TexturePath.cs
@@ -225,9 +225,6 @@ namespace DTXMania.Game.Lib.Resources
         /// <summary>Config stage normal item-row box.</summary>
         public const string ConfigItemBox = "Graphics/4_itembox.png";
 
-        /// <summary>Config stage "other" item-row box (navigation/read-only items).</summary>
-        public const string ConfigItemBoxOther = "Graphics/4_itembox other.png";
-
         /// <summary>Config stage item-row selection cursor.</summary>
         public const string ConfigItemBoxCursor = "Graphics/4_itembox cursor.png";
 
@@ -673,7 +670,6 @@ namespace DTXMania.Game.Lib.Resources
                 ConfigHeaderPanel,
                 ConfigFooterPanel,
                 ConfigItemBox,
-                ConfigItemBoxOther,
                 ConfigItemBoxCursor,
                 ConfigDescriptionPanel
             };
@@ -758,7 +754,6 @@ namespace DTXMania.Game.Lib.Resources
                 ConfigHeaderPanel,
                 ConfigFooterPanel,
                 ConfigItemBox,
-                ConfigItemBoxOther,
                 ConfigItemBoxCursor,
                 ConfigDescriptionPanel
             };

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -742,9 +742,9 @@ namespace DTXMania.Game.Lib.Stage
 
         protected virtual void DrawConfigBackground()
         {
-            // Draw the GALAXY WAVE background at the fixed 1280x720 virtual rect (not the raw
-            // viewport). The frame-wide viewport transform scales it uniformly to fill the screen,
-            // preserving aspect — drawing at viewport size here would stretch it out of proportion.
+            // Draw the GALAXY WAVE background at the fixed 1280x720 virtual rect. The stage draws
+            // 1:1 into the 1280x720 render target (letterboxed to the window by BaseGame), so
+            // drawing at the raw viewport size here would stretch it out of proportion.
             var full = ConfigUILayout.BackgroundRect;
 
             if (_backgroundTexture?.Texture != null)
@@ -883,8 +883,9 @@ namespace DTXMania.Game.Lib.Stage
 
         // Flush the current batch, narrow the scissor rectangle to the inner board, and reopen the
         // batch with scissor-test enabled so the item list is clipped to the board. The scissor
-        // rectangle is in render-target pixels; the frame's identity viewport transform (fixed
-        // 1280x720 target) maps it 1:1 to the virtual InnerBoardRect. Paired with EndItemClip.
+        // rectangle is in render-target pixels; the fixed 1280x720 render target is the draw
+        // surface, so no viewport transform is needed (coords are already 1:1 in virtual space).
+        // Paired with EndItemClip.
         [ExcludeFromCodeCoverage]
         protected virtual void BeginItemClip()
         {
@@ -892,8 +893,7 @@ namespace DTXMania.Game.Lib.Stage
             var graphicsDevice = _game.GraphicsDevice;
             _savedScissorRectangle = graphicsDevice.ScissorRectangle;
             graphicsDevice.ScissorRectangle = ConfigUILayout.InnerBoardRect;
-            _spriteBatch.Begin(rasterizerState: _itemClipRasterizer,
-                transformMatrix: CreateViewportTransform(GetViewport()));
+            _spriteBatch.Begin(rasterizerState: _itemClipRasterizer);
         }
 
         // Close the clipped batch, restore the previous scissor rectangle, and reopen the default
@@ -904,7 +904,7 @@ namespace DTXMania.Game.Lib.Stage
         {
             _spriteBatch.End();
             _game.GraphicsDevice.ScissorRectangle = _savedScissorRectangle;
-            _spriteBatch.Begin(transformMatrix: CreateViewportTransform(GetViewport()));
+            _spriteBatch.Begin();
         }
 
         // Extracts the value portion for the two-column item list by stripping the
@@ -1021,24 +1021,14 @@ namespace DTXMania.Game.Lib.Stage
             _font.DrawString(_spriteBatch, _importStatus, ConfigUILayout.ImportStatusPos, ImportStatusColor);
         }
 
-        // Letterbox transform that scales the fixed 1280x720 layout up to fill the actual
-        // back-buffer/viewport (which matches the configured screen resolution, e.g. 3840x2160),
-        // preserving aspect. Mirrors ResultScreenRenderer.CreateViewportTransform. Without it the
-        // stage renders 1:1 in the top-left corner of a high-res back buffer.
-        internal static Matrix CreateViewportTransform(Viewport viewport)
-        {
-            float scaleX = viewport.Width / (float)ConfigUILayout.ScreenWidth;
-            float scaleY = viewport.Height / (float)ConfigUILayout.ScreenHeight;
-            float scale = Math.Min(scaleX, scaleY);
-            float offsetX = viewport.X + (viewport.Width - ConfigUILayout.ScreenWidth * scale) / 2f;
-            float offsetY = viewport.Y + (viewport.Height - ConfigUILayout.ScreenHeight * scale) / 2f;
-            return Matrix.CreateScale(scale, scale, 1f) * Matrix.CreateTranslation(offsetX, offsetY, 0f);
-        }
-
+        // The stage draws into the fixed 1280x720 render target (letterboxed to the window once
+        // by BaseGame), so the SpriteBatch needs no viewport transform — layout coords are already
+        // 1:1 in virtual space. The previous per-stage letterbox transform was always identity
+        // under this scheme and has been removed.
         [ExcludeFromCodeCoverage]
         protected virtual void BeginDrawFrame()
         {
-            _spriteBatch.Begin(transformMatrix: CreateViewportTransform(GetViewport()));
+            _spriteBatch.Begin();
         }
 
         [ExcludeFromCodeCoverage]
@@ -1054,12 +1044,6 @@ namespace DTXMania.Game.Lib.Stage
                 return;
 
             _spriteBatch.Draw(_whitePixel, destinationRectangle, color);
-        }
-
-        [ExcludeFromCodeCoverage]
-        protected virtual Viewport GetViewport()
-        {
-            return _game.GraphicsDevice.Viewport;
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -73,6 +73,16 @@ namespace DTXMania.Game.Lib.Stage
         private ITexture? _itemBoxCursorTexture;
         private ITexture? _descriptionPanelTexture;
 
+        // Scissor state for clipping the scrolling item list to the inner board. A row stays
+        // visible while its box merely intersects the header→footer band, so rows near the top or
+        // bottom of the scroll extend past the board edges; without clipping that overflow draws on
+        // the bare background above the header / below the footer. Reopening the item-list batch with
+        // this rasterizer (ScissorTestEnable) confines the rows to the board so they slide under its
+        // frame instead of spilling. Created in InitializeGraphics; null in headless tests where the
+        // clip hooks are overridden to no-ops.
+        private RasterizerState? _itemClipRasterizer;
+        private Rectangle _savedScissorRectangle;
+
         // Light text reads on the dark NX config background.
         private static readonly Color LightText = new(235, 238, 248);
         // Value text sits on the itembox's white right cell, so it must be dark.
@@ -235,6 +245,8 @@ namespace DTXMania.Game.Lib.Stage
             _spriteBatch = null!;
             _whitePixel?.Dispose();
             _whitePixel = null!;
+            _itemClipRasterizer?.Dispose();
+            _itemClipRasterizer = null;
 
             _previousKeyboardState = default;
             _currentKeyboardState = default;
@@ -252,6 +264,7 @@ namespace DTXMania.Game.Lib.Stage
 
                 _whitePixel?.Dispose();
                 _spriteBatch?.Dispose();
+                _itemClipRasterizer?.Dispose();
 
                 _font?.RemoveReference();
                 _boldFont?.RemoveReference();
@@ -259,6 +272,7 @@ namespace DTXMania.Game.Lib.Stage
 
                 _whitePixel = null;
                 _spriteBatch = null;
+                _itemClipRasterizer = null;
                 _font = null;
                 _boldFont = null;
                 _resourceManager = null; // shared game-wide instance; do NOT dispose
@@ -275,6 +289,14 @@ namespace DTXMania.Game.Lib.Stage
         {
             var graphicsDevice = _game.GraphicsDevice;
             _spriteBatch = new SpriteBatch(graphicsDevice);
+
+            // CullMode.None so SpriteBatch quads are never winding-culled; ScissorTestEnable so the
+            // item-list batch is clipped to the inner board (see _itemClipRasterizer).
+            _itemClipRasterizer = new RasterizerState
+            {
+                CullMode = CullMode.None,
+                ScissorTestEnable = true
+            };
 
             _whitePixel = new Texture2D(graphicsDevice, 1, 1);
             _whitePixel.SetData(new[] { Color.White });
@@ -296,6 +318,8 @@ namespace DTXMania.Game.Lib.Stage
                 _whitePixel = null;
                 _spriteBatch?.Dispose();
                 _spriteBatch = null;
+                _itemClipRasterizer?.Dispose();
+                _itemClipRasterizer = null;
                 throw;
             }
 
@@ -793,56 +817,94 @@ namespace DTXMania.Game.Lib.Stage
             var category = _categories[_currentCategoryIndex];
             var items = category.Items;
 
-            // Box pass. Every item — value and navigation alike — uses the same normal itembox
-            // (dark name cell + white value cell) so the list reads uniformly. Only real items
-            // are drawn (non-cyclic), each at its scrolled Y.
-            for (int i = 0; i < items.Count; i++)
+            // Clip the scrolling list to the inner board so rows near the top/bottom of the scroll
+            // slide under the board frame instead of spilling onto the bare background above the
+            // header / below the footer. try/finally keeps the SpriteBatch balanced even on the
+            // early return in the text pass (so the description/header panels keep drawing).
+            BeginItemClip();
+            try
             {
-                int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
-                if (!ConfigUILayout.IsRowVisible(rowTopY))
-                    continue;
-                var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, ConfigUILayout.ItemBoxNormalWidth);
-                if (_itemBoxTexture?.Texture != null)
-                    _spriteBatch.Draw(_itemBoxTexture.Texture, boxRect, Color.White);
-                else
-                    DrawFilledRectangle(boxRect, ItemBoxFallbackColor);
-            }
-
-            // Fixed cursor at the focus row; items scroll under it.
-            if (!_focusOnMenu && category.HasItems)
-            {
-                if (_itemBoxCursorTexture?.Texture != null)
-                    _spriteBatch.Draw(_itemBoxCursorTexture.Texture, ConfigUILayout.ItemCursorRect, Color.White);
-                else
-                    DrawFilledRectangle(ConfigUILayout.ItemCursorRect, ItemCursorFallback);
-            }
-
-            if (_font == null || _boldFont == null)
-                return;
-
-            // Text pass.
-            for (int i = 0; i < items.Count; i++)
-            {
-                int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
-                if (!ConfigUILayout.IsRowVisible(rowTopY))
-                    continue;
-                var item = items[i];
-                bool selected = !_focusOnMenu && i == category.SelectedIndex;
-                var font = selected ? _boldFont : _font;
-
-                font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(rowTopY),
-                    selected ? SelectedNameText : LightText);
-
-                var value = GetItemValueText(item);
-                if (!string.IsNullOrEmpty(value))
+                // Box pass. Every item — value and navigation alike — uses the same normal itembox
+                // (dark name cell + white value cell) so the list reads uniformly. Only real items
+                // are drawn (non-cyclic), each at its scrolled Y.
+                for (int i = 0; i < items.Count; i++)
                 {
-                    var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
-                    var valuePos = ConfigUILayout.ItemValuePos(rowTopY);
-                    // Every value (including the nav ">" marker) sits on the itembox white cell -> dark.
-                    Color valueColor = selected ? SelectedValueText : ValueDarkText;
-                    font.DrawString(_spriteBatch, displayValue, valuePos, valueColor);
+                    int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
+                    if (!ConfigUILayout.IsRowVisible(rowTopY))
+                        continue;
+                    var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, ConfigUILayout.ItemBoxNormalWidth);
+                    if (_itemBoxTexture?.Texture != null)
+                        _spriteBatch.Draw(_itemBoxTexture.Texture, boxRect, Color.White);
+                    else
+                        DrawFilledRectangle(boxRect, ItemBoxFallbackColor);
+                }
+
+                // Fixed cursor at the focus row; items scroll under it.
+                if (!_focusOnMenu && category.HasItems)
+                {
+                    if (_itemBoxCursorTexture?.Texture != null)
+                        _spriteBatch.Draw(_itemBoxCursorTexture.Texture, ConfigUILayout.ItemCursorRect, Color.White);
+                    else
+                        DrawFilledRectangle(ConfigUILayout.ItemCursorRect, ItemCursorFallback);
+                }
+
+                if (_font == null || _boldFont == null)
+                    return;
+
+                // Text pass.
+                for (int i = 0; i < items.Count; i++)
+                {
+                    int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
+                    if (!ConfigUILayout.IsRowVisible(rowTopY))
+                        continue;
+                    var item = items[i];
+                    bool selected = !_focusOnMenu && i == category.SelectedIndex;
+                    var font = selected ? _boldFont : _font;
+
+                    font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(rowTopY),
+                        selected ? SelectedNameText : LightText);
+
+                    var value = GetItemValueText(item);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
+                        var valuePos = ConfigUILayout.ItemValuePos(rowTopY);
+                        // Every value (including the nav ">" marker) sits on the itembox white cell -> dark.
+                        Color valueColor = selected ? SelectedValueText : ValueDarkText;
+                        font.DrawString(_spriteBatch, displayValue, valuePos, valueColor);
+                    }
                 }
             }
+            finally
+            {
+                EndItemClip();
+            }
+        }
+
+        // Flush the current batch, narrow the scissor rectangle to the inner board, and reopen the
+        // batch with scissor-test enabled so the item list is clipped to the board. The scissor
+        // rectangle is in render-target pixels; the frame's identity viewport transform (fixed
+        // 1280x720 target) maps it 1:1 to the virtual InnerBoardRect. Paired with EndItemClip.
+        [ExcludeFromCodeCoverage]
+        protected virtual void BeginItemClip()
+        {
+            _spriteBatch.End();
+            var graphicsDevice = _game.GraphicsDevice;
+            _savedScissorRectangle = graphicsDevice.ScissorRectangle;
+            graphicsDevice.ScissorRectangle = ConfigUILayout.InnerBoardRect;
+            _spriteBatch.Begin(rasterizerState: _itemClipRasterizer,
+                transformMatrix: CreateViewportTransform(GetViewport()));
+        }
+
+        // Close the clipped batch, restore the previous scissor rectangle, and reopen the default
+        // (unclipped) batch so the description and header/footer panels draw normally. Paired with
+        // BeginItemClip.
+        [ExcludeFromCodeCoverage]
+        protected virtual void EndItemClip()
+        {
+            _spriteBatch.End();
+            _game.GraphicsDevice.ScissorRectangle = _savedScissorRectangle;
+            _spriteBatch.Begin(transformMatrix: CreateViewportTransform(GetViewport()));
         }
 
         // Extracts the value portion for the two-column item list by stripping the

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -884,12 +884,17 @@ namespace DTXMania.Game.Lib.Stage
         // rectangle is in render-target pixels; the fixed 1280x720 render target is the draw
         // surface, so no viewport transform is needed (coords are already 1:1 in virtual space).
         // Paired with EndItemClip.
+        //
+        // The SpriteBatch.End/Begin calls are delegated to FlushCurrentBatch/BeginClippedBatch so
+        // a headless test spy can no-op those (they need a real GraphicsDevice) while still
+        // exercising this method's ApplyScissorRectangle(GetItemClipRectangle()) wiring — the
+        // invariant that actually confines the rows to the board.
         [ExcludeFromCodeCoverage]
         protected virtual void BeginItemClip()
         {
-            _spriteBatch.End();
+            FlushCurrentBatch();
             ApplyScissorRectangle(GetItemClipRectangle());
-            _spriteBatch.Begin(rasterizerState: _itemClipRasterizer);
+            BeginClippedBatch(_itemClipRasterizer);
         }
 
         // Close the clipped batch, restore the previous scissor rectangle, and reopen the default
@@ -898,10 +903,26 @@ namespace DTXMania.Game.Lib.Stage
         [ExcludeFromCodeCoverage]
         protected virtual void EndItemClip()
         {
-            _spriteBatch.End();
+            FlushClippedBatch();
             RestoreScissorRectangle();
-            _spriteBatch.Begin();
+            BeginDefaultBatch();
         }
+
+        // SpriteBatch flush/reopen seams extracted from BeginItemClip/EndItemClip so a headless
+        // test spy can override them as no-ops (SpriteBatch.End/Begin need a real GraphicsDevice)
+        // while still exercising the scissor-rectangle wiring in the calling methods.
+        [ExcludeFromCodeCoverage]
+        protected virtual void FlushCurrentBatch() => _spriteBatch.End();
+
+        [ExcludeFromCodeCoverage]
+        protected virtual void BeginClippedBatch(RasterizerState rasterizer) =>
+            _spriteBatch.Begin(rasterizerState: rasterizer);
+
+        [ExcludeFromCodeCoverage]
+        protected virtual void FlushClippedBatch() => _spriteBatch.End();
+
+        [ExcludeFromCodeCoverage]
+        protected virtual void BeginDefaultBatch() => _spriteBatch.Begin();
 
         // The rectangle the item list is clipped to. Defaults to the inner board so the scrolling
         // rows slide under the board frame; extracted as a seam so a headless test can assert the

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -285,6 +285,7 @@ namespace DTXMania.Game.Lib.Stage
 
         #region Initialization
 
+        [ExcludeFromCodeCoverage]
         protected virtual void InitializeGraphics()
         {
             var graphicsDevice = _game.GraphicsDevice;

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -47,6 +47,10 @@ namespace DTXMania.Game.Lib.Stage
         private int _currentCategoryIndex = 0;
         private bool _focusOnMenu = true;
 
+        // Eased scroll position (fractional item index currently at the focus row). Tracks the
+        // selected item; snaps on a wrap/jump so last<->first never scrolls the whole list.
+        private double _itemScroll;
+
         private KeyboardState _previousKeyboardState;
         private KeyboardState _currentKeyboardState;
 
@@ -72,8 +76,16 @@ namespace DTXMania.Game.Lib.Stage
 
         // Light text reads on the dark NX config background.
         private static readonly Color LightText = new(235, 238, 248);
-        private static readonly Color SelectedText = Color.Yellow;
-        private static readonly Color ValueText = new(255, 226, 150);
+        // Value text sits on the itembox's white right cell, so it must be dark.
+        private static readonly Color ValueDarkText = new(24, 24, 32);
+        // Selected name / nav marker sit on a dark cell -> bright warm highlight.
+        private static readonly Color SelectedNameText = new(255, 238, 120);
+        // Selected value sits on the white cell -> dark warm highlight (readable on white).
+        private static readonly Color SelectedValueText = new(168, 52, 0);
+        // Selected menu label sits on the light menu cursor bar -> dark text.
+        private static readonly Color SelectedMenuText = new(36, 24, 72);
+        // Description title sits on the panel's white upper region -> dark text.
+        private static readonly Color DescriptionTitleText = new(24, 24, 32);
         private static readonly Color MenuCursorFallback = new(64, 96, 160, 180);
         private static readonly Color ItemCursorFallback = new(96, 96, 160, 180);
         private static readonly Color ImportStatusColor = new(180, 220, 255);
@@ -117,6 +129,7 @@ namespace DTXMania.Game.Lib.Stage
 
             _currentCategoryIndex = 0;
             _focusOnMenu = true;
+            _itemScroll = 0;
 
             // Clear any import status left over from a previous visit. StageManager reuses this
             // instance, so without this a stale "Imported N scores" / "cancelled" message would
@@ -141,6 +154,29 @@ namespace DTXMania.Game.Lib.Stage
             }
 
             HandleInput();
+            UpdateItemScroll(deltaTime);
+        }
+
+        // Ease the scroll position toward the selected item so it settles at the focus row.
+        // A wrap or multi-row jump snaps instead of scrolling the whole list backward.
+        private void UpdateItemScroll(double deltaTime)
+        {
+            if (_categories.Count == 0)
+                return;
+
+            var category = _categories[_currentCategoryIndex];
+            double target = category.HasItems ? category.SelectedIndex : 0;
+            double delta = target - _itemScroll;
+            if (Math.Abs(delta) > 1.5)
+            {
+                _itemScroll = target;
+                return;
+            }
+
+            double factor = Math.Min(1.0, deltaTime * 15.0);
+            _itemScroll += delta * factor;
+            if (Math.Abs(target - _itemScroll) < 0.01)
+                _itemScroll = target;
         }
 
         protected override void OnDraw(double deltaTime)
@@ -723,10 +759,14 @@ namespace DTXMania.Game.Lib.Stage
             {
                 bool selected = i == _currentCategoryIndex;
                 var font = selected ? _boldFont : _font;
-                var color = selected ? SelectedText : LightText;
+                var color = selected ? SelectedMenuText : LightText;
                 var label = _categories[i].Name;
                 var size = font.MeasureString(label);
-                var pos = new Vector2(ConfigUILayout.MenuLabelCenterX - size.X / 2f, ConfigUILayout.MenuRowY(i));
+                var cursor = ConfigUILayout.MenuCursorRect(i);
+                // Center the label horizontally on the panel and vertically within the cursor band.
+                var pos = new Vector2(
+                    ConfigUILayout.MenuLabelCenterX - size.X / 2f,
+                    cursor.Y + (ConfigUILayout.MenuCursorHeight - size.Y) / 2f);
                 font.DrawString(_spriteBatch, label, pos, color);
             }
         }
@@ -739,59 +779,59 @@ namespace DTXMania.Game.Lib.Stage
             var category = _categories[_currentCategoryIndex];
             var items = category.Items;
 
-            for (int row = 0; row < items.Count; row++)
+            // Box pass. Only real items are drawn (non-cyclic), each at its scrolled Y.
+            for (int i = 0; i < items.Count; i++)
             {
-                var box = (items[row] is NavigationConfigItem || items[row] is ReadOnlyConfigItem)
-                    ? _itemBoxOtherTexture
-                    : _itemBoxTexture;
-                if (box?.Texture != null)
-                    _spriteBatch.Draw(box.Texture, ConfigUILayout.ItemRowRect(row), Color.White);
+                int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
+                if (!ConfigUILayout.IsRowVisible(rowTopY))
+                    continue;
+                bool isNav = items[i] is NavigationConfigItem;
+                var boxTex = isNav ? _itemBoxOtherTexture : _itemBoxTexture;
+                int boxWidth = isNav ? ConfigUILayout.ItemBoxOtherWidth : ConfigUILayout.ItemBoxNormalWidth;
+                var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, boxWidth);
+                if (boxTex?.Texture != null)
+                    _spriteBatch.Draw(boxTex.Texture, boxRect, Color.White);
                 else
-                    DrawFilledRectangle(ConfigUILayout.ItemRowRect(row), ItemBoxFallbackColor);
+                    DrawFilledRectangle(boxRect, ItemBoxFallbackColor);
             }
 
+            // Fixed cursor at the focus row; items scroll under it.
             if (!_focusOnMenu && category.HasItems)
             {
-                var cursorRect = ConfigUILayout.ItemCursorRect(category.SelectedIndex);
                 if (_itemBoxCursorTexture?.Texture != null)
-                    _spriteBatch.Draw(_itemBoxCursorTexture.Texture, cursorRect, Color.White);
+                    _spriteBatch.Draw(_itemBoxCursorTexture.Texture, ConfigUILayout.ItemCursorRect, Color.White);
                 else
-                    DrawFilledRectangle(cursorRect, ItemCursorFallback);
+                    DrawFilledRectangle(ConfigUILayout.ItemCursorRect, ItemCursorFallback);
             }
 
             if (_font == null || _boldFont == null)
                 return;
 
-            for (int row = 0; row < items.Count; row++)
+            // Text pass.
+            for (int i = 0; i < items.Count; i++)
             {
-                var item = items[row];
-                bool selected = !_focusOnMenu && row == category.SelectedIndex;
+                int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
+                if (!ConfigUILayout.IsRowVisible(rowTopY))
+                    continue;
+                var item = items[i];
+                bool selected = !_focusOnMenu && i == category.SelectedIndex;
+                bool isNav = item is NavigationConfigItem;
                 var font = selected ? _boldFont : _font;
 
-                font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(row),
-                    selected ? SelectedText : LightText);
+                font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(rowTopY),
+                    selected ? SelectedNameText : LightText);
 
                 var value = GetItemValueText(item);
                 if (!string.IsNullOrEmpty(value))
                 {
-                    // Right-align the value at the box's right inner edge (ItemValueRightX) so it
-                    // never overflows the box and never runs under the description panel drawn next.
-                    // Reserve the measured name width plus ItemValueNameGap when deriving the value's
-                    // max width: truncating only to the static ItemValueMaxWidth lets the value's left
-                    // edge reach the name's left edge (namePos.X), which still overlaps the name
-                    // because the value is drawn after it (e.g. a deep macOS DTXPath overwriting the
-                    // "DTX Folder" label). The name-relative max width keeps the value strictly right
-                    // of the name's right edge plus a visual gap before right-aligning.
-                    var namePos = ConfigUILayout.ItemNamePos(row);
-                    var nameWidth = font.MeasureString(item.Name).X;
-                    var valueMaxWidth = Math.Max(0f,
-                        ConfigUILayout.ItemValueRightX - (namePos.X + nameWidth + ConfigUILayout.ItemValueNameGap));
-                    var displayValue = TextHelper.TruncateToWidth(value, valueMaxWidth, font);
-                    var valueWidth = font.MeasureString(displayValue).X;
-                    var valuePos = new Vector2(ConfigUILayout.ItemValueRightX - valueWidth,
-                        ConfigUILayout.ItemRowY(row) + ConfigUILayout.ItemTextInsetY);
-                    font.DrawString(_spriteBatch, displayValue, valuePos,
-                        selected ? SelectedText : ValueText);
+                    var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
+                    var valuePos = ConfigUILayout.ItemValuePos(rowTopY);
+                    // Nav marker (">") sits on the dark "other" box -> light; real values sit on the
+                    // itembox white cell -> dark.
+                    Color valueColor = isNav
+                        ? (selected ? SelectedNameText : LightText)
+                        : (selected ? SelectedValueText : ValueDarkText);
+                    font.DrawString(_spriteBatch, displayValue, valuePos, valueColor);
                 }
             }
         }
@@ -831,6 +871,15 @@ namespace DTXMania.Game.Lib.Stage
                 DrawFilledRectangle(ConfigUILayout.DescriptionPanelRect, PanelFallbackColor);
 
             var category = _categories[_currentCategoryIndex];
+
+            // Title: the focused item's name (or the category name on menu focus) on the white upper cell.
+            string title = _focusOnMenu
+                ? category.Name
+                : (category.SelectedItem?.Name ?? category.Name);
+            if (!string.IsNullOrEmpty(title) && _boldFont != null)
+                _boldFont.DrawString(_spriteBatch, title, ConfigUILayout.DescriptionTitlePos, DescriptionTitleText);
+
+            // Body: the description text, wrapped, on the black lower cell.
             string text = _focusOnMenu
                 ? category.Description
                 : (category.SelectedItem?.Description ?? string.Empty);
@@ -838,7 +887,7 @@ namespace DTXMania.Game.Lib.Stage
             if (string.IsNullOrEmpty(text) || _font == null)
                 return;
 
-            var pos = ConfigUILayout.DescriptionTextPos;
+            var pos = ConfigUILayout.DescriptionBodyPos;
             foreach (var line in WrapText(_font, text, ConfigUILayout.DescriptionWrapWidth))
             {
                 _font.DrawString(_spriteBatch, line, pos, LightText);

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -14,6 +14,7 @@ using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
@@ -82,6 +83,9 @@ namespace DTXMania.Game.Lib.Stage
         // clip hooks are overridden to no-ops.
         private RasterizerState? _itemClipRasterizer;
         private Rectangle _savedScissorRectangle;
+        // True between ApplyScissorRectangle and RestoreScissorRectangle. Guards against an
+        // unpaired Restore (subclass misuse) restoring the default {0,0,0,0} rectangle.
+        private bool _scissorSaved;
 
         // Light text reads on the dark NX config background.
         private static readonly Color LightText = new(235, 238, 248);
@@ -879,6 +883,39 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        // ---- Item-list scissor clip seam contract ----
+        //
+        // The following ten protected virtual methods form the scissor-clip lifecycle used to
+        // confine the scrolling item list to the inner board. They are extracted as seams so a
+        // headless test spy (ConfigStageRenderSpy) can override the SpriteBatch/GraphicsDevice
+        // touches as no-ops while still exercising the scissor-rectangle wiring — the invariant
+        // that actually confines the rows.
+        //
+        // Entry points: BeginItemClip / EndItemClip (called in matched pairs around the item-list
+        // draw). These are the only methods production code calls directly.
+        //
+        // Sub-seams invoked by the entry points:
+        //   - FlushCurrentBatch / BeginClippedBatch / FlushClippedBatch / BeginDefaultBatch
+        //     SpriteBatch.End/Begin wrappers (need a real GraphicsDevice).
+        //   - GetItemClipRectangle / CreateItemClipRasterizer
+        //     Pure value seams — return the clip rect / rasterizer state.
+        //   - ApplyScissorRectangle / RestoreScissorRectangle
+        //     Save/restore GraphicsDevice.ScissorRectangle around the clipped batch.
+        //
+        // Override contract for headless test spies:
+        //   1. Override the four SpriteBatch sub-seams as no-ops (no GraphicsDevice available).
+        //   2. Override ApplyScissorRectangle / RestoreScissorRectangle to record the rect without
+        //      touching GraphicsDevice (the spy records the applied rect for assertion).
+        //   3. Leave GetItemClipRectangle / CreateItemClipRasterizer at their defaults (pure
+        //      values, no device needed) so the spy can assert the real clip rect / rasterizer.
+        //   4. Do NOT override BeginItemClip / EndItemClip themselves — the entry points must run
+        //      so the wiring (Apply + Begin / Flush + Restore) is exercised by the test.
+        //
+        // Pairing invariant: every BeginItemClip must be matched by an EndItemClip before the next
+        // BeginItemClip or the end of OnDraw. RestoreScissorRectangle without a prior
+        // ApplyScissorRectangle restores the default {0,0,0,0} rectangle — only reachable by
+        // subclass misuse; the entry points enforce the pairing.
+
         // Flush the current batch, narrow the scissor rectangle to the inner board, and reopen the
         // batch with scissor-test enabled so the item list is clipped to the board. The scissor
         // rectangle is in render-target pixels; the fixed 1280x720 render target is the draw
@@ -947,22 +984,37 @@ namespace DTXMania.Game.Lib.Stage
         {
             var graphicsDevice = _game.GraphicsDevice;
             _savedScissorRectangle = graphicsDevice.ScissorRectangle;
+            _scissorSaved = true;
             graphicsDevice.ScissorRectangle = rect;
         }
 
-        // Restore the scissor rectangle saved by ApplyScissorRectangle.
+        // Restore the scissor rectangle saved by ApplyScissorRectangle. If called without a prior
+        // Apply (subclass misuse — the entry points BeginItemClip/EndItemClip enforce pairing),
+        // a Debug.Assert flags it and the restore is skipped so the default {0,0,0,0} rectangle
+        // is not written back into GraphicsDevice.
         [ExcludeFromCodeCoverage]
         protected virtual void RestoreScissorRectangle()
-            => _game.GraphicsDevice.ScissorRectangle = _savedScissorRectangle;
+        {
+            if (!_scissorSaved)
+            {
+                Debug.Assert(false,
+                    "RestoreScissorRectangle called without a prior ApplyScissorRectangle. " +
+                    "BeginItemClip/EndItemClip must be paired; this indicates subclass misuse.");
+                return;
+            }
+            _game.GraphicsDevice.ScissorRectangle = _savedScissorRectangle;
+            _scissorSaved = false;
+        }
 
         // Extracts the value portion for the two-column item list by stripping the
         // "{Name}: " prefix that GetDisplayText() prepends. This is coupled to every
         // concrete item type's GetDisplayText() format (Dropdown/Toggle/Integer/
-        // ReadOnly all use "$"{Name}: {value}""); a future item type that omits the
-        // prefix would render an empty value here. Adding a GetValueText() to
-        // IConfigItem would decouple this, but that value-semantics change is an
-        // explicit non-goal of the NX layout revamp — so the coupling is documented
-        // here instead.
+        // ReadOnly all use "$"{Name}: {value}""). A future item type that omits the
+        // prefix would silently render an empty value here, so a Debug.Assert flags the
+        // mismatch at development time; the empty fallback is retained for release
+        // builds. Adding a GetValueText() to IConfigItem would decouple this, but that
+        // value-semantics change is an explicit non-goal of the NX layout revamp — so
+        // the coupling is documented here instead.
         private static string GetItemValueText(IConfigItem item)
         {
             if (item is NavigationConfigItem)
@@ -970,9 +1022,15 @@ namespace DTXMania.Game.Lib.Stage
 
             var text = item.GetDisplayText();
             var prefix = item.Name + ": ";
-            return text.StartsWith(prefix, StringComparison.Ordinal)
-                ? text.Substring(prefix.Length)
-                : string.Empty;
+            if (!text.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                Debug.Assert(false,
+                    $"GetItemValueText: display text for '{item.Name}' does not start with " +
+                    $"expected prefix '{prefix}'. Got: '{text}'. A new IConfigItem type must " +
+                    $"either follow the \"{{Name}}: {{value}}\" convention or be handled here.");
+                return string.Empty;
+            }
+            return text.Substring(prefix.Length);
         }
 
         protected virtual void DrawDescriptionPanel()

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -70,7 +70,6 @@ namespace DTXMania.Game.Lib.Stage
         private ITexture? _headerPanelTexture;
         private ITexture? _footerPanelTexture;
         private ITexture? _itemBoxTexture;
-        private ITexture? _itemBoxOtherTexture;
         private ITexture? _itemBoxCursorTexture;
         private ITexture? _descriptionPanelTexture;
 
@@ -98,6 +97,11 @@ namespace DTXMania.Game.Lib.Stage
         // region stays visually delimited and text remains legible without the texture.
         private static readonly Color PanelFallbackColor = new(28, 32, 54, 220);
         private static readonly Color ItemBoxFallbackColor = new(34, 40, 68, 200);
+
+        // Inner board: dark translucent fill with a purple frame (matching the itembox border),
+        // drawn over the background to contain the config content and keep it readable.
+        private static readonly Color InnerBoardColor = new(8, 10, 22, 196);
+        private static readonly Color InnerBoardBorderColor = new(74, 62, 150, 224);
 
         private volatile string _importStatus = "";
         private volatile bool _importRunning;
@@ -187,6 +191,7 @@ namespace DTXMania.Game.Lib.Stage
             BeginDrawFrame();
 
             DrawConfigBackground();
+            DrawInnerBoard();
             DrawItemBar();
             DrawCategoryMenu();
             DrawItemList();
@@ -196,8 +201,10 @@ namespace DTXMania.Game.Lib.Stage
 
             if (_activePanel?.IsActive == true)
             {
-                var vp = GetViewport();
-                _activePanel.Draw(_spriteBatch, _font, _boldFont, _whitePixel, vp.Width, vp.Height);
+                // Panel draws in the same scaled 1280x720 space as the rest of the stage, so it
+                // receives the virtual dimensions (not the raw viewport) and centers within them.
+                _activePanel.Draw(_spriteBatch, _font, _boldFont, _whitePixel,
+                    ConfigUILayout.ScreenWidth, ConfigUILayout.ScreenHeight);
             }
 
             EndDrawFrame();
@@ -300,7 +307,6 @@ namespace DTXMania.Game.Lib.Stage
             _headerPanelTexture = TryLoadTexture(TexturePath.ConfigHeaderPanel);
             _footerPanelTexture = TryLoadTexture(TexturePath.ConfigFooterPanel);
             _itemBoxTexture = TryLoadTexture(TexturePath.ConfigItemBox);
-            _itemBoxOtherTexture = TryLoadTexture(TexturePath.ConfigItemBoxOther);
             _itemBoxCursorTexture = TryLoadTexture(TexturePath.ConfigItemBoxCursor);
             _descriptionPanelTexture = TryLoadTexture(TexturePath.ConfigDescriptionPanel);
         }
@@ -345,8 +351,6 @@ namespace DTXMania.Game.Lib.Stage
             _footerPanelTexture = null;
             _itemBoxTexture?.RemoveReference();
             _itemBoxTexture = null;
-            _itemBoxOtherTexture?.RemoveReference();
-            _itemBoxOtherTexture = null;
             _itemBoxCursorTexture?.RemoveReference();
             _itemBoxCursorTexture = null;
             _descriptionPanelTexture?.RemoveReference();
@@ -714,13 +718,23 @@ namespace DTXMania.Game.Lib.Stage
 
         protected virtual void DrawConfigBackground()
         {
-            var viewport = GetViewport();
-            var full = new Rectangle(0, 0, viewport.Width, viewport.Height);
+            // Draw the GALAXY WAVE background at the fixed 1280x720 virtual rect (not the raw
+            // viewport). The frame-wide viewport transform scales it uniformly to fill the screen,
+            // preserving aspect — drawing at viewport size here would stretch it out of proportion.
+            var full = ConfigUILayout.BackgroundRect;
 
             if (_backgroundTexture?.Texture != null)
                 _spriteBatch.Draw(_backgroundTexture.Texture, full, Color.White);
             else
                 DrawFilledRectangle(full, FallbackBackgroundColor);
+        }
+
+        // Dark translucent framed board over the background, behind the menu/item/description
+        // panels, so the config content stays readable against the busy background.
+        protected virtual void DrawInnerBoard()
+        {
+            DrawFilledRectangle(ConfigUILayout.InnerBoardBorderRect, InnerBoardBorderColor);
+            DrawFilledRectangle(ConfigUILayout.InnerBoardRect, InnerBoardColor);
         }
 
         protected virtual void DrawItemBar()
@@ -779,18 +793,17 @@ namespace DTXMania.Game.Lib.Stage
             var category = _categories[_currentCategoryIndex];
             var items = category.Items;
 
-            // Box pass. Only real items are drawn (non-cyclic), each at its scrolled Y.
+            // Box pass. Every item — value and navigation alike — uses the same normal itembox
+            // (dark name cell + white value cell) so the list reads uniformly. Only real items
+            // are drawn (non-cyclic), each at its scrolled Y.
             for (int i = 0; i < items.Count; i++)
             {
                 int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
                 if (!ConfigUILayout.IsRowVisible(rowTopY))
                     continue;
-                bool isNav = items[i] is NavigationConfigItem;
-                var boxTex = isNav ? _itemBoxOtherTexture : _itemBoxTexture;
-                int boxWidth = isNav ? ConfigUILayout.ItemBoxOtherWidth : ConfigUILayout.ItemBoxNormalWidth;
-                var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, boxWidth);
-                if (boxTex?.Texture != null)
-                    _spriteBatch.Draw(boxTex.Texture, boxRect, Color.White);
+                var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, ConfigUILayout.ItemBoxNormalWidth);
+                if (_itemBoxTexture?.Texture != null)
+                    _spriteBatch.Draw(_itemBoxTexture.Texture, boxRect, Color.White);
                 else
                     DrawFilledRectangle(boxRect, ItemBoxFallbackColor);
             }
@@ -815,7 +828,6 @@ namespace DTXMania.Game.Lib.Stage
                     continue;
                 var item = items[i];
                 bool selected = !_focusOnMenu && i == category.SelectedIndex;
-                bool isNav = item is NavigationConfigItem;
                 var font = selected ? _boldFont : _font;
 
                 font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(rowTopY),
@@ -826,11 +838,8 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
                     var valuePos = ConfigUILayout.ItemValuePos(rowTopY);
-                    // Nav marker (">") sits on the dark "other" box -> light; real values sit on the
-                    // itembox white cell -> dark.
-                    Color valueColor = isNav
-                        ? (selected ? SelectedNameText : LightText)
-                        : (selected ? SelectedValueText : ValueDarkText);
+                    // Every value (including the nav ">" marker) sits on the itembox white cell -> dark.
+                    Color valueColor = selected ? SelectedValueText : ValueDarkText;
                     font.DrawString(_spriteBatch, displayValue, valuePos, valueColor);
                 }
             }
@@ -861,28 +870,28 @@ namespace DTXMania.Game.Lib.Stage
             if (_categories.Count == 0)
                 return;
 
-            // The panel is a fixed UI region; always render its background (texture or fallback
-            // fill) so the layout stays consistent. Only the wrapped text is gated on content —
-            // every category/item has a description today (enforced by test), but decoupling the
-            // panel from the text avoids a surprise blank gap if that invariant ever changes.
+            // NX draws the description panel only while focus is on the item list
+            // (CStageConfig.cs:260, !bFocusIsOnMenu) — not while browsing the category menu. This
+            // keeps the busy GALAXY WAVE background clear on entry and stops the panel from
+            // overlapping the item boxes until the player is actually editing an item. The selected
+            // item sits at the focus row (y=189), above the panel top (y=270), so it stays readable.
+            if (_focusOnMenu)
+                return;
+
+            var category = _categories[_currentCategoryIndex];
+
             if (_descriptionPanelTexture?.Texture != null)
                 _spriteBatch.Draw(_descriptionPanelTexture.Texture, ConfigUILayout.DescriptionPanelRect, Color.White);
             else
                 DrawFilledRectangle(ConfigUILayout.DescriptionPanelRect, PanelFallbackColor);
 
-            var category = _categories[_currentCategoryIndex];
-
-            // Title: the focused item's name (or the category name on menu focus) on the white upper cell.
-            string title = _focusOnMenu
-                ? category.Name
-                : (category.SelectedItem?.Name ?? category.Name);
+            // Title: the selected item's name on the white upper cell.
+            string title = category.SelectedItem?.Name ?? category.Name;
             if (!string.IsNullOrEmpty(title) && _boldFont != null)
                 _boldFont.DrawString(_spriteBatch, title, ConfigUILayout.DescriptionTitlePos, DescriptionTitleText);
 
-            // Body: the description text, wrapped, on the black lower cell.
-            string text = _focusOnMenu
-                ? category.Description
-                : (category.SelectedItem?.Description ?? string.Empty);
+            // Body: the selected item's description, wrapped, on the black lower cell.
+            string text = category.SelectedItem?.Description ?? string.Empty;
 
             if (string.IsNullOrEmpty(text) || _font == null)
                 return;
@@ -950,10 +959,24 @@ namespace DTXMania.Game.Lib.Stage
             _font.DrawString(_spriteBatch, _importStatus, ConfigUILayout.ImportStatusPos, ImportStatusColor);
         }
 
+        // Letterbox transform that scales the fixed 1280x720 layout up to fill the actual
+        // back-buffer/viewport (which matches the configured screen resolution, e.g. 3840x2160),
+        // preserving aspect. Mirrors ResultScreenRenderer.CreateViewportTransform. Without it the
+        // stage renders 1:1 in the top-left corner of a high-res back buffer.
+        internal static Matrix CreateViewportTransform(Viewport viewport)
+        {
+            float scaleX = viewport.Width / (float)ConfigUILayout.ScreenWidth;
+            float scaleY = viewport.Height / (float)ConfigUILayout.ScreenHeight;
+            float scale = Math.Min(scaleX, scaleY);
+            float offsetX = viewport.X + (viewport.Width - ConfigUILayout.ScreenWidth * scale) / 2f;
+            float offsetY = viewport.Y + (viewport.Height - ConfigUILayout.ScreenHeight * scale) / 2f;
+            return Matrix.CreateScale(scale, scale, 1f) * Matrix.CreateTranslation(offsetX, offsetY, 0f);
+        }
+
         [ExcludeFromCodeCoverage]
         protected virtual void BeginDrawFrame()
         {
-            _spriteBatch.Begin();
+            _spriteBatch.Begin(transformMatrix: CreateViewportTransform(GetViewport()));
         }
 
         [ExcludeFromCodeCoverage]

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -292,12 +292,9 @@ namespace DTXMania.Game.Lib.Stage
             _spriteBatch = new SpriteBatch(graphicsDevice);
 
             // CullMode.None so SpriteBatch quads are never winding-culled; ScissorTestEnable so the
-            // item-list batch is clipped to the inner board (see _itemClipRasterizer).
-            _itemClipRasterizer = new RasterizerState
-            {
-                CullMode = CullMode.None,
-                ScissorTestEnable = true
-            };
+            // item-list batch is clipped to the inner board (see _itemClipRasterizer). Built via the
+            // CreateItemClipRasterizer seam so headless tests can assert ScissorTestEnable is set.
+            _itemClipRasterizer = CreateItemClipRasterizer();
 
             _whitePixel = new Texture2D(graphicsDevice, 1, 1);
             _whitePixel.SetData(new[] { Color.White });
@@ -891,9 +888,7 @@ namespace DTXMania.Game.Lib.Stage
         protected virtual void BeginItemClip()
         {
             _spriteBatch.End();
-            var graphicsDevice = _game.GraphicsDevice;
-            _savedScissorRectangle = graphicsDevice.ScissorRectangle;
-            graphicsDevice.ScissorRectangle = ConfigUILayout.InnerBoardRect;
+            ApplyScissorRectangle(GetItemClipRectangle());
             _spriteBatch.Begin(rasterizerState: _itemClipRasterizer);
         }
 
@@ -904,9 +899,40 @@ namespace DTXMania.Game.Lib.Stage
         protected virtual void EndItemClip()
         {
             _spriteBatch.End();
-            _game.GraphicsDevice.ScissorRectangle = _savedScissorRectangle;
+            RestoreScissorRectangle();
             _spriteBatch.Begin();
         }
+
+        // The rectangle the item list is clipped to. Defaults to the inner board so the scrolling
+        // rows slide under the board frame; extracted as a seam so a headless test can assert the
+        // clip rect matches the drawn board without a GraphicsDevice.
+        protected virtual Rectangle GetItemClipRectangle()
+            => ConfigUILayout.InnerBoardRect;
+
+        // The rasterizer used for the clipped item-list batch. Extracted as a seam so a headless
+        // test can assert ScissorTestEnable is set (the invariant that actually confines the rows).
+        protected virtual RasterizerState CreateItemClipRasterizer()
+            => new RasterizerState
+            {
+                CullMode = CullMode.None,
+                ScissorTestEnable = true
+            };
+
+        // Apply the item-list scissor rectangle, saving the previously active one so EndItemClip can
+        // restore it. Extracted as a seam so a headless spy can record the rect without touching a
+        // real GraphicsDevice.
+        [ExcludeFromCodeCoverage]
+        protected virtual void ApplyScissorRectangle(Rectangle rect)
+        {
+            var graphicsDevice = _game.GraphicsDevice;
+            _savedScissorRectangle = graphicsDevice.ScissorRectangle;
+            graphicsDevice.ScissorRectangle = rect;
+        }
+
+        // Restore the scissor rectangle saved by ApplyScissorRectangle.
+        [ExcludeFromCodeCoverage]
+        protected virtual void RestoreScissorRectangle()
+            => _game.GraphicsDevice.ScissorRectangle = _savedScissorRectangle;
 
         // Extracts the value portion for the two-column item list by stripping the
         // "{Name}: " prefix that GetDisplayText() prepends. This is coupled to every

--- a/DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
 
 namespace DTXMania.Game.Lib.Stage.DrumConfig
@@ -54,8 +55,8 @@ namespace DTXMania.Game.Lib.Stage.DrumConfig
     /// </summary>
     public static class DrumKitLayout
     {
-        public const int DesignWidth = 1280;
-        public const int DesignHeight = 720;
+        public const int DesignWidth = GameConstants.Display.VirtualWidth;
+        public const int DesignHeight = GameConstants.Display.VirtualHeight;
 
         public static IReadOnlyList<DrumZone> Zones { get; } = new[]
         {

--- a/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
@@ -154,7 +154,9 @@ namespace DTXMania.Game.Lib.Stage
             var virtualMouse = _game.MapMouseToVirtual(mouse.Position);
             if (leftClick && virtualMouse is { } vm)
             {
-                foreach (var chip in _popup.GetBindingChips(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight))
+                int vw = GameConstants.Display.VirtualWidth;
+                int vh = GameConstants.Display.VirtualHeight;
+                foreach (var chip in _popup.GetBindingChips(vw, vh))
                 {
                     if (chip.IsMidi && chip.DecrementVelocityThreshold.Contains(vm.X, vm.Y))
                     {
@@ -173,13 +175,13 @@ namespace DTXMania.Game.Lib.Stage
                         return;
                     }
                 }
-                if (_popup.GetDoneRect(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight).Contains(vm.X, vm.Y))
+                if (_popup.GetDoneRect(vw, vh).Contains(vm.X, vm.Y))
                 {
                     _popup.Close();
                     _selectedLane = -1;
                     return;
                 }
-                if (_popup.GetClearRect(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight).Contains(vm.X, vm.Y))
+                if (_popup.GetClearRect(vw, vh).Contains(vm.X, vm.Y))
                 {
                     // Popup is intent-only (no ClearLane): the stage clears the lane via Config.
                     ClearLaneInConfig(_popup.Lane);
@@ -306,8 +308,10 @@ namespace DTXMania.Game.Lib.Stage
             // doesn't also open a lane popup. Move focus onto the action so the highlight
             // reflects the click (matches keyboard focus landing here). The button is drawn in
             // virtual space, so hit-test against the virtual-space rect with the mapped mouse.
+            int rVw = GameConstants.Display.VirtualWidth;
+            int rVh = GameConstants.Display.VirtualHeight;
             if (leftClick && virtualMouse is { } vmClick
-                && GetResetButtonRect(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight).Contains(vmClick.X, vmClick.Y))
+                && GetResetButtonRect(rVw, rVh).Contains(vmClick.X, vmClick.Y))
             {
                 _focusIndex = DrumKitLayout.ResetActionIndex;
                 ResetDrumBindingsToDefault();

--- a/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
@@ -342,17 +342,17 @@ namespace DTXMania.Game.Lib.Stage
                 OpenPopup(_focusIndex);
         }
 
-        // "Reset to defaults" button (viewport space), top-right of the screen. Named rather than
+        // "Reset to defaults" button, top-right of the screen in virtual space. Named rather than
         // magic numbers so the geometry is discoverable; matches the popup's centralized-constant
-        // pattern. viewportHeight is unused (button is top-anchored); kept for call-symmetry with
-        // the other (viewportWidth, viewportHeight) rect getters.
+        // pattern. virtualHeight is unused (button is top-anchored); kept for call-symmetry with
+        // the other (virtualWidth, virtualHeight) rect getters.
         private const int ResetButtonWidth = 190;
         private const int ResetButtonHeight = 30;
-        private const int ResetButtonRightInset = 210; // right viewport edge -> button's left edge
+        private const int ResetButtonRightInset = 210; // right virtual edge -> button's left edge
         private const int ResetButtonTopInset = 12;
 
-        private static Rectangle GetResetButtonRect(int viewportWidth, int viewportHeight) =>
-            new Rectangle(viewportWidth - ResetButtonRightInset, ResetButtonTopInset,
+        private static Rectangle GetResetButtonRect(int virtualWidth, int virtualHeight) =>
+            new Rectangle(virtualWidth - ResetButtonRightInset, ResetButtonTopInset,
                           ResetButtonWidth, ResetButtonHeight);
 
         [ExcludeFromCodeCoverage]
@@ -361,7 +361,13 @@ namespace DTXMania.Game.Lib.Stage
             if (_spriteBatch == null || _renderer == null)
                 return;
 
-            var vp = _game.GraphicsDevice.Viewport;
+            // Draw against the fixed virtual render target (see GameConstants.Display). The stage
+            // is rendered into a VirtualWidth×VirtualHeight target and letterboxed once to the
+            // window in BaseGame.Draw, so every coordinate here is authored in that virtual space —
+            // matching the hit-test path, which already uses GameConstants.Display. Reading the
+            // GraphicsDevice viewport here would silently desync if the virtual target size changes.
+            int vw = GameConstants.Display.VirtualWidth;
+            int vh = GameConstants.Display.VirtualHeight;
             _spriteBatch.Begin();
 
             // Background: the bright startup artwork, calmed by a translucent light scrim so the
@@ -369,7 +375,7 @@ namespace DTXMania.Game.Lib.Stage
             // the texture or white pixel is unavailable, keeping DarkText legible.
             if (_background?.Texture != null && _whitePixel != null)
             {
-                var full = new Rectangle(0, 0, vp.Width, vp.Height);
+                var full = new Rectangle(0, 0, vw, vh);
                 _spriteBatch.Draw(_background.Texture, full, Color.White);
                 // Premultiplied light scrim (Color.White * a scales RGB and alpha together) so it
                 // reads as a ~25% white wash under the default premultiplied AlphaBlend, not a wipe.
@@ -377,23 +383,24 @@ namespace DTXMania.Game.Lib.Stage
             }
             else if (_whitePixel != null)
             {
-                _spriteBatch.Draw(_whitePixel, new Rectangle(0, 0, vp.Width, vp.Height),
+                _spriteBatch.Draw(_whitePixel, new Rectangle(0, 0, vw, vh),
                     FallbackBackgroundColor);
             }
 
             // Drum-kit hardware skeleton behind the pieces, so the kit reads as one assembled set.
             if (_skeleton?.Texture != null)
-                _spriteBatch.Draw(_skeleton.Texture, new Rectangle(0, 0, vp.Width, vp.Height), Color.White * 0.9f);
+                _spriteBatch.Draw(_skeleton.Texture, new Rectangle(0, 0, vw, vh), Color.White * 0.9f);
 
             // Decorative bass drum at the kit's center, behind the (clickable) bass pedals.
             // Reuses the renderer's KickTexture (same asset as the Kick zone) — one load, one owner.
+            // Coordinates are authored directly in the 1280×720 virtual space (no scaling needed
+            // because the draw target IS that virtual space).
             var bassDrum = _renderer?.KickTexture;
             if (bassDrum?.Texture != null)
             {
-                float dsx = vp.Width / 1280f, dsy = vp.Height / 720f;
-                int bw = (int)(240 * dsx), bh = (int)(220 * dsy);
+                const int bw = 240, bh = 220;
                 _spriteBatch.Draw(bassDrum.Texture,
-                    new Rectangle((int)(640 * dsx) - (bw / 2), (int)(486 * dsy) - (bh / 2), bw, bh), Color.White);
+                    new Rectangle(640 - (bw / 2), 486 - (bh / 2), bw, bh), Color.White);
             }
 
             if (_font != null)
@@ -416,9 +423,9 @@ namespace DTXMania.Game.Lib.Stage
             // Display reads the runtime, which always mirrors Config (persist-on-edit truth).
             _renderer.Draw(_spriteBatch, _input?.ModularInputManager.KeyBindings ?? new KeyBindings(),
                 _font, _whitePixel,
-                vp.Width, vp.Height, in highlights);
+                vw, vh, in highlights);
 
-            var resetRect = GetResetButtonRect(vp.Width, vp.Height);
+            var resetRect = GetResetButtonRect(vw, vh);
             if (_whitePixel != null)
             {
                 // Focus ring first (yellow, inflated) so the fill sits inside it, mirroring the
@@ -435,7 +442,7 @@ namespace DTXMania.Game.Lib.Stage
                 _font.DrawString(_spriteBatch, "Reset to defaults",
                     new Vector2(resetRect.X + 10, resetRect.Y + 6), Color.White);
 
-            _popup?.Draw(_spriteBatch, _font, _whitePixel, vp.Width, vp.Height);
+            _popup?.Draw(_spriteBatch, _font, _whitePixel, vw, vh);
 
             _spriteBatch.End();
         }

--- a/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
@@ -146,35 +146,40 @@ namespace DTXMania.Game.Lib.Stage
                 return;
             }
 
-            var vp = _game.GraphicsDevice.Viewport;
-            if (leftClick)
+            // The popup is drawn into the fixed 1280x720 render target (letterboxed to the
+            // window), so its rectangles are authored in virtual space. Hit-testing runs during
+            // Update where GraphicsDevice.Viewport is the back buffer (window size), so map the
+            // raw window mouse coords into virtual space and size the rects with the virtual
+            // dims to match what was drawn. A click on the letterbox bars maps to null = no hit.
+            var virtualMouse = _game.MapMouseToVirtual(mouse.Position);
+            if (leftClick && virtualMouse is { } vm)
             {
-                foreach (var chip in _popup.GetBindingChips(vp.Width, vp.Height))
+                foreach (var chip in _popup.GetBindingChips(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight))
                 {
-                    if (chip.IsMidi && chip.DecrementVelocityThreshold.Contains(mouse.X, mouse.Y))
+                    if (chip.IsMidi && chip.DecrementVelocityThreshold.Contains(vm.X, vm.Y))
                     {
                         AdjustMidiVelocityThreshold(chip.MidiNoteNumber, -1);
                         return;
                     }
-                    if (chip.IsMidi && chip.IncrementVelocityThreshold.Contains(mouse.X, mouse.Y))
+                    if (chip.IsMidi && chip.IncrementVelocityThreshold.Contains(vm.X, vm.Y))
                     {
                         AdjustMidiVelocityThreshold(chip.MidiNoteNumber, 1);
                         return;
                     }
-                    if (chip.Remove.Contains(mouse.X, mouse.Y))
+                    if (chip.Remove.Contains(vm.X, vm.Y))
                     {
                         // Popup is intent-only (no RemoveBinding): the stage unbinds via Config.
                         RemoveBindingFromConfig(chip.ButtonId);
                         return;
                     }
                 }
-                if (_popup.GetDoneRect(vp.Width, vp.Height).Contains(mouse.X, mouse.Y))
+                if (_popup.GetDoneRect(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight).Contains(vm.X, vm.Y))
                 {
                     _popup.Close();
                     _selectedLane = -1;
                     return;
                 }
-                if (_popup.GetClearRect(vp.Width, vp.Height).Contains(mouse.X, mouse.Y))
+                if (_popup.GetClearRect(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight).Contains(vm.X, vm.Y))
                 {
                     // Popup is intent-only (no ClearLane): the stage clears the lane via Config.
                     ClearLaneInConfig(_popup.Lane);
@@ -221,10 +226,13 @@ namespace DTXMania.Game.Lib.Stage
 
         private void UpdateSelection(MouseState mouse, bool leftClick)
         {
-            var vp = _game.GraphicsDevice.Viewport;
-            float designX = mouse.X * DrumKitLayout.DesignWidth / (float)vp.Width;
-            float designY = mouse.Y * DrumKitLayout.DesignHeight / (float)vp.Height;
-            _hoveredLane = DrumKitLayout.HitTest(designX, designY);
+            // The kit is drawn in the fixed 1280x720 virtual canvas and letterboxed to the
+            // window, so map raw window mouse coords back into virtual space (inverse of the
+            // letterbox blit). A point on the black bars maps to null = no zone hovered. The
+            // previous linear mouse*Design/vp.Width mapping assumed the kit filled the whole
+            // window, which only holds at exactly 16:9 with no bars.
+            var virtualMouse = _game.MapMouseToVirtual(mouse.Position);
+            _hoveredLane = virtualMouse is { } vm ? DrumKitLayout.HitTest(vm.X, vm.Y) : -1;
 
             // Moving the mouse is a clear signal the user is pointing, not keyboard-navigating, so
             // hide the keyboard focus highlight and let hover drive the highlight instead.
@@ -296,8 +304,10 @@ namespace DTXMania.Game.Lib.Stage
 
             // Reset-to-defaults button: check before zone hit-test so a click there
             // doesn't also open a lane popup. Move focus onto the action so the highlight
-            // reflects the click (matches keyboard focus landing here).
-            if (leftClick && GetResetButtonRect(vp.Width, vp.Height).Contains(mouse.X, mouse.Y))
+            // reflects the click (matches keyboard focus landing here). The button is drawn in
+            // virtual space, so hit-test against the virtual-space rect with the mapped mouse.
+            if (leftClick && virtualMouse is { } vmClick
+                && GetResetButtonRect(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight).Contains(vmClick.X, vmClick.Y))
             {
                 _focusIndex = DrumKitLayout.ResetActionIndex;
                 ResetDrumBindingsToDefault();

--- a/DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs
@@ -37,6 +37,6 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         void Update(double deltaTime, KeyboardState current, KeyboardState previous);
 
         void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont, Texture2D? whitePixel,
-                  int viewportWidth, int viewportHeight);
+                  int virtualWidth, int virtualHeight);
     }
 }

--- a/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -317,7 +318,7 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
 
             // Dim the whole stage behind the panel.
             if (whitePixel != null)
-                spriteBatch.Draw(whitePixel, new Rectangle(0, 0, viewportWidth, viewportHeight), BackdropColor);
+                DrawWhitePixel(spriteBatch, whitePixel, new Rectangle(0, 0, viewportWidth, viewportHeight), BackdropColor);
 
             // Centered framed board (all coordinates in the same scaled space as the config stage).
             const int boardW = 720;
@@ -327,8 +328,8 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
 
             if (whitePixel != null)
             {
-                spriteBatch.Draw(whitePixel, new Rectangle(boardX - 4, boardY - 4, boardW + 8, boardH + 8), BoardBorderColor);
-                spriteBatch.Draw(whitePixel, new Rectangle(boardX, boardY, boardW, boardH), BoardColor);
+                DrawWhitePixel(spriteBatch, whitePixel, new Rectangle(boardX - 4, boardY - 4, boardW + 8, boardH + 8), BoardBorderColor);
+                DrawWhitePixel(spriteBatch, whitePixel, new Rectangle(boardX, boardY, boardW, boardH), BoardColor);
             }
 
             // Title, centered on the board.
@@ -352,7 +353,7 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
                 bool sel = i == _selectedIndex;
 
                 if (sel && whitePixel != null)
-                    spriteBatch.Draw(whitePixel, new Rectangle(boardX + 20, y, boardW - 40, rowH - 6), SelectionBarColor);
+                    DrawWhitePixel(spriteBatch, whitePixel, new Rectangle(boardX + 20, y, boardW - 40, rowH - 6), SelectionBarColor);
 
                 bool awaiting = sel && _state == CaptureState.AwaitingKey;
                 string keyLabel = awaiting
@@ -396,13 +397,13 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
             }
         }
 
-        private static void DrawFooterButton(SpriteBatch sb, IFont? font, IFont? boldFont, Texture2D? wp,
+        private void DrawFooterButton(SpriteBatch sb, IFont? font, IFont? boldFont, Texture2D? wp,
             int x, int y, int w, int h, string label, bool selected)
         {
             if (wp != null)
             {
-                sb.Draw(wp, new Rectangle(x - 3, y - 3, w + 6, h + 6), BoardBorderColor);
-                sb.Draw(wp, new Rectangle(x, y, w, h), selected ? SelectionBarColor : RowFillColor);
+                DrawWhitePixel(sb, wp, new Rectangle(x - 3, y - 3, w + 6, h + 6), BoardBorderColor);
+                DrawWhitePixel(sb, wp, new Rectangle(x, y, w, h), selected ? SelectionBarColor : RowFillColor);
             }
 
             var picked = boldFont ?? font;
@@ -411,6 +412,18 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
             picked.DrawString(sb, label,
                 new Vector2(x + (w - size.X) / 2f, y + (h - size.Y) / 2f),
                 selected ? SelectedTextColor : RowNameColor);
+        }
+
+        /// <summary>
+        /// Draws a <paramref name="whitePixel"/> filled rectangle. Extracted as a virtual seam so
+        /// headless tests can override it to record draw calls instead of requiring a live
+        /// <see cref="SpriteBatch"/> (which needs a <see cref="GraphicsDevice"/>).
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        protected virtual void DrawWhitePixel(SpriteBatch spriteBatch, Texture2D whitePixel,
+            Rectangle rectangle, Color color)
+        {
+            spriteBatch.Draw(whitePixel, rectangle, color);
         }
 
         // Humanizes an action enum name for display: "MoveUp" -> "Move Up".

--- a/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
@@ -41,6 +41,22 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         private static readonly int RowCount = ActionCount + 2;
         private const double ConflictDuration = 2.0;
 
+        // Config-aligned palette (mirrors ConfigStage / ConfigUILayout) so the sub-panel reads as
+        // part of the same stage: a dark framed board with a purple border, light text, and a warm
+        // highlight on the selected row.
+        private static readonly Color BackdropColor = new(0, 0, 0, 200);
+        private static readonly Color BoardColor = new(14, 16, 34, 236);
+        private static readonly Color BoardBorderColor = new(74, 62, 150, 235);
+        private static readonly Color RowFillColor = new(30, 34, 60, 220);
+        private static readonly Color SelectionBarColor = new(120, 92, 30, 190);
+        private static readonly Color TitleColor = new(235, 238, 248);
+        private static readonly Color RowNameColor = new(235, 238, 248);
+        private static readonly Color RowKeyColor = new(190, 205, 232);
+        private static readonly Color SelectedTextColor = new(255, 238, 120);
+        private static readonly Color AwaitingKeyColor = new(120, 220, 255);
+        private static readonly Color ConflictColor = new(255, 96, 96);
+        private static readonly Color InstructionColor = new(170, 180, 205);
+
         private readonly InputManager _inputManager;
 
         // Working copy: action -> key (one-to-one)
@@ -299,17 +315,36 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         {
             if (!IsActive || spriteBatch == null) return;
 
-            // Dark overlay
+            // Dim the whole stage behind the panel.
             if (whitePixel != null)
-                spriteBatch.Draw(whitePixel,
-                    new Rectangle(0, 0, viewportWidth, viewportHeight), new Color(0, 0, 0, 210));
+                spriteBatch.Draw(whitePixel, new Rectangle(0, 0, viewportWidth, viewportHeight), BackdropColor);
 
-            const int panelX = 80;
-            int y = 50;
-            const int rowH = 36;
+            // Centered framed board (all coordinates in the same scaled space as the config stage).
+            const int boardW = 720;
+            const int boardH = 540;
+            int boardX = (viewportWidth - boardW) / 2;
+            int boardY = (viewportHeight - boardH) / 2;
 
-            DrawText(spriteBatch, font, boldFont, "SYSTEM KEY MAPPING", panelX, y, Color.White, false);
-            y += rowH + 8;
+            if (whitePixel != null)
+            {
+                spriteBatch.Draw(whitePixel, new Rectangle(boardX - 4, boardY - 4, boardW + 8, boardH + 8), BoardBorderColor);
+                spriteBatch.Draw(whitePixel, new Rectangle(boardX, boardY, boardW, boardH), BoardColor);
+            }
+
+            // Title, centered on the board.
+            const string title = "SYSTEM KEY MAPPING";
+            var titleFont = boldFont ?? font;
+            if (titleFont != null)
+            {
+                var size = titleFont.MeasureString(title);
+                titleFont.DrawString(spriteBatch, title,
+                    new Vector2(boardX + (boardW - size.X) / 2f, boardY + 20), TitleColor);
+            }
+
+            const int rowH = 40;
+            int nameX = boardX + 40;
+            int keyX = boardX + 360;
+            int y = boardY + 78;
 
             for (int i = 0; i < ActionCount; i++)
             {
@@ -317,44 +352,79 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
                 bool sel = i == _selectedIndex;
 
                 if (sel && whitePixel != null)
-                    spriteBatch.Draw(whitePixel, new Rectangle(panelX - 4, y, 600, rowH - 2),
-                        new Color(64, 64, 128, 150));
+                    spriteBatch.Draw(whitePixel, new Rectangle(boardX + 20, y, boardW - 40, rowH - 6), SelectionBarColor);
 
-                string keyLabel = (sel && _state == CaptureState.AwaitingKey)
-                    ? "[Press any key... Backspace to cancel]"
+                bool awaiting = sel && _state == CaptureState.AwaitingKey;
+                string keyLabel = awaiting
+                    ? "[Press a key... Backspace cancels]"
                     : GetDisplayKeyLabel(action);
 
-                string rowText = $"{i + 1}. {action,-18}  {keyLabel}";
-                DrawText(spriteBatch, font, boldFont, rowText, panelX, y + 6,
-                    sel ? Color.Yellow : Color.White, sel);
+                DrawText(spriteBatch, font, boldFont, FormatActionName(action), nameX, y + 8,
+                    sel ? SelectedTextColor : RowNameColor, sel);
+                DrawText(spriteBatch, font, boldFont, keyLabel, keyX, y + 8,
+                    awaiting ? AwaitingKeyColor : (sel ? SelectedTextColor : RowKeyColor), sel);
                 y += rowH;
             }
 
-            y += 8;
+            y += 14;
 
-            // Footer
-            DrawFooterRow(spriteBatch, font, boldFont, whitePixel, panelX, y, rowH, "SAVE",
+            // Footer buttons: SAVE and CANCEL, side by side and centered.
+            const int btnW = 210;
+            const int btnGap = 40;
+            int totalW = btnW * 2 + btnGap;
+            int saveX = boardX + (boardW - totalW) / 2;
+            DrawFooterButton(spriteBatch, font, boldFont, whitePixel, saveX, y, btnW, rowH, "SAVE",
                 _selectedIndex == FooterSave);
-            y += rowH;
-            DrawFooterRow(spriteBatch, font, boldFont, whitePixel, panelX, y, rowH, GetFooterCancelLabel(),
-                _selectedIndex == FooterCancel);
-            y += rowH + 8;
+            DrawFooterButton(spriteBatch, font, boldFont, whitePixel, saveX + btnW + btnGap, y, btnW, rowH,
+                GetFooterCancelLabel(), _selectedIndex == FooterCancel);
+            y += rowH + 16;
 
-            if (_conflictMessage != null)
-                DrawText(spriteBatch, font, boldFont, $"Conflict: {_conflictMessage}",
-                    panelX, y, Color.Red, false);
+            if (_conflictMessage != null && font != null)
+            {
+                var msg = $"Conflict: {_conflictMessage}";
+                var size = font.MeasureString(msg);
+                font.DrawString(spriteBatch, msg, new Vector2(boardX + (boardW - size.X) / 2f, y), ConflictColor);
+            }
 
-            int instrY = viewportHeight - 28;
-            DrawText(spriteBatch, font, boldFont, GetInstructionText(), panelX, instrY,
-                new Color(180, 180, 180), false);
+            // Instruction line pinned near the board bottom.
+            if (font != null)
+            {
+                var instr = GetInstructionText();
+                var size = font.MeasureString(instr);
+                font.DrawString(spriteBatch, instr,
+                    new Vector2(boardX + (boardW - size.X) / 2f, boardY + boardH - 34), InstructionColor);
+            }
         }
 
-        private static void DrawFooterRow(SpriteBatch sb, IFont? font, IFont? boldFont, Texture2D? wp,
-            int x, int y, int h, string label, bool selected)
+        private static void DrawFooterButton(SpriteBatch sb, IFont? font, IFont? boldFont, Texture2D? wp,
+            int x, int y, int w, int h, string label, bool selected)
         {
-            if (selected && wp != null)
-                sb.Draw(wp, new Rectangle(x - 4, y, 300, h - 2), new Color(64, 64, 128, 150));
-            DrawText(sb, font, boldFont, label, x, y + 6, selected ? Color.Yellow : Color.White, selected);
+            if (wp != null)
+            {
+                sb.Draw(wp, new Rectangle(x - 3, y - 3, w + 6, h + 6), BoardBorderColor);
+                sb.Draw(wp, new Rectangle(x, y, w, h), selected ? SelectionBarColor : RowFillColor);
+            }
+
+            var picked = boldFont ?? font;
+            if (picked == null) return;
+            var size = picked.MeasureString(label);
+            picked.DrawString(sb, label,
+                new Vector2(x + (w - size.X) / 2f, y + (h - size.Y) / 2f),
+                selected ? SelectedTextColor : RowNameColor);
+        }
+
+        // Humanizes an action enum name for display: "MoveUp" -> "Move Up".
+        private static string FormatActionName(InputCommandType action)
+        {
+            var s = action.ToString();
+            var sb = new System.Text.StringBuilder(s.Length + 4);
+            for (int i = 0; i < s.Length; i++)
+            {
+                if (i > 0 && char.IsUpper(s[i]) && !char.IsUpper(s[i - 1]))
+                    sb.Append(' ');
+                sb.Append(s[i]);
+            }
+            return sb.ToString();
         }
 
         private static void DrawText(SpriteBatch sb, IFont? font, IFont? boldFont, string text, int x, int y,

--- a/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
@@ -426,15 +426,24 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
             spriteBatch.Draw(whitePixel, rectangle, color);
         }
 
-        // Humanizes an action enum name for display: "MoveUp" -> "Move Up".
+        // Humanizes an action enum name for display: "MoveUp" -> "Move Up",
+        // "IncreaseScrollSpeed" -> "Increase Scroll Speed", "MoveURLPath" -> "Move URL Path".
         private static string FormatActionName(InputCommandType action)
         {
             var s = action.ToString();
             var sb = new System.Text.StringBuilder(s.Length + 4);
             for (int i = 0; i < s.Length; i++)
             {
-                if (i > 0 && char.IsUpper(s[i]) && !char.IsUpper(s[i - 1]))
-                    sb.Append(' ');
+                // Insert a space at word boundaries. Two cases:
+                //  1. lowercase -> Uppercase:        "MoveUp"   -> "Move Up"
+                //  2. Uppercase, prev Upper, next lower: "URLPath" -> "URL Path" (acronym end)
+                if (i > 0 && char.IsUpper(s[i]))
+                {
+                    bool prevLower = !char.IsUpper(s[i - 1]);
+                    bool acronymEnd = char.IsUpper(s[i - 1]) && i + 1 < s.Length && char.IsLower(s[i + 1]);
+                    if (prevLower || acronymEnd)
+                        sb.Append(' ');
+                }
                 sb.Append(s[i]);
             }
             return sb.ToString();

--- a/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/SystemKeyAssignPanel.cs
@@ -312,19 +312,19 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
         }
 
         public void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont, Texture2D? whitePixel,
-                         int viewportWidth, int viewportHeight)
+                         int virtualWidth, int virtualHeight)
         {
             if (!IsActive || spriteBatch == null) return;
 
             // Dim the whole stage behind the panel.
             if (whitePixel != null)
-                DrawWhitePixel(spriteBatch, whitePixel, new Rectangle(0, 0, viewportWidth, viewportHeight), BackdropColor);
+                DrawWhitePixel(spriteBatch, whitePixel, new Rectangle(0, 0, virtualWidth, virtualHeight), BackdropColor);
 
             // Centered framed board (all coordinates in the same scaled space as the config stage).
             const int boardW = 720;
             const int boardH = 540;
-            int boardX = (viewportWidth - boardW) / 2;
-            int boardY = (viewportHeight - boardH) / 2;
+            int boardX = (virtualWidth - boardW) / 2;
+            int boardY = (virtualHeight - boardH) / 2;
 
             if (whitePixel != null)
             {

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -140,10 +140,10 @@ namespace DTXMania.Game.Lib.Stage
             if (_spriteBatch == null)
                 return;
 
-            var viewport = _spriteBatch.GraphicsDevice.Viewport;
-            var transform = ResultScreenRenderer.CreateViewportTransform(viewport);
-
-            _spriteBatch.Begin(transformMatrix: transform);
+            // BaseGame now renders every stage into the fixed 1280×720 virtual render target and
+            // letterbox-scales it once to the window, so no per-stage viewport transform is needed
+            // here (the previous CreateViewportTransform call was always identity under that model).
+            _spriteBatch.Begin();
 
             if (_resultRenderer != null && _resultModel != null && _revealState != null)
             {

--- a/DTXMania.Game/Lib/Stage/ResultStage.cs
+++ b/DTXMania.Game/Lib/Stage/ResultStage.cs
@@ -441,8 +441,9 @@ namespace DTXMania.Game.Lib.Stage
             DrawStageBackground(_spriteBatch);
 
             // Draw fallback if no background loaded.
-            // Use NX virtual coordinates (1280x720) because the SpriteBatch
-            // has an active viewport transform that maps virtual→screen coords.
+            // BaseGame renders every stage into the fixed 1280x720 virtual render target and
+            // letterbox-scales it once to the window, so author the fallback rect in virtual
+            // coords (no per-stage viewport transform is applied here).
             if (!IsBackgroundReady)
             {
                 var backgroundRect = new Rectangle(0, 0,

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -506,16 +506,14 @@ namespace DTXMania.Game.Lib.Stage
         {
             _uiManager = new UIManager();
 
-            // Get viewport dimensions with fallback for test/headless environments
-            var viewport = _game.GraphicsDevice?.Viewport ?? default;
-            var width = viewport.Width > 0 ? viewport.Width : SongSelectionUILayout.SongListDisplay.Width;
-            var height = viewport.Height > 0 ? viewport.Height : SongSelectionUILayout.SongListDisplay.Height;
-
-            // Create main panel
+            // Create main panel sized to the fixed virtual resolution. InitializeUI runs during
+            // OnActivate (not during draw), so GraphicsDevice.Viewport is the back buffer (window
+            // size), NOT the 1280x720 render target. Sizing from the viewport would make the panel
+            // window-dependent and break the fixed-virtual-resolution model.
             _mainPanel = new UIPanel
             {
                 Position = Vector2.Zero,
-                Size = new Vector2(width, height),
+                Size = SongSelectionUILayout.SongListDisplay.Size,
                 BackgroundColor = Color.Black * SongSelectionUILayout.Background.MainPanelAlpha,
                 LayoutMode = PanelLayoutMode.Manual
             };

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1394,13 +1394,17 @@ namespace DTXMania.Game.Lib.Stage
 
             // 3. Mouse click routing for modal buttons
             //    Treat a null previous state as "all buttons released" so that the
-            //    very first click after the modal opens is not silently swallowed.
+            //    very first click after the modal opens is not silently swallowed. The modal's
+            //    button rects are authored in the fixed 1280x720 virtual canvas, so map the raw
+            //    window mouse coords into virtual space before hit-testing; a click on the
+            //    letterbox bars maps to null and is ignored.
             var mouseState = Microsoft.Xna.Framework.Input.Mouse.GetState();
             if ((_previousMouseState == null ||
                  _previousMouseState.Value.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Released) &&
-                mouseState.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Pressed)
+                mouseState.LeftButton == Microsoft.Xna.Framework.Input.ButtonState.Pressed &&
+                _game.MapMouseToVirtual(new Microsoft.Xna.Framework.Point(mouseState.X, mouseState.Y)) is { } virtualClick)
             {
-                _searchFilterModal.HandleClick(new Microsoft.Xna.Framework.Point(mouseState.X, mouseState.Y));
+                _searchFilterModal.HandleClick(virtualClick);
             }
             _previousMouseState = mouseState;
         }

--- a/DTXMania.Game/Lib/Stage/SongTransitionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongTransitionStage.cs
@@ -293,11 +293,13 @@ namespace DTXMania.Game.Lib.Stage
         {
             _uiManager = new UIManager();
             
-            // Create main panel with a visible background
+            // Create main panel sized to the fixed virtual resolution. InitializeUI runs during
+            // OnActivate (not during draw), so GraphicsDevice.Viewport is the back buffer (window
+            // size), NOT the 1280x720 render target.
             _mainPanel = new UIPanel
             {
                 Position = Vector2.Zero,
-                Size = new Vector2(_game.GraphicsDevice.Viewport.Width, _game.GraphicsDevice.Viewport.Height),
+                Size = new Vector2(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight),
                 BackgroundColor = Color.DarkBlue * 0.8f, // More visible background
                 LayoutMode = PanelLayoutMode.Manual
             };

--- a/DTXMania.Game/Lib/Stage/TitleStage.cs
+++ b/DTXMania.Game/Lib/Stage/TitleStage.cs
@@ -476,32 +476,38 @@ namespace DTXMania.Game.Lib.Stage
 
         private void HandleMouseInput()
         {
-            var mousePos = _currentMouseState.Position;
+            // Menu rects are authored in the fixed 1280x720 virtual canvas and letterboxed to
+            // the window, so map the raw window mouse position back into virtual space before
+            // hit-testing. A point on the black bars maps to null = no menu item hovered.
+            var mousePos = _game.MapMouseToVirtual(_currentMouseState.Position);
             var previousHoveredIndex = _hoveredMenuIndex;
             _hoveredMenuIndex = -1;
 
-            // Check if mouse is over any menu item
-            for (int i = 0; i < _menuItems.Length; i++)
+            if (mousePos is { } vm)
             {
-                var menuItemRect = new Rectangle(
-                    MenuX,
-                    MenuY + (i * MenuItemHeight),
-                    MenuItemWidth,
-                    MenuItemHeight
-                );
-
-                if (menuItemRect.Contains(mousePos))
+                // Check if mouse is over any menu item
+                for (int i = 0; i < _menuItems.Length; i++)
                 {
-                    _hoveredMenuIndex = i;
+                    var menuItemRect = new Rectangle(
+                        MenuX,
+                        MenuY + (i * MenuItemHeight),
+                        MenuItemWidth,
+                        MenuItemHeight
+                    );
 
-                    // If hover changed, update cursor position and play sound
-                    if (_hoveredMenuIndex != previousHoveredIndex && _hoveredMenuIndex != _currentMenuIndex)
+                    if (menuItemRect.Contains(vm))
                     {
-                        _currentMenuIndex = _hoveredMenuIndex;
-                        PlayCursorMoveSound();
-                        System.Diagnostics.Debug.WriteLine($"Mouse hover changed cursor to: {_menuItems[_currentMenuIndex]}");
+                        _hoveredMenuIndex = i;
+
+                        // If hover changed, update cursor position and play sound
+                        if (_hoveredMenuIndex != previousHoveredIndex && _hoveredMenuIndex != _currentMenuIndex)
+                        {
+                            _currentMenuIndex = _hoveredMenuIndex;
+                            PlayCursorMoveSound();
+                            System.Diagnostics.Debug.WriteLine($"Mouse hover changed cursor to: {_menuItems[_currentMenuIndex]}");
+                        }
+                        break;
                     }
-                    break;
                 }
             }
 

--- a/DTXMania.Game/Lib/Stage/TitleStage.cs
+++ b/DTXMania.Game/Lib/Stage/TitleStage.cs
@@ -1,6 +1,7 @@
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Stage;
@@ -153,9 +154,8 @@ namespace DTXMania.Game.Lib.Stage
             // Draw fallback if no background loaded
             if (!IsBackgroundReady && _whitePixel != null)
             {
-                var viewport = _game.GraphicsDevice.Viewport;
                 _spriteBatch.Draw(_whitePixel,
-                    new Rectangle(0, 0, viewport.Width, viewport.Height),
+                    new Rectangle(0, 0, GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight),
                     new Color(8, 8, 16));
             }
 

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -22,10 +22,12 @@ namespace DTXMania.Game.Lib.UI.Layout
         // background (4_background.png) but behind the menu/item/description panels, so the
         // config content stays legible and reads as a contained window. NX has no dedicated
         // asset for this — it is drawn with fills. The border rect is the outer frame; the
-        // board rect is the inset fill. Spans just inside the header (bottom=105) and footer
-        // (top=690), framing the menu (left), item list, and description panel.
-        public static Rectangle InnerBoardBorderRect => new(220, 112, 880, 574);
-        public static Rectangle InnerBoardRect => new(224, 116, 872, 566);
+        // board rect is the 4px-inset fill. The border spans the full band between the header
+        // (bottom=105) and footer (top=690) so it fully backs the scrolling item list: item
+        // rows are visible anywhere in that band, so a shorter board would leave partial rows
+        // sitting on the bare background at the top/bottom edges.
+        public static Rectangle InnerBoardBorderRect => new(220, 105, 880, 585);
+        public static Rectangle InnerBoardRect => new(224, 109, 872, 577);
 
         // Header / footer / title / instructions / import status.
         public static Rectangle HeaderRect => new(0, 0, ScreenWidth, 105);

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using Microsoft.Xna.Framework;
+using DTXMania.Game.Lib.Config;
 
 namespace DTXMania.Game.Lib.UI.Layout
 {
@@ -11,8 +12,8 @@ namespace DTXMania.Game.Lib.UI.Layout
     /// </summary>
     public static class ConfigUILayout
     {
-        public const int ScreenWidth = 1280;
-        public const int ScreenHeight = 720;
+        public const int ScreenWidth = GameConstants.Display.VirtualWidth;
+        public const int ScreenHeight = GameConstants.Display.VirtualHeight;
 
         // Background + vertical divider.
         public static Rectangle BackgroundRect => new(0, 0, ScreenWidth, ScreenHeight);

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -29,54 +29,52 @@ namespace DTXMania.Game.Lib.UI.Layout
 
         // Left category menu.
         public static Rectangle MenuPanelRect => new(245, 140, 180, 172);
-        public const int MenuFirstRowY = 156;
-        public const int MenuRowStride = 34;
-        public const int MenuLabelCenterX = 335;
-        public const int MenuCursorWidth = 150;
-        public const int MenuCursorHeight = 30;
-        public static int MenuRowY(int index) => MenuFirstRowY + index * MenuRowStride;
+        public const int MenuLabelCenterX = 335;   // panel center: 245 + 180/2
+        public const int MenuCursorX = 250;
+        public const int MenuCursorWidth = 170;
+        public const int MenuCursorHeight = 32;
+        public const int MenuFirstCursorY = 148;
+        public const int MenuRowStride = 32;
         public static Rectangle MenuCursorRect(int index) =>
-            new(250, MenuRowY(index) - 3, MenuCursorWidth, MenuCursorHeight);
+            new(MenuCursorX, MenuFirstCursorY + index * MenuRowStride, MenuCursorWidth, MenuCursorHeight);
 
-        // Right item list.
-        public const int ItemListX = 430;
-        public const int ItemFirstRowY = 150;
-        public const int ItemRowStride = 60;
-        public const int ItemBoxWidth = 360;
-        public const int ItemBoxHeight = 54;
-        public const int ItemNameInsetX = 24;
-        // Right-aligned value column: values anchor at the box's right inner edge so they never
-        // overflow the box and never run under the description panel (drawn afterward at x=800).
-        // A fixed left-aligned column left wide values stretching into the panel region.
-        public const int ItemValueRightInset = ItemNameInsetX; // symmetric with the name's left inset
-        public const int ItemTextInsetY = 14;
-        public static int ItemRowY(int row) => ItemFirstRowY + row * ItemRowStride;
-        public static Rectangle ItemRowRect(int row) =>
-            new(ItemListX, ItemRowY(row), ItemBoxWidth, ItemBoxHeight);
-        public static Rectangle ItemCursorRect(int row) =>
-            new(ItemListX - 4, ItemRowY(row) - 3, ItemBoxWidth + 8, ItemRowStride);
-        public static Vector2 ItemNamePos(int row) =>
-            new(ItemListX + ItemNameInsetX, ItemRowY(row) + ItemTextInsetY);
-        // Right anchor for value text; the draw layer subtracts the measured string width so the
-        // value's right edge sits here (inside the box, clear of the description panel).
-        public static int ItemValueRightX => ItemListX + ItemBoxWidth - ItemValueRightInset;
-        // Minimum horizontal gap kept between a measured item name and the right-aligned value
-        // drawn beside it. The draw layer subtracts the measured name width plus this gap from
-        // ItemValueRightX to derive the value's per-row max width before ellipsizing, so a long
-        // value (e.g. a deep macOS DTXPath) never touches or overwrites the name. This is required
-        // because the value is drawn after the name; reserving only the name's left edge (as
-        // ItemValueMaxWidth does below) lets the value's left edge sit exactly on that edge and
-        // still overlap the name's glyph run.
-        public const int ItemValueNameGap = 16;
-        // Theoretical maximum value width assuming a zero-width name: the full gap from the name
-        // column's left edge to the value's right anchor. Used only as an upper-bound ceiling
-        // (e.g. layout sanity assertions); the draw layer uses the per-row name-relative width
-        // derived via ItemValueNameGap instead, which is always <= this value for a real name.
-        public static int ItemValueMaxWidth => ItemBoxWidth - ItemValueRightInset - ItemNameInsetX;
+        // Right item list — scrolling viewport (selected item locked to the focus row).
+        public const int ItemListX = 420;
+        public const int ItemBoxHeight = 80;
+        public const int ItemBoxNormalWidth = 538;   // 4_itembox.png: dark name cell + white value cell
+        public const int ItemBoxOtherWidth = 438;    // 4_itembox other.png: single dark cell (navigation)
+        public const int ItemRowStride = 67;         // NX stride; boxes overlap 13px as the art tiles
+        public const int ItemFocusRowTopY = 189;     // panel-top Y of the centered/selected row
+        public const int ItemVisibleTopY = 105;      // header bottom
+        public const int ItemVisibleBottomY = 690;   // footer top
+        public const int ItemNameOffsetX = 20;
+        public const int ItemValueOffsetX = 260;
+        public const int ItemTextOffsetY = 24;
+        // Value text left-aligns at ItemListX+ItemValueOffsetX (680) and must stay left of the
+        // description panel (x=800), so cap its width. 800 - 680 - 4 margin = 116.
+        public const int ItemValueMaxWidth = 116;
+        // Selection cursor is fixed at the focus row; items scroll under it (NX 4_itembox cursor.png 497x68).
+        public static Rectangle ItemCursorRect => new(413, 193, 497, 68);
 
-        // Description panel.
+        // Panel-top Y of item `index` given the eased scroll position `scroll` (fractional index at focus).
+        public static int RowTopY(int index, double scroll) =>
+            ItemFocusRowTopY + (int)System.Math.Round((index - scroll) * ItemRowStride);
+
+        // True when the row's box intersects the visible band between header and footer.
+        public static bool IsRowVisible(int rowTopY) =>
+            (rowTopY + ItemBoxHeight) > ItemVisibleTopY && rowTopY < ItemVisibleBottomY;
+
+        public static Rectangle ItemBoxRect(int rowTopY, int width) =>
+            new(ItemListX, rowTopY, width, ItemBoxHeight);
+        public static Vector2 ItemNamePos(int rowTopY) =>
+            new(ItemListX + ItemNameOffsetX, rowTopY + ItemTextOffsetY);
+        public static Vector2 ItemValuePos(int rowTopY) =>
+            new(ItemListX + ItemValueOffsetX, rowTopY + ItemTextOffsetY);
+
+        // Description panel — art is white (top) over black (bottom); use both cells.
         public static Rectangle DescriptionPanelRect => new(800, 270, 280, 360);
-        public static Vector2 DescriptionTextPos => new(818, 288);
+        public static Vector2 DescriptionTitlePos => new(818, 300);   // white upper region -> dark text
+        public static Vector2 DescriptionBodyPos => new(818, 448);    // black lower region -> light text
         public const int DescriptionWrapWidth = 248;
         public const int DescriptionLineHeight = 22;
     }

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -18,6 +18,15 @@ namespace DTXMania.Game.Lib.UI.Layout
         public static Rectangle BackgroundRect => new(0, 0, ScreenWidth, ScreenHeight);
         public static Rectangle ItemBarRect => new(400, 0, 18, ScreenHeight);
 
+        // Inner board: a dark, translucent framed panel drawn over the busy GALAXY WAVE
+        // background (4_background.png) but behind the menu/item/description panels, so the
+        // config content stays legible and reads as a contained window. NX has no dedicated
+        // asset for this — it is drawn with fills. The border rect is the outer frame; the
+        // board rect is the inset fill. Spans just inside the header (bottom=105) and footer
+        // (top=690), framing the menu (left), item list, and description panel.
+        public static Rectangle InnerBoardBorderRect => new(220, 112, 880, 574);
+        public static Rectangle InnerBoardRect => new(224, 116, 872, 566);
+
         // Header / footer / title / instructions / import status.
         public static Rectangle HeaderRect => new(0, 0, ScreenWidth, 105);
         public static Rectangle FooterRect => new(0, 690, ScreenWidth, 30);

--- a/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs
@@ -53,7 +53,6 @@ namespace DTXMania.Game.Lib.UI.Layout
         public const int ItemListX = 420;
         public const int ItemBoxHeight = 80;
         public const int ItemBoxNormalWidth = 538;   // 4_itembox.png: dark name cell + white value cell
-        public const int ItemBoxOtherWidth = 438;    // 4_itembox other.png: single dark cell (navigation)
         public const int ItemRowStride = 67;         // NX stride; boxes overlap 13px as the art tiles
         public const int ItemFocusRowTopY = 189;     // panel-top Y of the centered/selected row
         public const int ItemVisibleTopY = 105;      // header bottom

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -155,9 +155,9 @@ namespace DTXMania.Game.Lib.UI.Layout
         };
         
         /// <summary>
-        /// Lane height - NX draws the drum lane panel through the full 720px playfield.
+        /// Lane height - NX draws the drum lane panel through the full virtual-height playfield.
         /// </summary>
-        public const int LaneHeight = 720;
+        public const int LaneHeight = ScreenHeight;
         
         #endregion
         
@@ -520,7 +520,7 @@ namespace DTXMania.Game.Lib.UI.Layout
         // Scroll-speed indicator (in-game toast shown when player adjusts scroll speed)
         public const float ScrollSpeedIndicatorDurationSeconds = 1.5f;
         public const float ScrollSpeedIndicatorFadeSeconds = 0.3f;
-        public const int ScrollSpeedIndicatorX = 640; // left edge at horizontal center of 1280-wide screen
+        public const int ScrollSpeedIndicatorX = ScreenWidth / 2; // left edge at horizontal center of the virtual screen
         public const int ScrollSpeedIndicatorY = 40;
 
         #endregion
@@ -668,26 +668,26 @@ namespace DTXMania.Game.Lib.UI.Layout
         /// </summary>
         public static class Background
         {
-            public static readonly Rectangle Bounds = new Rectangle(0, 0, 1280, 720);
+            public static readonly Rectangle Bounds = new Rectangle(0, 0, ScreenWidth, ScreenHeight);
         }
-        
+
         /// <summary>
         /// Stage Failed overlay
         /// </summary>
         public static class StageFailed
         {
-            public static readonly Rectangle Bounds = new Rectangle(0, 0, 1280, 720);
+            public static readonly Rectangle Bounds = new Rectangle(0, 0, ScreenWidth, ScreenHeight);
         }
-        
+
         /// <summary>
         /// Full Combo overlay
         /// </summary>
         public static class FullCombo
         {
-            // Centered, baseline calculation: (1280-w)/2, (720-h)/2
+            // Centered on the virtual screen: (ScreenWidth-w)/2, (ScreenHeight-h)/2
             public static Vector2 GetCenteredPosition(int textureWidth, int textureHeight)
             {
-                return new Vector2((1280 - textureWidth) / 2, (720 - textureHeight) / 2);
+                return new Vector2((ScreenWidth - textureWidth) / 2, (ScreenHeight - textureHeight) / 2);
             }
         }
         
@@ -926,7 +926,7 @@ namespace DTXMania.Game.Lib.UI.Layout
         
         public static class JudgementTextAssets
         {
-            public static readonly Rectangle Bounds = new Rectangle((int)(0.39f * 1280), (int)(0.77f * 720), (int)(0.22f * 1280), (int)(0.07f * 720));
+            public static readonly Rectangle Bounds = new Rectangle((int)(0.39f * ScreenWidth), (int)(0.77f * ScreenHeight), (int)(0.22f * ScreenWidth), (int)(0.07f * ScreenHeight));
             public const int AtlasRows = 1;
             public const int AtlasCols = 5;
             public static readonly Rectangle Padding = new Rectangle(2, 2, 2, 2);
@@ -1006,8 +1006,8 @@ namespace DTXMania.Game.Lib.UI.Layout
         
         public static class TimingIndicatorAssets
         {
-            public static readonly Rectangle EarlyBounds = new Rectangle((int)(0.335f * 1280), (int)(0.77f * 720), (int)(0.05f * 1280), (int)(0.05f * 720));
-            public static readonly Rectangle LateBounds = new Rectangle((int)(0.615f * 1280), (int)(0.77f * 720), (int)(0.05f * 1280), (int)(0.05f * 720));
+            public static readonly Rectangle EarlyBounds = new Rectangle((int)(0.335f * ScreenWidth), (int)(0.77f * ScreenHeight), (int)(0.05f * ScreenWidth), (int)(0.05f * ScreenHeight));
+            public static readonly Rectangle LateBounds = new Rectangle((int)(0.615f * ScreenWidth), (int)(0.77f * ScreenHeight), (int)(0.05f * ScreenWidth), (int)(0.05f * ScreenHeight));
             public const int AtlasRows = 1;
             public const int AtlasCols = 2;
             public static readonly Rectangle Padding = new Rectangle(2, 2, 2, 2);
@@ -1017,8 +1017,8 @@ namespace DTXMania.Game.Lib.UI.Layout
         
         public static class OverlayAssets
         {
-            public static readonly Rectangle PauseOverlay = new Rectangle(0, 0, 1280, 720);
-            public static readonly Rectangle DangerOverlay = new Rectangle(0, 0, 1280, 720);
+            public static readonly Rectangle PauseOverlay = new Rectangle(0, 0, ScreenWidth, ScreenHeight);
+            public static readonly Rectangle DangerOverlay = new Rectangle(0, 0, ScreenWidth, ScreenHeight);
         }
         
         public static class NotesAssets

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -1,4 +1,5 @@
 using Microsoft.Xna.Framework;
+using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Song.Entities;
 using System;
 using System.Linq;
@@ -17,17 +18,17 @@ namespace DTXMania.Game.Lib.UI.Layout
         /// <summary>
         /// DTXManiaNX screen resolution - 1280×720 letterboxed 16:9
         /// </summary>
-        public static readonly Vector2 ScreenResolution = new Vector2(1280, 720);
+        public static readonly Vector2 ScreenResolution = new(GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight);
         
         /// <summary>
         /// Screen width in pixels
         /// </summary>
-        public const int ScreenWidth = 1280;
+        public const int ScreenWidth = GameConstants.Display.VirtualWidth;
         
         /// <summary>
         /// Screen height in pixels
         /// </summary>
-        public const int ScreenHeight = 720;
+        public const int ScreenHeight = GameConstants.Display.VirtualHeight;
         
         public static Vector2 ScreenCenter => new Vector2(ScreenWidth / 2, ScreenHeight / 2);
         public static Vector2 ScreenSize => new Vector2(ScreenWidth, ScreenHeight);

--- a/DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/ResultUILayout.cs
@@ -1,3 +1,4 @@
+using DTXMania.Game.Lib.Config;
 using Microsoft.Xna.Framework;
 
 namespace DTXMania.Game.Lib.UI.Layout
@@ -46,8 +47,8 @@ namespace DTXMania.Game.Lib.UI.Layout
 
         public static class NXViewport
         {
-            public const int Width = 1280;
-            public const int Height = 720;
+            public const int Width = GameConstants.Display.VirtualWidth;
+            public const int Height = GameConstants.Display.VirtualHeight;
         }
 
         public static class Fonts

--- a/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/SongSelectionUILayout.cs
@@ -409,8 +409,8 @@ namespace DTXMania.Game.Lib.UI.Layout
         {
             public const int X = 0;
             public const int Y = 0;
-            public const int Width = 1280;  // Full screen width
-            public const int Height = 720;  // Full screen height
+            public const int Width = GameConstants.Display.VirtualWidth;  // Full screen width
+            public const int Height = GameConstants.Display.VirtualHeight;  // Full screen height
             
             public static Vector2 Position => new Vector2(X, Y);
             public static Vector2 Size => new Vector2(Width, Height);

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -886,6 +886,53 @@ namespace DTXMania.Test
             Assert.Equal(new Rectangle(320, 0, 1280, 720), dest);
         }
 
+        [Fact]
+        public void WindowToVirtualCoordinates_SameSize_IsIdentity()
+        {
+            var mapped = BaseGame.WindowToVirtualCoordinates(new Point(640, 360), new Rectangle(0, 0, 1280, 720), 1280, 720);
+
+            Assert.Equal(new Point(640, 360), mapped);
+        }
+
+        [Fact]
+        public void WindowToVirtualCoordinates_ScaledUp_MapsIntoVirtualSpace()
+        {
+            // 1920x1080 window, 16:9, scale 1.5, no bars. A click at window (960,540) (center)
+            // maps to virtual (640,360) (center of 1280x720).
+            var mapped = BaseGame.WindowToVirtualCoordinates(new Point(960, 540), new Rectangle(0, 0, 1920, 1080), 1280, 720);
+
+            Assert.Equal(new Point(640, 360), mapped);
+        }
+
+        [Fact]
+        public void WindowToVirtualCoordinates_Pillarboxed_OffsetsX()
+        {
+            // 1920x720 window -> pillarboxed: dest = (320,0,1280,720). Window x=960 -> dest x=640 -> virtual x=640.
+            var mapped = BaseGame.WindowToVirtualCoordinates(new Point(960, 360), new Rectangle(0, 0, 1920, 720), 1280, 720);
+
+            Assert.Equal(new Point(640, 360), mapped);
+        }
+
+        [Fact]
+        public void WindowToVirtualCoordinates_OnBlackBars_ReturnsNull()
+        {
+            // 1920x720 pillarboxed: left bar is x in [0,320). A click at x=100 is on the bar.
+            var mapped = BaseGame.WindowToVirtualCoordinates(new Point(100, 360), new Rectangle(0, 0, 1920, 720), 1280, 720);
+
+            Assert.Null(mapped);
+        }
+
+        [Fact]
+        public void WindowToVirtualCoordinates_RightEdgeClampsToVirtualBounds()
+        {
+            // 1920x1080, scale 1.5. The right edge of the dest (x=1919) maps just under 1280.
+            var mapped = BaseGame.WindowToVirtualCoordinates(new Point(1919, 1079), new Rectangle(0, 0, 1920, 1080), 1280, 720);
+
+            Assert.NotNull(mapped);
+            Assert.True(mapped!.Value.X < 1280 && mapped.Value.X >= 0);
+            Assert.True(mapped.Value.Y < 720 && mapped.Value.Y >= 0);
+        }
+
         private static IConfigManager CreateConfigManager(ConfigData config)
         {
             var configManager = new Mock<IConfigManager>();

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -932,6 +932,22 @@ namespace DTXMania.Test
             Assert.Equal(new Rectangle(320, 0, 1280, 720), dest);
         }
 
+        [Theory]
+        [InlineData(0, 720, 1280, 720)]   // zero-width viewport
+        [InlineData(1280, 0, 1280, 720)]  // zero-height viewport
+        [InlineData(1280, 720, 0, 720)]   // zero virtual width
+        [InlineData(1280, 720, 1280, 0)]  // zero virtual height
+        public void CalculateLetterboxDestination_DegenerateDims_ReturnsEmpty(
+            int viewportW, int viewportH, int virtualW, int virtualH)
+        {
+            // Guard prevents division by zero / negative destination sizes for degenerate inputs
+            // (e.g. a minimized window reporting a zero-sized viewport on some platforms).
+            var dest = BaseGame.CalculateLetterboxDestination(
+                new Rectangle(0, 0, viewportW, viewportH), virtualW, virtualH);
+
+            Assert.Equal(Rectangle.Empty, dest);
+        }
+
         [Fact]
         public void WindowToVirtualCoordinates_SameSize_IsIdentity()
         {

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -330,6 +330,52 @@ namespace DTXMania.Test
         }
 
         [Fact]
+        public void OnGameExiting_WithConcreteConfigManager_ShouldFlushPendingSave()
+        {
+            // OnGameExiting is a belt-and-suspenders handler that flushes any deferred config
+            // write (e.g. scroll-speed) even if the normal stage-deactivation path is skipped.
+            var tempDir = Path.Combine(
+                AppContext.BaseDirectory, "TestResults", "ongame-exiting-flush",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            var configPath = Path.Combine(tempDir, "Config.ini");
+            try
+            {
+                var configManager = new ConfigManager();
+                configManager.LoadConfig(configPath);
+                configManager.SetAutoPlay(true); // mark dirty
+                Assert.False(File.ReadAllText(configPath).Contains("AutoPlay=True"));
+
+                var game = CreateGameForLifecycle();
+                ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", configManager);
+
+                ReflectionHelpers.InvokePrivateMethod(game, "OnGameExiting", null!, EventArgs.Empty);
+
+                Assert.True(File.ReadAllText(configPath).Contains("AutoPlay=True"));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void OnGameExiting_WithMockConfigManager_ShouldNotThrow()
+        {
+            // When ConfigManager is not the concrete ConfigManager (e.g. a mock), the cast fails
+            // and FlushPendingSave is skipped — no crash.
+            var game = ReflectionHelpers.CreateGame();
+            var mockConfig = new Mock<IConfigManager>();
+            mockConfig.SetupGet(c => c.Config).Returns(new ConfigData());
+            ReflectionHelpers.SetPrivateField(game, "<ConfigManager>k__BackingField", mockConfig.Object);
+
+            var ex = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(game, "OnGameExiting", null!, EventArgs.Empty));
+
+            Assert.Null(ex);
+            mockConfig.Verify(c => c.FlushPendingSave(), Times.Never);
+        }
+
+        [Fact]
         public void ApplySavedSystemKeyBindings_WhenConfigManagerIsConcrete_ShouldLoadPersistedBindings()
         {
             var configManager = new ConfigManager();
@@ -933,11 +979,76 @@ namespace DTXMania.Test
             Assert.True(mapped.Value.Y < 720 && mapped.Value.Y >= 0);
         }
 
+        [Fact]
+        public void MapMouseToVirtual_WithoutGraphicsManager_ShouldReturnPointAsIs()
+        {
+            // Headless / pre-Initialize: no GraphicsManager means a 1:1 identity mapping so
+            // hit-testing against design-space rects still works instead of crashing.
+            var game = ReflectionHelpers.CreateGame();
+            // _graphicsManager is null by default in CreateGame (not set).
+            Assert.Null(ReflectionHelpers.GetPrivateField<IGraphicsManager>(game, "_graphicsManager"));
+
+            var result = game.MapMouseToVirtual(new Point(300, 200));
+
+            Assert.Equal(new Point(300, 200), result);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_WithGraphicsManagerButNoViewport_ShouldReturnPointAsIs()
+        {
+            // GraphicsManager is set but TryGetViewportBounds returns null (no GraphicsDevice in
+            // headless tests): the 1:1 fallback must still apply so hit-testing doesn't crash.
+            var game = CreateViewportSpyGame();
+            // Set _graphicsManager but leave viewport bounds unset (null) — simulates a game
+            // with a graphics manager but no live GraphicsDevice.
+            ReflectionHelpers.SetPrivateField(game, "_graphicsManager",
+                new StubGraphicsManager(isDeviceAvailable: false, CreateFailingRenderTargetManager()));
+
+            var result = game.MapMouseToVirtual(new Point(300, 200));
+
+            Assert.Equal(new Point(300, 200), result);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_WithViewport_ShouldDelegateToWindowToVirtualCoordinates()
+        {
+            // With a live viewport, MapMouseToVirtual delegates to WindowToVirtualCoordinates.
+            // A test-only subclass overrides the viewport seam with a known 1920x1080 rect so the
+            // 1.5x scale mapping can be asserted without a real GraphicsDevice.
+            var game = CreateViewportSpyGame();
+            game.SetViewportBounds(new Rectangle(0, 0, 1920, 1080));
+
+            var result = game.MapMouseToVirtual(new Point(960, 540));
+
+            // Center of 1920x1080 -> center of 1280x720.
+            Assert.Equal(new Point(640, 360), result);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_WithViewport_OnBlackBars_ShouldReturnNull()
+        {
+            // A click on the letterbox/pillarbox bars (outside the scaled destination) returns
+            // null so callers can treat it as "no hit".
+            var game = CreateViewportSpyGame();
+            game.SetViewportBounds(new Rectangle(0, 0, 1920, 720)); // pillarboxed: left bar [0,320)
+
+            var result = game.MapMouseToVirtual(new Point(100, 360));
+
+            Assert.Null(result);
+        }
+
         private static IConfigManager CreateConfigManager(ConfigData config)
         {
             var configManager = new Mock<IConfigManager>();
             configManager.SetupGet(manager => manager.Config).Returns(config);
             return configManager.Object;
+        }
+
+        private static ViewportSpyGame CreateViewportSpyGame()
+        {
+            var game = ReflectionHelpers.CreateUninitialized<ViewportSpyGame>();
+            ReflectionHelpers.SetPrivateField(game, "_mainThreadActions", new ConcurrentQueue<Action>());
+            return game;
         }
 
         private static RenderTargetManager CreateFailingRenderTargetManager()
@@ -1189,6 +1300,27 @@ namespace DTXMania.Test
             {
                 base.Draw(gameTime);
             }
+        }
+
+        /// <summary>
+        /// Test-only <see cref="BaseGame"/> that overrides the <see cref="BaseGame.TryGetViewportBounds"/>
+        /// seam with a controllable rectangle, so <see cref="BaseGame.MapMouseToVirtual"/> can be
+        /// exercised without a live <see cref="GraphicsDevice"/>.
+        /// </summary>
+        private sealed class ViewportSpyGame : BaseGame
+        {
+            private Rectangle? _viewportBounds;
+
+            public void SetViewportBounds(Rectangle bounds)
+            {
+                _viewportBounds = bounds;
+                // MapMouseToVirtual's first guard checks _graphicsManager; set a non-null stub so
+                // the method proceeds to TryGetViewportBounds instead of short-circuiting.
+                ReflectionHelpers.SetPrivateField(this, "_graphicsManager",
+                    new StubGraphicsManager(isDeviceAvailable: true, CreateFailingRenderTargetManager()));
+            }
+
+            protected override Rectangle? TryGetViewportBounds() => _viewportBounds;
         }
     }
 }

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -550,7 +550,12 @@ namespace DTXMania.Test
             Assert.True(config.FullScreen);
             Assert.False(config.VSyncWait);
             Assert.Same(fakeRenderTarget, ReflectionHelpers.GetPrivateField<object>(game, "_renderTarget"));
-            Assert.Equal(("MainRenderTarget", 1920, 1080), renderTargetManager.LastRequest);
+            // The render target is decoupled from the display resolution: even though the new
+            // settings request 1920x1080, the target is recreated at the fixed virtual size and
+            // letterbox-scaled to the physical window in Draw().
+            Assert.Equal(
+                ("MainRenderTarget", GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight),
+                renderTargetManager.LastRequest);
         }
 
         [Fact]
@@ -580,7 +585,7 @@ namespace DTXMania.Test
         [Fact]
         public void OnGraphicsDeviceReset_WhenRenderTargetRecreationSucceeds_ShouldReplaceRenderTarget()
         {
-            var config = new ConfigData { ScreenWidth = 1280, ScreenHeight = 720 };
+            var config = new ConfigData { ScreenWidth = 640, ScreenHeight = 480 };
             var fakeRenderTarget = ReflectionHelpers.CreateUninitialized<RenderTarget2D>();
             var renderTargetManager = new RecordingRenderTargetManager(fakeRenderTarget);
             var game = CreateGameForLifecycle(config);
@@ -591,7 +596,10 @@ namespace DTXMania.Test
             ReflectionHelpers.InvokePrivateMethod(game, "OnGraphicsDeviceReset", null!, EventArgs.Empty);
 
             Assert.Same(fakeRenderTarget, ReflectionHelpers.GetPrivateField<object>(game, "_renderTarget"));
-            Assert.Equal(("MainRenderTarget", 1280, 720), renderTargetManager.LastRequest);
+            // Recreated at the fixed virtual size, not the 640x480 configured resolution.
+            Assert.Equal(
+                ("MainRenderTarget", GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight),
+                renderTargetManager.LastRequest);
         }
 
         [Fact]
@@ -615,7 +623,10 @@ namespace DTXMania.Test
             game.InvokeBaseDraw(new GameTime());
 
             stageManager.Verify(value => value.Draw(0.0), Times.Once);
-            Assert.Equal(("MainRenderTarget", config.ScreenWidth, config.ScreenHeight), renderTargetManager.LastRequest);
+            // Recreated at the fixed virtual size, independent of the tiny 16x16 configured resolution.
+            Assert.Equal(
+                ("MainRenderTarget", GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight),
+                renderTargetManager.LastRequest);
             Assert.Same(renderTarget, ReflectionHelpers.GetPrivateField<object>(game, "_renderTarget"));
             Assert.True(pendingScreenshot.Task.IsCompletedSuccessfully);
             Assert.Equal(game.CapturedScreenshotToReturn, pendingScreenshot.Task.Result);
@@ -836,6 +847,43 @@ namespace DTXMania.Test
             ReflectionHelpers.SetPrivateField(server, "_cancellationTokenSource", cancellation);
             ReflectionHelpers.SetPrivateField(server, "_isRunning", true);
             return server;
+        }
+
+        [Fact]
+        public void CalculateLetterboxDestination_ExactSixteenByNine_FillsViewportWithNoBars()
+        {
+            // A 16:9 viewport that is an exact multiple of the 1280x720 virtual target
+            // scales up to fill it completely (no black bars).
+            var dest = BaseGame.CalculateLetterboxDestination(new Rectangle(0, 0, 3840, 2160), 1280, 720);
+
+            Assert.Equal(new Rectangle(0, 0, 3840, 2160), dest);
+        }
+
+        [Fact]
+        public void CalculateLetterboxDestination_SameSize_IsIdentity()
+        {
+            var dest = BaseGame.CalculateLetterboxDestination(new Rectangle(0, 0, 1280, 720), 1280, 720);
+
+            Assert.Equal(new Rectangle(0, 0, 1280, 720), dest);
+        }
+
+        [Fact]
+        public void CalculateLetterboxDestination_TallerViewport_LetterboxesVertically()
+        {
+            // 1280x800 (16:10) is the drawable macOS hands back for a 1280x720 fullscreen
+            // request. The image must keep 16:9 aspect and be centered with top/bottom bars,
+            // not stretched vertically to 800px.
+            var dest = BaseGame.CalculateLetterboxDestination(new Rectangle(0, 0, 1280, 800), 1280, 720);
+
+            Assert.Equal(new Rectangle(0, 40, 1280, 720), dest);
+        }
+
+        [Fact]
+        public void CalculateLetterboxDestination_WiderViewport_PillarboxesHorizontally()
+        {
+            var dest = BaseGame.CalculateLetterboxDestination(new Rectangle(0, 0, 1920, 720), 1280, 720);
+
+            Assert.Equal(new Rectangle(320, 0, 1280, 720), dest);
         }
 
         private static IConfigManager CreateConfigManager(ConfigData config)

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1077,6 +1077,27 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void DrawItemList_ShouldWrapTheListInASingleClipRegion()
+    {
+        // Rows near the top/bottom of the scroll extend past the board edges (IsRowVisible only
+        // requires the box to intersect the header→footer band), so the list must be drawn inside
+        // one balanced clip region that confines the overflow to the inner board.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            Assert.Equal(1, stage.BeginItemClipCount);
+            Assert.Equal(1, stage.EndItemClipCount);
+        }
+    }
+
+    [Fact]
     public void DrawItemList_WhenFocusOnMenu_ShouldNotDrawItemCursor()
     {
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
@@ -1813,6 +1834,9 @@ public class ConfigStageLogicTests
 
         public List<(Rectangle Rectangle, Color Color)> RectangleDrawCalls { get; } = [];
 
+        public int BeginItemClipCount { get; private set; }
+        public int EndItemClipCount { get; private set; }
+
         public void InitializeDrawingState()
         {
             var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
@@ -1831,6 +1855,20 @@ public class ConfigStageLogicTests
 
         protected override void EndDrawFrame()
         {
+        }
+
+        // The item-list clip flushes and reopens the real SpriteBatch and touches the
+        // GraphicsDevice scissor state; the spy uses an uninitialized SpriteBatch, so no-op the
+        // clip hooks (mirrors BeginDrawFrame/EndDrawFrame) and only count them so a test can assert
+        // the list is wrapped in a single balanced clip region.
+        protected override void BeginItemClip()
+        {
+            BeginItemClipCount++;
+        }
+
+        protected override void EndItemClip()
+        {
+            EndItemClipCount++;
         }
 
         protected override void DrawFilledRectangle(Rectangle destinationRectangle, Color color)

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -2080,7 +2080,7 @@ public class ConfigStageLogicTests
             LastDeltaTime = deltaTime;
         }
 
-        public void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont, Texture2D? whitePixel, int viewportWidth, int viewportHeight)
+        public void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont, Texture2D? whitePixel, int virtualWidth, int virtualHeight)
         {
             DrawCallCount++;
         }

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -407,10 +407,6 @@ public class ConfigStageLogicTests
             var normalRect = ConfigUILayout.ItemBoxRect(navRowTopY, ConfigUILayout.ItemBoxNormalWidth);
             Assert.Contains(stage.RectangleDrawCalls,
                 c => c.Rectangle == normalRect && c.Color == new Color(34, 40, 68, 200));
-
-            // The narrower "other" box must no longer be used for any row.
-            var otherRect = ConfigUILayout.ItemBoxRect(navRowTopY, ConfigUILayout.ItemBoxOtherWidth);
-            Assert.DoesNotContain(stage.RectangleDrawCalls, c => c.Rectangle == otherRect);
         }
     }
 

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -2188,20 +2188,26 @@ public class ConfigStageLogicTests
 
         // The item-list clip flushes and reopens the real SpriteBatch and touches the
         // GraphicsDevice scissor state; the spy uses an uninitialized SpriteBatch and has no
-        // GraphicsDevice, so skip the SpriteBatch.End/Begin calls but still exercise the same
-        // scissor-application seam production uses (ApplyScissorRectangle(GetItemClipRectangle()))
-        // so a test can assert the clip rect matches the inner board. Count the calls so a test can
-        // assert the list is wrapped in a single balanced clip region.
-        protected override void BeginItemClip()
+        // GraphicsDevice, so no-op the SpriteBatch.End/Begin seams but still let production's
+        // BeginItemClip/EndItemClip run for real — exercising the ApplyScissorRectangle(
+        // GetItemClipRectangle()) wiring that confines rows to the board. Count the flush calls so
+        // a test can assert the list is wrapped in a single balanced clip region.
+        protected override void FlushCurrentBatch()
         {
-            ApplyScissorRectangle(GetItemClipRectangle());
             BeginItemClipCount++;
         }
 
-        protected override void EndItemClip()
+        protected override void BeginClippedBatch(RasterizerState rasterizer)
         {
-            RestoreScissorRectangle();
+        }
+
+        protected override void FlushClippedBatch()
+        {
             EndItemClipCount++;
+        }
+
+        protected override void BeginDefaultBatch()
+        {
         }
 
         // Record the rect instead of touching a (null) GraphicsDevice.

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1095,6 +1095,45 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void DrawItemList_ShouldClipToTheInnerBoardRectangle()
+    {
+        // Regression guard for the "zero spill past the board" invariant: the scissor rect
+        // applied during the item-list clip must equal the inner board the rows slide under.
+        // A future change to the clip rect (or to the board rect it must match) would otherwise
+        // pass silently with green tests.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            Assert.NotNull(stage.LastAppliedScissorRectangle);
+            Assert.Equal(ConfigUILayout.InnerBoardRect, stage.LastAppliedScissorRectangle!.Value);
+        }
+    }
+
+    [Fact]
+    public void ItemClipRasterizer_ShouldEnableScissorTest()
+    {
+        // Regression guard for the scissor-test invariant: the rasterizer used for the clipped
+        // item-list batch must have ScissorTestEnable = true, otherwise the clip rect has no
+        // effect and rows spill past the board. CullMode.None keeps SpriteBatch quads visible
+        // regardless of winding.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            var rasterizer = stage.GetItemClipRasterizerForTest();
+
+            Assert.True(rasterizer.ScissorTestEnable);
+            Assert.Equal(CullMode.None, rasterizer.CullMode);
+        }
+    }
+
+    [Fact]
     public void DrawItemList_WhenFocusOnMenu_ShouldNotDrawItemCursor()
     {
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
@@ -2119,6 +2158,14 @@ public class ConfigStageLogicTests
         public int BeginItemClipCount { get; private set; }
         public int EndItemClipCount { get; private set; }
 
+        // The scissor rect applied by BeginItemClip, recorded via the ApplyScissorRectangle seam
+        // so a test can assert it matches the inner board (the "zero spill past the board"
+        // invariant) without a real GraphicsDevice.
+        public Rectangle? LastAppliedScissorRectangle { get; private set; }
+
+        // Exposes the pure rasterizer seam so a test can assert ScissorTestEnable is set.
+        public RasterizerState GetItemClipRasterizerForTest() => CreateItemClipRasterizer();
+
         public void InitializeDrawingState()
         {
             var spriteBatch = ReflectionHelpers.CreateUninitialized<SpriteBatch>();
@@ -2140,17 +2187,32 @@ public class ConfigStageLogicTests
         }
 
         // The item-list clip flushes and reopens the real SpriteBatch and touches the
-        // GraphicsDevice scissor state; the spy uses an uninitialized SpriteBatch, so no-op the
-        // clip hooks (mirrors BeginDrawFrame/EndDrawFrame) and only count them so a test can assert
-        // the list is wrapped in a single balanced clip region.
+        // GraphicsDevice scissor state; the spy uses an uninitialized SpriteBatch and has no
+        // GraphicsDevice, so skip the SpriteBatch.End/Begin calls but still exercise the same
+        // scissor-application seam production uses (ApplyScissorRectangle(GetItemClipRectangle()))
+        // so a test can assert the clip rect matches the inner board. Count the calls so a test can
+        // assert the list is wrapped in a single balanced clip region.
         protected override void BeginItemClip()
         {
+            ApplyScissorRectangle(GetItemClipRectangle());
             BeginItemClipCount++;
         }
 
         protected override void EndItemClip()
         {
+            RestoreScissorRectangle();
             EndItemClipCount++;
+        }
+
+        // Record the rect instead of touching a (null) GraphicsDevice.
+        protected override void ApplyScissorRectangle(Rectangle rect)
+        {
+            LastAppliedScissorRectangle = rect;
+        }
+
+        // No GraphicsDevice to restore in the spy.
+        protected override void RestoreScissorRectangle()
+        {
         }
 
         protected override void DrawFilledRectangle(Rectangle destinationRectangle, Color color)

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -348,10 +348,12 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void DrawBackground_ShouldFillViewportWithBackgroundColor()
+    public void DrawBackground_ShouldFillFixedVirtualRectRegardlessOfViewport()
     {
-        var viewport = new Viewport(0, 0, 1280, 720);
-        var (stage, inputManager) = CreateRenderSpyStage(viewport);
+        // The background is drawn at the fixed 1280x720 virtual rect; the frame-wide viewport
+        // transform scales it to fill the screen. Drawing at raw viewport size would stretch it
+        // out of aspect, so even a 4K viewport must still produce a (0,0,1280,720) fill.
+        var (stage, inputManager) = CreateRenderSpyStage(new Viewport(0, 0, 3840, 2160));
         using (inputManager)
         {
             stage.InitializeDrawingState();
@@ -359,10 +361,55 @@ public class ConfigStageLogicTests
             _ = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawConfigBackground"));
 
             var drawCall = Assert.Single(stage.RectangleDrawCalls);
-            Assert.Equal(new Rectangle(0, 0, viewport.Width, viewport.Height), drawCall.Rectangle);
+            Assert.Equal(ConfigUILayout.BackgroundRect, drawCall.Rectangle);
             // Must match ConfigStage.FallbackBackgroundColor: dark fill keeps LightText legible
             // when the background texture is unavailable (light-on-dark is the NX aesthetic).
             Assert.Equal(new Color(18, 20, 34), drawCall.Color);
+        }
+    }
+
+    [Fact]
+    public void DrawInnerBoard_ShouldFillBorderThenBoardRects()
+    {
+        // The inner board is a dark translucent frame over the background that contains the
+        // config content so it stays readable against the busy GALAXY WAVE background.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawInnerBoard");
+
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.InnerBoardBorderRect && c.Color == new Color(74, 62, 150, 224));
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.InnerBoardRect && c.Color == new Color(8, 10, 22, 196));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_ForNavigationItem_ShouldUseNormalItemBoxWidth()
+    {
+        // Navigation items (System Key Mapping / Import NX Scores / Drum Key Mapping) must use the
+        // same normal itembox as value items so the list reads uniformly — never the narrower
+        // "other" box, which made them look out of place.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System (index 5 = System Key Mapping)
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            var navRowTopY = ConfigUILayout.RowTopY(5, 0.0);
+            var normalRect = ConfigUILayout.ItemBoxRect(navRowTopY, ConfigUILayout.ItemBoxNormalWidth);
+            Assert.Contains(stage.RectangleDrawCalls,
+                c => c.Rectangle == normalRect && c.Color == new Color(34, 40, 68, 200));
+
+            // The narrower "other" box must no longer be used for any row.
+            var otherRect = ConfigUILayout.ItemBoxRect(navRowTopY, ConfigUILayout.ItemBoxOtherWidth);
+            Assert.DoesNotContain(stage.RectangleDrawCalls, c => c.Rectangle == otherRect);
         }
     }
 
@@ -1391,7 +1438,8 @@ public class ConfigStageLogicTests
             stage.InitializeDrawingState();
             ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
             ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
-            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
+            // Panel only renders on item focus (matches NX); menu focus draws nothing.
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
 
@@ -1521,32 +1569,33 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void DrawDescriptionPanel_WhenFocusOnMenu_ShouldDrawCategoryDescription()
+    public void DrawDescriptionPanel_WhenFocusOnMenu_ShouldNotDrawPanel()
     {
-        // Spec requirement: while focus = Menu, the description panel shows the focused
-        // category's Description. The render spy nulls the font, so this injects a mock
-        // font to capture the DrawString text content — the one spec assertion the
-        // fallback-rect tests can't cover.
+        // NX only shows the description panel while focus is on the item list, not while browsing
+        // the category menu (CStageConfig.cs:260). On menu focus nothing is drawn — no panel
+        // background and no text — so the entry view stays clear and the panel never overlaps the
+        // item boxes.
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
         using (inputManager)
         {
             stage.InitializeDrawingState();
             ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
-            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
             var mockFont = new Moq.Mock<IFont>();
             mockFont.Setup(f => f.MeasureString(Moq.It.IsAny<string>())).Returns(new Vector2(1, 1));
             ReflectionHelpers.SetPrivateField(stage, "_font", mockFont.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", mockFont.Object);
 
             ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0); // System
             ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", true);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
 
-            var expected = categories![0].Description;
+            Assert.DoesNotContain(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.DescriptionPanelRect);
             mockFont.Verify(
-                f => f.DrawString(Moq.It.IsAny<SpriteBatch>(), expected,
+                f => f.DrawString(Moq.It.IsAny<SpriteBatch>(), Moq.It.IsAny<string>(),
                     Moq.It.IsAny<Vector2>(), Moq.It.IsAny<Color>()),
-                Moq.Times.Once);
+                Moq.Times.Never);
         }
     }
 

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
 using DTXMania.Game.Lib.Input;
@@ -1765,6 +1766,180 @@ public class ConfigStageLogicTests
 
             Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"));
         }
+    }
+
+    // ---- Patch coverage: DrawCategoryMenu text loop, DrawItemList texture/scroll paths ----
+
+    [Fact]
+    public void DrawCategoryMenu_WithFonts_ShouldDrawSelectedCategoryLabelInSelectedColor()
+    {
+        // The text loop (lines after the null-font guard) centers each category label on the
+        // menu panel and vertically within the cursor band. The selected category uses
+        // SelectedMenuText; unselected uses LightText. This covers the font.MeasureString /
+        // font.DrawString path that the null-font RenderSpy tests skip.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 1); // Drums (selected)
+
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(60f, 16f));
+            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", font.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawCategoryMenu");
+
+            // The selected category (Drums, index 1) is drawn with SelectedMenuText.
+            var cursor = ConfigUILayout.MenuCursorRect(1);
+            var expectedPos = new Vector2(
+                ConfigUILayout.MenuLabelCenterX - 60f / 2f,
+                cursor.Y + (ConfigUILayout.MenuCursorHeight - 16f) / 2f);
+            font.Verify(
+                f => f.DrawString(It.IsAny<SpriteBatch>(), "Drums",
+                    It.Is<Vector2>(p => Math.Abs(p.X - expectedPos.X) < 0.01f && Math.Abs(p.Y - expectedPos.Y) < 0.01f),
+                    It.Is<Color>(c => c == new Color(36, 24, 72))),
+                Times.Once,
+                "selected category label should be centered in the cursor band with SelectedMenuText");
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WithItemBoxTexture_ShouldDrawTextureInsteadOfFallback()
+    {
+        // When _itemBoxTexture has a valid Texture, the box pass draws it via spriteBatch.Draw
+        // instead of the fallback fill. The RenderSpy's SpriteBatch is uninitialized so
+        // spriteBatch.Draw throws; we catch that and verify the fallback fill was NOT called,
+        // proving the texture-present branch was taken.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+
+            var mockTexture = new Mock<ITexture>();
+            mockTexture.SetupGet(t => t.Width).Returns(256);
+            mockTexture.SetupGet(t => t.Height).Returns(32);
+            mockTexture.SetupGet(t => t.Texture).Returns(CreateFakeTexture2D());
+            ReflectionHelpers.SetPrivateField(stage, "_itemBoxTexture", mockTexture.Object);
+
+            _ = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList"));
+
+            // The fallback fill must NOT be used for row 0 when the texture is present.
+            var row0Rect = ConfigUILayout.ItemBoxRect(
+                ConfigUILayout.RowTopY(0, 0.0), ConfigUILayout.ItemBoxNormalWidth);
+            Assert.DoesNotContain(stage.RectangleDrawCalls,
+                c => c.Rectangle == row0Rect && c.Color == new Color(34, 40, 68, 200));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WithItemBoxCursorTexture_ShouldDrawTextureInsteadOfFallback()
+    {
+        // When _itemBoxCursorTexture has a valid Texture and focus is on items, the fixed cursor
+        // draws the texture instead of the fallback fill. Same uninitialized-SpriteBatch approach
+        // as the box-texture test above.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            var mockTexture = new Mock<ITexture>();
+            mockTexture.SetupGet(t => t.Width).Returns(256);
+            mockTexture.SetupGet(t => t.Height).Returns(32);
+            mockTexture.SetupGet(t => t.Texture).Returns(CreateFakeTexture2D());
+            ReflectionHelpers.SetPrivateField(stage, "_itemBoxCursorTexture", mockTexture.Object);
+
+            _ = Record.Exception(() => ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList"));
+
+            // The cursor fallback fill must NOT appear when the texture is present.
+            Assert.DoesNotContain(stage.RectangleDrawCalls,
+                c => c.Rectangle == ConfigUILayout.ItemCursorRect && c.Color == new Color(96, 96, 160, 180));
+        }
+    }
+
+    [Fact]
+    public void DrawItemList_WithScrolledList_ShouldSkipOffscreenRows()
+    {
+        // When _itemScroll is large (e.g. scrolled to the last item), early rows fall outside the
+        // visible band and IsRowVisible returns false -> continue. This covers the skip branch in
+        // both the box pass and the text pass. Mock fonts are set so the text pass is reached
+        // (it early-returns when _font/_boldFont are null).
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            // Scroll to the last item so row 0 is well above the visible band.
+            var lastIndex = categories[0].Items.Count - 1;
+            categories[0].SelectedIndex = lastIndex;
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", (double)lastIndex);
+
+            // Set mock fonts so the text pass is reached (not short-circuited by the null guard).
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
+            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", font.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            // Row 0's box rect (at the scrolled position) must not be drawn — it's offscreen.
+            var row0TopY = ConfigUILayout.RowTopY(0, (double)lastIndex);
+            var row0Rect = ConfigUILayout.ItemBoxRect(row0TopY, ConfigUILayout.ItemBoxNormalWidth);
+            Assert.DoesNotContain(stage.RectangleDrawCalls, c => c.Rectangle == row0Rect);
+        }
+    }
+
+    [Fact]
+    public void DrawDescriptionPanel_WithBoldFont_ShouldDrawSelectedItemTitle()
+    {
+        // The title (selected item's name) is drawn on the white upper cell of the description
+        // panel with DescriptionTitleText via _boldFont. This covers the boldFont.DrawString title
+        // path that the null-boldFont tests skip.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            categories![0].SelectedIndex = 0; // Screen Resolution
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            var boldFont = new Mock<IFont>();
+            boldFont.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(100f, 16f));
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", boldFont.Object);
+            // _font must be non-null too so the body text path doesn't NRE.
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(1f, 1f));
+            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawDescriptionPanel");
+
+            var expectedTitle = categories[0].SelectedItem!.Name;
+            boldFont.Verify(
+                f => f.DrawString(It.IsAny<SpriteBatch>(), expectedTitle,
+                    ConfigUILayout.DescriptionTitlePos,
+                    It.Is<Color>(c => c == new Color(24, 24, 32))),
+                Times.Once,
+                "title should be drawn with DescriptionTitleText via boldFont");
+        }
+    }
+
+    private static Texture2D CreateFakeTexture2D()
+    {
+#pragma warning disable SYSLIB0050
+        var tex = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+#pragma warning restore SYSLIB0050
+        GC.SuppressFinalize(tex);
+        return tex;
     }
 
     private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -13,6 +13,7 @@ using DTXMania.Game.Lib.Stage.Config;
 using DTXMania.Game.Lib.Stage.KeyAssign;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Utilities;
+using DTXMania.Test.Helpers;
 using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -1338,17 +1339,40 @@ public class ConfigStageLogicTests
         Assert.Equal(">", InvokeGetItemValueText(item));
     }
 
+#if DEBUG
+    [Fact]
+    public void GetItemValueText_WhenDisplayTextDoesNotStartWithPrefix_ShouldFailDebugAssertion()
+    {
+        // A future item type whose GetDisplayText omits the "{Name}: " prefix is a bug.
+        // GetItemValueText fires a Debug.Assert so the mismatch is caught at development
+        // time. The throwing trace listener converts the assertion into an exception so it
+        // surfaces as a test failure instead of a modal dialog that hangs the run.
+        // InvokeGetItemValueText uses reflection, so the assertion exception is wrapped in a
+        // TargetInvocationException — unwrap and assert the inner exception type.
+        var item = new Mock<IConfigItem>();
+        item.SetupGet(i => i.Name).Returns("X");
+        item.Setup(i => i.GetDisplayText()).Returns("no prefix here");
+
+        using (ThrowingTraceListener.Install())
+        {
+            var wrapped = Assert.Throws<TargetInvocationException>(
+                () => InvokeGetItemValueText(item.Object));
+            Assert.IsType<DebugAssertFailedException>(wrapped.InnerException);
+        }
+    }
+#else
     [Fact]
     public void GetItemValueText_WhenDisplayTextDoesNotStartWithPrefix_ShouldReturnEmpty()
     {
-        // Defensive: a future item type whose GetDisplayText omits the "{Name}: " prefix renders
-        // an empty value column rather than echoing the whole display string into the value slot.
+        // In release builds the Debug.Assert is compiled out, so the defensive empty-string
+        // fallback is the only behavior.
         var item = new Mock<IConfigItem>();
         item.SetupGet(i => i.Name).Returns("X");
         item.Setup(i => i.GetDisplayText()).Returns("no prefix here");
 
         Assert.Equal(string.Empty, InvokeGetItemValueText(item.Object));
     }
+#endif
 
     private static string InvokeGetItemValueText(IConfigItem item)
     {

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -350,10 +350,10 @@ public class ConfigStageLogicTests
     [Fact]
     public void DrawBackground_ShouldFillFixedVirtualRectRegardlessOfViewport()
     {
-        // The background is drawn at the fixed 1280x720 virtual rect; the frame-wide viewport
-        // transform scales it to fill the screen. Drawing at raw viewport size would stretch it
-        // out of aspect, so even a 4K viewport must still produce a (0,0,1280,720) fill.
-        var (stage, inputManager) = CreateRenderSpyStage(new Viewport(0, 0, 3840, 2160));
+        // The background is drawn at the fixed 1280x720 virtual rect; BaseGame letterboxes the
+        // 1280x720 render target to the window once. Drawing at raw viewport size would stretch it
+        // out of aspect, so the fill must always be the (0,0,1280,720) virtual rect.
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
         using (inputManager)
         {
             stage.InitializeDrawingState();
@@ -1650,6 +1650,123 @@ public class ConfigStageLogicTests
         }
     }
 
+    [Fact]
+    public void UpdateItemScroll_EmptyCategories_ShouldEarlyReturnAndLeaveScrollUnchanged()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            // No SetupConfigItems: leave _categories empty so the guard returns immediately.
+            ReflectionHelpers.SetPrivateField(stage, "_categories", new List<ConfigCategory>());
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", 5.0);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateItemScroll", 0.016);
+
+            Assert.Equal(5.0, ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"));
+        }
+    }
+
+    [Fact]
+    public void UpdateItemScroll_LargeDelta_ShouldSnapToTarget()
+    {
+        // A wrap/multi-row jump (|delta| > 1.5) snaps instead of scrolling the whole list.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            categories[0].SelectedIndex = categories[0].Items.Count - 1; // a far row
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", 0.0);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateItemScroll", 0.016);
+
+            Assert.Equal((double)categories[0].SelectedIndex,
+                ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"));
+        }
+    }
+
+    [Fact]
+    public void UpdateItemScroll_SmallDelta_SmallDeltaTime_ShouldEasePartially()
+    {
+        // |delta| <= 1.5 eases: factor = min(1, dt*15). dt=0.04 -> factor=0.6, delta=1.0 ->
+        // scroll advances by 0.6 and does NOT yet reach the target.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            categories[0].SelectedIndex = 1;
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", 0.0);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateItemScroll", 0.04);
+
+            Assert.Equal(0.6, ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"), precision: 6);
+        }
+    }
+
+    [Fact]
+    public void UpdateItemScroll_SmallDelta_LargeDeltaTime_ShouldReachAndSnapToTarget()
+    {
+        // dt=1.0 -> factor=min(1,15)=1.0, so the full delta is applied in one step, then the
+        // sub-0.01 residual snaps to the exact target.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            categories[0].SelectedIndex = 1;
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", 0.0);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateItemScroll", 1.0);
+
+            Assert.Equal(1.0, ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"));
+        }
+    }
+
+    [Fact]
+    public void UpdateItemScroll_WithinSnapThreshold_ShouldClampToTarget()
+    {
+        // After the ease step the residual is < 0.01, so the value clamps to the exact target
+        // rather than leaving a tiny fractional drift.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            categories[0].SelectedIndex = 1;
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", 0.999);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateItemScroll", 0.001);
+
+            Assert.Equal(1.0, ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"));
+        }
+    }
+
+    [Fact]
+    public void UpdateItemScroll_EmptyCategory_ShouldTargetZero()
+    {
+        // A category with no items (e.g. Exit) targets 0 regardless of SelectedIndex.
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories")!;
+            var emptyCategory = categories.FirstOrDefault(c => !c.HasItems);
+            Assert.NotNull(emptyCategory);
+            var emptyIndex = categories.IndexOf(emptyCategory!);
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", emptyIndex);
+            ReflectionHelpers.SetPrivateField(stage, "_itemScroll", 3.0);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "UpdateItemScroll", 1.0);
+
+            Assert.Equal(0.0, ReflectionHelpers.GetPrivateField<double>(stage, "_itemScroll"));
+        }
+    }
+
     private static (ConfigStage Stage, ConfigManager ConfigManager, InputManagerCompat InputManager) CreateStage(ConfigManager? configManager = null)
     {
         configManager ??= new ConfigManager();
@@ -1661,16 +1778,13 @@ public class ConfigStageLogicTests
     }
 
     private static (RenderSpyConfigStage Stage, InputManagerCompat InputManager) CreateRenderSpyStageWithGraphicsDevice(ConfigManager? configManager = null)
-        => CreateRenderSpyStage(new Viewport(0, 0, 1280, 720), configManager);
-
-    private static (RenderSpyConfigStage Stage, InputManagerCompat InputManager) CreateRenderSpyStage(Viewport viewport, ConfigManager? configManager = null)
     {
         configManager ??= new ConfigManager();
         var inputManager = new InputManagerCompat(configManager, new TestMidiDeviceBackend());
         var game = ReflectionHelpers.CreateGame();
         ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
         ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
-        return (new RenderSpyConfigStage(game, viewport), inputManager);
+        return (new RenderSpyConfigStage(game), inputManager);
     }
 
     private static (ConfigStage Stage, InputManagerCompat InputManager) CreateLifecycleStage(ConfigManager? configManager = null)
@@ -1824,12 +1938,9 @@ public class ConfigStageLogicTests
 
     private sealed class RenderSpyConfigStage : ConfigStage
     {
-        private readonly Viewport _viewport;
-
-        public RenderSpyConfigStage(BaseGame game, Viewport viewport)
+        public RenderSpyConfigStage(BaseGame game)
             : base(game)
         {
-            _viewport = viewport;
         }
 
         public List<(Rectangle Rectangle, Color Color)> RectangleDrawCalls { get; } = [];
@@ -1874,11 +1985,6 @@ public class ConfigStageLogicTests
         protected override void DrawFilledRectangle(Rectangle destinationRectangle, Color color)
         {
             RectangleDrawCalls.Add((destinationRectangle, color));
-        }
-
-        protected override Viewport GetViewport()
-        {
-            return _viewport;
         }
     }
 }

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -1009,8 +1009,10 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void DrawItemList_WhenFocusOnItems_ShouldDrawItemCursorAtSelectedRow()
+    public void DrawItemList_WhenFocusOnItems_ShouldDrawFixedItemCursor()
     {
+        // The cursor is locked to the focus row (items scroll under it), so it always renders at
+        // the fixed ItemCursorRect regardless of which item is selected.
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
         using (inputManager)
         {
@@ -1023,7 +1025,7 @@ public class ConfigStageLogicTests
 
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
 
-            Assert.Contains(stage.RectangleDrawCalls, c => c.Rectangle == ConfigUILayout.ItemCursorRect(2));
+            Assert.Contains(stage.RectangleDrawCalls, c => c.Rectangle == ConfigUILayout.ItemCursorRect);
         }
     }
 
@@ -1041,7 +1043,7 @@ public class ConfigStageLogicTests
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
 
             Assert.DoesNotContain(stage.RectangleDrawCalls,
-                c => c.Rectangle == ConfigUILayout.ItemCursorRect(0));
+                c => c.Rectangle == ConfigUILayout.ItemCursorRect);
         }
     }
 
@@ -1253,11 +1255,11 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void DrawItemList_ShouldRightAlignValuesWithinTheBox()
+    public void DrawItemList_ShouldDrawValuesAtTheValueColumn()
     {
-        // Values anchor at the box's right inner edge (ItemValueRightX) so they never overflow the
-        // box and never run under the description panel drawn afterward at x=800. A fixed-width
-        // mock font lets us assert the exact right-aligned x position.
+        // Values left-align at the fixed value column (ItemListX + ItemValueOffsetX = 680), which
+        // sits on the itembox's white value cell. A fixed-width mock font keeps the value short so
+        // no truncation occurs and we can assert the exact left-aligned x.
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
         using (inputManager)
         {
@@ -1266,33 +1268,27 @@ public class ConfigStageLogicTests
             ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
 
-            const float measuredWidth = 80f;
             var font = new Mock<IFont>();
-            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(measuredWidth, 14f));
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
             ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
             ReflectionHelpers.SetPrivateField(stage, "_boldFont", font.Object);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
 
-            // Value x = right anchor (766) minus measured width (80) = 686. Names are drawn at the
-            // fixed ItemNamePos (x=454), so only the right-aligned values land at 686.
-            var expectedValueX = ConfigUILayout.ItemValueRightX - measuredWidth;
+            var expectedValueX = ConfigUILayout.ItemListX + ConfigUILayout.ItemValueOffsetX; // 680
             font.Verify(f => f.DrawString(It.IsAny<SpriteBatch>(), It.IsAny<string>(),
                 It.Is<Vector2>(p => Math.Abs(p.X - expectedValueX) < 0.01f), It.IsAny<Color>()),
                 Times.AtLeastOnce,
-                "value text should be right-aligned within the item box");
+                "value text should be left-aligned at the value column on the white cell");
         }
     }
 
     [Fact]
-    public void DrawItemList_WhenValueExceedsAvailableWidth_ShouldEllipsizeBeforeRightAligning()
+    public void DrawItemList_WhenValueExceedsAvailableWidth_ShouldEllipsizeToFitTheValueColumn()
     {
-        // A value wider than the gap between the name's left edge and the value's right anchor
-        // (ItemValueMaxWidth) must be ellipsized before the right-aligned position is computed.
-        // Otherwise valuePos.X = ItemValueRightX - fullWidth moves left of the name and, since the
-        // value is drawn after the name, overwrites it (e.g. the default macOS DTXPath under
-        // ~/Library/Application Support/...). The per-character mock font makes the overflow
-        // deterministic: 8px/char means a 56-char path measures 448px > 312px available.
+        // A value wider than the value column's budget (ItemValueMaxWidth) must be ellipsized so it
+        // stays on the white value cell and clear of the description panel (x=800). The
+        // per-character mock font makes the overflow deterministic: 8px/char.
         var longPath = "/Users/testuser/Library/Application Support/DTXManiaCX/DTXFiles";
         var configManager = new ConfigManager { Config = { DTXPath = longPath } };
         var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice(configManager);
@@ -1317,30 +1313,16 @@ public class ConfigStageLogicTests
 
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
 
-            // No text may start left of the name column: names sit at ItemNamePos.X (454) and
-            // right-aligned values must not cross that boundary.
-            var nameLeftX = ConfigUILayout.ItemNamePos(0).X;
-            Assert.All(draws, d => Assert.True(d.Position.X >= nameLeftX - 0.01f,
-                $"text \"{d.Text}\" drawn at x={d.Position.X} crosses left of the name column at x={nameLeftX}"));
-
-            // The long DTX path value must be ellipsized (ends with "...") and fit the available width.
+            // The long DTX path value must be ellipsized (ends with "...") and fit the value column.
             var pathDraw = draws.Single(d => d.Text.StartsWith("/Users/", StringComparison.Ordinal));
             Assert.EndsWith("...", pathDraw.Text);
             Assert.True(font.Object.MeasureString(pathDraw.Text).X <= ConfigUILayout.ItemValueMaxWidth + 0.01f,
                 $"ellipsized value width must fit ItemValueMaxWidth ({ConfigUILayout.ItemValueMaxWidth})");
 
-            // The value is drawn after the name, so its left edge must sit strictly right of the
-            // name's right edge plus the reserved gap. Reserving only the name's left edge (the
-            // static ItemValueMaxWidth) lets the value's left edge reach that same X and overwrite
-            // the name's glyphs (e.g. a deep macOS DTXPath overwriting the "DTX Folder" label).
-            // Per-character mock font: "DTX Folder" (10 chars) measures 80px -> right edge at 534.
-            var folderNameDraw = draws.Single(d => d.Text == "DTX Folder");
-            var folderNameRightEdge = folderNameDraw.Position.X
-                + font.Object.MeasureString("DTX Folder").X;
-            var expectedValueLeftFloor = folderNameRightEdge + ConfigUILayout.ItemValueNameGap;
-            Assert.True(pathDraw.Position.X >= expectedValueLeftFloor - 0.01f,
-                $"value drawn at x={pathDraw.Position.X} overlaps the name (right edge {folderNameRightEdge}) "
-                + $"+ gap ({ConfigUILayout.ItemValueNameGap}); expected >= {expectedValueLeftFloor}");
+            // The value is left-aligned at the value column (680), well clear of the name column (440).
+            var expectedValueX = ConfigUILayout.ItemListX + ConfigUILayout.ItemValueOffsetX;
+            Assert.True(Math.Abs(pathDraw.Position.X - expectedValueX) < 0.01f,
+                $"value drawn at x={pathDraw.Position.X}; expected the value column at x={expectedValueX}");
         }
     }
 
@@ -1374,8 +1356,11 @@ public class ConfigStageLogicTests
             ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
 
             // Every item row should get a fallback fill when its box texture is unavailable.
+            // Item 0 (Screen Resolution) uses the normal box at the settled focus row.
+            var row0Rect = ConfigUILayout.ItemBoxRect(
+                ConfigUILayout.RowTopY(0, 0.0), ConfigUILayout.ItemBoxNormalWidth);
             Assert.Contains(stage.RectangleDrawCalls,
-                c => c.Rectangle == ConfigUILayout.ItemRowRect(0) && c.Color == new Color(34, 40, 68, 200));
+                c => c.Rectangle == row0Rect && c.Color == new Color(34, 40, 68, 200));
         }
     }
 

--- a/DTXMania.Test/Config/KeyAssignPanelCoverageTests.cs
+++ b/DTXMania.Test/Config/KeyAssignPanelCoverageTests.cs
@@ -296,6 +296,25 @@ public class KeyAssignPanelCoverageTests
         return tex;
     }
 
+    [Theory]
+    [InlineData(InputCommandType.MoveUp, "Move Up")]
+    [InlineData(InputCommandType.MoveDown, "Move Down")]
+    [InlineData(InputCommandType.MoveLeft, "Move Left")]
+    [InlineData(InputCommandType.MoveRight, "Move Right")]
+    [InlineData(InputCommandType.Activate, "Activate")]
+    [InlineData(InputCommandType.Back, "Back")]
+    [InlineData(InputCommandType.IncreaseScrollSpeed, "Increase Scroll Speed")]
+    [InlineData(InputCommandType.DecreaseScrollSpeed, "Decrease Scroll Speed")]
+    [InlineData(InputCommandType.OpenSearch, "Open Search")]
+    public void FormatActionName_ShouldHumanizeEnumNames(InputCommandType action, string expected)
+    {
+        var method = typeof(SystemKeyAssignPanel).GetMethod(
+            "FormatActionName", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var result = (string)method!.Invoke(null, new object[] { action })!;
+        Assert.Equal(expected, result);
+    }
+
     /// <summary>
     /// Test-only <see cref="SystemKeyAssignPanel"/> that overrides the <see cref="SystemKeyAssignPanel.DrawWhitePixel"/>
     /// seam to record draw calls instead of hitting the uninitialized SpriteBatch.

--- a/DTXMania.Test/Config/KeyAssignPanelCoverageTests.cs
+++ b/DTXMania.Test/Config/KeyAssignPanelCoverageTests.cs
@@ -197,4 +197,122 @@ public class KeyAssignPanelCoverageTests
             return sb;
         }
     }
+
+    // ---- Patch coverage: whitePixel rendering + conflict message drawing ----
+
+    [Fact]
+    public void SystemPanel_Draw_WithWhitePixel_ShouldDrawBackdropBoardAndSelectionBar()
+    {
+        // With a non-null whitePixel, the Draw method renders the backdrop dim, the framed board
+        // (border + fill), and the selected row's selection bar — all via the DrawWhitePixel seam.
+        // The spy overrides DrawWhitePixel to record calls instead of hitting the uninitialized
+        // SpriteBatch.
+        using var inputManager = new InputManager();
+        var panel = new SpySystemKeyAssignPanel(inputManager);
+        panel.Activate();
+        ReflectionHelpers.SetPrivateField(panel, "_selectedIndex", 0); // first action row (selected)
+
+        var spriteBatch = FakeSpriteBatch.Create();
+        var fontMock = new Mock<IFont>();
+        fontMock.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
+        var boldFontMock = new Mock<IFont>();
+        boldFontMock.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
+        var whitePixel = CreateFakeTexture2D();
+
+        panel.Draw(spriteBatch, fontMock.Object, boldFontMock.Object, whitePixel, 1280, 720);
+
+        // Backdrop: full viewport dim.
+        Assert.Contains(panel.WhitePixelDraws,
+            d => d.Rectangle == new Rectangle(0, 0, 1280, 720) && d.Color == new Color(0, 0, 0, 200));
+        // Board border (4px larger than the board) and board fill.
+        Assert.Contains(panel.WhitePixelDraws, d => d.Color == new Color(74, 62, 150, 235));
+        Assert.Contains(panel.WhitePixelDraws, d => d.Color == new Color(14, 16, 34, 236));
+        // Selection bar on the first row.
+        Assert.Contains(panel.WhitePixelDraws, d => d.Color == new Color(120, 92, 30, 190));
+    }
+
+    [Fact]
+    public void SystemPanel_Draw_WithWhitePixel_ShouldDrawFooterButtonBackgrounds()
+    {
+        // DrawFooterButton draws a border rect and a fill rect (selected or unselected) via the
+        // DrawWhitePixel seam when whitePixel is non-null.
+        using var inputManager = new InputManager();
+        var panel = new SpySystemKeyAssignPanel(inputManager);
+        panel.Activate();
+        // Select the SAVE footer button so its fill uses SelectionBarColor.
+        ReflectionHelpers.SetPrivateField(panel, "_selectedIndex",
+            GetStaticIntField(typeof(SystemKeyAssignPanel), "FooterSave"));
+
+        var spriteBatch = FakeSpriteBatch.Create();
+        var fontMock = new Mock<IFont>();
+        fontMock.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
+        var boldFontMock = new Mock<IFont>();
+        boldFontMock.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
+        var whitePixel = CreateFakeTexture2D();
+
+        panel.Draw(spriteBatch, fontMock.Object, boldFontMock.Object, whitePixel, 1280, 720);
+
+        // The SAVE button's fill should use SelectionBarColor (selected).
+        Assert.Contains(panel.WhitePixelDraws, d => d.Color == new Color(120, 92, 30, 190));
+        // The CANCEL button's fill should use RowFillColor (unselected).
+        Assert.Contains(panel.WhitePixelDraws, d => d.Color == new Color(30, 34, 60, 220));
+        // Both buttons have a border rect.
+        var borderDraws = panel.WhitePixelDraws.Where(d => d.Color == new Color(74, 62, 150, 235));
+        // At least 2 border draws: one from the board, two from the footer buttons = 3 total.
+        Assert.True(borderDraws.Count() >= 3, "expected at least 3 BoardBorderColor draws (board + 2 footer buttons)");
+    }
+
+    [Fact]
+    public void SystemPanel_Draw_WithConflictMessage_ShouldDrawConflictText()
+    {
+        // When _conflictMessage is set and a font is provided, the conflict message is drawn
+        // centered on the board with ConflictColor. This covers the conflict-message drawing path.
+        using var inputManager = new InputManager();
+        var panel = new SpySystemKeyAssignPanel(inputManager);
+        panel.Activate();
+        ReflectionHelpers.InvokePrivateMethod(panel, "ShowConflict", "System conflict");
+
+        var spriteBatch = FakeSpriteBatch.Create();
+        var fontMock = new Mock<IFont>();
+        fontMock.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(100f, 14f));
+        var boldFontMock = new Mock<IFont>();
+        boldFontMock.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(new Vector2(40f, 14f));
+
+        panel.Draw(spriteBatch, fontMock.Object, boldFontMock.Object, null, 1280, 720);
+
+        fontMock.Verify(
+            f => f.DrawString(spriteBatch, "Conflict: System conflict",
+                It.IsAny<Vector2>(), It.Is<Color>(c => c == new Color(255, 96, 96))),
+            Times.Once,
+            "conflict message should be drawn with ConflictColor");
+    }
+
+    private static Texture2D CreateFakeTexture2D()
+    {
+#pragma warning disable SYSLIB0050
+        var tex = (Texture2D)FormatterServices.GetUninitializedObject(typeof(Texture2D));
+#pragma warning restore SYSLIB0050
+        GC.SuppressFinalize(tex);
+        return tex;
+    }
+
+    /// <summary>
+    /// Test-only <see cref="SystemKeyAssignPanel"/> that overrides the <see cref="SystemKeyAssignPanel.DrawWhitePixel"/>
+    /// seam to record draw calls instead of hitting the uninitialized SpriteBatch.
+    /// </summary>
+    private sealed class SpySystemKeyAssignPanel : SystemKeyAssignPanel
+    {
+        public List<(Rectangle Rectangle, Color Color)> WhitePixelDraws { get; } = [];
+
+        public SpySystemKeyAssignPanel(InputManager inputManager)
+            : base(inputManager)
+        {
+        }
+
+        protected override void DrawWhitePixel(SpriteBatch spriteBatch, Texture2D whitePixel,
+            Rectangle rectangle, Color color)
+        {
+            WhitePixelDraws.Add((rectangle, color));
+        }
+    }
 }

--- a/DTXMania.Test/Helpers/ThrowingTraceListener.cs
+++ b/DTXMania.Test/Helpers/ThrowingTraceListener.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Diagnostics;
+
+namespace DTXMania.Test.Helpers;
+
+/// <summary>
+/// Converts <see cref="Debug.Assert(bool)"/> / <see cref="Debug.Fail(string)"/> failures into
+/// thrown exceptions so assertions surface as test failures instead of modal dialogs (the
+/// default <see cref="DefaultTraceListener"/> shows a dialog that hangs headless test runs).
+/// Install via <see cref="Install"/> in a <c>using</c>-scope; the original listener set is
+/// restored on <see cref="IDisposable.Dispose"/>.
+/// </summary>
+internal sealed class ThrowingTraceListener : TraceListener
+{
+    public override void Fail(string? message) => throw new DebugAssertFailedException(message);
+    public override void Fail(string? message, string? detailMessage)
+        => throw new DebugAssertFailedException(
+            detailMessage is null ? message : $"{message}: {detailMessage}");
+    public override void Write(string? message) { }
+    public override void WriteLine(string? message) { }
+
+    /// <summary>
+    /// Replaces all trace listeners with a <see cref="ThrowingTraceListener"/> for the
+    /// duration of the returned scope. Restores the previous listener set on dispose.
+    /// </summary>
+    public static IDisposable Install()
+    {
+        var original = new TraceListener[Trace.Listeners.Count];
+        Trace.Listeners.CopyTo(original, 0);
+        Trace.Listeners.Clear();
+        Trace.Listeners.Add(new ThrowingTraceListener());
+        return new Scope(original);
+    }
+
+    private sealed class Scope : IDisposable
+    {
+        private readonly TraceListener[] _original;
+
+        public Scope(TraceListener[] original) => _original = original;
+
+        public void Dispose()
+        {
+            Trace.Listeners.Clear();
+            foreach (var listener in _original)
+                Trace.Listeners.Add(listener);
+        }
+    }
+}
+
+/// <summary>
+/// Thrown by <see cref="ThrowingTraceListener"/> when a <see cref="Debug.Assert(bool)"/> or
+/// <see cref="Debug.Fail(string)"/> fires while the throwing listener is installed.
+/// </summary>
+internal sealed class DebugAssertFailedException : Exception
+{
+    public DebugAssertFailedException(string? message) : base(message) { }
+}

--- a/DTXMania.Test/Resources/TexturePathTests.cs
+++ b/DTXMania.Test/Resources/TexturePathTests.cs
@@ -509,7 +509,6 @@ namespace DTXMania.Test.Resources
             Assert.Equal("Graphics/4_header panel.png", TexturePath.ConfigHeaderPanel);
             Assert.Equal("Graphics/4_footer panel.png", TexturePath.ConfigFooterPanel);
             Assert.Equal("Graphics/4_itembox.png", TexturePath.ConfigItemBox);
-            Assert.Equal("Graphics/4_itembox other.png", TexturePath.ConfigItemBoxOther);
             Assert.Equal("Graphics/4_itembox cursor.png", TexturePath.ConfigItemBoxCursor);
             Assert.Equal("Graphics/4_Description Panel.png", TexturePath.ConfigDescriptionPanel);
         }

--- a/DTXMania.Test/UI/ConfigUILayoutTests.cs
+++ b/DTXMania.Test/UI/ConfigUILayoutTests.cs
@@ -19,55 +19,62 @@ public class ConfigUILayoutTests
     }
 
     [Theory]
-    [InlineData(0, 156)]
-    [InlineData(1, 190)]
-    [InlineData(2, 224)]
-    public void MenuRowY_ShouldStepBy34(int index, int expected)
+    [InlineData(0, 148)]
+    [InlineData(1, 180)]
+    [InlineData(2, 212)]
+    public void MenuCursorRect_ShouldStepBy32(int index, int expectedY)
     {
-        Assert.Equal(expected, ConfigUILayout.MenuRowY(index));
+        Assert.Equal(new Rectangle(250, expectedY, 170, 32), ConfigUILayout.MenuCursorRect(index));
     }
 
     [Fact]
-    public void MenuCursorRect_ShouldSitOnSelectedRow()
+    public void MenuLabelCenterX_ShouldBePanelCenter()
     {
-        Assert.Equal(new Rectangle(250, 153, 150, 30), ConfigUILayout.MenuCursorRect(0));
-        Assert.Equal(new Rectangle(250, 221, 150, 30), ConfigUILayout.MenuCursorRect(2));
+        Assert.Equal(335, ConfigUILayout.MenuLabelCenterX);
     }
 
     [Fact]
-    public void ItemRowRect_ShouldStepBy60()
+    public void RowTopY_ShouldCenterSelectedItemWhenSettled()
     {
-        Assert.Equal(new Rectangle(430, 150, 360, 54), ConfigUILayout.ItemRowRect(0));
-        Assert.Equal(new Rectangle(430, 210, 360, 54), ConfigUILayout.ItemRowRect(1));
+        // p == selected index -> that row sits at the focus row.
+        Assert.Equal(189, ConfigUILayout.RowTopY(3, 3.0));
+        Assert.Equal(189, ConfigUILayout.RowTopY(0, 0.0));
     }
 
     [Fact]
-    public void ItemCursorRect_ShouldFrameTheRow()
+    public void RowTopY_ShouldStepByStride()
     {
-        Assert.Equal(new Rectangle(426, 147, 368, 60), ConfigUILayout.ItemCursorRect(0));
-        Assert.Equal(new Rectangle(426, 207, 368, 60), ConfigUILayout.ItemCursorRect(1));
+        Assert.Equal(189 + 67, ConfigUILayout.RowTopY(4, 3.0));
+        Assert.Equal(189 - 67, ConfigUILayout.RowTopY(2, 3.0));
+    }
+
+    [Theory]
+    [InlineData(189, true)]    // focus row
+    [InlineData(690, false)]   // top at footer edge -> below band
+    [InlineData(-213, false)]  // far above -> hidden behind header
+    [InlineData(60, true)]     // top above header bottom but box still intrudes band
+    public void IsRowVisible_ShouldGateOnVisibleBand(int rowTopY, bool expected)
+    {
+        Assert.Equal(expected, ConfigUILayout.IsRowVisible(rowTopY));
     }
 
     [Fact]
-    public void ItemTextPositions_ShouldOffsetFromRow()
+    public void ItemBoxAndTextPositions_ShouldMatchNx()
     {
-        Assert.Equal(new Vector2(454, 164), ConfigUILayout.ItemNamePos(0));
-        Assert.Equal(new Vector2(454, 224), ConfigUILayout.ItemNamePos(1));
+        Assert.Equal(new Rectangle(420, 189, 538, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxNormalWidth));
+        Assert.Equal(new Rectangle(420, 189, 438, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxOtherWidth));
+        Assert.Equal(new Vector2(440, 213), ConfigUILayout.ItemNamePos(189));
+        Assert.Equal(new Vector2(680, 213), ConfigUILayout.ItemValuePos(189));
+        Assert.Equal(new Rectangle(413, 193, 497, 68), ConfigUILayout.ItemCursorRect);
     }
 
     [Fact]
-    public void ItemValueRightX_ShouldSitInsideTheBoxClearOfTheDescriptionPanel()
+    public void DescriptionTitleAndBody_ShouldSitOnCorrectArtCells()
     {
-        // Value right anchor = box right edge (430 + 360 = 790) minus the symmetric inset (24).
-        // Values end at <= 790, so they never reach the description panel (x = 800).
-        Assert.Equal(766, ConfigUILayout.ItemValueRightX);
-        Assert.True(ConfigUILayout.ItemValueRightX < ConfigUILayout.DescriptionPanelRect.X);
-    }
-
-    [Fact]
-    public void DescriptionText_ShouldStartInsidePanel()
-    {
-        Assert.Equal(new Vector2(818, 288), ConfigUILayout.DescriptionTextPos);
+        // Title on the white upper region; body on the black lower region.
+        Assert.Equal(new Vector2(818, 300), ConfigUILayout.DescriptionTitlePos);
+        Assert.Equal(new Vector2(818, 448), ConfigUILayout.DescriptionBodyPos);
         Assert.Equal(248, ConfigUILayout.DescriptionWrapWidth);
+        Assert.True(ConfigUILayout.DescriptionBodyPos.Y > ConfigUILayout.DescriptionTitlePos.Y);
     }
 }

--- a/DTXMania.Test/UI/ConfigUILayoutTests.cs
+++ b/DTXMania.Test/UI/ConfigUILayoutTests.cs
@@ -16,15 +16,16 @@ public class ConfigUILayoutTests
         Assert.Equal(new Rectangle(0, 690, 1280, 30), ConfigUILayout.FooterRect);
         Assert.Equal(new Rectangle(245, 140, 180, 172), ConfigUILayout.MenuPanelRect);
         Assert.Equal(new Rectangle(800, 270, 280, 360), ConfigUILayout.DescriptionPanelRect);
-        Assert.Equal(new Rectangle(220, 112, 880, 574), ConfigUILayout.InnerBoardBorderRect);
-        Assert.Equal(new Rectangle(224, 116, 872, 566), ConfigUILayout.InnerBoardRect);
+        Assert.Equal(new Rectangle(220, 105, 880, 585), ConfigUILayout.InnerBoardBorderRect);
+        Assert.Equal(new Rectangle(224, 109, 872, 577), ConfigUILayout.InnerBoardRect);
     }
 
     [Fact]
     public void InnerBoard_ShouldSitBetweenHeaderAndFooterInsideBorder()
     {
-        // The inner board fill is fully contained by its border, and both live in the working
-        // band between the header (bottom=105) and footer (top=690).
+        // The inner board fill is fully contained by its border, and the border spans exactly the
+        // working band between the header (bottom=105) and footer (top=690) so it fully backs the
+        // scrolling item list (which is visible across that whole band).
         Assert.True(ConfigUILayout.InnerBoardBorderRect.Contains(ConfigUILayout.InnerBoardRect));
         Assert.True(ConfigUILayout.InnerBoardBorderRect.Top >= ConfigUILayout.HeaderRect.Bottom);
         Assert.True(ConfigUILayout.InnerBoardBorderRect.Bottom <= ConfigUILayout.FooterRect.Top);

--- a/DTXMania.Test/UI/ConfigUILayoutTests.cs
+++ b/DTXMania.Test/UI/ConfigUILayoutTests.cs
@@ -16,6 +16,18 @@ public class ConfigUILayoutTests
         Assert.Equal(new Rectangle(0, 690, 1280, 30), ConfigUILayout.FooterRect);
         Assert.Equal(new Rectangle(245, 140, 180, 172), ConfigUILayout.MenuPanelRect);
         Assert.Equal(new Rectangle(800, 270, 280, 360), ConfigUILayout.DescriptionPanelRect);
+        Assert.Equal(new Rectangle(220, 112, 880, 574), ConfigUILayout.InnerBoardBorderRect);
+        Assert.Equal(new Rectangle(224, 116, 872, 566), ConfigUILayout.InnerBoardRect);
+    }
+
+    [Fact]
+    public void InnerBoard_ShouldSitBetweenHeaderAndFooterInsideBorder()
+    {
+        // The inner board fill is fully contained by its border, and both live in the working
+        // band between the header (bottom=105) and footer (top=690).
+        Assert.True(ConfigUILayout.InnerBoardBorderRect.Contains(ConfigUILayout.InnerBoardRect));
+        Assert.True(ConfigUILayout.InnerBoardBorderRect.Top >= ConfigUILayout.HeaderRect.Bottom);
+        Assert.True(ConfigUILayout.InnerBoardBorderRect.Bottom <= ConfigUILayout.FooterRect.Top);
     }
 
     [Theory]

--- a/DTXMania.Test/UI/ConfigUILayoutTests.cs
+++ b/DTXMania.Test/UI/ConfigUILayoutTests.cs
@@ -75,7 +75,6 @@ public class ConfigUILayoutTests
     public void ItemBoxAndTextPositions_ShouldMatchNx()
     {
         Assert.Equal(new Rectangle(420, 189, 538, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxNormalWidth));
-        Assert.Equal(new Rectangle(420, 189, 438, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxOtherWidth));
         Assert.Equal(new Vector2(440, 213), ConfigUILayout.ItemNamePos(189));
         Assert.Equal(new Vector2(680, 213), ConfigUILayout.ItemValuePos(189));
         Assert.Equal(new Rectangle(413, 193, 497, 68), ConfigUILayout.ItemCursorRect);

--- a/docs/skin-system-implementation.md
+++ b/docs/skin-system-implementation.md
@@ -227,6 +227,22 @@ Fixed hardcoded paths in StartupStage and TitleStage that were causing "texture 
 ### Result
 Resources now load correctly from the current working directory using the proper skin system.
 
+## Skin Author Changelog
+
+Breaking changes to expected skin texture files. Skin authors should update their packs
+accordingly; the system fallback chain still loads the default `System/` assets when a
+custom skin omits a file.
+
+### 2026-06 — Config stage NX layout revamp (commit `09756ac`)
+
+- **Removed: `Graphics/4_itembox other.png`** (`TexturePath.ConfigItemBoxOther`).
+  The config stage previously rendered odd/even item rows with two separate box textures
+  (`4_itembox.png` and `4_itembox other.png`). Item-box rendering is now unified onto a
+  single texture (`Graphics/4_itembox.png`, `TexturePath.ConfigItemBox`). Custom skins
+  that shipped a `4_itembox other.png` file will silently stop using it — the file is no
+  longer referenced and can be deleted from skin packs. No fallback warning is emitted;
+  the extra texture is simply ignored.
+
 ## Summary
 
 The skin system implementation successfully provides:

--- a/docs/superpowers/plans/2026-06-25-config-stage-nx-layout.md
+++ b/docs/superpowers/plans/2026-06-25-config-stage-nx-layout.md
@@ -1,5 +1,7 @@
 # Config Stage NX Layout Revamp Implementation Plan
 
+> **Status:** Implemented. Subsequently refined: `ConfigItemBoxOther` was removed and item-box rendering unified (see commit `09756ac`). References to `ConfigItemBoxOther` in the tasks below are retained as the original plan; the shipped code uses a single `ConfigItemBox` texture.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Rebuild `ConfigStage` from a single flat list into the DTXManiaNX two-column master-detail layout (left category menu, right per-category item list, description panel, header/footer).

--- a/docs/superpowers/plans/2026-07-01-config-stage-nx-layout.md
+++ b/docs/superpowers/plans/2026-07-01-config-stage-nx-layout.md
@@ -27,7 +27,7 @@ Menu (left categories):
 - `MenuCursorRect(i) = (250, 148 + i*32, 170, 32)`
 
 Item list (scrolling viewport):
-- `ItemListX = 420`, `ItemBoxHeight = 80`, `ItemBoxNormalWidth = 538`, `ItemBoxOtherWidth = 438`
+- `ItemListX = 420`, `ItemBoxHeight = 80`, `ItemBoxNormalWidth = 538`
 - `ItemRowStride = 67`, `ItemFocusRowTopY = 189`
 - `ItemVisibleTopY = 105`, `ItemVisibleBottomY = 690`
 - `ItemNameOffsetX = 20`, `ItemValueOffsetX = 260`, `ItemTextOffsetY = 24`, `ItemValueMaxWidth = 116`
@@ -126,7 +126,7 @@ git commit -m "refactor: align config menu metrics to NX (stride 32, panel-cente
 - Test: `DTXMania.Test/UI/ConfigUILayoutTests.cs`
 
 **Interfaces:**
-- Produces: `ItemListX`, `ItemBoxHeight`, `ItemBoxNormalWidth`, `ItemBoxOtherWidth`, `ItemRowStride`, `ItemFocusRowTopY`, `ItemValueMaxWidth` (all int consts); `ItemCursorRect` (Rectangle); `RowTopY(int index, double scroll) -> int`; `IsRowVisible(int rowTopY) -> bool`; `ItemBoxRect(int rowTopY, int width) -> Rectangle`; `ItemNamePos(int rowTopY) -> Vector2`; `ItemValuePos(int rowTopY) -> Vector2`.
+- Produces: `ItemListX`, `ItemBoxHeight`, `ItemBoxNormalWidth`, `ItemRowStride`, `ItemFocusRowTopY`, `ItemValueMaxWidth` (all int consts); `ItemCursorRect` (Rectangle); `RowTopY(int index, double scroll) -> int`; `IsRowVisible(int rowTopY) -> bool`; `ItemBoxRect(int rowTopY, int width) -> Rectangle`; `ItemNamePos(int rowTopY) -> Vector2`; `ItemValuePos(int rowTopY) -> Vector2`.
 
 - [ ] **Step 1: Replace the item-list tests**
 
@@ -162,7 +162,6 @@ public void IsRowVisible_ShouldGateOnVisibleBand(int rowTopY, bool expected)
 public void ItemBoxAndTextPositions_ShouldMatchNx()
 {
     Assert.Equal(new Rectangle(420, 189, 538, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxNormalWidth));
-    Assert.Equal(new Rectangle(420, 189, 438, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxOtherWidth));
     Assert.Equal(new Vector2(440, 213), ConfigUILayout.ItemNamePos(189));
     Assert.Equal(new Vector2(680, 213), ConfigUILayout.ItemValuePos(189));
     Assert.Equal(new Rectangle(413, 193, 497, 68), ConfigUILayout.ItemCursorRect);
@@ -183,7 +182,6 @@ Replace the "Right item list" block with:
 public const int ItemListX = 420;
 public const int ItemBoxHeight = 80;
 public const int ItemBoxNormalWidth = 538;   // 4_itembox.png: dark name cell + white value cell
-public const int ItemBoxOtherWidth = 438;    // 4_itembox other.png: single dark cell (navigation)
 public const int ItemRowStride = 67;         // NX stride; boxes overlap 13px as the art tiles
 public const int ItemFocusRowTopY = 189;     // panel-top Y of the centered/selected row
 public const int ItemVisibleTopY = 105;      // header bottom
@@ -353,7 +351,7 @@ git commit -m "feat: align config menu labels and darken selected label for the 
 - Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs` (`OnActivate`, `OnUpdate`, `DrawItemList`, fields)
 
 **Interfaces:**
-- Consumes: `ConfigUILayout.RowTopY`, `IsRowVisible`, `ItemBoxRect`, `ItemNamePos`, `ItemValuePos`, `ItemCursorRect`, `ItemBoxNormalWidth`, `ItemBoxOtherWidth`, `ItemValueMaxWidth` (Task 2); colors (Task 4).
+- Consumes: `ConfigUILayout.RowTopY`, `IsRowVisible`, `ItemBoxRect`, `ItemNamePos`, `ItemValuePos`, `ItemCursorRect`, `ItemBoxNormalWidth`, `ItemValueMaxWidth` (Task 2); colors (Task 4).
 - Produces: `_itemScroll` (double) eased toward `SelectedIndex`.
 
 - [ ] **Step 1: Add the scroll field**
@@ -413,18 +411,17 @@ Replace the body of `DrawItemList` (after the `if (_categories.Count == 0) retur
 var category = _categories[_currentCategoryIndex];
 var items = category.Items;
 
-// Box pass.
+// Box pass. Every item — value and navigation alike — uses the same normal itembox
+// (dark name cell + white value cell) so the list reads uniformly. Only real items
+// are drawn (non-cyclic), each at its scrolled Y.
 for (int i = 0; i < items.Count; i++)
 {
     int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
     if (!ConfigUILayout.IsRowVisible(rowTopY))
         continue;
-    bool isNav = items[i] is NavigationConfigItem;
-    var boxTex = isNav ? _itemBoxOtherTexture : _itemBoxTexture;
-    int boxWidth = isNav ? ConfigUILayout.ItemBoxOtherWidth : ConfigUILayout.ItemBoxNormalWidth;
-    var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, boxWidth);
-    if (boxTex?.Texture != null)
-        _spriteBatch.Draw(boxTex.Texture, boxRect, Color.White);
+    var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, ConfigUILayout.ItemBoxNormalWidth);
+    if (_itemBoxTexture?.Texture != null)
+        _spriteBatch.Draw(_itemBoxTexture.Texture, boxRect, Color.White);
     else
         DrawFilledRectangle(boxRect, ItemBoxFallbackColor);
 }
@@ -449,7 +446,6 @@ for (int i = 0; i < items.Count; i++)
         continue;
     var item = items[i];
     bool selected = !_focusOnMenu && i == category.SelectedIndex;
-    bool isNav = item is NavigationConfigItem;
     var font = selected ? _boldFont : _font;
 
     font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(rowTopY),
@@ -460,11 +456,8 @@ for (int i = 0; i < items.Count; i++)
     {
         var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
         var valuePos = ConfigUILayout.ItemValuePos(rowTopY);
-        // Nav marker (">") sits on the dark "other" box -> light; real values sit on the
-        // itembox white cell -> dark.
-        Color valueColor = isNav
-            ? (selected ? SelectedNameText : LightText)
-            : (selected ? SelectedValueText : ValueDarkText);
+        // Every value (including the nav ">" marker) sits on the itembox white cell -> dark.
+        Color valueColor = selected ? SelectedValueText : ValueDarkText;
         font.DrawString(_spriteBatch, displayValue, valuePos, valueColor);
     }
 }
@@ -499,22 +492,28 @@ git commit -m "feat: scroll config item list with NX centered focus and per-cell
 
 - [ ] **Step 1: Rewrite the text portion of `DrawDescriptionPanel`**
 
-Keep the panel-background draw. Replace everything after it (from `var category = ...`) with:
+NX draws the description panel only while focus is on the item list
+(`CStageConfig.cs:260`, `!bFocusIsOnMenu`) — not while browsing the category menu.
+This keeps the busy GALAXY WAVE background clear on entry and stops the panel from
+overlapping the item boxes until the player is actually editing an item. The
+selected item sits at the focus row (y=189), above the panel top (y=270), so it
+stays readable. Add the early return at the top of the method, then keep the
+panel-background draw and replace everything after it (from `var category = ...`)
+with:
 
 ```csharp
+if (_focusOnMenu)
+    return;
+
 var category = _categories[_currentCategoryIndex];
 
-// Title: the focused item's name (or the category name on menu focus) on the white upper cell.
-string title = _focusOnMenu
-    ? category.Name
-    : (category.SelectedItem?.Name ?? category.Name);
+// Title: the focused item's name on the white upper cell.
+string title = category.SelectedItem?.Name ?? category.Name;
 if (!string.IsNullOrEmpty(title) && _boldFont != null)
     _boldFont.DrawString(_spriteBatch, title, ConfigUILayout.DescriptionTitlePos, DescriptionTitleText);
 
 // Body: the description text, wrapped, on the black lower cell.
-string text = _focusOnMenu
-    ? category.Description
-    : (category.SelectedItem?.Description ?? string.Empty);
+string text = category.SelectedItem?.Description ?? string.Empty;
 if (string.IsNullOrEmpty(text) || _font == null)
     return;
 
@@ -556,8 +555,8 @@ Launch the game, open Config (Title → Config), and confirm each state:
 - Item rows render full-size (no squish); names are light on the dark cell; values are dark on the white cell; the selected row is framed by the fixed cursor at center; selected name is warm yellow, selected value dark orange.
 - Scroll to the last item (System has 7): the selected item stays centered, rows scroll under the cursor, and no duplicate rows appear.
 - The read-only "DTX Folder" row shows its path in the white value cell (dark, truncated).
-- Navigation rows ("System Key Mapping", "Import NX Scores", "Drum Key Mapping") show a light ">" on the dark "other" box.
-- Description panel: bold title on the white upper region (dark), wrapped body on the black lower region (light).
+- Navigation rows ("System Key Mapping", "Import NX Scores", "Drum Key Mapping") show a dark ">" on the normal itembox white cell (same box as value rows).
+- Description panel: hidden while browsing the category menu; on item-list focus, bold title on the white upper region (dark), wrapped body on the black lower region (light).
 
 Fine-tune `ItemValueOffsetX`, `ItemNameOffsetX`, `ItemTextOffsetY`, `DescriptionTitlePos`/`DescriptionBodyPos` in `ConfigUILayout` (and the matching test expectations) if a screenshot shows any text off its cell.
 

--- a/docs/superpowers/plans/2026-07-01-config-stage-nx-layout.md
+++ b/docs/superpowers/plans/2026-07-01-config-stage-nx-layout.md
@@ -1,0 +1,584 @@
+# Config Stage NX Layout Refinement — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refine the Config stage to match DTXManiaNX's visual language — aligned category menu, correctly proportioned scrolling item rows with per-cell legible text, and a readable description panel — while adding a scrolling viewport so the list scales as categories grow.
+
+**Architecture:** Pure layout math (menu metrics, item scroll positions, description positions) lives in `ConfigUILayout` and is unit-tested without a GraphicsDevice. `ConfigStage` holds a single eased scroll position `_itemScroll` that tracks `SelectedIndex` (wrap-snapped) and renders items through the pure helpers. The selected item is locked to a fixed focus row with a fixed cursor; items scroll under it. Draw methods are visually verified; logic is covered by existing `ConfigStage*Tests`.
+
+**Tech Stack:** .NET 8, MonoGame 3.8 (SpriteBatch), xUnit + Moq.
+
+## Global Constraints
+
+- Virtual coordinate space is 1280×720 (copied verbatim from spec / `ConfigUILayout`).
+- Runtime skin art is present at `~/Library/Application Support/DTXManiaCX/System/Graphics/`; every draw stays null-guarded with the existing fallback fill (no behavior change if art is absent).
+- Draw/layout only: no change to input handling, navigation, value editing, deferred save, or NX-score import.
+- Mac test project is `DTXMania.Test/DTXMania.Test.Mac.csproj`; `ConfigUILayoutTests` runs there (pure, no GraphicsDevice).
+- Follow `.editorconfig`: 4-space indent, LF, `_camelCase` private fields.
+
+---
+
+## Reference constants (authoritative for all tasks)
+
+Menu (left categories):
+- `MenuPanelRect = (245,140,180,172)` (unchanged)
+- `MenuLabelCenterX = 335`, `MenuCursorX = 250`, `MenuCursorWidth = 170`, `MenuCursorHeight = 32`
+- `MenuFirstCursorY = 148`, `MenuRowStride = 32`
+- `MenuCursorRect(i) = (250, 148 + i*32, 170, 32)`
+
+Item list (scrolling viewport):
+- `ItemListX = 420`, `ItemBoxHeight = 80`, `ItemBoxNormalWidth = 538`, `ItemBoxOtherWidth = 438`
+- `ItemRowStride = 67`, `ItemFocusRowTopY = 189`
+- `ItemVisibleTopY = 105`, `ItemVisibleBottomY = 690`
+- `ItemNameOffsetX = 20`, `ItemValueOffsetX = 260`, `ItemTextOffsetY = 24`, `ItemValueMaxWidth = 116`
+- `ItemCursorRect = (413, 193, 497, 68)`
+- `RowTopY(i, p) = ItemFocusRowTopY + round((i - p) * ItemRowStride)`
+- `IsRowVisible(rowTopY) = (rowTopY + ItemBoxHeight) > ItemVisibleTopY && rowTopY < ItemVisibleBottomY`
+
+Description panel:
+- `DescriptionPanelRect = (800,270,280,360)` (unchanged)
+- `DescriptionTitlePos = (818, 300)` (white top → dark text)
+- `DescriptionBodyPos = (818, 448)` (black bottom → light text)
+- `DescriptionWrapWidth = 248`, `DescriptionLineHeight = 22`
+
+Colors (added to `ConfigStage`):
+- `LightText = (235,238,248)` (existing) — names on dark cell, menu labels on purple, description body on black
+- `ValueDarkText = (24,24,32)` — value on white cell
+- `SelectedNameText = (255,238,120)` — selected name / nav marker on dark
+- `SelectedValueText = (168,52,0)` — selected value on white cell
+- `SelectedMenuText = (36,24,72)` — selected menu label on light cursor
+- `DescriptionTitleText = (24,24,32)` — title on white top
+
+---
+
+## Task 1: Menu metrics in `ConfigUILayout`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs`
+- Test: `DTXMania.Test/UI/ConfigUILayoutTests.cs`
+
+**Interfaces:**
+- Produces: `MenuLabelCenterX` (int), `MenuFirstCursorY` (int), `MenuRowStride` (int), `MenuCursorRect(int) -> Rectangle`.
+
+- [ ] **Step 1: Replace the menu test with the new metrics**
+
+In `ConfigUILayoutTests.cs`, replace `MenuRowY_ShouldStepBy34` and `MenuCursorRect_ShouldSitOnSelectedRow` with:
+
+```csharp
+[Theory]
+[InlineData(0, 148)]
+[InlineData(1, 180)]
+[InlineData(2, 212)]
+public void MenuCursorRect_ShouldStepBy32(int index, int expectedY)
+{
+    Assert.Equal(new Rectangle(250, expectedY, 170, 32), ConfigUILayout.MenuCursorRect(index));
+}
+
+[Fact]
+public void MenuLabelCenterX_ShouldBePanelCenter()
+{
+    Assert.Equal(335, ConfigUILayout.MenuLabelCenterX);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: FAIL (compile error / old values).
+
+- [ ] **Step 3: Update `ConfigUILayout` menu section**
+
+Replace the "Left category menu" block with:
+
+```csharp
+// Left category menu.
+public static Rectangle MenuPanelRect => new(245, 140, 180, 172);
+public const int MenuLabelCenterX = 335;
+public const int MenuCursorX = 250;
+public const int MenuCursorWidth = 170;
+public const int MenuCursorHeight = 32;
+public const int MenuFirstCursorY = 148;
+public const int MenuRowStride = 32;
+public static Rectangle MenuCursorRect(int index) =>
+    new(MenuCursorX, MenuFirstCursorY + index * MenuRowStride, MenuCursorWidth, MenuCursorHeight);
+```
+
+Remove the old `MenuFirstRowY`, `MenuRowStride` (old value), `MenuCursorWidth/Height` (old), `MenuRowY`, and the old `MenuCursorRect`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: PASS (menu tests; other tests may still fail — updated in later tasks).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs DTXMania.Test/UI/ConfigUILayoutTests.cs
+git commit -m "refactor: align config menu metrics to NX (stride 32, panel-center labels)"
+```
+
+---
+
+## Task 2: Item scroll math in `ConfigUILayout`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs`
+- Test: `DTXMania.Test/UI/ConfigUILayoutTests.cs`
+
+**Interfaces:**
+- Produces: `ItemListX`, `ItemBoxHeight`, `ItemBoxNormalWidth`, `ItemBoxOtherWidth`, `ItemRowStride`, `ItemFocusRowTopY`, `ItemValueMaxWidth` (all int consts); `ItemCursorRect` (Rectangle); `RowTopY(int index, double scroll) -> int`; `IsRowVisible(int rowTopY) -> bool`; `ItemBoxRect(int rowTopY, int width) -> Rectangle`; `ItemNamePos(int rowTopY) -> Vector2`; `ItemValuePos(int rowTopY) -> Vector2`.
+
+- [ ] **Step 1: Replace the item-list tests**
+
+In `ConfigUILayoutTests.cs`, replace `ItemRowRect_ShouldStepBy60`, `ItemCursorRect_ShouldFrameTheRow`, `ItemTextPositions_ShouldOffsetFromRow`, and `ItemValueRightX_ShouldSitInsideTheBoxClearOfTheDescriptionPanel` with:
+
+```csharp
+[Fact]
+public void RowTopY_ShouldCenterSelectedItemWhenSettled()
+{
+    // p == selected index -> that row sits at the focus row.
+    Assert.Equal(189, ConfigUILayout.RowTopY(3, 3.0));
+    Assert.Equal(189, ConfigUILayout.RowTopY(0, 0.0));
+}
+
+[Fact]
+public void RowTopY_ShouldStepByStride()
+{
+    Assert.Equal(189 + 67, ConfigUILayout.RowTopY(4, 3.0));
+    Assert.Equal(189 - 67, ConfigUILayout.RowTopY(2, 3.0));
+}
+
+[Theory]
+[InlineData(189, true)]    // focus row
+[InlineData(690, false)]   // top at footer edge -> below band
+[InlineData(-213, false)]  // far above -> hidden behind header
+[InlineData(60, true)]     // top above header bottom but box still intrudes band
+public void IsRowVisible_ShouldGateOnVisibleBand(int rowTopY, bool expected)
+{
+    Assert.Equal(expected, ConfigUILayout.IsRowVisible(rowTopY));
+}
+
+[Fact]
+public void ItemBoxAndTextPositions_ShouldMatchNx()
+{
+    Assert.Equal(new Rectangle(420, 189, 538, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxNormalWidth));
+    Assert.Equal(new Rectangle(420, 189, 438, 80), ConfigUILayout.ItemBoxRect(189, ConfigUILayout.ItemBoxOtherWidth));
+    Assert.Equal(new Vector2(440, 213), ConfigUILayout.ItemNamePos(189));
+    Assert.Equal(new Vector2(680, 213), ConfigUILayout.ItemValuePos(189));
+    Assert.Equal(new Rectangle(413, 193, 497, 68), ConfigUILayout.ItemCursorRect);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: FAIL (members undefined).
+
+- [ ] **Step 3: Replace the item-list section of `ConfigUILayout`**
+
+Replace the "Right item list" block with:
+
+```csharp
+// Right item list — scrolling viewport (selected item locked to the focus row).
+public const int ItemListX = 420;
+public const int ItemBoxHeight = 80;
+public const int ItemBoxNormalWidth = 538;   // 4_itembox.png: dark name cell + white value cell
+public const int ItemBoxOtherWidth = 438;    // 4_itembox other.png: single dark cell (navigation)
+public const int ItemRowStride = 67;         // NX stride; boxes overlap 13px as the art tiles
+public const int ItemFocusRowTopY = 189;     // panel-top Y of the centered/selected row
+public const int ItemVisibleTopY = 105;      // header bottom
+public const int ItemVisibleBottomY = 690;   // footer top
+public const int ItemNameOffsetX = 20;
+public const int ItemValueOffsetX = 260;
+public const int ItemTextOffsetY = 24;
+// Value text left-aligns at ItemListX+ItemValueOffsetX (680) and must stay left of the
+// description panel (x=800), so cap its width. 800 - 680 - 4 margin = 116.
+public const int ItemValueMaxWidth = 116;
+// Selection cursor is fixed at the focus row; items scroll under it (NX 4_itembox cursor.png 497x68).
+public static Rectangle ItemCursorRect => new(413, 193, 497, 68);
+
+// Panel-top Y of item `index` given the eased scroll position `scroll` (fractional index at focus).
+public static int RowTopY(int index, double scroll) =>
+    ItemFocusRowTopY + (int)System.Math.Round((index - scroll) * ItemRowStride);
+
+// True when the row's box intersects the visible band between header and footer.
+public static bool IsRowVisible(int rowTopY) =>
+    (rowTopY + ItemBoxHeight) > ItemVisibleTopY && rowTopY < ItemVisibleBottomY;
+
+public static Rectangle ItemBoxRect(int rowTopY, int width) =>
+    new(ItemListX, rowTopY, width, ItemBoxHeight);
+public static Vector2 ItemNamePos(int rowTopY) =>
+    new(ItemListX + ItemNameOffsetX, rowTopY + ItemTextOffsetY);
+public static Vector2 ItemValuePos(int rowTopY) =>
+    new(ItemListX + ItemValueOffsetX, rowTopY + ItemTextOffsetY);
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: PASS for the item tests (description test updated next task).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs DTXMania.Test/UI/ConfigUILayoutTests.cs
+git commit -m "feat: add NX scrolling-viewport item layout math to ConfigUILayout"
+```
+
+---
+
+## Task 3: Description title/body positions in `ConfigUILayout`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs`
+- Test: `DTXMania.Test/UI/ConfigUILayoutTests.cs`
+
+**Interfaces:**
+- Produces: `DescriptionTitlePos` (Vector2), `DescriptionBodyPos` (Vector2), `DescriptionWrapWidth` (int), `DescriptionLineHeight` (int). Removes `DescriptionTextPos`.
+
+- [ ] **Step 1: Replace the description test**
+
+Replace `DescriptionText_ShouldStartInsidePanel` with:
+
+```csharp
+[Fact]
+public void DescriptionTitleAndBody_ShouldSitOnCorrectArtCells()
+{
+    // Title on the white upper region; body on the black lower region.
+    Assert.Equal(new Vector2(818, 300), ConfigUILayout.DescriptionTitlePos);
+    Assert.Equal(new Vector2(818, 448), ConfigUILayout.DescriptionBodyPos);
+    Assert.Equal(248, ConfigUILayout.DescriptionWrapWidth);
+    Assert.True(ConfigUILayout.DescriptionBodyPos.Y > ConfigUILayout.DescriptionTitlePos.Y);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: FAIL (`DescriptionTitlePos` undefined).
+
+- [ ] **Step 3: Update the description section of `ConfigUILayout`**
+
+Replace the "Description panel" block with:
+
+```csharp
+// Description panel — art is white (top) over black (bottom); use both cells.
+public static Rectangle DescriptionPanelRect => new(800, 270, 280, 360);
+public static Vector2 DescriptionTitlePos => new(818, 300);   // white upper region -> dark text
+public static Vector2 DescriptionBodyPos => new(818, 448);    // black lower region -> light text
+public const int DescriptionWrapWidth = 248;
+public const int DescriptionLineHeight = 22;
+```
+
+- [ ] **Step 4: Run to verify the full layout test file passes**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigUILayoutTests"`
+Expected: PASS (all layout tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs DTXMania.Test/UI/ConfigUILayoutTests.cs
+git commit -m "feat: split config description panel into title/body art cells"
+```
+
+---
+
+## Task 4: Colors + menu draw in `ConfigStage`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs` (color fields near line 74; `DrawCategoryMenu` ~line 698)
+
+**Interfaces:**
+- Consumes: `ConfigUILayout.MenuCursorRect`, `MenuLabelCenterX`, `MenuCursorHeight` (Task 1).
+- Produces: new `Color` fields `ValueDarkText`, `SelectedNameText`, `SelectedValueText`, `SelectedMenuText`, `DescriptionTitleText`.
+
+- [ ] **Step 1: Add color constants**
+
+After the existing `ValueText` field, add:
+
+```csharp
+// Value text sits on the itembox's white right cell, so it must be dark.
+private static readonly Color ValueDarkText = new(24, 24, 32);
+// Selected name/nav marker sit on a dark cell -> bright warm highlight.
+private static readonly Color SelectedNameText = new(255, 238, 120);
+// Selected value sits on the white cell -> dark warm highlight (readable on white).
+private static readonly Color SelectedValueText = new(168, 52, 0);
+// Selected menu label sits on the light menu cursor bar -> dark text.
+private static readonly Color SelectedMenuText = new(36, 24, 72);
+// Description title sits on the panel's white upper region -> dark text.
+private static readonly Color DescriptionTitleText = new(24, 24, 32);
+```
+
+- [ ] **Step 2: Rewrite `DrawCategoryMenu` label loop for alignment + selected color**
+
+Replace the label loop (the `for` over `_categories`) with:
+
+```csharp
+for (int i = 0; i < _categories.Count; i++)
+{
+    bool selected = i == _currentCategoryIndex;
+    var font = selected ? _boldFont : _font;
+    var color = selected ? SelectedMenuText : LightText;
+    var label = _categories[i].Name;
+    var size = font.MeasureString(label);
+    var cursor = ConfigUILayout.MenuCursorRect(i);
+    // Center the label horizontally on the panel and vertically within the cursor band.
+    var pos = new Vector2(
+        ConfigUILayout.MenuLabelCenterX - size.X / 2f,
+        cursor.Y + (ConfigUILayout.MenuCursorHeight - size.Y) / 2f);
+    font.DrawString(_spriteBatch, label, pos, color);
+}
+```
+
+Also update the cursor draw in `DrawCategoryMenu` to use `ConfigUILayout.MenuCursorRect(_currentCategoryIndex)` (already does via `cursorRect` — confirm it still compiles after Task 1 removed `MenuRowY`).
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeded (no references to removed `MenuRowY`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ConfigStage.cs
+git commit -m "feat: align config menu labels and darken selected label for the light cursor"
+```
+
+---
+
+## Task 5: Scroll state + scrolling item list in `ConfigStage`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs` (`OnActivate`, `OnUpdate`, `DrawItemList`, fields)
+
+**Interfaces:**
+- Consumes: `ConfigUILayout.RowTopY`, `IsRowVisible`, `ItemBoxRect`, `ItemNamePos`, `ItemValuePos`, `ItemCursorRect`, `ItemBoxNormalWidth`, `ItemBoxOtherWidth`, `ItemValueMaxWidth` (Task 2); colors (Task 4).
+- Produces: `_itemScroll` (double) eased toward `SelectedIndex`.
+
+- [ ] **Step 1: Add the scroll field**
+
+After `private bool _focusOnMenu = true;` add:
+
+```csharp
+// Eased scroll position (fractional item index currently at the focus row). Tracks the
+// selected item; snaps on a wrap/jump so last<->first never scrolls the whole list.
+private double _itemScroll;
+```
+
+- [ ] **Step 2: Reset scroll on activate**
+
+In `OnActivate`, after `_focusOnMenu = true;` add:
+
+```csharp
+_itemScroll = 0;
+```
+
+- [ ] **Step 3: Step the scroll in `OnUpdate`**
+
+In `OnUpdate`, after the `HandleInput();` call (and only when no active panel), add a step. Replace the tail of `OnUpdate` so it reads:
+
+```csharp
+HandleInput();
+UpdateItemScroll(deltaTime);
+```
+
+Then add the method:
+
+```csharp
+private void UpdateItemScroll(double deltaTime)
+{
+    if (_categories.Count == 0)
+        return;
+    var category = _categories[_currentCategoryIndex];
+    double target = category.HasItems ? category.SelectedIndex : 0;
+    double delta = target - _itemScroll;
+    if (System.Math.Abs(delta) > 1.5)
+    {
+        _itemScroll = target;   // wrap / multi-row jump: snap, don't scroll the whole list
+        return;
+    }
+    double factor = System.Math.Min(1.0, deltaTime * 15.0);
+    _itemScroll += delta * factor;
+    if (System.Math.Abs(target - _itemScroll) < 0.01)
+        _itemScroll = target;
+}
+```
+
+- [ ] **Step 4: Rewrite `DrawItemList` as a scrolling viewport**
+
+Replace the body of `DrawItemList` (after the `if (_categories.Count == 0) return;` guard) with:
+
+```csharp
+var category = _categories[_currentCategoryIndex];
+var items = category.Items;
+
+// Box pass.
+for (int i = 0; i < items.Count; i++)
+{
+    int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
+    if (!ConfigUILayout.IsRowVisible(rowTopY))
+        continue;
+    bool isNav = items[i] is NavigationConfigItem;
+    var boxTex = isNav ? _itemBoxOtherTexture : _itemBoxTexture;
+    int boxWidth = isNav ? ConfigUILayout.ItemBoxOtherWidth : ConfigUILayout.ItemBoxNormalWidth;
+    var boxRect = ConfigUILayout.ItemBoxRect(rowTopY, boxWidth);
+    if (boxTex?.Texture != null)
+        _spriteBatch.Draw(boxTex.Texture, boxRect, Color.White);
+    else
+        DrawFilledRectangle(boxRect, ItemBoxFallbackColor);
+}
+
+// Fixed cursor at the focus row (items scroll under it).
+if (!_focusOnMenu && category.HasItems)
+{
+    if (_itemBoxCursorTexture?.Texture != null)
+        _spriteBatch.Draw(_itemBoxCursorTexture.Texture, ConfigUILayout.ItemCursorRect, Color.White);
+    else
+        DrawFilledRectangle(ConfigUILayout.ItemCursorRect, ItemCursorFallback);
+}
+
+if (_font == null || _boldFont == null)
+    return;
+
+// Text pass.
+for (int i = 0; i < items.Count; i++)
+{
+    int rowTopY = ConfigUILayout.RowTopY(i, _itemScroll);
+    if (!ConfigUILayout.IsRowVisible(rowTopY))
+        continue;
+    var item = items[i];
+    bool selected = !_focusOnMenu && i == category.SelectedIndex;
+    bool isNav = item is NavigationConfigItem;
+    var font = selected ? _boldFont : _font;
+
+    font.DrawString(_spriteBatch, item.Name, ConfigUILayout.ItemNamePos(rowTopY),
+        selected ? SelectedNameText : LightText);
+
+    var value = GetItemValueText(item);
+    if (!string.IsNullOrEmpty(value))
+    {
+        var displayValue = TextHelper.TruncateToWidth(value, ConfigUILayout.ItemValueMaxWidth, font);
+        var valuePos = ConfigUILayout.ItemValuePos(rowTopY);
+        // Nav marker (">") sits on the dark "other" box -> light; real values sit on the
+        // itembox white cell -> dark.
+        Color valueColor = isNav
+            ? (selected ? SelectedNameText : LightText)
+            : (selected ? SelectedValueText : ValueDarkText);
+        font.DrawString(_spriteBatch, displayValue, valuePos, valueColor);
+    }
+}
+```
+
+- [ ] **Step 5: Build to verify it compiles**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 6: Run the config logic tests (no behavior regressions)**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~ConfigStage"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ConfigStage.cs
+git commit -m "feat: scroll config item list with NX centered focus and per-cell text colors"
+```
+
+---
+
+## Task 6: Description panel title/body in `ConfigStage`
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs` (`DrawDescriptionPanel` ~line 819)
+
+**Interfaces:**
+- Consumes: `ConfigUILayout.DescriptionTitlePos`, `DescriptionBodyPos`, `DescriptionWrapWidth`, `DescriptionLineHeight`, `DescriptionPanelRect`; `DescriptionTitleText`, `LightText`.
+
+- [ ] **Step 1: Rewrite the text portion of `DrawDescriptionPanel`**
+
+Keep the panel-background draw. Replace everything after it (from `var category = ...`) with:
+
+```csharp
+var category = _categories[_currentCategoryIndex];
+
+// Title: the focused item's name (or the category name on menu focus) on the white upper cell.
+string title = _focusOnMenu
+    ? category.Name
+    : (category.SelectedItem?.Name ?? category.Name);
+if (!string.IsNullOrEmpty(title) && _boldFont != null)
+    _boldFont.DrawString(_spriteBatch, title, ConfigUILayout.DescriptionTitlePos, DescriptionTitleText);
+
+// Body: the description text, wrapped, on the black lower cell.
+string text = _focusOnMenu
+    ? category.Description
+    : (category.SelectedItem?.Description ?? string.Empty);
+if (string.IsNullOrEmpty(text) || _font == null)
+    return;
+
+var pos = ConfigUILayout.DescriptionBodyPos;
+foreach (var line in WrapText(_font, text, ConfigUILayout.DescriptionWrapWidth))
+{
+    _font.DrawString(_spriteBatch, line, pos, LightText);
+    pos.Y += ConfigUILayout.DescriptionLineHeight;
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj`
+Expected: Build succeeded (no remaining references to removed `DescriptionTextPos`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Stage/ConfigStage.cs
+git commit -m "feat: render config description as title on white cell + body on black cell"
+```
+
+---
+
+## Task 7: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full Mac test suite**
+
+Run: `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`
+Expected: PASS (all tests, including `ConfigUILayoutTests` and `ConfigStage*Tests`).
+
+- [ ] **Step 2: Visual verification**
+
+Launch the game, open Config (Title → Config), and confirm each state:
+- Menu labels are centered and vertically aligned in their cursor band; the selected label is dark on the light cursor.
+- Item rows render full-size (no squish); names are light on the dark cell; values are dark on the white cell; the selected row is framed by the fixed cursor at center; selected name is warm yellow, selected value dark orange.
+- Scroll to the last item (System has 7): the selected item stays centered, rows scroll under the cursor, and no duplicate rows appear.
+- The read-only "DTX Folder" row shows its path in the white value cell (dark, truncated).
+- Navigation rows ("System Key Mapping", "Import NX Scores", "Drum Key Mapping") show a light ">" on the dark "other" box.
+- Description panel: bold title on the white upper region (dark), wrapped body on the black lower region (light).
+
+Fine-tune `ItemValueOffsetX`, `ItemNameOffsetX`, `ItemTextOffsetY`, `DescriptionTitlePos`/`DescriptionBodyPos` in `ConfigUILayout` (and the matching test expectations) if a screenshot shows any text off its cell.
+
+- [ ] **Step 3: Final commit if any tuning was applied**
+
+```bash
+git add -A
+git commit -m "fix: tune config text offsets against visual verification"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Menu alignment → Task 1 + Task 4. ✓
+- Text readability (value on white, selected colors, menu selected, description) → Task 4, 5, 6. ✓
+- "Missing" background / squished rows → Task 2 + Task 5 (native box sizes). ✓
+- Scrolling for future expansion → Task 2 (`RowTopY`/`IsRowVisible`) + Task 5 (`_itemScroll`, wrap-snap). ✓
+- Tests updated → Tasks 1–3; regressions guarded by Task 5 step 6 / Task 7. ✓
+
+**Placeholder scan:** none — every step has concrete code/constants.
+
+**Type consistency:** `RowTopY(int,double)`, `IsRowVisible(int)`, `ItemBoxRect(int,int)`, `ItemNamePos(int)`, `ItemValuePos(int)`, `MenuCursorRect(int)`, `_itemScroll` (double) used identically across Tasks 2/5. Color names (`ValueDarkText`, `SelectedNameText`, `SelectedValueText`, `SelectedMenuText`, `DescriptionTitleText`) defined in Task 4 and consumed in Tasks 5/6. ✓

--- a/docs/superpowers/specs/2026-06-25-config-stage-nx-layout-design.md
+++ b/docs/superpowers/specs/2026-06-25-config-stage-nx-layout-design.md
@@ -1,7 +1,7 @@
 # Config Stage NX Layout Revamp — Design
 
 **Date:** 2026-06-25
-**Status:** Approved (brainstorming), ready for implementation planning
+**Status:** Implemented. Subsequently refined: `ConfigItemBoxOther` was removed and item-box rendering unified (see commit `09756ac`). References to `ConfigItemBoxOther` below are retained as the original design intent; the shipped code uses a single `ConfigItemBox` texture.
 
 ## Summary
 

--- a/docs/superpowers/specs/2026-07-01-config-stage-nx-layout-design.md
+++ b/docs/superpowers/specs/2026-07-01-config-stage-nx-layout-design.md
@@ -1,0 +1,182 @@
+# Config Stage — NX Layout Refinement (Design)
+
+Date: 2026-07-01
+Status: Approved (user requested scrolling be included for future list expansion)
+
+## Problem
+
+The Config stage UX is messy relative to DTXManiaNX:
+
+- **Menu items not aligned** — the left category menu (System / Drums / Exit) uses
+  metrics (`MenuLabelCenterX=335`, stride `34`, first-row `Y=156`) that drift from
+  NX (`340` / `32` / `144`), and labels are not vertically centered in the cursor
+  band.
+- **Text hard to read** — the item-row art (`4_itembox.png`, 538×80) is a **dark
+  left cell for the name** plus a **white right cell for the value**. The current
+  code draws the value in light gold (`255,226,150`) and the selected value in
+  `Yellow` — both illegible on the white cell. The description panel
+  (`4_Description Panel.png`) is **white on top / black on bottom**, but the code
+  draws all description text in light color from `y=288`, i.e. light text on the
+  white upper region.
+- **"Missing" panel background / distorted rows** — the 538×80 item-box art is
+  squished into a `360×54` rectangle (`ItemRowRect`), distorting the art and
+  collapsing the name/value cells so the value cell (white background) is cut off,
+  reading as a missing background.
+
+The runtime skin art **is** present at
+`~/Library/Application Support/DTXManiaCX/System/Graphics/` (verified), so the fix
+is layout constants + text colors, not missing assets.
+
+## Goal
+
+Refine the Config stage to match NX's visual language: aligned menu, correctly
+proportioned item rows, and text colors that are legible against each art cell —
+without changing behavior (navigation, value editing, save-on-exit, NX import).
+
+## Scope decision: NX center-locked scrolling list (future-proof for long lists)
+
+NX's item list is a vertically-scrolling list with the selected item locked to the
+screen center; rows scroll past a fixed cursor. We adopt that model so the list
+scales when categories grow (the primary reason to include scrolling now, while
+System = 7 / Drums = 4). The architecture is a **scrolling viewport**:
+
+- The **selected item is drawn at a fixed focus row** (NX center, panel-top y=189);
+  every other item `i` renders at `focusY + (i − p)·stride`, where `p` is an
+  animated scroll position that eases toward `selectedIndex`.
+- **Non-cyclic display**: only real items (indices `0..count−1`) are drawn. A slot
+  mapping outside that range draws nothing — so short lists show blank space above/
+  below the centered selection (the authentic NX look, clearly "a scrollable list")
+  and **never** show duplicate rows the way a naïve cyclic ring would for a 4-item
+  list.
+- **Wrap-safe animation**: `ConfigCategory` selection wraps (`% count`). Adjacent
+  moves ease `p` by one row; a wrap (last↔first) **snaps** `p` to the target instead
+  of scrolling the whole list backward. Concretely: on update, ease
+  `p += (sel − p)·factor`, but if `|sel − p| > 1.5` (a wrap or multi-row jump), set
+  `p = sel`.
+- The **cursor is fixed** at the focus row (NX `4_itembox cursor.png` at 413,193);
+  items scroll under it. Only real items within the visible band
+  (header bottom 105 .. footer top 690) are drawn.
+
+The scroll math (index → screen Y, and which items are visible) lives in a pure,
+unit-tested `ConfigUILayout` helper; only the eased `p` value and its per-frame
+step live in the stage. This keeps arbitrary-length support testable without a
+GraphicsDevice.
+
+## Authentic NX reference coordinates (1280×720)
+
+From `DTXManiaNX/.../04.Config/CStageConfig.cs` and `CActConfigList.cs`:
+
+| Element            | NX value |
+|--------------------|----------|
+| Background         | (0,0) 1280×720 |
+| Item bar divider   | (400,0) 18×720 |
+| Menu panel         | (245,140) 180×172 |
+| Menu label center  | x≈340, first `menuY=144`, stride `32` |
+| Menu cursor        | x=250, y=146+i·32, width≈170, height 32 (light bar) |
+| Item panel X       | 420 |
+| Item name          | (panelX+20, y+24) |
+| Item value         | (panelX+260, y+24) |
+| Item cursor        | (413,193), art `4_itembox cursor.png` 497×68 |
+| Description panel  | (800,270) 280×360 |
+| Item box art       | `4_itembox.png` 538×80 (dark name cell + white value cell); `4_itembox other.png` 438×80 (single dark cell) |
+
+## Design
+
+### 1. Left category menu (`ConfigUILayout` + `DrawCategoryMenu`)
+
+- `MenuLabelCenterX = 335` (true panel center: 245 + 180/2).
+- Menu cursor: `x=250`, `width=170`, `height=32`; first cursor `Y=148`, stride `32`
+  (3 rows → 148 / 180 / 212, inside the 140..312 panel).
+- Draw each label **vertically centered** in its 32-px cursor band
+  (`labelY = cursorY + (32 - textHeight)/2`) instead of at a fixed row Y.
+- **Selected** label color becomes **dark** (`SelectedMenuText ≈ 36,24,72`) because
+  it sits on the light cursor bar; non-selected labels stay light
+  (`LightText 235,238,248`) on the purple panel.
+
+### 2. Item rows — scrolling viewport (`ConfigUILayout` + `DrawItemList`)
+
+- `ItemListX = 420`; boxes drawn at the art's **native** size (no squish):
+  - Normal box (`4_itembox.png`): **538×80** — dark name cell + white value cell.
+  - Other box (`4_itembox other.png`): **438×80** — single dark cell (navigation /
+    read-only rows, which have no value).
+- `ItemRowStride = 67` (NX; boxes overlap 13 px, matching how the art tiles).
+- `ItemFocusRowY = 189` — panel-top Y of the centered/selected row.
+- Per-item panel-top Y (pure helper):
+  `RowTopY(i, p) = ItemFocusRowY + round((i − p)·ItemRowStride)`, where `p` is the
+  eased scroll position. Draw item `i` only when its box intersects the visible band
+  `[105, 690]`. The selected item lands at `ItemFocusRowY` once `p` settles.
+- **Name** text at `(boxX + 20, rowTopY + 24)` in `LightText` (dark cell → light).
+- **Value** text at `(boxX + 260, rowTopY + 24)` in a **new dark**
+  `ValueText (24,24,32)` (white cell → dark). Keep the existing width-truncation so a
+  long value (e.g. a deep `DTXPath`) never overflows past the box / into the
+  description panel.
+- **Selected** row: name in `SelectedNameText (255,238,120)` (warm yellow on the
+  dark cell); value in `SelectedValueText (168,52,0)` (dark orange on the white
+  cell). No more yellow-on-white.
+- Item cursor: `4_itembox cursor.png` (497×68) drawn **fixed** at `(413, 193)` (the
+  focus row) when focus is on the item list; items scroll under it.
+- The normal box (ends at 420+538 = 958) extends under the description panel
+  (x=800); the description panel is drawn **after** the rows, covering the right ends
+  exactly as NX does. Value text at 680 + width stays left of x=800 after truncation.
+
+### 3. Description panel (`DrawDescriptionPanel`)
+
+The panel art is white (top ~270..430) over black (~430..630). Use both cells:
+
+- **Title** (bold) — current item/category name — in the white upper region,
+  **dark** text (≈ `24,24,32`) at ~`(818, 300)`.
+- **Body** — the description string, wrapped — in the black lower region, **light**
+  text (`LightText`) starting ~`(818, 445)`, wrap width 248, line height 22.
+
+This removes the light-on-white illegibility and fills the two-tone panel the way
+the art intends.
+
+### 4. Unchanged
+
+- Background, item-bar divider, header panel + "CONFIGURATION" title, footer panel
+  + instructions text, NX-import status line — all keep their current positions and
+  colors (not part of the reported problems). The header art is transparent with a
+  "FREE STAGE" badge; the title sits on the (dark) background and stays light.
+- All input handling, navigation, value editing, deferred save, and NX-score
+  import logic are untouched. This is a **draw/layout-only** change.
+
+## Files touched
+
+- `DTXMania.Game/Lib/UI/Layout/ConfigUILayout.cs` — menu metrics; item-list scroll
+  constants (`ItemListX`, native box sizes, `ItemRowStride`, `ItemFocusRowY`, visible
+  band, name/value offsets, fixed cursor rect); the pure `RowTopY(i, p)` helper and a
+  visibility predicate; description title + body positions.
+- `DTXMania.Game/Lib/Stage/ConfigStage.cs` — a scroll field `p` (eased toward
+  `SelectedIndex`, wrap-snapped) stepped in `OnUpdate`; `DrawCategoryMenu` (vertical
+  centering, selected-label dark color); `DrawItemList` (native box sizes, scrolling
+  viewport, name light / value dark, selected highlights, fixed cursor);
+  `DrawDescriptionPanel` (title on white + body on black). New `Color` constants.
+  Reset `p` to the selected index in `OnActivate` so re-entry starts settled.
+- `DTXMania.Test/UI/ConfigUILayoutTests.cs` — update pinned constants to the new
+  NX-aligned values; add tests for the scroll math (`RowTopY` centering the selected
+  item, stride, visibility band) and menu/description positions.
+
+## Testing
+
+- Update `ConfigUILayoutTests` to assert the new constants and the scroll math:
+  `RowTopY(sel, sel) == ItemFocusRowY` (selected item centered when settled),
+  `RowTopY(i+1, p) − RowTopY(i, p) == ItemRowStride`, the visibility predicate for
+  in- and out-of-band rows, menu row/cursor rects, and description title/body
+  positions. These are the regression guard for arbitrary-length scrolling.
+- Existing `ConfigStage*Tests` (logic: navigation, value editing, NX import) must
+  continue to pass unchanged — behavior is not modified.
+- Optionally assert the eased-scroll step converges toward / snaps on wrap (pure
+  double math, no GraphicsDevice).
+- Visual verification: launch the game, open Config, and screenshot each state
+  (menu focus, item focus, a toggle row, the read-only `DTX Folder` row, an item
+  with a long value, and scroll to the last item) to confirm alignment, contrast,
+  the centered selection, and that the description title/body land on the correct
+  art cells. Fine-tune name/value offsets and description Y against the screenshot.
+
+## Non-goals
+
+- NX's exact multi-stage accel-scroll curve — we use a single eased ease-toward step
+  (wrap-snapped). Feel can be tuned later.
+- Cyclic display that repeats items to fill the viewport for short lists.
+- Any change to config values, item semantics, or `IConfigItem`.
+- Header / footer / background art or their text.

--- a/docs/superpowers/specs/2026-07-01-config-stage-nx-layout-design.md
+++ b/docs/superpowers/specs/2026-07-01-config-stage-nx-layout-design.md
@@ -97,8 +97,11 @@ From `DTXManiaNX/.../04.Config/CStageConfig.cs` and `CActConfigList.cs`:
 
 - `ItemListX = 420`; boxes drawn at the art's **native** size (no squish):
   - Normal box (`4_itembox.png`): **538×80** — dark name cell + white value cell.
-  - Other box (`4_itembox other.png`): **438×80** — single dark cell (navigation /
-    read-only rows, which have no value).
+    All rows — value items **and** navigation/read-only rows — use this single box
+    so the list reads uniformly. NX has a separate `4_itembox other.png` (438×80,
+    single dark cell) for nav rows, but it looked out of place next to value rows;
+    we intentionally use the normal box for every row and do not load the "other"
+    texture.
 - `ItemRowStride = 67` (NX; boxes overlap 13 px, matching how the art tiles).
 - `ItemFocusRowY = 189` — panel-top Y of the centered/selected row.
 - Per-item panel-top Y (pure helper):
@@ -121,7 +124,15 @@ From `DTXManiaNX/.../04.Config/CStageConfig.cs` and `CActConfigList.cs`:
 
 ### 3. Description panel (`DrawDescriptionPanel`)
 
-The panel art is white (top ~270..430) over black (~430..630). Use both cells:
+The panel is drawn **only while focus is on the item list** (`!_focusOnMenu`),
+matching NX (`CStageConfig.cs:260`, `!bFocusIsOnMenu`). While browsing the
+category menu the panel is suppressed so the busy GALAXY WAVE background stays
+clear on entry and the panel does not overlap the item boxes until the player is
+actually editing an item. The selected item sits at the focus row (y=189), above
+the panel top (y=270), so it stays readable.
+
+When focus is on the item list, the panel art is white (top ~270..430) over
+black (~430..630); use both cells:
 
 - **Title** (bold) — current item/category name — in the white upper region,
   **dark** text (≈ `24,24,32`) at ~`(818, 300)`.

--- a/docs/superpowers/specs/2026-07-03-config-stage-foundation-changes.md
+++ b/docs/superpowers/specs/2026-07-03-config-stage-foundation-changes.md
@@ -94,6 +94,24 @@ lower-risk path.
   spilled into the gap between the clip rect (`y ∈ [109, 686)`) and the
   header/footer in any scroll state. The default `SpriteSortMode.Deferred`
   is sufficient; no fallback to `SpriteSortMode.Immediate` needed.
-- All four 1280×720 virtual-dimension copies (`GameConstants.Display`,
-  `ConfigUILayout`, `DrumKitLayout`, `PerformanceUILayout`) are now linked
-  to `GameConstants.Display` as the single source of truth.
+- Automated scissor-clip regression guard: `ConfigStage` exposes the item-
+  list clip via three seams — `GetItemClipRectangle()` (the rect to clip to),
+  `CreateItemClipRasterizer()` (the rasterizer with `ScissorTestEnable`),
+  and `ApplyScissorRectangle(Rectangle)` (the GraphicsDevice apply step).
+  `RenderSpyConfigStage` overrides `ApplyScissorRectangle` to record the
+  rect without a device, and tests assert the recorded rect equals
+  `ConfigUILayout.InnerBoardRect` and the rasterizer has
+  `ScissorTestEnable = true` / `CullMode = None`. A future change to the
+  clip rect or rasterizer that breaks the "zero spill past the board"
+  invariant now fails a test instead of regressing silently.
+- Virtual-dimension source of truth: `GameConstants.Display.VirtualWidth/
+  Height` is the single source for screen-dimension constants. The layout
+  classes that author in 1280×720 space link to it: `ConfigUILayout`
+  (`ScreenWidth`/`ScreenHeight`), `DrumKitLayout` (`DesignWidth`/
+  `DesignHeight`), `PerformanceUILayout` (`ScreenWidth`/`ScreenHeight`,
+  plus the derived `LaneHeight`, full-screen overlay bounds, centered
+  positioning, and proportional atlas bounds), `ResultUILayout.NXViewport`
+  (`Width`/`Height`), and `SongSelectionUILayout.SongListDisplay`
+  (`Width`/`Height`). Texture-atlas source rectangles (e.g. the 720px-tall
+  lane source rects in `PerformanceUILayout`) remain hardcoded by design —
+  they describe texture dimensions, not the screen.

--- a/docs/superpowers/specs/2026-07-03-config-stage-foundation-changes.md
+++ b/docs/superpowers/specs/2026-07-03-config-stage-foundation-changes.md
@@ -1,0 +1,99 @@
+# Config Stage NX Layout — Foundation Changes (Design Note)
+
+Date: 2026-07-03
+Status: Ratifying (post-implementation)
+Branch: `refactor/config-stage-nx-layout`
+
+## Purpose
+
+The config-stage NX layout plan (`2026-07-01-config-stage-nx-layout.md`) scoped
+work to three files: `ConfigUILayout.cs`, `ConfigStage.cs`, and
+`ConfigUILayoutTests.cs`. During implementation, four foundation-level changes
+were required to make the NX layout correct and testable. This note documents
+why each was needed so the scope expansion is explicit rather than implicit.
+
+## Foundation changes outside the original plan
+
+### 1. Fixed virtual render target + letterboxing (commit `f73b8d9`)
+
+**What:** `BaseGame` now renders every stage into a fixed 1280×720 render
+target (`GameConstants.Display.VirtualWidth/Height`) and letterbox-scales that
+target once to fill the physical window.
+
+**Why needed:** The config layout constants are authored in DTXManiaNX's
+1280×720 space. Without a fixed virtual target, stages drew directly to the
+back buffer at the configured resolution (e.g. 1920×1080), so the authored
+coordinates were wrong at any resolution other than 1280×720. The NX layout
+requires pixel-accurate placement of the item boxes, cursor, and description
+panel; a scaling back buffer breaks that. The fixed render target makes the
+authored coordinates correct at every window size.
+
+**Files:** `Game1.cs`, `GameConstants.cs` (new `Display` constants),
+`ConfigStage.cs` (scissor clip for the item list).
+
+### 2. Window-to-virtual coordinate mapping for hit-testing (commit `7e14f08`)
+
+**What:** `BaseGame.WindowToVirtualCoordinates` and `MapMouseToVirtual` convert
+raw window mouse positions into the 1280×720 virtual space. Clicks on
+letterbox bars map to null.
+
+**Why needed:** Once stages draw into the letterboxed virtual target, mouse
+hit-testing must convert window coords back to virtual coords to match the
+authored rectangles. Without this, clicks would test against the wrong
+coordinates at any window size that isn't exactly 1280×720. Four stages had
+per-stage viewport transform methods (`CreateViewportTransform`, `GetViewport`)
+that were removed in favor of the single centralized mapping.
+
+**Files:** `Game1.cs`, `ConfigStage.cs`, `DrumConfigStage.cs`,
+`SongSelectionStage.cs`, `TitleStage.cs`.
+
+### 3. Headless test seams (commit `8f1f7a5`)
+
+**What:** Extracted `BaseGame.TryGetViewportBounds` and
+`SystemKeyAssignPanel.DrawWhitePixel` as virtual seams so headless tests can
+override them without a GraphicsDevice.
+
+**Why needed:** The virtual render target and coordinate mapping logic needed
+unit coverage, but `BaseGame` methods touch `GraphicsDevice` for viewport
+bounds. The seams let tests verify `MapMouseToVirtual` and the
+`SystemKeyAssignPanel` draw path without a device — the same pattern
+`ConfigStage.BeginItemClip/EndItemClip` already uses.
+
+**Files:** `Game1.cs`, `SystemKeyAssignPanel.cs`, `ConfigStage.cs`, plus
+test files.
+
+### 4. SystemKeyAssignPanel redesign (commit `5238bf1`)
+
+**What:** `SystemKeyAssignPanel` was redesigned to the NX layout with the
+virtual coordinate space, and its draw path was made testable via the
+`DrawWhitePixel` seam.
+
+**Why needed:** The panel is opened from the Config stage's System category
+("System Key Mapping" item). It shared the same coordinate-space problem as
+the rest of the Config stage — without the virtual target, its hit-testing
+and layout were wrong at non-1280×720 resolutions. Fixing the Config stage
+without fixing the panel it opens would leave a broken navigation path.
+
+**Files:** `SystemKeyAssignPanel.cs`.
+
+## Scope decision
+
+These four changes are tightly coupled to the config layout work: the NX
+layout is incorrect without the virtual render target, and the panel opened
+from Config is incorrect without the coordinate mapping. Splitting them into
+a separate PR would require either a broken intermediate state (config layout
+without the virtual target) or reverting the layout work to land the
+foundation first. Keeping them in one PR with this ratification note is the
+lower-risk path.
+
+## Verification
+
+- Visual scissor-clip verification performed (Task 7 Step 2): launched the
+  Mac game, navigated to Config, scrolled past the top and bottom of the
+  item list, and pixel-analyzed the screenshots. Zero item-box pixels
+  spilled into the gap between the clip rect (`y ∈ [109, 686)`) and the
+  header/footer in any scroll state. The default `SpriteSortMode.Deferred`
+  is sufficient; no fallback to `SpriteSortMode.Immediate` needed.
+- All four 1280×720 virtual-dimension copies (`GameConstants.Display`,
+  `ConfigUILayout`, `DrumKitLayout`, `PerformanceUILayout`) are now linked
+  to `GameConstants.Display` as the single source of truth.

--- a/docs/superpowers/specs/2026-07-03-config-stage-foundation-changes.md
+++ b/docs/superpowers/specs/2026-07-03-config-stage-foundation-changes.md
@@ -8,7 +8,7 @@ Branch: `refactor/config-stage-nx-layout`
 
 The config-stage NX layout plan (`2026-07-01-config-stage-nx-layout.md`) scoped
 work to three files: `ConfigUILayout.cs`, `ConfigStage.cs`, and
-`ConfigUILayoutTests.cs`. During implementation, four foundation-level changes
+`ConfigUILayoutTests.cs`. During implementation, six foundation-level changes
 were required to make the NX layout correct and testable. This note documents
 why each was needed so the scope expansion is explicit rather than implicit.
 
@@ -76,15 +76,78 @@ without fixing the panel it opens would leave a broken navigation path.
 
 **Files:** `SystemKeyAssignPanel.cs`.
 
+### 5. Centralize virtual resolution constants across layout classes (commits `15f4bff`, `cbcc0a7`)
+
+**What:** The hardcoded `1280`/`720` magic numbers in the layout classes were
+replaced with references to the single source of truth,
+`GameConstants.Display.VirtualWidth/Height`. Each layout class now links to
+that constant instead of restating the dimensions.
+
+**Why needed:** Foundation change #1 introduced `GameConstants.Display` as the
+single source for the virtual dimensions. Leaving the layout classes with
+hardcoded `1280`/`720` would mean a future change to the virtual resolution
+requires editing every layout file in lockstep — the exact duplication the
+centralization was meant to eliminate. The layout classes author in 1280×720
+space, so they are the primary consumers of the constant and the highest-value
+place to wire it in.
+
+**Files:** `DrumKitLayout.cs` (`DesignWidth`/`DesignHeight`),
+`ConfigUILayout.cs` (`ScreenWidth`/`ScreenHeight`),
+`PerformanceUILayout.cs` (`ScreenWidth`/`ScreenHeight`, plus the derived
+`LaneHeight`, full-screen overlay bounds, centered positioning, and
+proportional atlas bounds),
+`ResultUILayout.cs` (`NXViewport.Width`/`Height`),
+`SongSelectionUILayout.cs` (`SongListDisplay.Width`/`Height`).
+
+Texture-atlas source rectangles (e.g. the 720px-tall lane source rects in
+`PerformanceUILayout`) remain hardcoded by design — they describe texture
+dimensions, not the screen.
+
+### 6. Remove redundant per-stage viewport reads (commits `cbcc0a7`, `36e7496`)
+
+**What:** Four stages had code that read `GraphicsDevice.Viewport` at draw or
+UI-init time to size a panel or compute a transform. Once every stage renders
+into the fixed 1280×720 virtual target, the back-buffer viewport is the window
+size (not the virtual size), so those reads return the wrong dimensions. They
+were replaced with direct references to the virtual dimensions.
+
+**Why needed:** Foundation change #1 made the back-buffer viewport irrelevant
+to stage layout — stages draw in virtual space and `BaseGame` letterboxes the
+result. Any stage that still read `GraphicsDevice.Viewport` for sizing would
+size against the window (e.g. 1920×1080) instead of the virtual target,
+breaking the layout. `SongTransitionStage`, `SongSelectionStage`, and
+`TitleStage` sized their main panel / fallback background from the viewport;
+`ResultStage` computed a per-stage viewport transform that was always identity
+under the virtual-target model (the transform mapped the virtual viewport to
+itself). Removing the transform is a semantic change to `ResultStage` (it no
+longer calls `ResultScreenRenderer.CreateViewportTransform`), but the call was
+a no-op once the virtual target landed, so the visible behavior is unchanged.
+
+**Files:** `ResultStage.cs` (removed the identity `CreateViewportTransform`
+call from `OnDraw`, now uses a plain `_spriteBatch.Begin()`),
+`SongTransitionStage.cs` (`InitializeUI` sizes the main panel to
+`GameConstants.Display.VirtualWidth/Height` instead of the viewport),
+`SongSelectionStage.cs` (`InitializeUI` sizes the main panel to
+`SongSelectionUILayout.SongListDisplay.Size` instead of the viewport),
+`TitleStage.cs` (fallback background draw uses
+`GameConstants.Display.VirtualWidth/Height` instead of the viewport).
+
+`SongSelectionStage.cs` and `TitleStage.cs` were also touched by foundation
+change #2 (commit `7e14f08`) to remove their per-stage viewport transform
+methods; this entry covers the separate panel-sizing fix from `36e7496`.
+
 ## Scope decision
 
-These four changes are tightly coupled to the config layout work: the NX
-layout is incorrect without the virtual render target, and the panel opened
-from Config is incorrect without the coordinate mapping. Splitting them into
-a separate PR would require either a broken intermediate state (config layout
-without the virtual target) or reverting the layout work to land the
-foundation first. Keeping them in one PR with this ratification note is the
-lower-risk path.
+These six changes are tightly coupled to the config layout work: the NX
+layout is incorrect without the virtual render target (#1), the panel opened
+from Config is incorrect without the coordinate mapping (#2), the layout
+classes can't safely reference a single dimension source until it exists (#5),
+and the per-stage viewport reads (#6) are dead code once the virtual target
+lands. Splitting them into a separate PR would require either a broken
+intermediate state (config layout without the virtual target, or layout
+classes still carrying magic numbers after the centralization constant
+exists) or reverting the layout work to land the foundation first. Keeping
+them in one PR with this ratification note is the lower-risk path.
 
 ## Verification
 
@@ -115,3 +178,31 @@ lower-risk path.
   (`Width`/`Height`). Texture-atlas source rectangles (e.g. the 720px-tall
   lane source rects in `PerformanceUILayout`) remain hardcoded by design —
   they describe texture dimensions, not the screen.
+
+## Contracts and known drift
+
+- **Scissor save/restore pairing:** `ConfigStage._savedScissorRectangle` is
+  a default-initialized `Rectangle` (`{0,0,0,0}`) and is only meaningful
+  after `ApplyScissorRectangle` writes the device's current scissor into it.
+  `RestoreScissorRectangle` reads it back. The contract is that
+  `RestoreScissorRectangle` must only be called after a matching
+  `ApplyScissorRectangle`; `BeginItemClip`/`EndItemClip` enforce this via
+  try/finally, so the pairing holds as long as callers go through that pair
+  rather than calling the seams directly. Calling `RestoreScissorRectangle`
+  without a prior `Apply` would set the device scissor to `{0,0,0,0}`.
+- **`DescriptionBodyPos.Y` drift (445 → 448):** The design spec
+  (`2026-07-01-config-stage-nx-layout-design.md`) places the description
+  body at `~(818, 445)`. The implementation uses `(818, 448)`. The 3px
+  shift is within the design spec's own `~` (approximate) tolerance and was
+  applied during fine-tuning (the plan `2026-07-01-config-stage-nx-layout.md`
+  and the layout test both assert 448). The design spec's `445` is stale;
+  the implementation is the source of truth.
+- **`GetItemValueText` prefix-stripping coupling:** `ConfigStage.GetItemValueText`
+  extracts the value column by stripping the `"{Name}: "` prefix that
+  `IConfigItem.GetDisplayText()` prepends. This is coupled to every concrete
+  item type's `GetDisplayText` format (Dropdown/Toggle/Integer/ReadOnly all
+  use `"{Name}: {value}"`); a future item type that omits the prefix would
+  render an empty value here. The coupling is documented in-code at the
+  method. Adding a `GetValueText()` to `IConfigItem` would decouple this,
+  but that value-semantics change is an explicit non-goal of the NX layout
+  revamp — so the coupling is documented rather than resolved.


### PR DESCRIPTION
## Summary
- Refactor ConfigStage to match NX layout with inner board, scrolling item list, and unified key-assignment rendering.
- Render at fixed 1280x720 virtual resolution and letterbox to the actual window in Game1.
- Add `VirtualResolutionWidth` / `VirtualResolutionHeight` constants to GameConstants.
- Update ConfigUILayout and SystemKeyAssignPanel to use NX layout constants.
- Add design and implementation plan docs under docs/plans.
- Extend tests for ConfigStage logic, ConfigUILayout, and base game resolution behavior.

#### Test plan
- [x] `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj` passes (6175 tests, 0 failures).
- [ ] CI Windows test suite passes.

Generated with [Devin](https://devin.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a fixed virtual display canvas (1280×720) with letterbox/pillarbox scaling for menus and configuration screens, keeping UI layout consistent across window sizes.
  * Updated configuration-style “NX” panels with fixed focus cursor scrolling and refreshed inner-board rendering.

* **Bug Fixes**
  * Fixed mouse hover/click hit-testing in letterboxed/pillarboxed windows (including modals and selection popups).
  * Improved item list clipping and rendering to prevent overlap and keep text/boxes within the board area.

* **Documentation**
  * Updated skin implementation docs: the deprecated “itembox other” texture is no longer used for config-stage item boxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->