### PR TITLE
chore(deps): bump System.Text.Encoding.CodePages to 10.0.9

### DIFF
--- a/DTXMania.Game/DTXMania.Game.Mac.csproj
+++ b/DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="NVorbis" Version="0.10.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.17" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
   </ItemGroup>
 
   <!-- SIL Open Font License files for Orbitron and ShareTechMono. The OFL

--- a/DTXMania.Game/DTXMania.Game.Windows.csproj
+++ b/DTXMania.Game/DTXMania.Game.Windows.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="NVorbis" Version="0.10.5" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.17" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
   </ItemGroup>
 
   <!-- SIL Open Font License files for Orbitron and ShareTechMono. The OFL


### PR DESCRIPTION
Replacement for the closed Dependabot PR #89. This keeps the original package update against the current main branch.