### PR TITLE
chore: trigger HPA-192 CI fix

### DIFF
--- a/.github/hpa192-ci-fix-trigger
+++ b/.github/hpa192-ci-fix-trigger
@@ -1,0 +1,1 @@
+Trigger the one-time HPA-192 Windows test fixture fix.


### PR DESCRIPTION
One-time same-repository trigger for the trusted HPA-192 Windows test fixture repair workflow. This PR will not be merged.