### PR TITLE
feat(ci): automate releases from main pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,6 +312,11 @@ jobs:
         with:
           name: dtxmania-windows-installer
           path: installer/windows/Output/DTXMania-Setup-${{ env.APP_VERSION }}.exe
+          # GITHUB_RUN_ID is stable across reruns (only GITHUB_RUN_ATTEMPT
+          # increments), and upload-artifact v4 defaults overwrite to false,
+          # so a rerun would 409 on the prior attempt's immutable artifact.
+          # Mirror create-release's --clobber rerun handling.
+          overwrite: true
 
   mac-installer:
     needs: prepare-release
@@ -595,6 +600,7 @@ jobs:
         with:
           name: dtxmania-macos-dmg
           path: output/DTXMania-${{ env.APP_VERSION }}-arm64.dmg
+          overwrite: true # see windows-installer upload note; same rerun concern
 
   create-release:
     name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     outputs:
       release_tag: ${{ steps.release.outputs.release_tag }}
       checkout_ref: ${{ steps.release.outputs.checkout_ref }}
+      target_sha: ${{ steps.release.outputs.target_sha }}
       prerelease: ${{ steps.release.outputs.prerelease }}
 
     steps:
@@ -60,6 +61,7 @@ jobs:
             # a tag moved between this step and checkout can't pull in the
             # wrong commit.
             checkout_ref="$COMMIT_SHA"
+            target_sha="$COMMIT_SHA"
 
             # Re-runs keep the original tag stable. Refuse to continue if a
             # tag with the generated name was moved to another commit.
@@ -86,18 +88,33 @@ jobs:
             # checkouts, which would let Windows/macOS build a different
             # commit from each other and from TARGET_SHA.
             checkout_ref="$COMMIT_SHA"
+            target_sha="$COMMIT_SHA"
           elif [[ -n "$INPUT_TAG" ]]; then
             release_tag="$INPUT_TAG"
             # Explicitly requested historical tag. github.sha for a dispatch
-            # is the selected branch tip, not this tag's commit, so the tag
-            # name is the only way to resolve the intended commit.
-            checkout_ref="$INPUT_TAG"
+            # is the selected branch tip, not this tag's commit, so resolve
+            # the tag once to its immutable commit SHA here. git refs can be
+            # rewritten, so both installer jobs must check out the resolved
+            # SHA (not the tag name) and create-release must target it —
+            # otherwise a force-moved tag could make Windows and macOS build
+            # different commits, and the release could point elsewhere again.
+            encoded_tag="$(jq -rn --arg v "$INPUT_TAG" '$v | @uri')"
+            if ! resolved_sha="$(gh api \
+                -H 'Accept: application/vnd.github.sha' \
+                "repos/${GITHUB_REPOSITORY}/commits/${encoded_tag}")"; then
+              echo "::error::Could not resolve input tag '${INPUT_TAG}' to a commit via the GitHub API." >&2
+              exit 1
+            fi
+            checkout_ref="$resolved_sha"
+            target_sha="$resolved_sha"
+            echo "Resolved tag ${release_tag} to ${resolved_sha}."
           else
             release_tag="v0.0.0-dev.${RUN_NUMBER}"
             # No-tag manual dispatch: checkout the immutable dispatch-time
             # commit (COMMIT_SHA = github.sha), not the branch ref. The
             # selected branch can advance while installer jobs are queued.
             checkout_ref="$COMMIT_SHA"
+            target_sha="$COMMIT_SHA"
           fi
 
           prerelease=false
@@ -108,10 +125,12 @@ jobs:
           {
             echo "release_tag=$release_tag"
             echo "checkout_ref=$checkout_ref"
+            echo "target_sha=$target_sha"
             echo "prerelease=$prerelease"
           } >> "$GITHUB_OUTPUT"
           echo "Release tag: $release_tag"
           echo "Checkout ref: $checkout_ref"
+          echo "Target SHA: $target_sha"
 
   windows-installer:
     needs: prepare-release
@@ -579,6 +598,38 @@ jobs:
           name: dtxmania-macos-dmg
           path: release-assets
 
+      - name: Verify release tag still resolves to build commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # This job does not check out the repository, so there is no local
+          # git remote for `gh` to resolve the repository from. GH_TOKEN only
+          # authenticates; it does not select a repository. Set GH_REPO so the
+          # gh api calls below target this repository.
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          TARGET_SHA: ${{ needs.prepare-release.outputs.target_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # git refs can be rewritten. Before publishing, confirm the release
+          # tag still resolves to the commit the artifacts were built from, so
+          # a force-push to the tag while the installer jobs were queued can't
+          # publish a release whose binaries came from a different commit. A
+          # dev (no-tag) dispatch has no tag yet — gh release create below
+          # creates it at TARGET_SHA — so a missing tag is fine.
+          encoded_tag="$(jq -rn --arg v "$RELEASE_TAG" '$v | @uri')"
+          if current_sha="$(gh api \
+              -H 'Accept: application/vnd.github.sha' \
+              "repos/${GH_REPO}/commits/${encoded_tag}" 2>/dev/null)"; then
+            if [[ "$current_sha" != "$TARGET_SHA" ]]; then
+              echo "::error::Tag $RELEASE_TAG now resolves to $current_sha, expected $TARGET_SHA. Refusing to publish artifacts built from $TARGET_SHA." >&2
+              exit 1
+            fi
+            echo "Tag $RELEASE_TAG still points at $TARGET_SHA."
+          else
+            echo "Tag $RELEASE_TAG does not exist yet; it will be created at $TARGET_SHA."
+          fi
+
       - name: Create GitHub release with build assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -590,7 +641,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
           PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
-          TARGET_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ needs.prepare-release.outputs.target_sha }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,120 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to build (e.g. v1.2.3). Defaults to a dev version.'
+        description: 'Release tag to build (e.g. v1.2.3). Defaults to a unique dev release.'
         required: false
         type: string
 
+# A push to main creates a unique CI tag at the pushed commit and continues in
+# this same workflow run. Tag pushes and manual runs use the existing tag/input
+# behavior below. A GITHUB_TOKEN-created tag does not recursively trigger a
+# second workflow run, so the release must continue from this run.
+
 # One release pipeline per tag at a time. Cancel in-flight runs for the same
-# tag so re-publishing a release doesn't race on asset uploads.
+# tag so release creation and asset uploads do not race.
 concurrency:
-  group: release-${{ github.event.release.tag_name || github.event.inputs.tag || github.run_id }}
+  group: release-${{ github.event_name == 'push' && github.ref_type == 'tag' && github.ref_name || github.event_name == 'push' && github.ref == 'refs/heads/main' && format('v0.0.0-main.{0}', github.run_number) || github.event.inputs.tag || format('v0.0.0-dev.{0}', github.run_number) }}
   cancel-in-progress: false
 
 permissions: {}
 
 jobs:
+  prepare-release:
+    name: Prepare release tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      release_tag: ${{ steps.release.outputs.release_tag }}
+      checkout_ref: ${{ steps.release.outputs.checkout_ref }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+
+    steps:
+      - name: Create tag for main push
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+            release_tag="v0.0.0-main.${RUN_NUMBER}"
+            checkout_ref="$release_tag"
+
+            # Re-runs keep the original tag stable. Refuse to continue if a
+            # tag with the generated name was moved to another commit.
+            if existing_sha=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${release_tag}" \
+              --jq '.object.sha' 2>/dev/null); then
+              if [[ "$existing_sha" != "$COMMIT_SHA" ]]; then
+                echo "Tag ${release_tag} already points to ${existing_sha}, expected ${COMMIT_SHA}." >&2
+                exit 1
+              fi
+              echo "Tag ${release_tag} already points to ${COMMIT_SHA}."
+            else
+              gh api --method POST \
+                "repos/${GITHUB_REPOSITORY}/git/refs" \
+                -f "ref=refs/tags/${release_tag}" \
+                -f "sha=${COMMIT_SHA}"
+              echo "Created tag ${release_tag} at ${COMMIT_SHA}."
+            fi
+          elif [[ "$EVENT_NAME" == "push" ]]; then
+            release_tag="$REF_NAME"
+            checkout_ref="$release_tag"
+          elif [[ -n "$INPUT_TAG" ]]; then
+            release_tag="$INPUT_TAG"
+            checkout_ref="$INPUT_TAG"
+          else
+            release_tag="v0.0.0-dev.${RUN_NUMBER}"
+            checkout_ref="$REF"
+          fi
+
+          prerelease=false
+          if [[ "$release_tag" == *-* ]]; then
+            prerelease=true
+          fi
+
+          {
+            echo "release_tag=$release_tag"
+            echo "checkout_ref=$checkout_ref"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
+          echo "Release tag: $release_tag"
+          echo "Checkout ref: $checkout_ref"
+
   windows-installer:
+    needs: prepare-release
     runs-on: windows-latest
     timeout-minutes: 30
     permissions:
-      contents: write
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
-          # For release events this defaults to the published tag; for
-          # workflow_dispatch we must explicitly check out inputs.tag so a
-          # manual rerun of an older tag builds that tag's source, not the
-          # default branch. Empty (no tag input) falls back to the default
-          # branch for dev builds.
-          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.checkout_ref }}
 
       - name: Normalize version from tag
         shell: pwsh
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag || 'v0.0.0-dev' }}
         run: |
           $tag = "$env:RELEASE_TAG"
           $version = $tag -replace '^v', ''
@@ -180,16 +254,11 @@ jobs:
       - name: Upload installer artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: dtxmania-windows-installer-${{ env.APP_VERSION }}
+          name: dtxmania-windows-installer
           path: installer/windows/Output/DTXMania-Setup-${{ env.APP_VERSION }}.exe
 
-      - name: Attach installer to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
-        with:
-          files: installer/windows/Output/DTXMania-Setup-${{ env.APP_VERSION }}.exe
-
   mac-installer:
+    needs: prepare-release
     # Pin to macos-15 (Apple Silicon / arm64) instead of macos-latest. This
     # job publishes an arm64-only .app bundle and builds FFmpeg from source
     # for the host architecture (./configure passes no --arch flag), so an
@@ -201,20 +270,18 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 30
     permissions:
-      contents: write
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
-          # See windows-installer job: check out inputs.tag on manual runs so
-          # the built source matches the version label.
-          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          ref: ${{ needs.prepare-release.outputs.checkout_ref }}
 
       - name: Normalize version from tag
-        env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag || 'v0.0.0-dev' }}
         run: |
           tag="$RELEASE_TAG"
           version="${tag#v}"
@@ -470,11 +537,39 @@ jobs:
       - name: Upload DMG artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: dtxmania-macos-dmg-${{ env.APP_VERSION }}
+          name: dtxmania-macos-dmg
           path: output/DTXMania-${{ env.APP_VERSION }}-arm64.dmg
 
-      - name: Attach DMG to release
-        if: github.event_name == 'release'
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-release
+      - windows-installer
+      - mac-installer
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download Windows installer
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dtxmania-windows-installer
+          path: release-assets
+
+      - name: Download macOS DMG
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dtxmania-macos-dmg
+          path: release-assets
+
+      - name: Create GitHub release with build assets
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
-          files: output/DTXMania-${{ env.APP_VERSION }}-arm64.dmg
+          tag_name: ${{ needs.prepare-release.outputs.release_tag }}
+          target_commitish: ${{ github.sha }}
+          name: DTXManiaCX ${{ needs.prepare-release.outputs.release_tag }}
+          generate_release_notes: true
+          prerelease: ${{ needs.prepare-release.outputs.prerelease }}
+          files: release-assets/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,13 +80,24 @@ jobs:
             fi
           elif [[ "$EVENT_NAME" == "push" ]]; then
             release_tag="$REF_NAME"
-            checkout_ref="$release_tag"
+            # Tag push: checkout the immutable commit the tag pointed to at
+            # push time (COMMIT_SHA = github.sha), not the tag ref itself.
+            # A tag can be moved between this step and the installer jobs'
+            # checkouts, which would let Windows/macOS build a different
+            # commit from each other and from TARGET_SHA.
+            checkout_ref="$COMMIT_SHA"
           elif [[ -n "$INPUT_TAG" ]]; then
             release_tag="$INPUT_TAG"
+            # Explicitly requested historical tag. github.sha for a dispatch
+            # is the selected branch tip, not this tag's commit, so the tag
+            # name is the only way to resolve the intended commit.
             checkout_ref="$INPUT_TAG"
           else
             release_tag="v0.0.0-dev.${RUN_NUMBER}"
-            checkout_ref="$REF"
+            # No-tag manual dispatch: checkout the immutable dispatch-time
+            # commit (COMMIT_SHA = github.sha), not the branch ref. The
+            # selected branch can advance while installer jobs are queued.
+            checkout_ref="$COMMIT_SHA"
           fi
 
           prerelease=false
@@ -571,6 +582,12 @@ jobs:
       - name: Create GitHub release with build assets
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job does not check out the repository, so there is no local
+          # git remote for `gh` to resolve the repository from. GH_TOKEN only
+          # authenticates; it does not select a repository. Set GH_REPO so the
+          # gh release view/upload/create commands below target this repository
+          # instead of failing with "could not determine repository".
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
           PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
           TARGET_SHA: ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ jobs:
       checkout_ref: ${{ steps.release.outputs.checkout_ref }}
       target_sha: ${{ steps.release.outputs.target_sha }}
       prerelease: ${{ steps.release.outputs.prerelease }}
+      # Only the no-tag manual dev dispatch reaches create-release without an
+      # existing tag (gh release create makes it at target_sha). Every other
+      # path — main push, tag push, explicit-tag dispatch — has a tag by this
+      # point, so a missing tag there is an error, not an expected state.
+      allow_missing_tag: ${{ steps.release.outputs.allow_missing_tag }}
 
     steps:
       - name: Create tag for main push
@@ -52,6 +57,12 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           set -euo pipefail
+
+          # A tag is expected to already exist for every path except the
+          # no-tag manual dev dispatch, where gh release create makes it at
+          # target_sha. create-release uses this to decide whether a missing
+          # tag is an expected state or an integrity failure.
+          allow_missing_tag=false
 
           if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
             release_tag="v0.0.0-main.${RUN_NUMBER}"
@@ -115,6 +126,9 @@ jobs:
             # selected branch can advance while installer jobs are queued.
             checkout_ref="$COMMIT_SHA"
             target_sha="$COMMIT_SHA"
+            # gh release create below creates this tag at target_sha, so it
+            # legitimately does not exist yet when create-release verifies.
+            allow_missing_tag=true
           fi
 
           prerelease=false
@@ -127,6 +141,7 @@ jobs:
             echo "checkout_ref=$checkout_ref"
             echo "target_sha=$target_sha"
             echo "prerelease=$prerelease"
+            echo "allow_missing_tag=$allow_missing_tag"
           } >> "$GITHUB_OUTPUT"
           echo "Release tag: $release_tag"
           echo "Checkout ref: $checkout_ref"
@@ -608,27 +623,63 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
           TARGET_SHA: ${{ needs.prepare-release.outputs.target_sha }}
+          ALLOW_MISSING_TAG: ${{ needs.prepare-release.outputs.allow_missing_tag }}
         shell: bash
         run: |
           set -euo pipefail
           # git refs can be rewritten. Before publishing, confirm the release
           # tag still resolves to the commit the artifacts were built from, so
           # a force-push to the tag while the installer jobs were queued can't
-          # publish a release whose binaries came from a different commit. A
-          # dev (no-tag) dispatch has no tag yet — gh release create below
-          # creates it at TARGET_SHA — so a missing tag is fine.
+          # publish a release whose binaries came from a different commit.
+          #
+          # Only the no-tag manual dev dispatch reaches this step without an
+          # existing tag (gh release create below creates it at TARGET_SHA);
+          # prepare-release signals that via ALLOW_MISSING_TAG=true. Every
+          # other path — main push, tag push, explicit-tag dispatch — has a
+          # tag by now, so a missing tag there is an integrity failure, not
+          # an expected state. And a missing tag is only acceptable when it is
+          # an actual HTTP 404; an auth, rate-limit, network, or server
+          # failure must not be treated as "tag does not exist", or the check
+          # becomes fail-open.
           encoded_tag="$(jq -rn --arg v "$RELEASE_TAG" '$v | @uri')"
-          if current_sha="$(gh api \
+          # Use -i so we can read the HTTP status from the response even on a
+          # non-2xx, distinguishing a real 404 from auth/rate-limit/server
+          # errors. gh api still exits non-zero on 4xx/5xx, so swallow its
+          # exit status and parse the captured output.
+          response="$(gh api -i \
               -H 'Accept: application/vnd.github.sha' \
-              "repos/${GH_REPO}/commits/${encoded_tag}" 2>/dev/null)"; then
-            if [[ "$current_sha" != "$TARGET_SHA" ]]; then
-              echo "::error::Tag $RELEASE_TAG now resolves to $current_sha, expected $TARGET_SHA. Refusing to publish artifacts built from $TARGET_SHA." >&2
+              "repos/${GH_REPO}/commits/${encoded_tag}" 2>/dev/null)" || true
+          # Status line is the first line: "HTTP/2.0 200 OK". Strip any
+          # trailing CR so a CRLF blank-line separator is detectable later.
+          status="$(printf '%s\n' "$response" | sed 's/\r$//' | head -n1 | awk '{print $2}')"
+
+          case "$status" in
+            200)
+              # Body is the bare SHA after the blank line separating headers
+              # from the body. Print lines following the first blank line and
+              # take the last non-empty one as the SHA.
+              current_sha="$(printf '%s\n' "$response" | sed 's/\r$//' \
+                | awk 'NF==0{blank=1;next} blank{print}' \
+                | tail -n1 | tr -d '[:space:]')"
+              if [[ "$current_sha" != "$TARGET_SHA" ]]; then
+                echo "::error::Tag $RELEASE_TAG now resolves to $current_sha, expected $TARGET_SHA. Refusing to publish artifacts built from $TARGET_SHA." >&2
+                exit 1
+              fi
+              echo "Tag $RELEASE_TAG still points at $TARGET_SHA."
+              ;;
+            404)
+              if [[ "$ALLOW_MISSING_TAG" == "true" ]]; then
+                echo "Tag $RELEASE_TAG does not exist yet; it will be created at $TARGET_SHA."
+              else
+                echo "::error::Tag $RELEASE_TAG does not exist but is required for this release path. Refusing to publish without verifying tag-to-build relationship." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unable to verify tag $RELEASE_TAG: GitHub API returned HTTP ${status:-<no response>}. Refusing to publish without verifying tag-to-build relationship." >&2
               exit 1
-            fi
-            echo "Tag $RELEASE_TAG still points at $TARGET_SHA."
-          else
-            echo "Tag $RELEASE_TAG does not exist yet; it will be created at $TARGET_SHA."
-          fi
+              ;;
+          esac
 
       - name: Create GitHub release with build assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,16 @@ jobs:
             # SHA (not the tag name) and create-release must target it —
             # otherwise a force-moved tag could make Windows and macOS build
             # different commits, and the release could point elsewhere again.
-            encoded_tag="$(jq -rn --arg v "$INPUT_TAG" '$v | @uri')"
+            # Qualify with tags/ so the commits endpoint resolves the tag ref
+            # unambiguously. A bare short name is also accepted, but when a
+            # branch and tag share the same name Git resolves refs/heads/
+            # before refs/tags/, so the lookup would silently resolve the
+            # branch instead of the tag and defeat the integrity check below.
+            qualified_tag="tags/${INPUT_TAG}"
+            encoded_ref="$(jq -rn --arg v "$qualified_tag" '$v | @uri')"
             if ! resolved_sha="$(gh api \
                 -H 'Accept: application/vnd.github.sha' \
-                "repos/${GITHUB_REPOSITORY}/commits/${encoded_tag}")"; then
+                "repos/${GITHUB_REPOSITORY}/commits/${encoded_ref}")"; then
               echo "::error::Could not resolve input tag '${INPUT_TAG}' to a commit via the GitHub API." >&2
               exit 1
             fi
@@ -641,14 +647,24 @@ jobs:
           # an actual HTTP 404; an auth, rate-limit, network, or server
           # failure must not be treated as "tag does not exist", or the check
           # becomes fail-open.
-          encoded_tag="$(jq -rn --arg v "$RELEASE_TAG" '$v | @uri')"
+          # Qualify with tags/ so the commits endpoint resolves the tag ref
+          # unambiguously. A bare short name is also accepted, but when a
+          # branch and tag share the same name Git resolves refs/heads/
+          # before refs/tags/, so the lookup would silently resolve the
+          # branch instead of the tag. The verification would then compare
+          # the branch SHA against TARGET_SHA (also resolved from the
+          # branch in prepare-release) and pass, while gh release create
+          # --target is ignored for an existing tag — shipping assets built
+          # from the branch commit under a release tagged at a different one.
+          qualified_tag="tags/${RELEASE_TAG}"
+          encoded_ref="$(jq -rn --arg v "$qualified_tag" '$v | @uri')"
           # Use -i so we can read the HTTP status from the response even on a
           # non-2xx, distinguishing a real 404 from auth/rate-limit/server
           # errors. gh api still exits non-zero on 4xx/5xx, so swallow its
           # exit status and parse the captured output.
           response="$(gh api -i \
               -H 'Accept: application/vnd.github.sha' \
-              "repos/${GH_REPO}/commits/${encoded_tag}" 2>/dev/null)" || true
+              "repos/${GH_REPO}/commits/${encoded_ref}" 2>/dev/null)" || true
           # Status line is the first line: "HTTP/2.0 200 OK". Strip any
           # trailing CR so a CRLF blank-line separator is detectable later.
           status="$(printf '%s\n' "$response" | sed 's/\r$//' | head -n1 | awk '{print $2}')"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,12 @@ jobs:
 
           if [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
             release_tag="v0.0.0-main.${RUN_NUMBER}"
-            checkout_ref="$release_tag"
+            # Checkout the triggering commit directly instead of the generated
+            # tag. The tag is still created above for publishing (release_tag),
+            # but downstream jobs should check out the immutable commit SHA so
+            # a tag moved between this step and checkout can't pull in the
+            # wrong commit.
+            checkout_ref="$COMMIT_SHA"
 
             # Re-runs keep the original tag stable. Refuse to continue if a
             # tag with the generated name was moved to another commit.
@@ -564,12 +569,43 @@ jobs:
           path: release-assets
 
       - name: Create GitHub release with build assets
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
-        with:
-          tag_name: ${{ needs.prepare-release.outputs.release_tag }}
-          target_commitish: ${{ github.sha }}
-          name: DTXManiaCX ${{ needs.prepare-release.outputs.release_tag }}
-          generate_release_notes: true
-          prerelease: ${{ needs.prepare-release.outputs.prerelease }}
-          files: release-assets/*
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare-release.outputs.release_tag }}
+          PRERELEASE: ${{ needs.prepare-release.outputs.prerelease }}
+          TARGET_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Match fail_on_unmatched_files: true — bash's default glob expands
+          # to the literal pattern when nothing matches (nullglob is off), so
+          # enable nullglob temporarily to get an empty array and check it.
+          shopt -s nullglob
+          assets=(release-assets/*)
+          shopt -u nullglob
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "::error::No release assets found in release-assets/" >&2
+            exit 1
+          fi
+
+          prerelease_args=()
+          if [ "$PRERELEASE" = "true" ]; then
+            prerelease_args+=(--prerelease)
+          fi
+
+          # Re-runs of a failed create-release job may encounter a release
+          # that already exists for the tag. softprops/action-gh-release
+          # updated it in place; replicate that by uploading assets with
+          # --clobber instead of erroring on the existing release.
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; uploading assets."
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+          else
+            gh release create "$RELEASE_TAG" \
+              --target "$TARGET_SHA" \
+              --title "DTXManiaCX $RELEASE_TAG" \
+              --generate-notes \
+              "${prerelease_args[@]}" \
+              "${assets[@]}"
+          fi


### PR DESCRIPTION
## Summary

- Trigger the release workflow on pushes to `main` and on version-tag pushes.
- Create a unique `v0.0.0-main.<run-number>` tag at each `main` commit and continue the release in the same workflow run.
- Build Windows and macOS installers, then publish them as assets on a GitHub prerelease.
- Preserve manual dispatch and explicit version-tag behavior.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`

The change is limited to `.github/workflows/release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases can now be triggered automatically by updates to the main branch and version tags, as well as manually.
  * GitHub releases include generated release notes and accurately indicate prerelease status.
  * Release artifacts use consistent names and are uploaded safely across reruns.
* **Bug Fixes**
  * Improved validation helps prevent incorrect assets from being attached to releases.
  * Release builds now use consistent source references across supported platforms.
  * Release creation is more reliable when workflows are rerun.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->