### PR TITLE
docs: define configurable multiple song folders

### DIFF
--- a/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
@@ -1,0 +1,848 @@
+# HPA-191 Configurable Multiple Song Folders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let players persist, edit, and live-reload an ordered list of song-library roots while preserving atomic HPA-192 publication, retained user data, and a coherent active Song Select stage.
+
+**Architecture:** Configuration owns the ordered `SongRoots` list and keeps `DTXPath` only as a compatibility mirror. `SongManager` owns comparer-aware root identity and publishes copied, versioned library snapshots rather than live collection wrappers. Config uses one operation coordinator for NX score import and song-root reload; Song Select consumes publication notifications only on the update thread.
+
+**Tech Stack:** .NET 8, C# 12, MonoGame 3.8, Entity Framework Core SQLite, xUnit, WinForms on Windows, `osascript` Standard Additions on macOS.
+
+## Global Constraints
+
+- DTXCreator is out of scope.
+- Do not change chart parsing, `set.def`, `box.def`, database schema, or synthetic root navigation.
+- `SongRoots` is the configured-root source of truth; `DTXPath` is serialization/migration compatibility only.
+- Keep Config.ini parsing section-agnostic and split each assignment on the first `=` only.
+- Create only `AppPaths.GetDefaultSongsPath()` automatically; never create a missing custom root.
+- Root comparison is ordinal-ignore-case on Windows/macOS and ordinal on Linux/other platforms, through a testable comparer seam.
+- `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
+- Parent/child overlap uses segment-wise comparison through the root comparer; do not use `Path.GetRelativePath` for this policy.
+- Physical-target deduplication for symlinks, junctions, aliases, bind mounts, or inodes remains out of scope.
+- Never expose `_rootSongs` or `_currentSearchPaths` through a live collection wrapper.
+- Publish hierarchy, active roots, counts, and publication version as one coherent snapshot.
+- Startup may explicitly publish an empty library without database cleanup; a normal live reload with zero active roots must not import or publish.
+- Any changed ordered root list, including reorder-only changes, performs one full HPA-192 scan; an unchanged list performs none.
+- HPA-192 enumeration-batch root failures are authoritative for roots actually rejected at scan time.
+- Database commit through hierarchy publication is a non-cancellable terminal section.
+- Config NX score import and song-root reload share one exclusive, throw-safe operation lifecycle.
+- Worker threads may report progress into a queue; only the game update thread mutates Config or Song Select UI state.
+- Runtime `Config.DTXPath` reads are forbidden outside an explicit serialization/migration compatibility allowlist.
+- Platform picker implementation files must not compile into the opposite platform project.
+- The slices land in order: **1a → 1b → 2 → 3a → 3b**.
+- Each slice must remain reviewable within three engineer days. Split a slice rather than broadening it.
+
+---
+
+## File Structure
+
+### New shared production files
+
+- `DTXMania.Game/Lib/Config/SongRootConfigModels.cs` — persistence statuses, diagnostics, and immutable change-event snapshots.
+- `DTXMania.Game/Lib/Song/SongRootPolicy.cs` — normalization, testable comparer construction, deduplication, overlap validation, and availability probing.
+- `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs` — immutable publication snapshot and event arguments.
+- `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs` — common Config overlay lifecycle.
+- `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs` — picker interface/result contract.
+- `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs` — isolated draft-list UI.
+- `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs` — one exclusive Config song-operation lease.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs` — orchestration statuses and progress snapshots.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs` — HPA-192 adapter and result mapping.
+
+### New platform files
+
+- `DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs`
+- `DTXMania.Game/Platform/Mac/MacFolderPickerService.cs`
+- `DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs`
+- `DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs`
+
+The Windows and macOS projects must exclude the opposite platform directory/factory file through explicit `<Compile Remove=...>` entries.
+
+### Primary modified production files
+
+- `DTXMania.Game/Lib/Config/ConfigData.cs`
+- `DTXMania.Game/Lib/Config/IConfigManager.cs`
+- `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- `DTXMania.Game/Lib/Song/SongImportModels.cs`
+- `DTXMania.Game/Lib/Song/SongManager.cs`
+- `DTXMania.Game/Lib/Stage/StartupStage.cs`
+- `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- `DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs`
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
+- `DTXMania.Game/DTXMania.Game.Windows.csproj`
+- `DTXMania.Game/DTXMania.Game.Mac.csproj`
+
+### New focused tests
+
+- `DTXMania.Test/Config/SongRootConfigTests.cs`
+- `DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs`
+- `DTXMania.Test/Song/SongRootPolicyTests.cs`
+- `DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs`
+- `DTXMania.Test/Config/SongFolderPanelTests.cs`
+- `DTXMania.Test/Config/FolderPickerContractTests.cs`
+- `DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs`
+- `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
+- `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
+
+Existing tests remain the regression home where the behavior already belongs, especially `ConfigManagerTests`, `StartupStageLogicTests`, `SongManagerBulkEnumerationTests`, `ConfigStageNxImportTests`, `PreviewImagePanelTests`, and `SongSelectionStageLogicTests`.
+
+---
+
+## Slice 1a — Configuration Model and Persistence
+
+### Task 1A: Persist Ordered Song Roots Without Runtime Consumer Changes
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Config/SongRootConfigModels.cs`
+- Create: `DTXMania.Test/Config/SongRootConfigTests.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigData.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- Modify: `DTXMania.Test/Config/ConfigDataTests.cs`
+- Modify: `DTXMania.Test/Config/ConfigManagerTests.cs`
+
+**Interfaces:**
+
+```csharp
+public enum SongRootUpdateStatus
+{
+    Updated,
+    Unchanged,
+    ValidationFailed,
+    PersistenceFailed
+}
+
+public sealed record SongRootDiagnostic(
+    string Path,
+    string Message,
+    bool IsWarning);
+
+public sealed record SongRootUpdateResult(
+    SongRootUpdateStatus Status,
+    IReadOnlyList<string> CanonicalRoots,
+    IReadOnlyList<SongRootDiagnostic> Diagnostics);
+
+public sealed class SongRootsChangedEventArgs : EventArgs
+{
+    public IReadOnlyList<string> OldRoots { get; }
+    public IReadOnlyList<string> NewRoots { get; }
+}
+```
+
+This slice defines the models and file format but does not add Config UI or live reload. The final comparer-aware `SetSongRoots` implementation is completed in Slice 1b after `SongRootPolicy` exists.
+
+- [ ] **Step 1: Add red tests for default, repeated load, and indexed parsing**
+
+Add tests named:
+
+```text
+DefaultConfig_ShouldContainManagedSongRootAndMirror
+LoadConfig_ShouldClearSongRootsBeforeSecondParse
+LoadConfig_ShouldReadIndexedRootsInNumericOrder
+LoadConfig_ShouldUseLastDuplicateIndexAndWarn
+LoadConfig_ShouldPreferIndexedRootsOverLegacyDTXPath
+LoadConfig_ShouldMigrateLegacyDTXPathAndPersistIndexedRoot
+SaveConfig_ShouldWriteDenseIndexesAndFirstRootMirror
+```
+
+Use temporary Config.ini files. Include an INI with unrelated section headers and prove `SongRoot.*` remains global because the current parser does not track sections.
+
+- [ ] **Step 2: Run the focused red tests**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongRootConfigTests|FullyQualifiedName~ConfigManagerTests|FullyQualifiedName~ConfigDataTests"
+```
+
+Expected: failures because `SongRoots` and indexed serialization do not exist.
+
+- [ ] **Step 3: Add the ConfigData and load/save model**
+
+Add to `ConfigData`:
+
+```csharp
+public List<string> SongRoots { get; } = new();
+```
+
+At the start of every `LoadConfig`, call `Config.SongRoots.Clear()` beside the existing MIDI-threshold clearing. Parse `SongRoot.<non-negative integer>` into a temporary index/value map, then finalize the list after all lines are read. Keep `[Section]` lines ignored exactly as today.
+
+Finalize with this precedence:
+
+1. Accepted indexed roots in ascending index order.
+2. Legacy `DTXPath` migrated into one root.
+3. Managed default root.
+
+Save dense `SongRoot.0..N` entries and write `DTXPath` as the first root.
+
+- [ ] **Step 4: Remove unconditional custom-root creation**
+
+Replace the current `EnsureDirectorySafe(Config.DTXPath)` behavior with managed-default-only creation. Add tests proving:
+
+- missing custom roots remain strings in Config;
+- no custom directory is created during load, migration, or save;
+- the managed default is created when selected as fallback;
+- directories created by older versions are not deleted.
+
+- [ ] **Step 5: Correct pending-save path clearing**
+
+When an explicit full config save succeeds, clear `_pendingSavePath` only when its normalized path equals the file just written. A save to another path must leave the pending marker intact.
+
+Add tests:
+
+```text
+SaveConfig_ShouldClearMatchingPendingPath
+SaveConfig_ShouldRetainDifferentPendingPath
+FlushPendingSave_ShouldRetryAfterFailure
+```
+
+- [ ] **Step 6: Add immutable persistence/event model tests**
+
+Construct `SongRootsChangedEventArgs` from mutable source lists, mutate the sources, and prove the event snapshots remain unchanged. Do not raise the event from load/reset.
+
+- [ ] **Step 7: Run Slice 1a gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongRootConfigTests|FullyQualifiedName~ConfigManagerTests|FullyQualifiedName~ConfigDataTests"
+
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+```
+
+Expected: all focused tests pass and the macOS game project builds.
+
+- [ ] **Step 8: Commit Slice 1a**
+
+```bash
+git add DTXMania.Game/Lib/Config \
+  DTXMania.Test/Config/ConfigDataTests.cs \
+  DTXMania.Test/Config/ConfigManagerTests.cs \
+  DTXMania.Test/Config/SongRootConfigTests.cs
+git commit -m "feat: persist ordered song roots"
+```
+
+**Review gate:** verify the serialized format, repeated-load clearing, section-agnostic behavior, custom-directory behavior removal, and pending-save path handling before starting Slice 1b.
+
+---
+
+## Slice 1b — Root Policy, SongManager Snapshots, and Startup Consumers
+
+### Task 1B: Centralize Root Identity and Publish Safe Library Snapshots
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/SongRootPolicy.cs`
+- Create: `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs`
+- Create: `DTXMania.Test/Song/SongRootPolicyTests.cs`
+- Create: `DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs`
+- Create: `DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs`
+- Modify: `DTXMania.Game/Lib/Config/IConfigManager.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- Modify: `DTXMania.Game/Lib/Song/SongImportModels.cs`
+- Modify: `DTXMania.Game/Lib/Song/SongManager.cs`
+- Modify: `DTXMania.Game/Lib/Stage/StartupStage.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
+- Modify: relevant existing SongManager, startup, and preview tests.
+
+**Interfaces:**
+
+```csharp
+internal sealed class SongRootPolicy
+{
+    internal SongRootPolicy(StringComparer comparer);
+    internal static SongRootPolicy ForCurrentPlatform();
+    internal static StringComparer CreateComparer(bool ignoreCase);
+
+    internal SongRootValidationResult Validate(IReadOnlyList<string> roots);
+    internal bool IsAncestor(string parent, string child);
+    internal SongRootAvailability Probe(string normalizedRoot);
+}
+
+public sealed record SongLibrarySnapshot(
+    long Version,
+    IReadOnlyList<SongListNode> RootSongs,
+    IReadOnlyList<string> ActiveRoots,
+    int EnumeratedFileCount,
+    int DiscoveredScoreCount);
+
+public sealed class SongLibraryPublishedEventArgs : EventArgs
+{
+    public SongLibrarySnapshot Snapshot { get; }
+}
+```
+
+`SongManager.GetLibrarySnapshot()` returns copied root and root-path arrays captured under `_lockObject`. `RootSongs` may remain as a compatibility property only if it returns the copied snapshot list, never `_rootSongs.AsReadOnly()`.
+
+- [ ] **Step 1: Write the comparer and overlap red tests**
+
+Add theory coverage that executes both policies on every host:
+
+```csharp
+[Theory]
+[InlineData(true, true)]
+[InlineData(false, false)]
+public void DuplicatePolicy_ShouldFollowInjectedCaseMode(
+    bool ignoreCase,
+    bool expectedDuplicate)
+```
+
+Add explicit parent/child matrices including:
+
+```text
+/Users/me/Songs + /Users/me/SONGS/Extra
+C:\Songs + c:\songs\Pack
+/songs + /Songs/Pack under ordinal mode
+```
+
+Assert overlap compares path segments through the injected comparer and does not call `Path.GetRelativePath`.
+
+- [ ] **Step 2: Implement `SongRootPolicy`**
+
+The policy must:
+
+1. Normalize absolute paths with `SongPathIdentity.Normalize`.
+2. Preserve first occurrence and configured order.
+3. Detect duplicate roots through the injected comparer.
+4. Split normalized roots into root/segment components and compare each segment through the same comparer.
+5. Reject same-path and parent/child overlap symmetrically.
+6. Probe existence/access without creating directories.
+
+Use `CreateComparer(true)` for ignore-case tests and `CreateComparer(false)` for ordinal tests. `ForCurrentPlatform()` selects the production mode.
+
+- [ ] **Step 3: Complete the typed Config setter**
+
+Add to `IConfigManager`:
+
+```csharp
+SongRootUpdateResult SetSongRoots(
+    string configFilePath,
+    IReadOnlyList<string> roots);
+
+event EventHandler<SongRootsChangedEventArgs>? SongRootsChanged;
+```
+
+`ConfigManager.SetSongRoots` validates through `SongRootPolicy`, writes the complete config immediately, rolls back memory on persistence failure, raises one event after success, and returns `Unchanged` without writing or raising when the canonical ordered list is equal.
+
+- [ ] **Step 4: Replace live library views with coherent snapshots**
+
+Under `_lockObject`, capture:
+
+```csharp
+new SongLibrarySnapshot(
+    ++_publicationVersion,
+    _rootSongs.ToArray(),
+    _currentSearchPaths.ToArray(),
+    EnumeratedFileCount,
+    DiscoveredScoreCount)
+```
+
+Required changes:
+
+- `GetLibrarySnapshot()` returns a copied snapshot.
+- `PublishEnumeration` replaces hierarchy/roots/counts, increments one version, then raises `SongLibraryPublished` outside the lock.
+- `PublishEmptyLibrary` clears hierarchy, active roots, and counts in one version and raises the same event.
+- `SetCurrentSearchPaths(Array.Empty<string>())` clears `_currentSearchPaths`; remove the current empty-input early return.
+- defensive deduplication in `SetCurrentSearchPaths` and `CreateBatchBuilder` uses `SongRootPolicy`.
+
+Do not mutate a previously published root list after it has been handed to a consumer.
+
+- [ ] **Step 5: Add zero-active-root import behavior**
+
+Extend `SongEnumerationResult` with an explicit outcome such as:
+
+```csharp
+public enum SongEnumerationOutcome
+{
+    ImportedAndPublished,
+    NoActiveRoots
+}
+```
+
+When `BuildEnumerationBatchAsync` returns a complete batch with no active roots:
+
+- do not call `ImportSongsCoreAsync`;
+- do not call `PublishEnumeration`;
+- return `NoActiveRoots` with batch root-failure errors available to callers;
+- always release the enumeration slot.
+
+A clean startup with no available roots calls `PublishEmptyLibrary()` explicitly after deciding not to clean/import.
+
+- [ ] **Step 6: Migrate startup and preview consumers**
+
+`StartupStage` snapshots `Config.SongRoots`, uses the shared policy, and chooses cache/enumeration paths from the accepted roots. `SongSelectionStage` initializes from one `SongLibrarySnapshot`.
+
+Replace `PreviewImagePanel.SongsRootPath` with:
+
+```csharp
+public IReadOnlyList<string> ActiveSongRootPaths { get; set; }
+```
+
+Absolute chart paths remain authoritative. Relative fallback tries active roots in order.
+
+- [ ] **Step 7: Add architecture and concurrency regression tests**
+
+Tests must prove:
+
+- `RootSongs`/`GetLibrarySnapshot` remain stable while another thread publishes;
+- filter projection and `BookmarkStateReconciler.Apply` cannot observe collection modification;
+- root list and active roots share one publication version;
+- empty publication clears both;
+- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync` receive deduplicated roots;
+- no production `Config.DTXPath` read remains outside Config serialization/migration allowlist.
+
+The architecture test should scan `DTXMania.Game/**/*.cs` and list the allowed files explicitly so a future runtime read fails the test.
+
+- [ ] **Step 8: Run Slice 1b gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongRootPolicyTests|FullyQualifiedName~SongManagerLibrarySnapshotTests|FullyQualifiedName~SongManagerBulkEnumerationTests|FullyQualifiedName~StartupStageLogicTests|FullyQualifiedName~PreviewImagePanelTests|FullyQualifiedName~DTXPathCompatibilityArchitectureTests"
+
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+```
+
+- [ ] **Step 9: Commit Slice 1b**
+
+```bash
+git add DTXMania.Game/Lib/Song \
+  DTXMania.Game/Lib/Config \
+  DTXMania.Game/Lib/Stage/StartupStage.cs \
+  DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+  DTXMania.Test
+git commit -m "feat: publish versioned song library snapshots"
+```
+
+**Review gate:** no live `RootSongs` wrapper, no empty-root stale snapshot, no platform-dependent untested comparer branch, and no runtime `DTXPath` consumer.
+
+---
+
+## Slice 2 — Cross-Platform SongFolderPanel
+
+### Task 2: Add Draft Editing and Platform Folder Selection
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs`
+- Create: platform picker/factory files listed in File Structure.
+- Create: `DTXMania.Test/Config/SongFolderPanelTests.cs`
+- Create: `DTXMania.Test/Config/FolderPickerContractTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs`
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- Modify: both platform `.csproj` files.
+- Modify: `DTXMania.Test/Config/ConfigStageLogicTests.cs`
+
+**Interfaces:**
+
+```csharp
+public interface IConfigOverlayPanel
+{
+    bool IsActive { get; }
+    event EventHandler? Saved;
+    event EventHandler? Closed;
+    void Activate();
+    void Deactivate();
+    void Update(double deltaTime, KeyboardState current, KeyboardState previous);
+    void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont,
+        Texture2D? whitePixel, int virtualWidth, int virtualHeight);
+}
+
+public interface IFolderPickerService
+{
+    Task<FolderPickerResult> PickFolderAsync(
+        string? initialDirectory,
+        CancellationToken cancellationToken);
+}
+```
+
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`. `ConfigStage._activePanel` uses the generalized interface.
+
+- [ ] **Step 1: Add panel-lifecycle and draft red tests**
+
+Cover:
+
+```text
+Activate_ShouldCopyConfiguredRoots
+CancelAndBack_ShouldDiscardDraft
+Add_ShouldAppendSelectedFolder
+PickerCancellation_ShouldNotMutateDraft
+Remove_ShouldProtectLastRoot
+MoveUpAndMoveDown_ShouldPreserveSelection
+StructuralError_ShouldKeepPanelOpen
+AvailabilityWarning_ShouldAllowApply
+Saved_ShouldFireBeforeClosed
+```
+
+Use an injected fake picker and fake apply delegate. The panel never receives `IConfigManager`.
+
+- [ ] **Step 2: Add `IConfigOverlayPanel` and adapt key panels**
+
+Move only the common lifecycle members into the new interface. Preserve the existing key-panel requirement that `Saved` fires before `Closed`.
+
+Run existing key assignment tests immediately after this refactor.
+
+- [ ] **Step 3: Implement `SongFolderPanel`**
+
+The panel owns:
+
+- a copied draft root list;
+- selected row/action indexes;
+- async picker state and activation generation;
+- structural diagnostics and availability warnings;
+- a Config-owned apply delegate.
+
+Use the root policy for validation. Picker completion may modify draft state only if the captured panel generation is current.
+
+- [ ] **Step 4: Add platform picker implementations**
+
+Windows:
+
+- use `FolderBrowserDialog`;
+- own STA dispatch in the platform service;
+- return Selected/Cancelled/Failed without blocking the game update thread.
+
+macOS:
+
+- invoke `/usr/bin/osascript` with `ProcessStartInfo.ArgumentList`;
+- use `choose folder` and `default location` only when valid;
+- await exit asynchronously;
+- distinguish normal user cancellation from authorization/privacy failure;
+- include stderr only in structured diagnostics.
+
+Do not launch real dialogs in unit tests.
+
+- [ ] **Step 5: Isolate platform compilation**
+
+Add explicit compile exclusions:
+
+```xml
+<!-- Windows project -->
+<Compile Remove="Platform/Mac/**/*.cs" />
+<Compile Remove="Platform/FolderPickerServiceFactory.Mac.cs" />
+
+<!-- Mac project -->
+<Compile Remove="Platform/Windows/**/*.cs" />
+<Compile Remove="Platform/FolderPickerServiceFactory.Windows.cs" />
+```
+
+The exact glob may be adjusted to the final directory layout, but each project must compile only one factory and one native implementation.
+
+- [ ] **Step 6: Wire Config navigation with temporary restart behavior**
+
+Replace read-only **DTX Folder** with a `NavigationConfigItem` named **Song Folders**. Display `1 folder` or `<n> folders`.
+
+For Slice 2, the Config-owned delegate calls `SetSongRoots`. On `Updated`, close the panel and show a restart-required status. On `Unchanged`, close without status. On failure, keep the panel open.
+
+- [ ] **Step 7: Run Slice 2 gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongFolderPanelTests|FullyQualifiedName~FolderPickerContractTests|FullyQualifiedName~ConfigStageLogicTests|FullyQualifiedName~KeyAssign"
+
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
+```
+
+- [ ] **Step 8: Commit Slice 2**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Config \
+  DTXMania.Game/Lib/Stage/KeyAssign \
+  DTXMania.Game/Lib/Stage/ConfigStage.cs \
+  DTXMania.Game/Platform \
+  DTXMania.Game/*.csproj \
+  DTXMania.Test/Config
+git commit -m "feat: add song folder configuration panel"
+```
+
+**Review gate:** panel draft isolation, platform build isolation, async picker lifecycle, and restart persistence through Startup.
+
+---
+
+## Slice 3a — Config Operation Coordinator and Live Reload
+
+### Task 3A: Serialize Config Song Operations and Start One Live Reload
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs`
+- Create: `DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs`
+- Create: `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- Modify: `DTXMania.Test/Stage/ConfigStageNxImportTests.cs`
+- Modify: relevant SongManager bulk-enumeration tests.
+
+**Interfaces:**
+
+```csharp
+internal enum ConfigSongOperationKind
+{
+    NxScoreImport,
+    SongFolderReload
+}
+
+internal sealed class ConfigSongOperationLease : IDisposable
+{
+    public ConfigSongOperationKind Kind { get; }
+}
+
+internal interface ISongLibraryReloadService
+{
+    Task<SongLibraryReloadResult> ReloadAsync(
+        IReadOnlyList<string> configuredRoots,
+        IProgress<SongLibraryReloadProgress>? progress,
+        CancellationToken cancellationToken);
+}
+```
+
+Persistence and orchestration results remain separate. Config maps `SongRootUpdateResult` into a panel-facing orchestration result that may additionally be `Busy` or `Started`.
+
+- [ ] **Step 1: Write coordinator red tests**
+
+Cover:
+
+```text
+TryAcquire_ShouldAllowOneOwner
+TryAcquire_ShouldRejectDifferentOperationWhileBusy
+Dispose_ShouldReleaseExactlyOnce
+ThrowDuringOperationConstruction_ShouldReleaseLease
+TerminalContinuationRegistrationFailure_ShouldReleaseLease
+```
+
+Use an injectable continuation/task factory to force each synchronous handoff failure.
+
+- [ ] **Step 2: Implement a scoped coordinator**
+
+The coordinator owns one atomic state. A lease releases through `Dispose()` exactly once. Do not expose check-then-set booleans.
+
+`ConfigStage` uses one method for song-root Apply:
+
+```text
+validate/compare
+→ acquire lease
+→ persist roots
+→ create CTS
+→ construct reload task
+→ register observation/progress/terminal release
+→ store operation handle
+→ return Started to panel
+```
+
+All synchronous steps remain inside one `try/finally`. `Saved` only reports that the draft was accepted; it does not acquire, transfer, or release the lease.
+
+- [ ] **Step 3: Implement the reload adapter**
+
+`SongLibraryReloadService` calls the existing HPA-192 operation once with the configured roots.
+
+Result mapping:
+
+- occupied lower-level enumeration slot → `Busy`;
+- `SongEnumerationOutcome.NoActiveRoots` → `NoAvailableRoots`, old hierarchy retained;
+- successful import/publication → `Success`;
+- pre-commit cancellation/failure → old hierarchy retained;
+- unexpected post-commit publication failure → partial-success/restart-required.
+
+For completed enumeration, count unavailable roots from `Batch.Errors.Where(error => error.IsRootFailure)`. A shallow preflight may provide early UI warnings, but it cannot override the batch result.
+
+- [ ] **Step 4: Migrate NX import onto the same lifecycle**
+
+Remove `_importRunning` check-then-set ownership. NX import must:
+
+- acquire `ConfigSongOperationKind.NxScoreImport`;
+- use the same activation generation;
+- enqueue progress/status rather than writing `_importStatus` from a worker;
+- cancel on Config deactivation;
+- attach an observation continuation;
+- dispose CTS and release lease exactly once in the terminal continuation.
+
+Both operations must reject each other with a concise status.
+
+- [ ] **Step 5: Add update-thread status marshalling**
+
+Use a thread-safe queue of immutable operation updates. `ConfigStage.OnUpdate` drains only updates whose activation generation is current. Deactivation increments the generation before cancellation.
+
+Never wait synchronously for filesystem or SQLite work during stage teardown.
+
+- [ ] **Step 6: Preserve the commit-to-publication terminal section**
+
+Ensure HPA-192 does not check cancellation after database commit and before `FinalizePendingNodes`/`PublishEnumeration`. Add a regression test where cancellation arrives after commit and publication still completes successfully.
+
+- [ ] **Step 7: Add operation integration tests**
+
+Required tests:
+
+```text
+UnchangedApply_ShouldNotAcquirePersistOrScan
+BusyApply_ShouldNotPersist
+ReorderOnlyApply_ShouldInvokeImporterOnce
+NoActiveRoots_ShouldRetainCurrentSnapshot
+BatchRootFailures_ShouldDriveWarningCount
+NxImportAndReload_ShouldNotOverlap
+Deactivate_ShouldCancelWithoutBlocking
+WorkerProgress_ShouldReachUIOnlyThroughUpdateDrain
+EveryTerminalPath_ShouldDisposeCtsAndReleaseLeaseOnce
+```
+
+- [ ] **Step 8: Run Slice 3a gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~ConfigSongOperationCoordinatorTests|FullyQualifiedName~SongLibraryReloadServiceTests|FullyQualifiedName~ConfigStageNxImportTests|FullyQualifiedName~SongManagerBulkEnumerationTests"
+```
+
+- [ ] **Step 9: Commit Slice 3a**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Config \
+  DTXMania.Game/Lib/Stage/ConfigStage.cs \
+  DTXMania.Game/Lib/Song \
+  DTXMania.Test/Config \
+  DTXMania.Test/Stage/ConfigStageNxImportTests.cs \
+  DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+git commit -m "feat: live reload configured song roots"
+```
+
+**Review gate:** no split lease ownership, no worker-thread UI writes, no NX/reload overlap, and no normal publication for a zero-active-root batch.
+
+---
+
+## Slice 3b — Active Song Select Reconciliation and Retained Views
+
+### Task 3B: Reconcile Runtime Publication on the Update Thread
+
+**Files:**
+- Create: `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
+- Modify: existing Song Selection, bookmark, recent, and preview tests.
+
+**Interfaces:**
+
+`SongSelectionStage` subscribes to `SongManager.SongLibraryPublished` on activation and unsubscribes on deactivation. The event handler stores only the newest pending publication version; it never changes UI collections.
+
+- [ ] **Step 1: Write publication-reconciliation red tests**
+
+Create scenarios for:
+
+```text
+PublicationWhileActive_ShouldApplyOnUpdateThread
+PublicationInsideRetainedBox_ShouldRestoreNavigation
+PublicationInsideRemovedBox_ShouldResetToRoot
+PublicationWithRetainedSelection_ShouldRestoreByStableIdentity
+PublicationRemovingSelection_ShouldStopPreviewAndClearPanels
+PublicationOnBookmarks_ShouldFilterToActiveRoots
+PublicationOnRecent_ShouldFilterToActiveRoots
+MultiplePublications_ShouldApplyNewestVersionOnly
+NotificationAfterDeactivate_ShouldBeIgnored
+```
+
+Use test snapshots with stable chart/database identities and distinct publication versions.
+
+- [ ] **Step 2: Add event subscription and pending-version state**
+
+On activation:
+
+- capture one `SongLibrarySnapshot`;
+- subscribe to publication;
+- remember current activation version.
+
+The event handler atomically records the highest pending version only. On deactivation, unsubscribe before disposing stage resources.
+
+- [ ] **Step 3: Reconcile one coherent snapshot in `OnUpdate`**
+
+When a pending version exceeds the applied version:
+
+1. fetch one current `SongLibrarySnapshot`;
+2. ignore it if superseded or stage generation changed;
+3. replace root-list and active-root state from that snapshot;
+4. restore navigation by stable path/database identity if possible;
+5. restore selected chart by stable chart/database identity if possible;
+6. otherwise reset deterministically to root/first item;
+7. rebuild filter, Bookmarks, Recent, breadcrumb, preview roots, and empty state;
+8. stop preview and clear status/history when selection disappeared;
+9. mark the snapshot version as applied.
+
+Do not mix `RootSongs` from one version with active roots from another.
+
+- [ ] **Step 4: Filter Bookmarks and Recent to active roots**
+
+Database-backed tab loaders must filter chart paths through the active-root snapshot from the same publication version. Off-root rows remain stored and reappear after a successful root re-add.
+
+- [ ] **Step 5: Implement deliberate empty states**
+
+Distinguish:
+
+```text
+No active roots:
+No song folders are currently available. Open Config to reconnect or change them.
+
+Active roots with no supported charts:
+No songs were found in the active song folders.
+```
+
+Keep copy in one testable resolver method so future localization does not duplicate conditions.
+
+- [ ] **Step 6: Add concurrent-publication regression coverage**
+
+Run filter projection and bookmark reconciliation against a copied snapshot while publishing another version. Assert no `InvalidOperationException`, no background-thread mutation, and final UI data all references the newest applied version.
+
+- [ ] **Step 7: Run Slice 3b gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongSelectionPublicationTests|FullyQualifiedName~SongSelectionStageLogicTests|FullyQualifiedName~SongSelectionStageBookmark|FullyQualifiedName~PreviewImagePanelTests"
+```
+
+- [ ] **Step 8: Commit Slice 3b**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+  DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs \
+  DTXMania.Test/Stage \
+  DTXMania.Test/UI
+git commit -m "feat: reconcile live song library publication"
+```
+
+**Review gate:** active Song Select never enumerates a live backing list, applies publication only on the update thread, and keeps hierarchy/tabs/previews on one version.
+
+---
+
+## Final Verification
+
+- [ ] **Run the complete unit suite**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj -c Release
+```
+
+Expected: zero failed tests.
+
+- [ ] **Build both game targets**
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Release
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Release
+```
+
+Expected: both builds succeed; each compiles only its own picker implementation.
+
+- [ ] **Run production consumer audit**
+
+```bash
+rg "Config\??\.DTXPath|ConfigData\.DTXPath|\.DTXPath" DTXMania.Game --glob '*.cs'
+```
+
+Expected: matches only the compatibility property plus Config load/save/migration code allowed by `DTXPathCompatibilityArchitectureTests`.
+
+- [ ] **Manual smoke checks**
+
+1. Migrate an existing one-root Config.ini and verify roots persist after restart.
+2. Add a second local root, reorder, Apply, and verify one reload.
+3. Configure one missing removable root plus one available root; verify available songs load and warning count matches scan errors.
+4. Remove a root; verify songs/bookmarks/recent disappear from active views but return after re-add.
+5. Leave Config during reload and enter Song Select; verify post-publication reconciliation without stale selection or crash.
+6. Start NX score import and attempt Apply; verify Busy and no config write.
+7. Test picker cancellation on Windows and macOS.
+
+- [ ] **Final commit/checkpoint**
+
+Do not squash slice commits until all review gates pass. The final PR should show the five bounded implementation checkpoints clearly enough to bisect regressions.

--- a/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
@@ -2,51 +2,58 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Let players persist, edit, and live-reload an ordered list of song-library roots while preserving atomic HPA-192 publication, retained user data, and a coherent active Song Select stage.
+**Goal:** Let players persist, edit, and live-reload an ordered list of song-library roots while preserving HPA-192 atomic publication, retained user data, and a coherent active Song Select stage.
 
-**Architecture:** Configuration owns the ordered `SongRoots` list and keeps `DTXPath` only as a compatibility mirror. `SongManager` owns comparer-aware root identity and publishes copied, versioned library snapshots rather than live collection wrappers. Config uses one operation coordinator for NX score import and song-root reload; Song Select consumes publication notifications only on the update thread.
+**Architecture:** Configuration owns ordered `SongRoots` and keeps `DTXPath` only as a compatibility mirror. `SongManager` centralizes comparer-aware root identity and publishes copied, versioned `SongLibrarySnapshot` values. Config serializes NX score import and song-root reload through one scoped operation coordinator; Song Select consumes publication only on the update thread.
 
-**Tech Stack:** .NET 8, C# 12, MonoGame 3.8, Entity Framework Core SQLite, xUnit, WinForms on Windows, `osascript` Standard Additions on macOS.
+**Tech Stack:** .NET 8, C# 12, MonoGame 3.8, Entity Framework Core SQLite, xUnit, WinForms on Windows, `/usr/bin/osascript` Standard Additions on macOS.
 
 ## Global Constraints
 
 - DTXCreator is out of scope.
-- Do not change chart parsing, `set.def`, `box.def`, database schema, or synthetic root navigation.
+- Do not change chart parsing, `set.def`, `box.def`, database schema, or root-navigation semantics.
 - `SongRoots` is the configured-root source of truth; `DTXPath` is serialization/migration compatibility only.
-- Keep Config.ini parsing section-agnostic and split each assignment on the first `=` only.
+- Config.ini parsing remains section-agnostic and splits on the first `=` only.
 - Create only `AppPaths.GetDefaultSongsPath()` automatically; never create a missing custom root.
-- Root comparison is ordinal-ignore-case on Windows/macOS and ordinal on Linux/other platforms, through a testable comparer seam.
+- Root comparison is ordinal-ignore-case on Windows/macOS and ordinal on Linux/other platforms, through an injectable test seam.
 - `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
 - Parent/child overlap uses segment-wise comparison through the root comparer; do not use `Path.GetRelativePath` for this policy.
 - Physical-target deduplication for symlinks, junctions, aliases, bind mounts, or inodes remains out of scope.
 - Never expose `_rootSongs` or `_currentSearchPaths` through a live collection wrapper.
-- Publish hierarchy, active roots, counts, and publication version as one coherent snapshot.
-- Startup may explicitly publish an empty library without database cleanup; a normal live reload with zero active roots must not import or publish.
-- Any changed ordered root list, including reorder-only changes, performs one full HPA-192 scan; an unchanged list performs none.
-- HPA-192 enumeration-batch root failures are authoritative for roots actually rejected at scan time.
+- Hierarchy, active roots, counts, and publication version change as one coherent snapshot.
+- Startup may explicitly publish an empty library without cleanup. A normal live reload with zero active roots must not import or publish.
+- Any changed ordered root list, including reorder-only changes, performs one full HPA-192 scan; unchanged lists perform none.
+- HPA-192 enumeration-batch root failures are authoritative for roots rejected at scan time.
 - Database commit through hierarchy publication is a non-cancellable terminal section.
 - Config NX score import and song-root reload share one exclusive, throw-safe operation lifecycle.
-- Worker threads may report progress into a queue; only the game update thread mutates Config or Song Select UI state.
-- Runtime `Config.DTXPath` reads are forbidden outside an explicit serialization/migration compatibility allowlist.
-- Platform picker implementation files must not compile into the opposite platform project.
-- The slices land in order: **1a → 1b → 2 → 3a → 3b**.
-- Each slice must remain reviewable within three engineer days. Split a slice rather than broadening it.
+- Worker threads report immutable progress updates; only the game update thread changes Config or Song Select UI state.
+- Runtime `Config.DTXPath` reads are forbidden outside an explicit compatibility allowlist.
+- Platform picker source must not compile into the opposite platform target.
+- Slices land in order: **1a → 1b → 2 → 3a → 3b**.
+- Each slice must remain reviewable within three engineer days.
+
+## Branch and PR Strategy
+
+1. Merge documentation PR #109 first.
+2. Create a fresh implementation branch from updated `main`; do not add production code to the documentation PR.
+3. Use one implementation PR with five clearly separated slice commits and review gates.
+4. Do not squash during implementation; retain slice boundaries until the complete feature passes final verification.
 
 ---
 
-## File Structure
+## File Map
 
-### New shared production files
+### New shared files
 
-- `DTXMania.Game/Lib/Config/SongRootConfigModels.cs` — persistence statuses, diagnostics, and immutable change-event snapshots.
-- `DTXMania.Game/Lib/Song/SongRootPolicy.cs` — normalization, testable comparer construction, deduplication, overlap validation, and availability probing.
-- `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs` — immutable publication snapshot and event arguments.
-- `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs` — common Config overlay lifecycle.
-- `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs` — picker interface/result contract.
+- `DTXMania.Game/Lib/Config/SongRootConfigModels.cs` — persistence statuses, diagnostics, and immutable event snapshots.
+- `DTXMania.Game/Lib/Song/SongRootPolicy.cs` — normalization, comparer construction, deduplication, overlap validation, and availability probing.
+- `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs` — copied publication snapshot and event args.
+- `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs` — generalized Config overlay lifecycle.
+- `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs` — picker and panel-apply contracts.
 - `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs` — isolated draft-list UI.
-- `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs` — one exclusive Config song-operation lease.
-- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs` — orchestration statuses and progress snapshots.
-- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs` — HPA-192 adapter and result mapping.
+- `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs` — exclusive scoped lease.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs` — reload progress/result contracts.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs` — HPA-192 adapter.
 
 ### New platform files
 
@@ -55,9 +62,7 @@
 - `DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs`
 - `DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs`
 
-The Windows and macOS projects must exclude the opposite platform directory/factory file through explicit `<Compile Remove=...>` entries.
-
-### Primary modified production files
+### Primary modified files
 
 - `DTXMania.Game/Lib/Config/ConfigData.cs`
 - `DTXMania.Game/Lib/Config/IConfigManager.cs`
@@ -72,25 +77,11 @@ The Windows and macOS projects must exclude the opposite platform directory/fact
 - `DTXMania.Game/DTXMania.Game.Windows.csproj`
 - `DTXMania.Game/DTXMania.Game.Mac.csproj`
 
-### New focused tests
-
-- `DTXMania.Test/Config/SongRootConfigTests.cs`
-- `DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs`
-- `DTXMania.Test/Song/SongRootPolicyTests.cs`
-- `DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs`
-- `DTXMania.Test/Config/SongFolderPanelTests.cs`
-- `DTXMania.Test/Config/FolderPickerContractTests.cs`
-- `DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs`
-- `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
-- `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
-
-Existing tests remain the regression home where the behavior already belongs, especially `ConfigManagerTests`, `StartupStageLogicTests`, `SongManagerBulkEnumerationTests`, `ConfigStageNxImportTests`, `PreviewImagePanelTests`, and `SongSelectionStageLogicTests`.
-
 ---
 
 ## Slice 1a — Configuration Model and Persistence
 
-### Task 1A: Persist Ordered Song Roots Without Runtime Consumer Changes
+### Task 1A: Persist Ordered Song Roots
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Config/SongRootConfigModels.cs`
@@ -100,7 +91,7 @@ Existing tests remain the regression home where the behavior already belongs, es
 - Modify: `DTXMania.Test/Config/ConfigDataTests.cs`
 - Modify: `DTXMania.Test/Config/ConfigManagerTests.cs`
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 public enum SongRootUpdateStatus
@@ -128,25 +119,26 @@ public sealed class SongRootsChangedEventArgs : EventArgs
 }
 ```
 
-This slice defines the models and file format but does not add Config UI or live reload. The final comparer-aware `SetSongRoots` implementation is completed in Slice 1b after `SongRootPolicy` exists.
+This slice adds the stored model and compatibility behavior. The comparer-aware setter is completed in Slice 1b after `SongRootPolicy` exists.
 
-- [ ] **Step 1: Add red tests for default, repeated load, and indexed parsing**
+- [ ] **Step 1: Write red tests for the persisted format**
 
-Add tests named:
+Add tests:
 
 ```text
 DefaultConfig_ShouldContainManagedSongRootAndMirror
 LoadConfig_ShouldClearSongRootsBeforeSecondParse
 LoadConfig_ShouldReadIndexedRootsInNumericOrder
-LoadConfig_ShouldUseLastDuplicateIndexAndWarn
+LoadConfig_ShouldUseLastDuplicateIndex
 LoadConfig_ShouldPreferIndexedRootsOverLegacyDTXPath
 LoadConfig_ShouldMigrateLegacyDTXPathAndPersistIndexedRoot
 SaveConfig_ShouldWriteDenseIndexesAndFirstRootMirror
+LoadConfig_ShouldRemainSectionAgnostic
 ```
 
-Use temporary Config.ini files. Include an INI with unrelated section headers and prove `SongRoot.*` remains global because the current parser does not track sections.
+Use temporary Config.ini files. Include unrelated `[System]` and `[Other]` headers and prove keys remain global.
 
-- [ ] **Step 2: Run the focused red tests**
+- [ ] **Step 2: Run the red tests**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
@@ -155,38 +147,40 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj \
 
 Expected: failures because `SongRoots` and indexed serialization do not exist.
 
-- [ ] **Step 3: Add the ConfigData and load/save model**
+- [ ] **Step 3: Implement load/save and migration**
 
-Add to `ConfigData`:
+Add:
 
 ```csharp
 public List<string> SongRoots { get; } = new();
 ```
 
-At the start of every `LoadConfig`, call `Config.SongRoots.Clear()` beside the existing MIDI-threshold clearing. Parse `SongRoot.<non-negative integer>` into a temporary index/value map, then finalize the list after all lines are read. Keep `[Section]` lines ignored exactly as today.
+At every `LoadConfig` start, call `Config.SongRoots.Clear()` beside `MidiVelocityThresholds.Clear()`. Collect `SongRoot.<non-negative integer>` entries during parsing and finalize after all lines are read.
 
-Finalize with this precedence:
+Precedence:
 
-1. Accepted indexed roots in ascending index order.
-2. Legacy `DTXPath` migrated into one root.
-3. Managed default root.
+1. accepted indexed roots in numeric order;
+2. migrated legacy `DTXPath`;
+3. managed default root.
 
-Save dense `SongRoot.0..N` entries and write `DTXPath` as the first root.
+Save dense `SongRoot.0..N` and mirror the first root into `DTXPath`.
 
-- [ ] **Step 4: Remove unconditional custom-root creation**
+- [ ] **Step 4: Remove custom-root auto-creation**
 
-Replace the current `EnsureDirectorySafe(Config.DTXPath)` behavior with managed-default-only creation. Add tests proving:
+Replace unconditional `EnsureDirectorySafe(Config.DTXPath)` with managed-default-only creation.
 
-- missing custom roots remain strings in Config;
-- no custom directory is created during load, migration, or save;
-- the managed default is created when selected as fallback;
-- directories created by older versions are not deleted.
+Tests must prove:
 
-- [ ] **Step 5: Correct pending-save path clearing**
+- missing custom paths remain configured;
+- load/migration/save never creates them;
+- managed default creation still works;
+- old directories are not deleted.
 
-When an explicit full config save succeeds, clear `_pendingSavePath` only when its normalized path equals the file just written. A save to another path must leave the pending marker intact.
+- [ ] **Step 5: Correct pending-save clearing**
 
-Add tests:
+After a full save, clear `_pendingSavePath` only when its normalized path equals the path just written. A save to another file must retain the pending marker.
+
+Add:
 
 ```text
 SaveConfig_ShouldClearMatchingPendingPath
@@ -194,38 +188,38 @@ SaveConfig_ShouldRetainDifferentPendingPath
 FlushPendingSave_ShouldRetryAfterFailure
 ```
 
-- [ ] **Step 6: Add immutable persistence/event model tests**
+- [ ] **Step 6: Verify immutable model snapshots**
 
-Construct `SongRootsChangedEventArgs` from mutable source lists, mutate the sources, and prove the event snapshots remain unchanged. Do not raise the event from load/reset.
+Construct event args/results from mutable lists, mutate the originals, and assert exposed values are unchanged. Use copied read-only arrays, not caller-owned lists.
 
-- [ ] **Step 7: Run Slice 1a gate**
+- [ ] **Step 7: Run the Slice 1a gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongRootConfigTests|FullyQualifiedName~ConfigManagerTests|FullyQualifiedName~ConfigDataTests"
-
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 ```
 
-Expected: all focused tests pass and the macOS game project builds.
-
-- [ ] **Step 8: Commit Slice 1a**
+- [ ] **Step 8: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Config \
+git add \
+  DTXMania.Game/Lib/Config/SongRootConfigModels.cs \
+  DTXMania.Game/Lib/Config/ConfigData.cs \
+  DTXMania.Game/Lib/Config/ConfigManager.cs \
+  DTXMania.Test/Config/SongRootConfigTests.cs \
   DTXMania.Test/Config/ConfigDataTests.cs \
-  DTXMania.Test/Config/ConfigManagerTests.cs \
-  DTXMania.Test/Config/SongRootConfigTests.cs
+  DTXMania.Test/Config/ConfigManagerTests.cs
 git commit -m "feat: persist ordered song roots"
 ```
 
-**Review gate:** verify the serialized format, repeated-load clearing, section-agnostic behavior, custom-directory behavior removal, and pending-save path handling before starting Slice 1b.
+**Gate:** indexed format, repeated-load clearing, section-agnostic parsing, custom-directory behavior removal, and pending-save correctness.
 
 ---
 
-## Slice 1b — Root Policy, SongManager Snapshots, and Startup Consumers
+## Slice 1b — Root Policy, Safe SongManager Snapshots, and Consumers
 
-### Task 1B: Centralize Root Identity and Publish Safe Library Snapshots
+### Task 1B: Centralize Root Identity and Publication
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Song/SongRootPolicy.cs`
@@ -240,9 +234,9 @@ git commit -m "feat: persist ordered song roots"
 - Modify: `DTXMania.Game/Lib/Stage/StartupStage.cs`
 - Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
 - Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
-- Modify: relevant existing SongManager, startup, and preview tests.
+- Modify: focused existing SongManager/startup/preview tests.
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 internal sealed class SongRootPolicy
@@ -269,11 +263,11 @@ public sealed class SongLibraryPublishedEventArgs : EventArgs
 }
 ```
 
-`SongManager.GetLibrarySnapshot()` returns copied root and root-path arrays captured under `_lockObject`. `RootSongs` may remain as a compatibility property only if it returns the copied snapshot list, never `_rootSongs.AsReadOnly()`.
+All snapshot lists are copied and wrapped read-only. Published node graphs are not structurally mutated after publication.
 
-- [ ] **Step 1: Write the comparer and overlap red tests**
+- [ ] **Step 1: Write root-policy red tests**
 
-Add theory coverage that executes both policies on every host:
+Execute both policies on every CI host:
 
 ```csharp
 [Theory]
@@ -284,30 +278,21 @@ public void DuplicatePolicy_ShouldFollowInjectedCaseMode(
     bool expectedDuplicate)
 ```
 
-Add explicit parent/child matrices including:
+Add overlap cases:
 
 ```text
 /Users/me/Songs + /Users/me/SONGS/Extra
 C:\Songs + c:\songs\Pack
-/songs + /Songs/Pack under ordinal mode
+/songs + /Songs/Pack in ordinal mode
 ```
 
-Assert overlap compares path segments through the injected comparer and does not call `Path.GetRelativePath`.
+- [ ] **Step 2: Implement segment-wise `SongRootPolicy`**
 
-- [ ] **Step 2: Implement `SongRootPolicy`**
+The policy must normalize, preserve first occurrence/order, detect duplicates, and compare root/path segments using the injected comparer. Do not delegate overlap to `Path.GetRelativePath`.
 
-The policy must:
+`ForCurrentPlatform()` uses the production OS policy; tests use `CreateComparer(true/false)`.
 
-1. Normalize absolute paths with `SongPathIdentity.Normalize`.
-2. Preserve first occurrence and configured order.
-3. Detect duplicate roots through the injected comparer.
-4. Split normalized roots into root/segment components and compare each segment through the same comparer.
-5. Reject same-path and parent/child overlap symmetrically.
-6. Probe existence/access without creating directories.
-
-Use `CreateComparer(true)` for ignore-case tests and `CreateComparer(false)` for ordinal tests. `ForCurrentPlatform()` selects the production mode.
-
-- [ ] **Step 3: Complete the typed Config setter**
+- [ ] **Step 3: Complete `SetSongRoots`**
 
 Add to `IConfigManager`:
 
@@ -319,34 +304,36 @@ SongRootUpdateResult SetSongRoots(
 event EventHandler<SongRootsChangedEventArgs>? SongRootsChanged;
 ```
 
-`ConfigManager.SetSongRoots` validates through `SongRootPolicy`, writes the complete config immediately, rolls back memory on persistence failure, raises one event after success, and returns `Unchanged` without writing or raising when the canonical ordered list is equal.
+Validate through `SongRootPolicy`, persist immediately, roll memory back on failure, raise one event after success, and return `Unchanged` without write/event for an equal canonical ordered list.
 
-- [ ] **Step 4: Replace live library views with coherent snapshots**
+- [ ] **Step 4: Replace live SongManager views**
 
-Under `_lockObject`, capture:
+Make `SetCurrentSearchPaths` `internal` for direct tests while keeping it non-public.
+
+Publication methods, not reads, increment `_publicationVersion`:
 
 ```csharp
-new SongLibrarySnapshot(
-    ++_publicationVersion,
-    _rootSongs.ToArray(),
-    _currentSearchPaths.ToArray(),
-    EnumeratedFileCount,
-    DiscoveredScoreCount)
+private SongLibrarySnapshot CreateSnapshotLocked() =>
+    new(
+        _publicationVersion,
+        Array.AsReadOnly(_rootSongs.ToArray()),
+        Array.AsReadOnly(_currentSearchPaths.ToArray()),
+        EnumeratedFileCount,
+        DiscoveredScoreCount);
 ```
 
-Required changes:
+Required behavior:
 
-- `GetLibrarySnapshot()` returns a copied snapshot.
-- `PublishEnumeration` replaces hierarchy/roots/counts, increments one version, then raises `SongLibraryPublished` outside the lock.
-- `PublishEmptyLibrary` clears hierarchy, active roots, and counts in one version and raises the same event.
-- `SetCurrentSearchPaths(Array.Empty<string>())` clears `_currentSearchPaths`; remove the current empty-input early return.
-- defensive deduplication in `SetCurrentSearchPaths` and `CreateBatchBuilder` uses `SongRootPolicy`.
+- `GetLibrarySnapshot()` reads the current version without incrementing it.
+- `PublishEnumeration` replaces hierarchy/roots/counts, increments once, captures one snapshot, then raises `SongLibraryPublished` outside the lock.
+- `PublishEmptyLibrary` clears hierarchy/roots/counts, increments once, and publishes one empty snapshot.
+- empty input to `SetCurrentSearchPaths` clears active roots.
+- `RootSongs`, if retained, returns the copied snapshot list rather than `_rootSongs.AsReadOnly()`.
+- `SetCurrentSearchPaths` and `CreateBatchBuilder` use `SongRootPolicy` deduplication.
 
-Do not mutate a previously published root list after it has been handed to a consumer.
+- [ ] **Step 5: Add a non-null zero-active-root result**
 
-- [ ] **Step 5: Add zero-active-root import behavior**
-
-Extend `SongEnumerationResult` with an explicit outcome such as:
+Update models:
 
 ```csharp
 public enum SongEnumerationOutcome
@@ -354,20 +341,21 @@ public enum SongEnumerationOutcome
     ImportedAndPublished,
     NoActiveRoots
 }
+
+public sealed record SongEnumerationResult(
+    SongEnumerationOutcome Outcome,
+    SongEnumerationBatch Batch,
+    SongBulkImportResult Import,
+    TimeSpan HierarchyDuration);
 ```
 
-When `BuildEnumerationBatchAsync` returns a complete batch with no active roots:
+Add `SongBulkImportResult.Empty` with empty read-only chart map, zero counts, and zero durations. When a complete batch has no active roots, return `NoActiveRoots` with `Empty`; do not import or publish, and always release the enumeration slot.
 
-- do not call `ImportSongsCoreAsync`;
-- do not call `PublishEnumeration`;
-- return `NoActiveRoots` with batch root-failure errors available to callers;
-- always release the enumeration slot.
-
-A clean startup with no available roots calls `PublishEmptyLibrary()` explicitly after deciding not to clean/import.
+Startup with no accepted roots calls `PublishEmptyLibrary()` explicitly.
 
 - [ ] **Step 6: Migrate startup and preview consumers**
 
-`StartupStage` snapshots `Config.SongRoots`, uses the shared policy, and chooses cache/enumeration paths from the accepted roots. `SongSelectionStage` initializes from one `SongLibrarySnapshot`.
+`StartupStage` snapshots `Config.SongRoots`. `SongSelectionStage` initializes from one `SongLibrarySnapshot`.
 
 Replace `PreviewImagePanel.SongsRootPath` with:
 
@@ -375,62 +363,70 @@ Replace `PreviewImagePanel.SongsRootPath` with:
 public IReadOnlyList<string> ActiveSongRootPaths { get; set; }
 ```
 
-Absolute chart paths remain authoritative. Relative fallback tries active roots in order.
+Absolute chart path remains authoritative; relative fallback tries active roots in order.
 
-- [ ] **Step 7: Add architecture and concurrency regression tests**
+- [ ] **Step 7: Add architecture and concurrency tests**
 
-Tests must prove:
+Prove:
 
-- `RootSongs`/`GetLibrarySnapshot` remain stable while another thread publishes;
-- filter projection and `BookmarkStateReconciler.Apply` cannot observe collection modification;
-- root list and active roots share one publication version;
+- snapshots remain stable while another thread publishes;
+- filter and bookmark reconciliation cannot observe collection mutation;
+- hierarchy and active roots share one version;
 - empty publication clears both;
-- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync` receive deduplicated roots;
-- no production `Config.DTXPath` read remains outside Config serialization/migration allowlist.
+- cache/database/enumeration callers use aligned deduplication;
+- no production `Config.DTXPath` read remains outside an explicit allowlist.
 
-The architecture test should scan `DTXMania.Game/**/*.cs` and list the allowed files explicitly so a future runtime read fails the test.
-
-- [ ] **Step 8: Run Slice 1b gate**
+- [ ] **Step 8: Run the Slice 1b gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongRootPolicyTests|FullyQualifiedName~SongManagerLibrarySnapshotTests|FullyQualifiedName~SongManagerBulkEnumerationTests|FullyQualifiedName~StartupStageLogicTests|FullyQualifiedName~PreviewImagePanelTests|FullyQualifiedName~DTXPathCompatibilityArchitectureTests"
-
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 ```
 
-- [ ] **Step 9: Commit Slice 1b**
+- [ ] **Step 9: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Song \
-  DTXMania.Game/Lib/Config \
+git add \
+  DTXMania.Game/Lib/Song/SongRootPolicy.cs \
+  DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs \
+  DTXMania.Game/Lib/Song/SongImportModels.cs \
+  DTXMania.Game/Lib/Song/SongManager.cs \
+  DTXMania.Game/Lib/Config/IConfigManager.cs \
+  DTXMania.Game/Lib/Config/ConfigManager.cs \
   DTXMania.Game/Lib/Stage/StartupStage.cs \
   DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
-  DTXMania.Test
+  DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs \
+  DTXMania.Test/Song/SongRootPolicyTests.cs \
+  DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs \
+  DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs \
+  DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs \
+  DTXMania.Test/Stage/StartupStageLogicTests.cs \
+  DTXMania.Test/UI/PreviewImagePanelTests.cs
 git commit -m "feat: publish versioned song library snapshots"
 ```
 
-**Review gate:** no live `RootSongs` wrapper, no empty-root stale snapshot, no platform-dependent untested comparer branch, and no runtime `DTXPath` consumer.
+**Gate:** no live root wrapper, no stale active roots after empty publication, both comparer modes tested, and no runtime `DTXPath` consumer.
 
 ---
 
 ## Slice 2 — Cross-Platform SongFolderPanel
 
-### Task 2: Add Draft Editing and Platform Folder Selection
+### Task 2: Add Draft Editing and Platform Pickers
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs`
 - Create: `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs`
 - Create: `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs`
-- Create: platform picker/factory files listed in File Structure.
+- Create: four platform files listed above.
 - Create: `DTXMania.Test/Config/SongFolderPanelTests.cs`
 - Create: `DTXMania.Test/Config/FolderPickerContractTests.cs`
 - Modify: `DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs`
 - Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
-- Modify: both platform `.csproj` files.
+- Modify: both game `.csproj` files.
 - Modify: `DTXMania.Test/Config/ConfigStageLogicTests.cs`
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 public interface IConfigOverlayPanel
@@ -451,115 +447,81 @@ public interface IFolderPickerService
         string? initialDirectory,
         CancellationToken cancellationToken);
 }
+
+internal enum SongFolderApplyStatus
+{
+    Updated,
+    Unchanged,
+    Busy,
+    ValidationFailed,
+    PersistenceFailed,
+    Started
+}
 ```
 
-`IKeyAssignPanel` inherits `IConfigOverlayPanel`. `ConfigStage._activePanel` uses the generalized interface.
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`.
 
-- [ ] **Step 1: Add panel-lifecycle and draft red tests**
+- [ ] **Step 1: Write panel red tests**
 
-Cover:
+Cover isolated draft, Add, Remove-last protection, Move Up/Down, Cancel/Back, structural errors, availability warnings, picker cancellation/failure, stale picker generation, and `Saved` before `Closed`.
 
-```text
-Activate_ShouldCopyConfiguredRoots
-CancelAndBack_ShouldDiscardDraft
-Add_ShouldAppendSelectedFolder
-PickerCancellation_ShouldNotMutateDraft
-Remove_ShouldProtectLastRoot
-MoveUpAndMoveDown_ShouldPreserveSelection
-StructuralError_ShouldKeepPanelOpen
-AvailabilityWarning_ShouldAllowApply
-Saved_ShouldFireBeforeClosed
-```
+- [ ] **Step 2: Generalize overlay lifecycle**
 
-Use an injected fake picker and fake apply delegate. The panel never receives `IConfigManager`.
-
-- [ ] **Step 2: Add `IConfigOverlayPanel` and adapt key panels**
-
-Move only the common lifecycle members into the new interface. Preserve the existing key-panel requirement that `Saved` fires before `Closed`.
-
-Run existing key assignment tests immediately after this refactor.
+Extract only common members into `IConfigOverlayPanel`; preserve existing key-panel semantics and run key-assignment tests.
 
 - [ ] **Step 3: Implement `SongFolderPanel`**
 
-The panel owns:
+The panel owns copied draft state and receives a fakeable picker, root policy, and Config-owned apply delegate. It never holds `IConfigManager`.
 
-- a copied draft root list;
-- selected row/action indexes;
-- async picker state and activation generation;
-- structural diagnostics and availability warnings;
-- a Config-owned apply delegate.
+- [ ] **Step 4: Implement platform pickers**
 
-Use the root policy for validation. Picker completion may modify draft state only if the captured panel generation is current.
+Windows uses `FolderBrowserDialog` on an owned STA dispatcher. macOS uses `/usr/bin/osascript`, `ProcessStartInfo.ArgumentList`, asynchronous exit, and distinct cancellation vs authorization failure mapping.
 
-- [ ] **Step 4: Add platform picker implementations**
+- [ ] **Step 5: Isolate compilation**
 
-Windows:
+Add explicit `<Compile Remove=...>` entries so each target compiles exactly one picker implementation and factory.
 
-- use `FolderBrowserDialog`;
-- own STA dispatch in the platform service;
-- return Selected/Cancelled/Failed without blocking the game update thread.
+- [ ] **Step 6: Wire Config with restart-required behavior**
 
-macOS:
+Replace **DTX Folder** with **Song Folders**, showing `1 folder` or `<n> folders`. Slice 2 apply calls `SetSongRoots`; `Updated` closes with restart-required status, `Unchanged` closes silently, failures keep the panel open.
 
-- invoke `/usr/bin/osascript` with `ProcessStartInfo.ArgumentList`;
-- use `choose folder` and `default location` only when valid;
-- await exit asynchronously;
-- distinguish normal user cancellation from authorization/privacy failure;
-- include stderr only in structured diagnostics.
-
-Do not launch real dialogs in unit tests.
-
-- [ ] **Step 5: Isolate platform compilation**
-
-Add explicit compile exclusions:
-
-```xml
-<!-- Windows project -->
-<Compile Remove="Platform/Mac/**/*.cs" />
-<Compile Remove="Platform/FolderPickerServiceFactory.Mac.cs" />
-
-<!-- Mac project -->
-<Compile Remove="Platform/Windows/**/*.cs" />
-<Compile Remove="Platform/FolderPickerServiceFactory.Windows.cs" />
-```
-
-The exact glob may be adjusted to the final directory layout, but each project must compile only one factory and one native implementation.
-
-- [ ] **Step 6: Wire Config navigation with temporary restart behavior**
-
-Replace read-only **DTX Folder** with a `NavigationConfigItem` named **Song Folders**. Display `1 folder` or `<n> folders`.
-
-For Slice 2, the Config-owned delegate calls `SetSongRoots`. On `Updated`, close the panel and show a restart-required status. On `Unchanged`, close without status. On failure, keep the panel open.
-
-- [ ] **Step 7: Run Slice 2 gate**
+- [ ] **Step 7: Run the Slice 2 gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongFolderPanelTests|FullyQualifiedName~FolderPickerContractTests|FullyQualifiedName~ConfigStageLogicTests|FullyQualifiedName~KeyAssign"
-
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
 ```
 
-- [ ] **Step 8: Commit Slice 2**
+- [ ] **Step 8: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Stage/Config \
-  DTXMania.Game/Lib/Stage/KeyAssign \
+git add \
+  DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs \
+  DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs \
+  DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs \
+  DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs \
   DTXMania.Game/Lib/Stage/ConfigStage.cs \
-  DTXMania.Game/Platform \
-  DTXMania.Game/*.csproj \
-  DTXMania.Test/Config
+  DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs \
+  DTXMania.Game/Platform/Mac/MacFolderPickerService.cs \
+  DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs \
+  DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs \
+  DTXMania.Game/DTXMania.Game.Windows.csproj \
+  DTXMania.Game/DTXMania.Game.Mac.csproj \
+  DTXMania.Test/Config/SongFolderPanelTests.cs \
+  DTXMania.Test/Config/FolderPickerContractTests.cs \
+  DTXMania.Test/Config/ConfigStageLogicTests.cs
 git commit -m "feat: add song folder configuration panel"
 ```
 
-**Review gate:** panel draft isolation, platform build isolation, async picker lifecycle, and restart persistence through Startup.
+**Gate:** isolated draft, async picker lifecycle, platform build isolation, and persisted roots consumed after restart.
 
 ---
 
-## Slice 3a — Config Operation Coordinator and Live Reload
+## Slice 3a — Config Coordinator and Live Reload
 
-### Task 3A: Serialize Config Song Operations and Start One Live Reload
+### Task 3A: Serialize Config Song Operations
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs`
@@ -569,9 +531,9 @@ git commit -m "feat: add song folder configuration panel"
 - Create: `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
 - Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
 - Modify: `DTXMania.Test/Stage/ConfigStageNxImportTests.cs`
-- Modify: relevant SongManager bulk-enumeration tests.
+- Modify: `DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs`
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 internal enum ConfigSongOperationKind
@@ -594,215 +556,168 @@ internal interface ISongLibraryReloadService
 }
 ```
 
-Persistence and orchestration results remain separate. Config maps `SongRootUpdateResult` into a panel-facing orchestration result that may additionally be `Busy` or `Started`.
+Persistence results remain in Config; orchestration adds Busy/Started without changing `IConfigManager` concerns.
 
 - [ ] **Step 1: Write coordinator red tests**
 
-Cover:
+Cover single ownership, cross-operation Busy, exactly-once release, task-construction throw, continuation-registration throw, and repeated Dispose.
+
+- [ ] **Step 2: Implement the scoped coordinator**
+
+Replace check-then-set booleans with atomic lease acquisition. One Config method owns:
 
 ```text
-TryAcquire_ShouldAllowOneOwner
-TryAcquire_ShouldRejectDifferentOperationWhileBusy
-Dispose_ShouldReleaseExactlyOnce
-ThrowDuringOperationConstruction_ShouldReleaseLease
-TerminalContinuationRegistrationFailure_ShouldReleaseLease
-```
-
-Use an injectable continuation/task factory to force each synchronous handoff failure.
-
-- [ ] **Step 2: Implement a scoped coordinator**
-
-The coordinator owns one atomic state. A lease releases through `Dispose()` exactly once. Do not expose check-then-set booleans.
-
-`ConfigStage` uses one method for song-root Apply:
-
-```text
-validate/compare
+compare/validate
 → acquire lease
-→ persist roots
+→ persist
 → create CTS
-→ construct reload task
-→ register observation/progress/terminal release
-→ store operation handle
-→ return Started to panel
+→ construct operation task
+→ register progress and terminal observation
+→ transfer release to terminal continuation
+→ return Started
 ```
 
-All synchronous steps remain inside one `try/finally`. `Saved` only reports that the draft was accepted; it does not acquire, transfer, or release the lease.
+All synchronous steps stay inside one `try/finally`. `SongFolderPanel.Saved` does not transfer lease ownership.
 
-- [ ] **Step 3: Implement the reload adapter**
+- [ ] **Step 3: Implement reload result mapping**
 
-`SongLibraryReloadService` calls the existing HPA-192 operation once with the configured roots.
+Call HPA-192 once.
 
-Result mapping:
+Map:
 
-- occupied lower-level enumeration slot → `Busy`;
-- `SongEnumerationOutcome.NoActiveRoots` → `NoAvailableRoots`, old hierarchy retained;
-- successful import/publication → `Success`;
-- pre-commit cancellation/failure → old hierarchy retained;
+- occupied enumeration slot → Busy;
+- `NoActiveRoots` → retain old hierarchy;
+- success → published snapshot;
+- pre-commit cancel/failure → retain old hierarchy;
 - unexpected post-commit publication failure → partial-success/restart-required.
 
-For completed enumeration, count unavailable roots from `Batch.Errors.Where(error => error.IsRootFailure)`. A shallow preflight may provide early UI warnings, but it cannot override the batch result.
+For completed enumeration, derive unavailable count from `Batch.Errors.Where(e => e.IsRootFailure)`. Preflight may show an early warning but never overrides batch truth.
 
-- [ ] **Step 4: Migrate NX import onto the same lifecycle**
+- [ ] **Step 4: Migrate NX import fully**
 
-Remove `_importRunning` check-then-set ownership. NX import must:
+Remove `_importRunning` ownership and worker writes to `_importStatus`. NX import uses the same coordinator, activation generation, immutable update queue, task observation, CTS disposal, and terminal release.
 
-- acquire `ConfigSongOperationKind.NxScoreImport`;
-- use the same activation generation;
-- enqueue progress/status rather than writing `_importStatus` from a worker;
-- cancel on Config deactivation;
-- attach an observation continuation;
-- dispose CTS and release lease exactly once in the terminal continuation.
+- [ ] **Step 5: Marshal progress on the update thread**
 
-Both operations must reject each other with a concise status.
+Worker continuations enqueue immutable updates tagged with activation generation. `ConfigStage.OnUpdate` drains current-generation updates only. Deactivation increments generation, requests cancellation, and never waits synchronously.
 
-- [ ] **Step 5: Add update-thread status marshalling**
+- [ ] **Step 6: Protect commit-to-publication**
 
-Use a thread-safe queue of immutable operation updates. `ConfigStage.OnUpdate` drains only updates whose activation generation is current. Deactivation increments the generation before cancellation.
+Add a regression test proving cancellation after database commit cannot prevent finalization/publication.
 
-Never wait synchronously for filesystem or SQLite work during stage teardown.
+- [ ] **Step 7: Run operation tests**
 
-- [ ] **Step 6: Preserve the commit-to-publication terminal section**
-
-Ensure HPA-192 does not check cancellation after database commit and before `FinalizePendingNodes`/`PublishEnumeration`. Add a regression test where cancellation arrives after commit and publication still completes successfully.
-
-- [ ] **Step 7: Add operation integration tests**
-
-Required tests:
+Required cases:
 
 ```text
 UnchangedApply_ShouldNotAcquirePersistOrScan
 BusyApply_ShouldNotPersist
-ReorderOnlyApply_ShouldInvokeImporterOnce
+ReorderOnlyApply_ShouldImportOnce
 NoActiveRoots_ShouldRetainCurrentSnapshot
 BatchRootFailures_ShouldDriveWarningCount
 NxImportAndReload_ShouldNotOverlap
 Deactivate_ShouldCancelWithoutBlocking
-WorkerProgress_ShouldReachUIOnlyThroughUpdateDrain
-EveryTerminalPath_ShouldDisposeCtsAndReleaseLeaseOnce
+WorkerProgress_ShouldUpdateOnlyWhenDrained
+EveryTerminalPath_ShouldDisposeAndReleaseOnce
 ```
 
-- [ ] **Step 8: Run Slice 3a gate**
+- [ ] **Step 8: Run the Slice 3a gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~ConfigSongOperationCoordinatorTests|FullyQualifiedName~SongLibraryReloadServiceTests|FullyQualifiedName~ConfigStageNxImportTests|FullyQualifiedName~SongManagerBulkEnumerationTests"
 ```
 
-- [ ] **Step 9: Commit Slice 3a**
+- [ ] **Step 9: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Stage/Config \
+git add \
+  DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs \
+  DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs \
+  DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs \
   DTXMania.Game/Lib/Stage/ConfigStage.cs \
-  DTXMania.Game/Lib/Song \
-  DTXMania.Test/Config \
+  DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs \
+  DTXMania.Test/Config/SongLibraryReloadServiceTests.cs \
   DTXMania.Test/Stage/ConfigStageNxImportTests.cs \
   DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
 git commit -m "feat: live reload configured song roots"
 ```
 
-**Review gate:** no split lease ownership, no worker-thread UI writes, no NX/reload overlap, and no normal publication for a zero-active-root batch.
+**Gate:** no split lease ownership, no worker-thread UI writes, no NX/reload overlap, and no live publication for a zero-active-root batch.
 
 ---
 
-## Slice 3b — Active Song Select Reconciliation and Retained Views
+## Slice 3b — Active Song Select Reconciliation
 
-### Task 3B: Reconcile Runtime Publication on the Update Thread
+### Task 3B: Apply Publications on the Update Thread
 
 **Files:**
 - Create: `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
 - Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
 - Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
-- Modify: existing Song Selection, bookmark, recent, and preview tests.
+- Modify: `DTXMania.Test/Stage/SongSelectionStageLogicTests.cs`
+- Modify: `DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs`
+- Modify: `DTXMania.Test/UI/PreviewImagePanelTests.cs`
 
-**Interfaces:**
+**Consumes:** `SongLibraryPublished` and `GetLibrarySnapshot()` from Slice 1b.
 
-`SongSelectionStage` subscribes to `SongManager.SongLibraryPublished` on activation and unsubscribes on deactivation. The event handler stores only the newest pending publication version; it never changes UI collections.
+- [ ] **Step 1: Write reconciliation red tests**
 
-- [ ] **Step 1: Write publication-reconciliation red tests**
+Cover active publication, retained/removed box navigation, retained/removed selected chart, Bookmarks, Recent, multiple publications, and post-deactivation notification.
 
-Create scenarios for:
+- [ ] **Step 2: Subscribe safely**
 
-```text
-PublicationWhileActive_ShouldApplyOnUpdateThread
-PublicationInsideRetainedBox_ShouldRestoreNavigation
-PublicationInsideRemovedBox_ShouldResetToRoot
-PublicationWithRetainedSelection_ShouldRestoreByStableIdentity
-PublicationRemovingSelection_ShouldStopPreviewAndClearPanels
-PublicationOnBookmarks_ShouldFilterToActiveRoots
-PublicationOnRecent_ShouldFilterToActiveRoots
-MultiplePublications_ShouldApplyNewestVersionOnly
-NotificationAfterDeactivate_ShouldBeIgnored
-```
+Subscribe on activation and unsubscribe on deactivation. The event handler records only the highest pending version; it never mutates UI collections.
 
-Use test snapshots with stable chart/database identities and distinct publication versions.
+- [ ] **Step 3: Reconcile one snapshot in `OnUpdate`**
 
-- [ ] **Step 2: Add event subscription and pending-version state**
+When pending version exceeds applied version:
 
-On activation:
-
-- capture one `SongLibrarySnapshot`;
-- subscribe to publication;
-- remember current activation version.
-
-The event handler atomically records the highest pending version only. On deactivation, unsubscribe before disposing stage resources.
-
-- [ ] **Step 3: Reconcile one coherent snapshot in `OnUpdate`**
-
-When a pending version exceeds the applied version:
-
-1. fetch one current `SongLibrarySnapshot`;
-2. ignore it if superseded or stage generation changed;
-3. replace root-list and active-root state from that snapshot;
-4. restore navigation by stable path/database identity if possible;
-5. restore selected chart by stable chart/database identity if possible;
-6. otherwise reset deterministically to root/first item;
+1. fetch one current snapshot;
+2. verify activation/version;
+3. replace roots and active paths;
+4. restore navigation by stable path/database identity when possible;
+5. restore selected chart by stable identity when possible;
+6. otherwise reset deterministically;
 7. rebuild filter, Bookmarks, Recent, breadcrumb, preview roots, and empty state;
-8. stop preview and clear status/history when selection disappeared;
-9. mark the snapshot version as applied.
+8. stop preview and clear panels when selection disappeared;
+9. mark the version applied.
 
-Do not mix `RootSongs` from one version with active roots from another.
+Never mix hierarchy from one version with active roots from another.
 
-- [ ] **Step 4: Filter Bookmarks and Recent to active roots**
+- [ ] **Step 4: Filter retained tabs by active roots**
 
-Database-backed tab loaders must filter chart paths through the active-root snapshot from the same publication version. Off-root rows remain stored and reappear after a successful root re-add.
+Bookmarks and Recent hide off-active-root rows without deleting database records. Re-add makes retained rows visible again.
 
-- [ ] **Step 5: Implement deliberate empty states**
+- [ ] **Step 5: Add explicit empty-state resolver**
 
-Distinguish:
+Return distinct states for no active roots versus active roots containing no supported charts. Keep condition resolution in one testable method.
 
-```text
-No active roots:
-No song folders are currently available. Open Config to reconnect or change them.
+- [ ] **Step 6: Add concurrent-publication coverage**
 
-Active roots with no supported charts:
-No songs were found in the active song folders.
-```
+Run filter projection and bookmark reconciliation on an old copied snapshot while publishing a new one. Assert no collection-modified exception and final UI uses only the newest version.
 
-Keep copy in one testable resolver method so future localization does not duplicate conditions.
-
-- [ ] **Step 6: Add concurrent-publication regression coverage**
-
-Run filter projection and bookmark reconciliation against a copied snapshot while publishing another version. Assert no `InvalidOperationException`, no background-thread mutation, and final UI data all references the newest applied version.
-
-- [ ] **Step 7: Run Slice 3b gate**
+- [ ] **Step 7: Run the Slice 3b gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongSelectionPublicationTests|FullyQualifiedName~SongSelectionStageLogicTests|FullyQualifiedName~SongSelectionStageBookmark|FullyQualifiedName~PreviewImagePanelTests"
 ```
 
-- [ ] **Step 8: Commit Slice 3b**
+- [ ] **Step 8: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+git add \
+  DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
   DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs \
-  DTXMania.Test/Stage \
-  DTXMania.Test/UI
+  DTXMania.Test/Stage/SongSelectionPublicationTests.cs \
+  DTXMania.Test/Stage/SongSelectionStageLogicTests.cs \
+  DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs \
+  DTXMania.Test/UI/PreviewImagePanelTests.cs
 git commit -m "feat: reconcile live song library publication"
 ```
 
-**Review gate:** active Song Select never enumerates a live backing list, applies publication only on the update thread, and keeps hierarchy/tabs/previews on one version.
+**Gate:** active Song Select enumerates only copied snapshots, applies publication only on update, and keeps hierarchy/tabs/previews on one version.
 
 ---
 
@@ -816,33 +731,38 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj -c Release
 
 Expected: zero failed tests.
 
-- [ ] **Build both game targets**
+- [ ] **Build both targets**
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Release
 dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Release
 ```
 
-Expected: both builds succeed; each compiles only its own picker implementation.
+Expected: both succeed and compile only their own picker implementation.
 
-- [ ] **Run production consumer audit**
+- [ ] **Run the compatibility audit**
 
 ```bash
 rg "Config\??\.DTXPath|ConfigData\.DTXPath|\.DTXPath" DTXMania.Game --glob '*.cs'
 ```
 
-Expected: matches only the compatibility property plus Config load/save/migration code allowed by `DTXPathCompatibilityArchitectureTests`.
+Expected: only allowlisted Config compatibility code.
 
-- [ ] **Manual smoke checks**
+- [ ] **Manual smoke matrix**
 
-1. Migrate an existing one-root Config.ini and verify roots persist after restart.
-2. Add a second local root, reorder, Apply, and verify one reload.
-3. Configure one missing removable root plus one available root; verify available songs load and warning count matches scan errors.
-4. Remove a root; verify songs/bookmarks/recent disappear from active views but return after re-add.
-5. Leave Config during reload and enter Song Select; verify post-publication reconciliation without stale selection or crash.
-6. Start NX score import and attempt Apply; verify Busy and no config write.
-7. Test picker cancellation on Windows and macOS.
+1. Migrate an existing one-root Config.ini and restart.
+2. Add/reorder two local roots and verify one reload.
+3. Combine one unavailable removable root with one available root and compare warning count with batch root failures.
+4. Remove/re-add a root and verify retained scores, Bookmarks, and Recent.
+5. Leave Config during reload and enter Song Select; verify deterministic post-publication reconciliation.
+6. Start NX import and attempt Apply; verify Busy and no write.
+7. Cancel platform pickers on Windows and macOS.
 
-- [ ] **Final commit/checkpoint**
+## Plan Self-Review Checklist
 
-Do not squash slice commits until all review gates pass. The final PR should show the five bounded implementation checkpoints clearly enough to bisect regressions.
+- [x] Every design acceptance criterion maps to a slice and test gate.
+- [x] Both comparer branches are testable on every CI host.
+- [x] Publication version increments only during publication.
+- [x] Zero-active-root results keep a non-null empty import result.
+- [x] Commit commands stage explicit files only.
+- [x] No placeholders or undefined cross-slice interfaces remain.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -41,8 +41,7 @@ the game through boot-only startup state.
   frameworks from shared game code.
 - Reject configurations that would scan the same textual subtree more than
   once under the selected root-comparison policy.
-- Keep startup behavior deterministic when some or all configured roots are
-  unavailable.
+- Keep startup deterministic when some or all configured roots are unavailable.
 - Serialize Config-initiated song-library mutation operations so NX score import
   and song-folder reload cannot write or rebuild the library concurrently.
 
@@ -88,8 +87,8 @@ Three root states are distinguished throughout the design:
 - **Available roots:** configured roots that currently exist and pass a minimal
   access probe.
 - **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy. Active roots change only after a successful publication, or during
-  a clean startup that intentionally publishes an empty active library.
+  hierarchy. Active roots change only after successful publication, or during a
+  clean startup that intentionally publishes an empty active library.
 
 Configured roots and active roots may temporarily differ. For example, a player
 can save new roots and then encounter a failed reload; Song Select must continue
@@ -331,27 +330,56 @@ refactor.
 - A commit delegate owned by `ConfigStage`:
 
 ```csharp
-Func<IReadOnlyList<string>, SongRootUpdateResult> commitRoots
+Func<IReadOnlyList<string>, SongFolderCommitResult> commitRoots
 ```
 
 The panel owns a private draft list. Opening, reordering, adding, removing, or
 cancelling does not mutate `ConfigData`.
 
-On **Apply**:
+The Config-owned delegate is the only commit owner. For a draft snapshot it:
 
-1. The panel validates its draft.
-2. The panel passes an immutable draft snapshot to the Config-owned delegate.
-3. The delegate is the only caller of `IConfigManager.SetSongRoots`.
-4. Validation or persistence failure is returned to the panel; the panel stays
-   open and shows the error.
-5. On `Updated` or `Unchanged`, the panel stores the immutable committed
-   snapshot, raises `Saved`, then raises `Closed`.
-6. `ConfigStage` reads the committed snapshot during `Saved`. It starts a reload
-   only for `Updated`; `Unchanged` closes without a scan.
+1. Canonicalizes and compares against the current configured snapshot.
+2. Returns `Unchanged` without acquiring an operation slot or writing.
+3. For a changed list, attempts to reserve the Config operation slot as
+   `SongFolderReload` **before** calling `SetSongRoots`.
+4. Returns `Busy` without persisting when NX import or another reload owns the
+   slot.
+5. Calls `IConfigManager.SetSongRoots` only after the slot is reserved.
+6. Releases the slot immediately when validation or persistence fails.
+7. Retains the reserved slot on `Updated` so the `Saved` handler can start the
+   matching reload without a race.
+
+On **Apply**, the panel passes an immutable draft snapshot to that delegate.
+Validation, persistence, or busy failure keeps the panel open and displays the
+returned diagnostic. On `Updated` or `Unchanged`, the panel stores the immutable
+committed snapshot, raises `Saved`, then raises `Closed`.
+
+`ConfigStage` reads the committed snapshot during `Saved`:
+
+- `Unchanged`: no operation slot is held and no reload starts.
+- `Updated`: the reload starts using the already-reserved slot. The handler must
+  either attach the reload task or release the slot before returning; it must
+  not leave a reserved slot orphaned if task construction fails.
 
 The panel never holds `IConfigManager` and never persists roots independently.
-This prevents double commits and keeps event ordering consistent with existing
-Config panels.
+
+The panel-level result distinguishes orchestration from persistence:
+
+```csharp
+public enum SongFolderCommitStatus
+{
+    Updated,
+    Unchanged,
+    Busy,
+    ValidationFailed,
+    PersistenceFailed
+}
+
+public sealed record SongFolderCommitResult(
+    SongFolderCommitStatus Status,
+    IReadOnlyList<string> CanonicalRoots,
+    IReadOnlyList<SongRootDiagnostic> Diagnostics);
+```
 
 Supported actions:
 
@@ -403,9 +431,7 @@ construction, or native picker types. Headless tests inject a deterministic fake
 picker. A future native `NSOpenPanel` helper may replace AppleScript without
 changing the shared interface.
 
-## Commit and Persistence Flow
-
-Applying roots is an explicit user commit and requires immediate persistence.
+## Config Persistence API
 
 `IConfigManager` gains:
 
@@ -415,7 +441,7 @@ SongRootUpdateResult SetSongRoots(
     IReadOnlyList<string> roots);
 ```
 
-The result contract is:
+This persistence-level result remains independent of Config's `Busy` status:
 
 ```csharp
 public enum SongRootUpdateStatus
@@ -438,7 +464,7 @@ public sealed record SongRootUpdateResult(
 ```
 
 The implementation may adjust concrete type names but must preserve those four
-outcomes and immutable snapshots.
+persistence outcomes and immutable snapshots.
 
 The operation:
 
@@ -480,26 +506,29 @@ reorder-only path. HPA-192 remains the sole importer and publication authority.
 
 ### Apply sequence
 
-1. `SongFolderPanel` validates and commits its draft.
-2. `ConfigManager.SetSongRoots` atomically persists the canonical ordered list.
-3. `Saved` fires before `Closed`; Config captures the committed snapshot.
-4. `Unchanged` closes with no reload.
-5. `Updated` acquires the Config song-operation slot and displays reload status.
-6. The reload service probes all configured roots.
-7. When at least one root is available, one enumeration/import starts with only
+1. The panel validates its draft locally.
+2. Config's commit delegate detects `Unchanged` or reserves the
+   `SongFolderReload` operation slot for a changed list.
+3. A busy slot returns `Busy`; roots are not persisted and the panel stays open.
+4. With the slot reserved, `ConfigManager.SetSongRoots` atomically persists the
+   canonical ordered list.
+5. Validation/persistence failure releases the slot and keeps the panel open.
+6. `Updated` stores the committed snapshot and raises `Saved` before `Closed`.
+7. Config's `Saved` handler starts reload using the existing slot reservation.
+8. The reload service probes all configured roots.
+9. When at least one root is available, one enumeration/import starts with only
    those roots.
-8. The old hierarchy remains active while discovery and persistence run.
-9. On successful commit, finalization and publication replace the hierarchy and
-   active-root snapshot atomically.
-10. Config reports folder, chart, unavailable-folder, and error counts. Logical
+10. The old hierarchy remains active while discovery and persistence run.
+11. On successful commit, finalization and publication replace the hierarchy and
+    active-root snapshot atomically.
+12. Config reports folder, chart, unavailable-folder, and error counts. Logical
     song counts remain structured-log detail rather than user-facing copy.
 
 Unavailable configured roots are omitted from the scan and listed as warnings.
 Their database records remain outside active import cleanup.
 
-When no configured root is available, Config skips the importer and retains the
-current active hierarchy. The roots remain saved and Config reports that the
-current library is retained until a later successful reload or restart.
+When no configured root is available, Config skips the importer, retains the
+current active hierarchy, reports the warning, and releases the operation slot.
 
 ### Config operation mutual exclusion
 
@@ -509,13 +538,14 @@ current library is retained until a later successful reload or restart.
 None | NxScoreImport | SongFolderReload
 ```
 
-Both `StartNxScoreImport` and song-folder Apply must acquire this slot before
-starting work and release it only in their terminal continuation.
+Both `StartNxScoreImport` and changed-root Apply must reserve this slot before
+performing persistence or database work and release it only in their terminal
+continuation.
 
 Required behavior:
 
-- Apply while NX import is running is rejected with a clear status; roots are
-  not re-persisted and no reload starts.
+- Apply while NX import is running returns `Busy`; roots are not persisted and
+  no reload starts.
 - NX import while reload is running is rejected with a clear status.
 - A second reload is rejected while reload is active.
 - Existing `SongManager` enumeration-slot rejection is converted to a `Busy`
@@ -533,20 +563,19 @@ The HPA-192 transaction commit through hierarchy publication is treated as a
 non-cancellable terminal section:
 
 - Cancellation is honored during probing, discovery, parsing, matching, and
-  persistence before the database commit.
-- Once the bulk import commits successfully, the caller must not perform another
+  persistence before database commit.
+- Once bulk import commits successfully, the caller must not perform another
   cancellation check before `FinalizePendingNodes` and `PublishEnumeration`.
 - A cancellation request arriving after commit is ignored until publication
   completes; the result is success, not cancellation.
-- This rule prevents the database from reflecting the new active-root cleanup
-  while the old hierarchy remains published solely because cancellation arrived
-  in the commit-to-publish gap.
+- This prevents the database from reflecting new active-root cleanup while the
+  old hierarchy remains solely because cancellation arrived in the
+  commit-to-publish gap.
 
 If an unexpected finalization or publication exception occurs after commit, the
 old hierarchy remains atomically intact, but the database may already reflect
 the new import. Report a distinct partial-success failure requiring restart;
-do not claim rollback. This is an exceptional recovery path, not normal
-cancellation behavior.
+do not claim rollback.
 
 ### Config deactivation
 
@@ -560,6 +589,7 @@ Use the same pattern as `StartupStage`:
 - Cancel the operation CTS.
 - Attach an execute-synchronously observation continuation.
 - Observe any fault and dispose the CTS only after task termination.
+- Release the Config operation slot in that terminal continuation.
 - Suppress UI/status writes from stale generations.
 
 The game-wide `SongManager` operation may finish after Config deactivates. A
@@ -570,11 +600,12 @@ feedback is suppressed.
 
 Before database commit, failure or cancellation means:
 
-- Persisted configured roots remain saved.
+- Persisted configured roots remain saved when persistence had already
+  succeeded.
 - Database transaction rolls back.
 - Previous active hierarchy and active-root snapshot remain published.
 - No partial hierarchy is exposed.
-- Config reports that the saved roots will be retried on startup or Apply.
+- Config reports that saved roots will be retried on startup or Apply.
 
 After database commit, cancellation no longer changes the success path. An
 unexpected post-commit publication failure uses the partial-success recovery
@@ -612,7 +643,7 @@ Known consumers include:
 - `ConfigStage`: replace the read-only DTX Folder item.
 - `SongSelectionStage` / `PreviewImagePanel`: remove the single
   `SongsRootPath` fallback.
-- Any E2E fixture or runtime helper that supplies the production configuration.
+- Any E2E fixture or runtime helper that supplies production configuration.
 
 ### Preview resolution
 
@@ -639,20 +670,19 @@ Product rule:
 - All Songs uses the published active hierarchy.
 - Bookmarks and Recent filter database-backed results to the current active-root
   snapshot.
-- If a reload fails and the previous hierarchy stays active, the previous roots'
-  Bookmarks and Recent entries remain visible because those roots are still
-  active.
-- After a successful removal reload, off-root Bookmarks and Recent entries are
+- If reload fails and the previous hierarchy stays active, previous roots'
+  Bookmarks and Recent entries remain visible because those roots remain active.
+- After successful removal reload, off-root Bookmarks and Recent entries are
   hidden but retained.
 - Re-adding and successfully publishing the root makes retained entries visible
-  again with their user-owned data intact.
+  again with user-owned data intact.
 
 ## Empty Library UX
 
 Song Select must show a deliberate empty state rather than a blank list:
 
-- Configured roots exist but none are active/available: **No song folders are
-  currently available. Open Config to reconnect or change them.**
+- No active roots and no configured root is currently available: **No song
+  folders are currently available. Open Config to reconnect or change them.**
 - At least one active root exists but contains no supported charts: **No songs
   were found in the active song folders.**
 
@@ -671,7 +701,7 @@ The existing HPA-192 contracts remain in force:
 - Charts and songs outside those roots are retained.
 - Bookmarks, score-speed variants, play counts, recent timestamps, ranks,
   full-combo state, and performance history remain user-owned.
-- The replacement hierarchy is published only after transaction commit.
+- Replacement hierarchy is published only after transaction commit.
 
 HPA-191 prevents textual parent/child overlaps before they reach `SongManager`.
 The importer is not responsible for resolving physical aliases or choosing
@@ -709,8 +739,7 @@ Config user-facing examples:
 
 ### Configuration unit tests
 
-- Default config contains exactly the managed default root and mirrors it to
-  `DTXPath`.
+- Default config contains exactly managed default root and mirrors `DTXPath`.
 - Indexed roots round-trip in order and rewrite densely.
 - Legacy `DTXPath` migrates to one indexed root and persists immediately.
 - Legacy default `Songs` migration still resolves to `DTXFiles`.
@@ -726,7 +755,7 @@ Config user-facing examples:
 - Managed default root is created when restored.
 - Persistence failure restores old roots and emits no event.
 - Successful update raises one event with immutable snapshots.
-- `Unchanged`, `ValidationFailed`, and `PersistenceFailed` results are distinct.
+- Persistence result statuses are distinct.
 
 ### Config and panel tests
 
@@ -736,24 +765,27 @@ Config user-facing examples:
 - Add, remove, reorder, Apply, Cancel, and Back are deterministic.
 - Async picker cancellation/failure does not mutate the draft.
 - Stale picker completion cannot update a reactivated/disposed panel.
-- Structural errors keep the panel open; availability warnings may be applied.
+- Structural errors keep panel open; availability warnings may be applied.
 - Last configured root cannot be removed without adding another.
-- Config's commit delegate is the only `SetSongRoots` caller.
+- Config's delegate is the only `SetSongRoots` caller.
+- Busy changed-root Apply does not persist.
+- Persistence failure releases the reserved slot, keeps panel open, and starts
+  no reload.
 - `Saved` fires before `Closed` after successful commit.
-- Persistence failure keeps the panel open and starts no reload.
-- Active overlay polymorphism continues supporting existing key panels.
+- Updated `Saved` handler cannot orphan the reserved slot.
+- Active overlay polymorphism continues supporting key panels.
 
 ### Operation and reload tests
 
-- Unchanged ordered roots perform no write and no scan.
+- Unchanged ordered roots perform no write, slot acquisition, or scan.
 - Reorder-only changed roots perform exactly one full importer call.
-- One successful Apply invokes importer once with available roots in order.
+- Successful Apply invokes importer once with available roots in order.
 - Unavailable roots are skipped without blocking available roots.
-- No available roots skip import and retain existing hierarchy.
-- Apply is rejected while NX import runs.
+- No available roots skip import, retain hierarchy, and release the slot.
+- Apply is rejected without persistence while NX import runs.
 - NX import is rejected while reload runs.
-- Lower-level enumeration busy is mapped to a user-visible Busy result.
-- Leaving Config cancels and asynchronously observes the active operation.
+- Lower-level enumeration busy maps to a user-visible Busy result.
+- Leaving Config cancels and asynchronously observes active operation.
 - Stale generation continuations cannot write Config UI state.
 - Pre-commit failure/cancellation preserves old hierarchy.
 - Cancellation after commit cannot suppress publication and reports success.
@@ -762,16 +794,16 @@ Config user-facing examples:
 ### Startup and runtime integration tests
 
 - Startup consumes `SongRoots`, not compatibility `DTXPath`.
-- Every production `DTXPath` consumer is removed or explicitly compatibility-only.
+- Every production `DTXPath` consumer is removed or compatibility-only.
 - Multiple roots appear in configured order.
-- Root aliases are imported once under the selected root comparer.
+- Root aliases are imported once under selected root comparer.
 - Charts under distinct roots are imported once each.
-- Root N preview fallback resolves using active roots, not configured root zero.
+- Root N preview fallback uses active roots, not configured root zero.
 - Removed-root songs disappear from active hierarchy after success but remain in
   SQLite with scores/bookmarks intact.
 - Bookmarks and Recent hide off-active-root rows and restore them after re-add.
 - Missing removable root does not block another root.
-- No available roots publish an empty active library without database cleanup.
+- No available roots publish empty active library without database cleanup.
 - Distinct Song Select empty states are selected correctly.
 - Windows and macOS compile with only their picker implementation.
 - Existing HPA-192 cancellation, retention, and performance tests remain green.
@@ -783,13 +815,13 @@ Slice 3**. Each is intended to fit within three engineer days.
 
 ### Slice 1: Canonical multi-root configuration and consumer migration
 
-- Add `SongRoots`, indexed INI format, compatibility mirror, migration, result
-  contract, immutable event snapshots, and immediate persistence.
-- Add internal `SongRootPolicy` with the explicit root comparer, overlap
-  validation, normalization, and availability probing.
-- Align `SongManager` defensive root deduplication with the root policy.
-- Update startup to consume root snapshots and publish an empty active library
-  when no root is available.
+- Add `SongRoots`, indexed INI format, compatibility mirror, migration,
+  persistence result, immutable event snapshots, and immediate persistence.
+- Add internal `SongRootPolicy` with explicit root comparer, overlap validation,
+  normalization, and availability probing.
+- Align `SongManager` defensive root deduplication with root policy.
+- Update startup to consume snapshots and publish empty active library when no
+  root is available.
 - Audit and migrate all production `DTXPath` consumers, including active-root
   preview fallback and active-root snapshot exposure.
 - Add configuration, startup, preview, and consumer-audit tests.
@@ -805,7 +837,7 @@ Depends on Slice 1.
 - Replace **DTX Folder** with **Song Folders** and implement draft editing.
 - Commit through Config's single commit delegate and `SetSongRoots`.
 - Show temporary `restart required` status after `Updated` until Slice 3.
-- Verify the persisted roots are consumed by Startup on the next launch.
+- Verify persisted roots are consumed by Startup on next launch.
 - Add panel, picker-threading, and platform-boundary tests.
 
 ### Slice 3: Live reload and retained-data integration
@@ -813,7 +845,8 @@ Depends on Slice 1.
 Depends on Slices 1 and 2.
 
 - Add `ISongLibraryReloadService`.
-- Add Config operation mutual exclusion shared by NX import and reload.
+- Add Config operation mutual exclusion shared by NX import and reload, with
+  reservation before changed-root persistence.
 - Add progress, unavailable-root summaries, non-blocking cancellation
   observation, commit-to-publish terminal semantics, and failure feedback.
 - Add active-root filtering for Bookmarks/Recent and deliberate empty-state UX.
@@ -824,34 +857,35 @@ Depends on Slices 1 and 2.
 ## Acceptance Criteria
 
 - Existing one-path `DTXPath` configurations migrate without library loss.
-- A fresh install has one managed default song root.
+- Fresh install has one managed default song root.
 - Config allows adding, removing, and reordering roots on Windows and macOS.
 - Ordered roots survive restart and are read by startup after Slice 2.
-- Root duplicate comparison is explicitly ignore-case on Windows/macOS and
-  ordinal on Linux; chart canonical identity remains ordinal.
+- Root duplicate comparison is ignore-case on Windows/macOS and ordinal on
+  Linux; chart canonical identity remains ordinal.
 - Duplicate and textual parent/child-overlapping roots cannot be applied.
 - Missing custom roots remain configured and are never created automatically.
 - Previously auto-created custom directories are not deleted by migration.
-- Unchanged roots do not scan; any changed ordered list performs at most one full
-  scan, including reorder-only changes.
+- Unchanged roots do not acquire slot or scan; any changed ordered list performs
+  at most one full scan, including reorder-only changes.
+- Busy changed-root Apply does not persist the draft.
 - Every available root is scanned in configured order.
 - NX import and song reload cannot run concurrently from Config.
 - Busy lower-level enumeration is reported without an unhandled exception.
 - One unavailable root does not prevent available roots from loading.
-- A successful reload replaces active hierarchy atomically.
-- Pre-commit failure or cancellation never exposes a partial hierarchy.
+- Successful reload replaces active hierarchy atomically.
+- Pre-commit failure or cancellation never exposes partial hierarchy.
 - Cancellation after commit cannot suppress hierarchy publication.
-- Config deactivation never blocks the game thread waiting for reload/import.
-- No available root during Apply retains the previous active hierarchy.
-- No available root during startup reaches Title with an empty active library
-  and leaves SQLite untouched.
+- Config deactivation never blocks game thread waiting for reload/import.
+- No available root during Apply retains previous active hierarchy.
+- No available root during startup reaches Title with empty active library and
+  leaves SQLite untouched.
 - Preview fallback under any active root resolves correctly.
-- Removing a root hides its songs, Bookmarks, and Recent entries after successful
-  reload while preserving their database records and user-owned data.
+- Removing a root hides songs, Bookmarks, and Recent after successful reload
+  while preserving database records and user-owned data.
 - Re-adding a root restores retained user data and active views.
 - Song Select distinguishes unavailable folders from available-but-empty roots.
-- `DTXPath` remains a compatibility mirror only; every runtime consumer uses
-  configured or active root snapshots as appropriate.
-- Symlink/junction/physical-target deduplication is explicitly outside scope.
+- `DTXPath` remains compatibility mirror only; every runtime consumer uses
+  configured or active snapshots as appropriate.
+- Symlink/junction/physical-target deduplication is outside scope.
 - No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
   included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -2,126 +2,137 @@
 
 **Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
 **Date:** 2026-08-01  
-**Status:** Revised after second-pass design review
+**Status:** Revised after third-pass design review
 
 ## Context
 
-DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath`,
-writes it as `DTXPath=` in `Config.ini`, displays it as a read-only **DTX
-Folder** item in `ConfigStage`, and wraps it in a one-element array during
-startup.
+DTXManiaCX currently has one configured song-library root:
 
-The lower-level song system is already substantially multi-root capable:
+- `ConfigData.DTXPath` is serialized as `DTXPath=`.
+- `ConfigStage` shows a read-only **DTX Folder** item.
+- `StartupStage` wraps the path in a one-element array.
+- `SongSelectionStage` gives `PreviewImagePanel` one fallback root.
 
-- `SongManager` accepts ordered arrays of search roots.
-- Enumeration normalizes and deduplicates roots.
-- Root traversal order is preserved in the published hierarchy.
-- HPA-192 bulk import and stale cleanup are scoped to the active roots supplied
-  to a completed import.
-- Rows outside active roots are retained, protecting bookmarks, score variants,
-  play history, ranks, full-combo state, and performance history when a library
-  is removed or unavailable.
+The lower-level song system already accepts ordered root arrays. HPA-192 owns
+filesystem traversal, bulk persistence, retained-data cleanup, hierarchy
+finalization, and publication after database commit. HPA-191 therefore does not
+add another importer or a database schema migration.
 
-HPA-191 therefore does not introduce another importer or a database schema
-migration. It makes the ordered root list a first-class configuration value,
-adds safe Config editing and platform folder selection, migrates every runtime
-consumer away from the single-root compatibility property, and performs one
-atomic live reload without routing the game through boot-only `StartupStage`
-state.
+The work is to make ordered roots a first-class configuration value, expose safe
+cross-platform editing, align every runtime consumer, and support live
+publication while stages are active.
+
+Several current implementation details affect the design:
+
+- `SongPathIdentity.CanonicalComparer` is ordinal, while
+  `LegacyAliasComparer` is ignore-case on Windows/macOS and ordinal elsewhere.
+- `SongManager.SetCurrentSearchPaths` and enumeration-batch root deduplication
+  currently use the ordinal comparer.
+- `SongManager.RootSongs` currently returns `_rootSongs.AsReadOnly()`, which is a
+  live wrapper over a list mutated by `PublishEnumeration`.
+- `SetCurrentSearchPaths` currently ignores empty arrays, so it cannot clear a
+  stale active-root snapshot.
+- `NormalizeConfigPaths` currently creates every custom `DTXPath` directory.
+- `ConfigStage` NX import uses a separate `_importRunning` flag and writes status
+  from a background task.
+- No production stage currently observes `EnumerationCompleted`.
+
+Those behaviors are safe enough during startup-only publication, but they are
+not sufficient for an in-game library reload.
 
 ## Goals
 
 - Allow players to add, remove, and reorder song-library roots from Config.
-- Persist one or more ordered roots while migrating existing `DTXPath`
-  configurations without library loss.
-- Apply valid changes immediately and perform at most one live reload.
-- Preserve the currently published hierarchy until a replacement library has
-  committed and published successfully.
-- Preserve database rows and user-owned state for removed or temporarily
-  unavailable roots.
-- Support Windows and macOS folder selection without platform UI dependencies
-  in shared game code.
-- Reject textual duplicate or parent/child root combinations that would scan the
-  same subtree more than once under the selected root-comparison policy.
-- Keep startup deterministic when some or all configured roots are unavailable.
-- Serialize Config-initiated library mutation operations so NX score import and
-  song-folder reload cannot race.
-- Keep an already-active Song Select stage coherent when a reload publishes
-  after Config has deactivated.
+- Persist one or more ordered roots while migrating legacy `DTXPath` safely.
+- Perform at most one full reload for a changed ordered root list.
+- Keep the old published hierarchy until a replacement commits and publishes.
+- Preserve bookmarks, scores, variants, history, and other user data belonging
+  to removed or temporarily unavailable roots.
+- Keep Config-initiated NX import and song-folder reload mutually exclusive.
+- Make publication safe while Song Select and other consumers are active.
+- Keep configured, available, and active roots distinct.
+- Keep every implementation slice within roughly three engineer days.
 
 ## Non-goals
 
 - DTXCreator changes.
-- Chart parser, `set.def`, or `box.def` semantic changes.
+- Parser, `set.def`, or `box.def` semantic changes.
 - Song database schema changes.
-- Filesystem watchers or automatic reload when removable media mounts.
-- Rescanning after each individual draft edit.
-- A database-only reorder fast path. Any changed ordered root list performs one
-  full enumeration/import in HPA-191.
-- Editing or creating chart files from Config.
-- Synthetic top-level boxes for each configured root.
+- Filesystem watchers or automatic mounting detection.
+- Scanning after every draft edit.
+- A database-only reorder fast path.
+- Synthetic top-level root boxes.
 - Merging same-named folders or songs across roots.
-- Deleting retained records for removed roots.
-- Resolving filesystem aliases to physical targets. Symlinks, junctions, bind
-  mounts, aliases, and case-sensitive macOS volumes may expose one target through
-  distinct paths; realpath/inode-based deduplication is deferred.
-- General-purpose file-picker infrastructure beyond folder selection.
-- Replacing the macOS AppleScript adapter with a native `NSOpenPanel` helper.
-- Linux-specific picker integration. The configuration and reload contracts
-  remain platform-neutral, but HPA-191 targets the existing Windows and macOS
-  projects.
+- Deleting retained rows for removed roots.
+- Resolving symlinks, junctions, aliases, bind mounts, or physical filesystem
+  targets. Textually different paths may still reach the same physical folder.
+- Linux-specific folder-picker UI.
+- Replacing the initial macOS AppleScript adapter with `NSOpenPanel`.
 
-## Chosen Approach
+## Root State Model
 
-Add an ordered `SongRoots` collection as the sole configured-root source of
-truth. Keep `DTXPath` only as a serialized compatibility mirror of the first
-root. A Config overlay edits a private draft and commits through one
-Config-owned delegate. An asynchronous platform picker supplies new paths.
-After the changed list is persisted atomically, a focused reload service invokes
-the existing HPA-192 enumeration/import path once.
+The design distinguishes three ordered snapshots:
 
-The old hierarchy remains active until the complete replacement batch commits,
-finalizes, and publishes. Failure or cancellation before commit cannot expose a
-partial list.
+- **Configured roots:** normalized paths persisted in `Config.ini`.
+- **Available roots:** configured roots that appear accessible at a particular
+  check.
+- **Active roots:** roots represented by the currently published hierarchy.
 
-The design distinguishes three root states:
+Configured and active roots may differ. For example, Config may persist a new
+root list and then encounter a pre-commit reload failure. Runtime surfaces that
+represent the published library must continue using the old active snapshot.
 
-- **Configured roots:** ordered normalized paths persisted in `Config.ini`.
-- **Available roots:** configured roots that currently exist and pass a shallow
-  access probe.
-- **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy.
+## Chosen Architecture
 
-Configured and active roots may differ after a failed reload. Runtime surfaces
-that represent the published library must use the active-root snapshot, not the
-new configured list.
+1. `ConfigData` gains ordered `SongRoots`; `DTXPath` becomes a compatibility
+   mirror of the first root.
+2. An internal `SongRootPolicy` owns normalization, duplicate comparison,
+   overlap detection, and availability classification.
+3. `SongManager` exposes copied, versioned library snapshots. It never hands out
+   a live view of the mutable root list.
+4. `SongFolderPanel` edits an isolated draft and delegates Apply to one
+   Config-owned operation.
+5. That Config operation owns the entire changed-root sequence: lease
+   acquisition, persistence, reload task construction, terminal observation,
+   and lease release.
+6. HPA-192 remains the importer and commit/publication authority.
+7. Song Select observes publication versions and reconciles on the update
+   thread.
 
 ## Alternatives Considered
 
 ### Save and require restart
 
-This is the smallest change but leaves the active library stale and provides
-weak confirmation. It is rejected for the completed feature. Slice 2 uses a
-temporary restart-required state until Slice 3 lands.
+This is the temporary Slice 2 behavior but not the completed feature. It leaves
+the active library stale and gives weak confirmation.
 
-### Transition Config through StartupStage
+### Re-enter StartupStage
 
-`StartupStage` owns boot phases, activation generations, timing summaries, and
-exactly-once startup telemetry. Re-entering it for a user operation would couple
-unrelated lifecycles and make telemetry ambiguous. It is rejected.
+Rejected. Startup owns boot-only phases, activation generations, timing traces,
+and exactly-once telemetry.
 
-### Rebuild from SQLite for reorder-only changes
+### Reorder from SQLite without parsing
 
-The hierarchy builder could potentially republish roots in a new order without
-parsing charts. HPA-191 deliberately does not add that branch. Apply is an
-explicit refresh and one full scan also observes filesystem changes made while
-the panel was open. A future measured optimization may specialize reorder-only
-changes.
+Deferred. Any changed ordered list performs one full scan in HPA-191. This also
+observes filesystem changes made while Config was open.
 
-### Store one delimited value
+### Transfer a lease through `Saved` event handling
 
-A delimiter conflicts with legal path characters and complicates escaping and
-hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
+Rejected after review. The previous draft acquired a lease in the panel commit
+delegate, persisted roots, raised `Saved`, and transferred release ownership to
+a reload continuation constructed by another handler. Although `try/finally`
+and failure injection could make that correct, the ownership boundary was
+unnecessarily subtle.
+
+The final design keeps acquire, persist, reload construction, continuation
+registration, and release ownership in one Config method. `Saved` remains a UI
+lifecycle notification only.
+
+### Collapse orchestration and persistence result types
+
+Rejected. `Busy` belongs to Config operation coordination and must not leak into
+`IConfigManager`. The types remain separate but are composed rather than
+repeating independent logic.
 
 ## Configuration Contract
 
@@ -133,21 +144,17 @@ hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
 public List<string> SongRoots { get; } = new();
 ```
 
-The property remains get-only. Load, reset, and successful updates clear and
-refill the existing collection instead of replacing its reference. Consumers
-must never retain or mutate the live list. Startup, UI, events, and reload
-boundaries receive copied immutable snapshots.
+The collection is get-only. Load, reset, and successful updates clear and refill
+it rather than replacing the list reference. Consumers receive copied immutable
+snapshots and must never retain or mutate the live list.
 
-`DTXPath` remains for source and downgrade compatibility only:
+`DTXPath` remains for serialization and downgrade compatibility only:
 
-- After load, reset, or a successful update, it equals the first normalized
-  configured root.
-- Startup, Config, reload, active views, previews, and all other runtime behavior
-  consume configured or active root snapshots instead.
-- Direct mutation of `DTXPath` is not a supported runtime update mechanism.
+- It always mirrors the first configured root after load/reset/update.
+- Runtime behavior consumes configured or active root snapshots instead.
+- Direct mutation is not a supported update mechanism.
 
-At least one configured root is required. Availability is not required; the
-only root may be a disconnected removable or network location.
+At least one configured root is required, but it may currently be unavailable.
 
 ### Persisted format
 
@@ -158,286 +165,126 @@ SongRoot.0=C:\DTX\Main
 SongRoot.1=D:\Community Charts
 ```
 
+The existing INI parser is section-agnostic: section headers are presentation
+only and keys are globally parsed. HPA-191 must not add section-scoped parsing
+for `SongRoot.*` unless the entire configuration parser is redesigned in a
+separate issue.
+
 Rules:
 
-1. `SongRoot.<index>` uses a non-negative decimal integer.
+1. `SongRoot.<index>` uses a non-negative decimal index.
 2. Entries load in ascending numeric order; gaps are allowed.
-3. Malformed suffixes, negative indexes, and blank values are ignored with a
+3. Blank values, malformed suffixes, and negative indexes are ignored with a
    warning.
 4. Duplicate indexes use the last parsed value and emit a warning.
-5. Values may contain `=` because parsing splits on the first `=` only.
+5. Values may contain `=` because parsing splits only on the first `=`.
 6. Save rewrites indexes densely from zero.
-7. `DTXPath` mirrors the first root.
-8. At least one structurally valid indexed entry makes `SongRoot.*`
-   authoritative.
-9. With no valid indexed entry, load migrates legacy `DTXPath` into a one-root
-   list.
-10. If neither representation yields a valid path, load restores the managed
-    default.
+7. Indexed roots are authoritative when at least one structurally valid entry
+   exists.
+8. Otherwise legacy `DTXPath` is migrated into one root.
+9. If neither representation yields a valid path, restore the managed default.
+10. `DTXPath` is serialized as the first normalized root.
 
-A successful legacy migration is immediately persisted through the existing
-atomic temp-file replacement.
+At the beginning of every `LoadConfig`, clear `SongRoots` before parsing, just as
+`MidiVelocityThresholds` is cleared today. Loading twice into the same manager
+must not accumulate prior roots.
 
-### Downgrade compatibility caveat
+A successful migration is persisted immediately through the existing atomic
+temp-file replacement.
 
-The `DTXPath` mirror is best-effort compatibility, not a guarantee that older
-build behavior is safe. If the first root is an unavailable removable or
-network path and the user runs a pre-HPA-191 build, that older build may execute
-its unconditional directory-creation behavior and create an empty directory at
-that path. HPA-191 cannot prevent behavior after a downgrade; ordering a stable
-local root first reduces that risk.
+### Legacy default migration
 
-### Legacy path migration
-
-The existing known-default migration from `Songs` to the managed `DTXFiles`
-location remains. It applies to the fallback legacy value before it becomes
-`SongRoots[0]`. Indexed custom roots are not remapped merely because their final
-segment is named `Songs`.
-
-Previous builds may already have created empty custom directories while a
-removable or network root was unavailable. HPA-191 does not delete or move such
-folders.
+The known legacy default forms of `Songs` continue migrating to the managed
+`DTXFiles` directory. Indexed custom paths ending in `Songs` are not remapped.
 
 ### Deliberate removal of custom-root auto-creation
 
-Today `NormalizeConfigPaths` unconditionally calls
-`EnsureDirectorySafe(Config.DTXPath)`, creating every configured custom path at
-load. Slice 1 deliberately removes that behavior.
+Slice 1a deliberately removes the current unconditional
+`EnsureDirectorySafe(Config.DTXPath)` behavior.
 
 After HPA-191:
 
-- The game may create only `AppPaths.GetDefaultSongsPath()` when the managed
-  default is selected or restored as fallback.
-- Missing custom roots are retained as unavailable configuration values.
-- No load, migration, Apply, startup, or availability probe creates a custom
-  directory.
-- Existing directories created by older versions are left untouched.
+- Only `AppPaths.GetDefaultSongsPath()` may be created automatically when it is
+  selected or restored as fallback.
+- Missing custom roots remain configured but unavailable.
+- Load, migration, Apply, startup, and availability checks never create custom
+  folders.
+- Empty folders previously created by old builds are not deleted.
 
-This is an intentional product behavior change, not merely an implementation
-detail of the multi-root format.
+This is an intentional product behavior change.
 
-## Root Path Identity and Validation
+### Downgrade mirror caveat
 
-Root identity is intentionally separate from HPA-192 chart identity.
-`SongPathIdentity.CanonicalComparer` remains ordinal for exact persisted chart
-identity.
+`DTXPath` is best-effort compatibility. If its first root is an unavailable
+removable/network path and the user runs an older build, that build may recreate
+an empty directory through its legacy unconditional behavior. HPA-191 cannot
+control behavior after downgrade.
 
-### Shared root policy
+## SongRootPolicy
 
-Add internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. Config
-load, Config UI, `SetSongRoots`, startup, defensive `SongManager` root
-deduplication, overlap checks, and availability probing all use this policy.
+### Testable comparer selection
 
-`SongRootPolicy.RootComparer` uses
-`SongPathIdentity.LegacyAliasComparer`:
+`LegacyAliasComparer` is resolved from the running OS, so both comparison
+branches cannot be covered reliably by platform CI alone. `SongRootPolicy`
+therefore has an explicit test seam:
 
-- Windows and macOS: ordinal ignore-case.
-- Linux and other platforms: ordinal case-sensitive.
+```csharp
+internal sealed class SongRootPolicy
+{
+    internal SongRootPolicy(StringComparer rootComparer);
 
-On a case-sensitive macOS volume, case-only root variants are still treated as
-duplicates for HPA-191. Physical-case and real-target discovery are out of
-scope.
+    internal static StringComparer CreateRootComparer(bool ignoreCase) =>
+        ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
-`SongPathIdentity` remains internal. No public exposure is necessary because the
-policy and consumers live in the shared assembly; tests use the repository's
-internal-test access pattern.
+    internal static SongRootPolicy PlatformDefault { get; }
+}
+```
 
-### Canonicalization
+Production creates `PlatformDefault` using Windows/macOS ignore-case behavior.
+Tests instantiate both comparer modes on every CI platform. The policy is
+internal; no public API exposure is required.
 
-For each non-blank input:
+### Normalization
 
-1. Expand supported home-relative forms through `AppPaths`.
-2. Resolve legacy relative paths against the existing app-data base.
-3. Convert to an absolute full path.
-4. Normalize separators and trailing separators with
+For each input:
+
+1. Reject blank values.
+2. Expand supported home-relative forms through `AppPaths`.
+3. Resolve legacy relative values against the existing app-data base.
+4. Convert to a full absolute path.
+5. Normalize separators and trim ending separators through
    `SongPathIdentity.Normalize`.
-5. Compare roots with `SongRootPolicy.RootComparer`.
-6. Persist the normalized absolute value.
+6. Compare roots with the policy comparer.
+7. Persist the normalized absolute value.
 
-Root order controls traversal and root-level presentation order.
+### Duplicate policy
 
-### Defensive SongManager alignment
+- Windows/macOS mode: case-insensitive.
+- Linux/ordinal mode: case-sensitive.
+- Preserve first occurrence and authored order.
 
-`SongManager.SetCurrentSearchPaths`, enumeration-batch root creation, and every
-other defensive root deduplication point must use
-`SongRootPolicy.RootComparer`, not the ordinal chart comparer. Direct callers
-must not reintroduce aliases that Config rejects.
+This root policy does not change ordinal chart identity.
 
-This is a deliberate behavior change for all `SetCurrentSearchPaths` callers,
-including startup cache/database paths such as `LoadScoreCacheAsync`,
-`BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync`. On Windows
-and macOS, roots differing only by case will now collapse to one root in those
-paths as well as during fresh enumeration.
+### Overlap policy
 
-Slice 1 must add focused coverage for `SetCurrentSearchPaths` behavior and its
-snapshot, plus caller-path tests for cache load, database hierarchy rebuild, and
-enumeration decisions. The comparer change must not rely only on Config-panel
-integration tests.
+Root-overlap validation must not call
+`SongPathIdentity.IsUnderNormalizedRoot` or rely on `Path.GetRelativePath`.
+Those APIs follow platform path semantics that disagree with the chosen
+ignore-case macOS root policy.
 
-### Blocking structural errors
+Implement dedicated segment-wise comparison:
 
-Apply is blocked by:
+1. Parse the normalized root prefix/volume/share and remaining path segments.
+2. Compare root prefixes and each segment with `RootComparer`.
+3. Equality is a duplicate.
+4. If every segment of the shorter root matches the corresponding segment of
+   the longer root, the shorter root is an ancestor and the pair is rejected.
+5. Perform the check symmetrically.
 
-- No roots.
-- Blank or syntactically invalid paths.
-- Duplicates under `SongRootPolicy.RootComparer`.
-- Parent/child overlap in either direction after normalization.
+Tests cover case-differing parent/child paths in ignore-case mode, including the
+macOS policy case `/Users/me/Songs` and `/Users/me/SONGS/Extra`.
 
-Overlap segment comparison uses the same root comparer. Authored order does not
-make overlap valid.
-
-Hand-edited invalid configuration must not prevent startup. Load processes
-entries in numeric order; the first accepted root wins and later duplicate or
-overlapping entries are dropped with warnings. If all are rejected, the managed
-default is restored.
-
-Symlink, junction, mount, and alias targets are not resolved. Two textually
-different non-overlapping paths reaching the same physical directory may both
-scan in v1.
-
-### Availability warnings
-
-Missing and inaccessible roots are warnings, not structural failures. They stay
-configured so removable and network libraries can return later.
-
-The shallow probe:
-
-- Checks directory existence.
-- Attempts to begin a shallow directory enumeration.
-- Catches path, I/O, and authorization failures and returns a diagnostic.
-- Never recursively scans charts and never creates directories.
-
-Only available roots are supplied to startup or live reload. A root may still
-fail during scanning if availability changes; that follows the reload failure
-contract.
-
-## Config User Experience
-
-### System menu entry
-
-Replace **DTX Folder** with a navigation item named **Song Folders**. Its value
-is `1 folder` or `<n> folders`. The description says folders are scanned in the
-displayed order and Apply reloads once.
-
-### Overlay abstraction
-
-Introduce `IConfigOverlayPanel` with the common lifecycle currently carried by
-`IKeyAssignPanel`:
-
-- `IsActive`
-- `Closed`
-- `Saved`
-- `Activate()` / `Deactivate()`
-- `Update(...)`
-- `Draw(...)`
-
-`IKeyAssignPanel` inherits it and keeps the existing `Saved`-before-`Closed`
-contract. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
-targeted boundary correction, not a broad UI rewrite.
-
-### SongFolderPanel ownership
-
-`SongFolderPanel` receives:
-
-- An immutable configured-root snapshot.
-- `IFolderPickerService`.
-- The shared validation policy.
-- A Config-owned commit delegate:
-
-```csharp
-Func<IReadOnlyList<string>, SongFolderCommitResult> commitRoots
-```
-
-The panel owns a private draft. Add, remove, reorder, Back, and Cancel never
-mutate configuration.
-
-The delegate is the only commit owner:
-
-1. Canonicalize and compare the draft with the current configured snapshot.
-2. Return `Unchanged` without acquiring a slot or writing.
-3. For a changed list, reserve the Config operation slot as
-   `SongFolderReload` before persistence.
-4. Return `Busy` without persisting if NX import or another reload owns the
-   slot.
-5. Call `SetSongRoots` only while holding the reservation.
-6. Release the slot immediately on validation or persistence failure.
-7. Retain the reservation on `Updated` for handoff to the reload task.
-
-On Apply, failure or `Busy` keeps the panel open with a diagnostic. On `Updated`
-or `Unchanged`, the panel stores an immutable committed snapshot, raises
-`Saved`, then `Closed`.
-
-The panel never holds `IConfigManager` and never persists independently.
-
-```csharp
-public enum SongFolderCommitStatus
-{
-    Updated,
-    Unchanged,
-    Busy,
-    ValidationFailed,
-    PersistenceFailed
-}
-
-public sealed record SongFolderCommitResult(
-    SongFolderCommitStatus Status,
-    IReadOnlyList<string> CanonicalRoots,
-    IReadOnlyList<SongRootDiagnostic> Diagnostics);
-```
-
-Supported actions:
-
-- **Add Folder**
-- **Remove** while one draft root remains
-- **Move Up** / **Move Down**
-- **Apply**
-- **Cancel**
-
-Structural errors keep the panel open. Availability warnings do not disable
-Apply. Picker cancellation is a no-op; picker failure leaves the draft
-unchanged.
-
-## Platform Folder Picker
-
-Shared code uses:
-
-```csharp
-public interface IFolderPickerService
-{
-    Task<FolderPickerResult> PickFolderAsync(
-        string? initialDirectory,
-        CancellationToken cancellationToken);
-}
-```
-
-The result distinguishes Selected, Cancelled, Unavailable, and Failed. While a
-picker is active, repeat Add actions are ignored. Completion updates panel state
-only when its activation generation remains current.
-
-### Windows
-
-`FolderBrowserDialog` is acceptable because the Windows project already enables
-WinForms. The platform implementation owns STA dispatch; shared update code does
-not assume it runs on an STA thread. The dialog starts from the selected root or
-managed default when valid.
-
-### macOS
-
-Invoke `osascript` using Standard Additions `choose folder`, with a clear prompt
-and `default location` when the initial directory exists. Build arguments with
-`ProcessStartInfo.ArgumentList`, never shell interpolation. Await exit
-asynchronously, distinguish the standard user-cancel error, terminate on
-cancellation when safe, and log stderr for non-cancellation failures.
-
-The first invocation may display macOS system consent or privacy UI depending on
-the host process and selected location. The product must not promise a specific
-System Settings pane. Cancellation remains a normal `Cancelled` result;
-permission or authorization denial is `Failed` with a concise user message and
-structured diagnostic.
-
-Shared code must not reference WinForms, AppleScript construction, or native
-picker types. Headless tests inject a deterministic fake. A future
-`NSOpenPanel` helper may replace the adapter without changing the interface.
+Physical aliases remain outside scope.
 
 ## Config Persistence API
 
@@ -461,466 +308,584 @@ public enum SongRootUpdateStatus
 public sealed record SongRootUpdateResult(
     SongRootUpdateStatus Status,
     IReadOnlyList<string> CanonicalRoots,
-    IReadOnlyList<SongRootDiagnostic> Diagnostics)
+    IReadOnlyList<SongRootDiagnostic> Diagnostics);
+```
+
+The method:
+
+1. Validates/canonicalizes the complete list.
+2. Returns `Unchanged` without writing when ordered roots are equal.
+3. Captures prior `SongRoots` and `DTXPath` snapshots.
+4. Clears/refills `SongRoots` and updates `DTXPath` in memory.
+5. Writes the complete configuration atomically.
+6. Restores prior in-memory state if persistence fails.
+7. Raises `SongRootsChanged` only after persistence succeeds.
+8. Returns copied immutable snapshots.
+
+After a successful explicit save, clear `_pendingSavePath` only when it denotes
+the same normalized config file that was just written. A pending save for a
+different path must not be silently discarded.
+
+Event subscriber exceptions are isolated and cannot roll back persisted state.
+
+## Safe SongManager Snapshots
+
+### Root list
+
+The existing `RootSongs` getter must no longer return `_rootSongs.AsReadOnly()`.
+That wrapper is live and can throw `InvalidOperationException` when
+`PublishEnumeration` mutates the backing list during external enumeration.
+
+Use one of these equivalent contracts:
+
+```csharp
+public IReadOnlyList<SongListNode> RootSongs
 {
-    public bool IsSuccess =>
-        Status is SongRootUpdateStatus.Updated
-            or SongRootUpdateStatus.Unchanged;
+    get
+    {
+        lock (_lockObject)
+            return _rootSongs.ToArray();
+    }
 }
 ```
 
-The persistence operation:
+or a mandatory `GetRootSongsSnapshot()` API. Existing runtime consumers are
+migrated to the copied snapshot contract.
 
-1. Validates and canonicalizes the complete list.
-2. Captures prior `SongRoots` and `DTXPath` snapshots.
-3. Clears/refills `SongRoots` and updates the mirror in memory.
-4. Writes the complete config through atomic temp-file replacement.
-5. Clears the deferred-save marker on success because all settings were written.
-6. Restores prior in-memory values if persistence fails.
-7. Raises `SongRootsChanged` only after persistence succeeds.
-8. Returns `Unchanged` without write or event for an equal ordered list.
+### Composite publication snapshot
 
-Event args carry copied immutable old/new snapshots. Subscriber exceptions are
-isolated and cannot roll back accepted configuration.
+Add a coherent versioned snapshot:
 
-## Live Library Reload
+```csharp
+public sealed record SongLibrarySnapshot(
+    long Version,
+    IReadOnlyList<SongListNode> RootSongs,
+    IReadOnlyList<string> ActiveRoots);
 
-### Boundary
+public SongLibrarySnapshot GetPublishedLibrarySnapshot();
+```
 
-Introduce `ISongLibraryReloadService` so `ConfigStage` does not directly own raw
-singleton orchestration.
+The method copies root nodes and active roots under the same `_lockObject` and
+returns one publication version. Consumers must not combine separately-read
+roots and active paths.
 
-The production service:
+### Publication event
 
-- Probes the persisted configured snapshot.
-- Adapts `EnumerationProgress` to Config status.
-- Calls `SongManager.EnumerateAndImportSongsAsync` exactly once for every changed
-  ordered list, including reorder-only changes.
-- Returns active roots, aggregate counts, unavailable warnings, Busy,
-  cancellation, pre-commit failure, or post-commit partial failure.
-- Allows one in-flight reload.
+Publish a notification only after the new hierarchy and active roots are both
+installed:
 
-It does not call `NeedsEnumerationAsync` or create another cache/reorder path.
+```csharp
+public event EventHandler<SongLibraryPublishedEventArgs>? SongLibraryPublished;
+```
 
-### Apply sequence
+The event carries the monotonically increasing version and copied active-root
+snapshot. Handlers must not mutate game UI directly.
 
-1. Panel validates the draft locally.
-2. Config's delegate returns `Unchanged` or reserves `SongFolderReload`.
-3. A busy slot returns `Busy`; no persistence occurs.
-4. With the slot reserved, `SetSongRoots` persists the canonical list.
-5. Failure releases the slot and keeps the panel open.
-6. `Updated` raises `Saved` before `Closed`.
-7. The `Saved` handler starts reload using the reservation.
-8. Reload probes configured roots.
-9. With at least one available root, it starts one enumeration/import.
-10. The previous hierarchy stays active during discovery and persistence.
-11. Commit, finalization, and publication replace hierarchy and active roots.
-12. Config reports folder, chart, unavailable-folder, and error counts.
+`EnumerationCompleted` may remain for compatibility, but HPA-191 uses the
+explicit publication event.
 
-If no root is available, import is skipped, the previous hierarchy is retained,
-a warning is shown, and the operation slot is released.
+### Publication implementation
 
-### Config operation mutual exclusion
+Under `_lockObject`:
 
-`ConfigStage` owns:
+1. Replace root contents.
+2. Replace `_currentSearchPaths` with a copied active-root array.
+3. Update compatibility counts.
+4. Increment publication version.
+5. Capture event data.
+
+Invoke subscribers after releasing the lock, with per-subscriber exception
+isolation.
+
+### Empty publication
+
+Add a dedicated `PublishEmptyLibrary()` operation that:
+
+- clears root nodes;
+- assigns `_currentSearchPaths = Array.Empty<string>()`;
+- resets relevant counts;
+- increments publication version; and
+- raises the same publication event.
+
+Also remove or revise `SetCurrentSearchPaths`'s empty-array early return so an
+explicit empty snapshot cannot leave stale roots. Empty publication must not
+call database import or stale cleanup.
+
+### Concurrency coverage
+
+Tests must prove that:
+
+- a filter projection can iterate a copied root snapshot while another thread
+  publishes a replacement;
+- bookmark reconciliation can iterate a copied snapshot during publication;
+- no collection-modified exception occurs;
+- a snapshot remains stable after later publication; and
+- roots and active paths come from the same version.
+
+## Defensive Root Alignment
+
+`SetCurrentSearchPaths`, enumeration-batch root creation, and every other
+root-deduplication boundary use `SongRootPolicy.RootComparer`.
+
+This deliberately changes startup cache/database behavior as well as fresh
+enumeration. Direct tests cover:
+
+- `SetCurrentSearchPaths` first-occurrence/order behavior;
+- immutable copied current-path snapshots;
+- `LoadScoreCacheAsync`;
+- `BuildSongListFromDatabasePublicAsync`;
+- `NeedsEnumerationAsync`;
+- fresh enumeration; and
+- both comparer modes through the injected policy seam.
+
+## Root Availability and Import Authority
+
+A shallow availability check remains useful only for early UX and the
+all-unavailable decision. It is not authoritative because filesystem state can
+change immediately afterward.
+
+### Preflight responsibilities
+
+- Detect obvious all-unavailable cases without starting a costly reload.
+- Give immediate Config/startup diagnostics.
+- Never create directories.
+
+### Importer responsibilities
+
+When preflight finds at least one apparently available root, pass the complete
+configured snapshot to HPA-192. The enumeration batch is authoritative for:
+
+- normalized active roots;
+- missing/invalid/inaccessible root diagnostics;
+- the final unavailable-root count; and
+- what was actually scanned.
+
+User-facing unavailable counts after an attempted scan come from
+`batch.Errors` entries where `IsRootFailure`, not from preflight results.
+
+After the batch is built, if `ActiveRoots` is empty:
+
+- do not begin database import;
+- do not publish the empty batch through the normal reload path;
+- return a structured `NoAvailableRoots` result with batch diagnostics.
+
+Config retains the old hierarchy. Startup explicitly calls
+`PublishEmptyLibrary()` because clean startup has no prior active library to
+retain.
+
+This guard closes the TOCTOU case where roots disappear after preflight but
+before traversal.
+
+## Config UI
+
+### Menu entry
+
+Replace **DTX Folder** with **Song Folders**. Display `1 folder` or `<n>
+folders`. The description says Apply saves the ordered list and reloads once.
+
+### Overlay abstraction
+
+Introduce `IConfigOverlayPanel` containing the common lifecycle currently on
+`IKeyAssignPanel`. `IKeyAssignPanel` inherits it, preserving
+`Saved`-before-`Closed` behavior.
+
+### SongFolderPanel
+
+The panel receives:
+
+- an immutable configured-root snapshot;
+- `IFolderPickerService`;
+- validation/availability formatting; and
+- a Config-owned apply delegate.
+
+It owns a private draft. Add/remove/reorder/Cancel/Back do not mutate config.
+
+Supported actions:
+
+- **Add Folder**
+- **Remove** while at least one draft root remains
+- **Move Up** / **Move Down**
+- **Apply**
+- **Cancel**
+
+Structural errors keep the panel open. Availability warnings do not block
+Apply.
+
+## Folder Picker
+
+```csharp
+public interface IFolderPickerService
+{
+    Task<FolderPickerResult> PickFolderAsync(
+        string? initialDirectory,
+        CancellationToken cancellationToken);
+}
+```
+
+The result distinguishes Selected, Cancelled, Unavailable, and Failed. A stale
+picker completion cannot update an inactive/reactivated panel.
+
+### Windows
+
+Use `FolderBrowserDialog` behind a platform implementation that owns STA
+dispatch. Shared update code does not assume STA.
+
+### macOS
+
+Use `osascript` Standard Additions `choose folder`, with a prompt and optional
+existing default location. Build arguments with `ProcessStartInfo.ArgumentList`,
+await asynchronously, distinguish normal cancellation, and log stderr for
+failures.
+
+The first invocation may display system consent/privacy UI depending on the
+host process and selected location. Do not promise a particular System Settings
+pane. Authorization denial maps to Failed.
+
+## Config Song Operation Coordinator
+
+Introduce one Config-scoped coordinator/lease:
 
 ```text
 None | NxScoreImport | SongFolderReload
 ```
 
-NX import and changed-root Apply acquire the same slot. Apply while NX import is
-active returns `Busy` without persistence. NX import while reload is active is
-rejected. A second reload is rejected. Lower-level
-`InvalidOperationException` from an occupied SongManager enumeration slot is
-mapped to a user-visible Busy result.
+The coordinator provides atomic acquire and exactly-once release. Future Config
+operations that mutate/rebuild the library use the same coordinator.
 
-### Throw-safe reservation handoff
+### Apply ownership
 
-The reservation-to-task handoff is a strict implementation invariant. Acquiring
-the slot, persisting, raising `Saved`, constructing the reload task, and
-transferring release ownership must use `try/finally` or an equivalent scoped
-lease.
+The panel calls one Config-owned method, conceptually:
 
-Required ownership rule:
+```csharp
+SongFolderApplyResult ApplySongRoots(IReadOnlyList<string> draft);
+```
 
-- Before the reload task is attached, synchronous code owns the lease and must
-  release it in `finally` on every exit or exception.
-- Only after the terminal continuation is attached may release ownership move
-  to that continuation.
-- Task-construction, event-subscriber, or continuation-registration failure
-  cannot orphan the slot.
-- The terminal continuation releases exactly once.
+This method owns the full synchronous handoff:
 
-A dedicated test injects a throw at each handoff point and verifies the next
-operation can acquire the slot.
+1. Canonicalize and compare the draft.
+2. Return Unchanged without acquiring or writing.
+3. Acquire `SongFolderReload`; return Busy without persistence if unavailable.
+4. Call `SetSongRoots`.
+5. On validation/persistence failure, return failure and release in `finally`.
+6. Construct the reload task.
+7. Register terminal observation/release continuation.
+8. Transfer lease ownership to that continuation only after registration
+   succeeds.
+9. Return Updated/ReloadStarted.
+10. Release synchronously in `finally` on every path where ownership was not
+    transferred.
 
-### Cancellation, commit, and publication
+The panel closes and raises `Saved` only after Updated or Unchanged. `Saved` is
+not responsible for constructing the reload task or transferring the lease.
 
-Database commit through hierarchy publication is non-cancellable:
+`SongFolderApplyResult` composes `SongRootUpdateResult` and adds orchestration
+states such as Busy or ReloadStartFailed; it does not duplicate persistence
+logic or add Busy to `IConfigManager`.
 
-- Cancellation is honored during probing, discovery, parsing, matching, and
-  persistence before commit.
-- After commit succeeds, no cancellation check occurs before
-  `FinalizePendingNodes` and `PublishEnumeration`.
-- A request arriving after commit is ignored until publication completes and is
-  reported as success.
+### NX import migration
 
-This prevents the database from reflecting new active-root cleanup while the
-old hierarchy remains solely because cancellation arrived in the commit-to-
-publish gap.
+Slice 3a must migrate `StartNxScoreImport` completely onto the same coordinator:
 
-An unexpected finalization/publication exception after commit reports a distinct
-partial-success/restart-required outcome. It must not claim rollback.
+- replace `_importRunning` check-then-set with atomic lease acquisition;
+- use activation-generation fencing;
+- marshal progress/status updates through an update-thread queue or pending
+  state, never write UI-visible status directly from the worker;
+- observe the task and faults;
+- dispose its CTS only after terminal completion;
+- release the lease exactly once in the terminal continuation; and
+- cancel without synchronously blocking on deactivation.
+
+Merely checking the shared slot while retaining the old fire-and-forget
+lifecycle is insufficient.
+
+## Live Reload
+
+`ISongLibraryReloadService` adapts Config to HPA-192. It:
+
+- accepts an immutable configured snapshot;
+- performs preflight only for early all-unavailable detection;
+- invokes the existing enumeration/import path once for a changed list;
+- maps lower-level enumeration-busy exceptions to Busy;
+- reports progress through thread-safe state;
+- returns success, NoAvailableRoots, Busy, cancellation, pre-commit failure, or
+  post-commit partial failure.
+
+### Commit/publication terminal section
+
+Cancellation is honored before database commit. After commit succeeds, no
+cancellation check may occur before hierarchy finalization/publication. A late
+request is reported as success after publication.
+
+Unexpected finalization/publication failure after commit reports a distinct
+partial-success/restart-required result and never claims rollback.
 
 ### Config deactivation
 
-Leaving Config requests cancellation but never blocks the update thread waiting
-for filesystem or SQLite work.
+Deactivation:
 
-Use the `StartupStage` retirement pattern:
+- increments activation generation;
+- requests cancellation;
+- attaches an execute-synchronously observation continuation;
+- observes faults;
+- disposes CTS after termination;
+- releases lease in terminal continuation; and
+- suppresses stale UI writes.
 
-- Increment an activation generation.
-- Cancel the operation CTS.
-- Attach an execute-synchronously observation continuation.
-- Observe faults and dispose the CTS only after termination.
-- Release the operation lease in the terminal continuation.
-- Suppress Config UI/status writes from stale generations.
-
-A post-commit reload may finish and publish after Config deactivates.
+It never waits synchronously for filesystem or SQLite work on the game thread.
 
 ## Startup Integration
 
-`StartupStage` reads an immutable `SongRoots` snapshot, never `DTXPath`.
+Startup reads an immutable configured-root snapshot.
 
-Before cache/enumeration selection:
+- Preflight detects an obvious all-unavailable case.
+- Cache/enumeration decisions use the aligned root policy.
+- If enumeration produces no active roots, no import/publication occurs through
+  the normal path.
+- Startup then calls `PublishEmptyLibrary()` without database cleanup.
+- Title remains reachable and SQLite rows remain untouched.
 
-- Probe configured roots.
-- Pass available roots in configured order to `NeedsEnumerationAsync`, cache
-  hierarchy construction, or enumeration.
-- Log unavailable roots once.
-
-When no root is available on clean startup, publish an empty active hierarchy
-and empty active-root snapshot through a dedicated SongManager operation that
-does not import, stale-clean, or delete database rows. Startup completes and
-Title remains reachable.
+If at least one root is active, startup uses the normal cache/enumeration path
+and publishes the resulting versioned snapshot.
 
 ## Runtime Consumer Audit
 
-Slice 1 must grep and classify every production `DTXPath` read. No runtime
-consumer may silently remain first-root-only.
+Slice 1b must grep every production `DTXPath` read and classify it. No runtime
+consumer remains silently first-root-only.
 
-Known consumers:
+Known production consumers:
 
-- `StartupStage`: configured `SongRoots` snapshot.
-- `ConfigStage`: replace the read-only item.
-- `SongSelectionStage` / `PreviewImagePanel`: active-root fallback snapshot.
-- E2E fixtures and runtime helpers that provide production configuration.
+- Startup configuration.
+- Config display.
+- Song Select preview fallback.
+- E2E/runtime fixture setup.
 
-A source-level architecture test or explicit allowlist must fail if a new
-runtime `Config.DTXPath` read is introduced outside serialization/migration
-compatibility code.
+Add a source architecture test or explicit allowlist that permits `DTXPath` only
+inside compatibility serialization/migration code.
 
-### Preview resolution
+## Preview Resolution
 
-The normalized absolute `SongChart.FilePath` is authoritative. For legacy nodes
-with relative directories, replace `PreviewImagePanel.SongsRootPath` with an
-immutable ordered active-root snapshot such as `ActiveSongRootPaths`, trying
-each active root in order.
-
-Configured roots must not be used for this fallback because failed reload leaves
-the previous active hierarchy authoritative. Root N greater than zero must
-resolve correctly.
-
-`SongManager` exposes a copied current-search-path snapshot for Song Select
-activation and refresh.
+The normalized absolute chart path remains authoritative. For legacy nodes with
+relative directories, `PreviewImagePanel` receives the active-root snapshot and
+tries roots in order. It never uses newly configured roots when an old
+hierarchy remains active.
 
 ## Active Song Select Publication Handling
 
-A reload can commit and publish after Config deactivates. A player may reach an
-already-active Song Select stage before that terminal publication. Today Song
-Select copies `SongManager.RootSongs` during initialization and does not observe
-later publication, so merely proving that the stale list does not crash is
-insufficient.
+Publication while Song Select is deactivated needs no extra mechanism because
+normal activation rebuilds its list. The additional contract applies only while
+Song Select is already active.
 
-HPA-191 requires an update-thread refresh contract:
+On activation, subscribe to `SongLibraryPublished`; on deactivation, unsubscribe.
+The handler only records the newest pending version.
 
-- Song Select subscribes on activation and unsubscribes on deactivation to a
-  library-published notification. The existing `EnumerationCompleted` event may
-  be used if its post-publication contract is made explicit; otherwise add a
-  dedicated `SongLibraryPublished` event carrying a monotonically increasing
-  publication version and active-root snapshot.
-- The event handler never mutates UI collections. It records a pending version
-  or enqueues a refresh request guarded by the stage activation version.
-- `OnUpdate` snapshots `RootSongs` and active roots and replaces the displayed
-  root list on the game thread.
-- If the current navigation path still exists, restore it by stable path or
-  database identity. Otherwise reset to the root.
-- Preserve the selected chart by stable chart/database identity when possible;
-  otherwise select the first valid item.
-- Stop previews and clear status/history panels when the selected item no longer
-  exists.
-- Rebuild active All Songs, Bookmarks, Recent, filter, breadcrumb, preview-root,
-  and empty-state data from one publication version so the UI never mixes old
-  and new snapshots.
-- Stale or deactivated-stage notifications are ignored.
+On the update thread:
 
-Integration coverage must publish a replacement library while Song Select is
-active, including while inside a box and while Bookmarks or Recent is selected,
-and verify safe deterministic reconciliation rather than stale display or
-background-thread mutation.
+1. Fetch one `SongLibrarySnapshot`.
+2. Ignore stale versions.
+3. Replace the local root list and active-root fallback snapshot.
+4. Restore navigation by stable folder path/database identity when possible;
+   otherwise return to root.
+5. Restore selected chart by stable chart/database identity when possible;
+   otherwise choose the first valid item.
+6. Stop preview and clear status/history when the old selection disappeared.
+7. Rebuild All Songs, filters, Bookmarks, Recent, breadcrumb, preview roots, and
+   empty-state data from the same publication version.
+8. Never mutate UI collections from the publication callback thread.
+
+Multiple fast publications collapse to the newest version.
+
+All direct `RootSongs` consumers, including filter projection and bookmark
+reconciliation, now iterate copied snapshots. Tests publish concurrently while
+those operations enumerate.
 
 ## Active Views and Retained Data
 
-Removed/unavailable rows stay in SQLite, but active views do not surface them
-after a successful publication excludes their root:
-
-- All Songs uses the active hierarchy.
-- Bookmarks and Recent filter database-backed rows to active roots.
-- If reload fails, old active roots and their entries remain visible.
-- After successful removal, off-root entries are hidden but retained.
-- Successful re-add makes them visible with user data intact.
+- All Songs uses the active published hierarchy.
+- Bookmarks and Recent filter database-backed results to active roots.
+- A failed reload leaves old active entries visible.
+- Successful removal hides off-root entries but retains rows.
+- Successful re-add restores them with user data.
 
 ## Empty Library UX
 
 Song Select distinguishes:
 
-- No active roots and no configured root currently available: **No song folders
-  are currently available. Open Config to reconnect or change them.**
-- At least one active root but no supported charts: **No songs were found in the
-  active song folders.**
+- no active/available roots: **No song folders are currently available. Open
+  Config to reconnect or change them.**
+- active roots with no supported charts: **No songs were found in the active
+  song folders.**
 
-Exact wording may be localized later; the conditions remain distinct.
-
-## SongManager and Database Interaction
-
-No database migration is required.
-
-HPA-192 contracts remain authoritative:
-
-- Enumeration/persistence receive an ordered root array.
-- Root aliases are defensively deduplicated through `SongRootPolicy`.
-- Cleanup affects only roots supplied to a successful import.
-- Off-root charts and songs are retained.
-- User-owned scores, bookmarks, timestamps, ranks, combos, and history are
-  preserved.
-- Publication follows transaction commit.
-
-HPA-191 prevents textual overlap before import. The importer does not resolve
-physical aliases.
-
-Multiple roots remain flattened into the current root-level hierarchy. Equal
-display titles are allowed; identity remains path/database based.
-
-## Logging and User Feedback
+## Logging
 
 Structured logs include:
 
-- `DTXPath` migration and indexed-root parsing warnings.
-- Deliberate suppression of custom-root directory creation.
-- Old/new normalized root snapshots after commit.
-- Availability diagnostics.
-- Picker selected/cancelled outcomes at debug level and failures at warning.
-- Config operation-slot busy decisions and lease handoff failures.
-- Reload start, success, cancellation, pre-commit failure, and post-commit
-  partial failure.
-- Song Select publication-version refresh and reconciliation outcome.
+- legacy migration and indexed parsing warnings;
+- deliberate suppression of custom-root creation;
+- root-policy mode and dropped duplicates/overlaps;
+- preflight warnings and authoritative batch root failures;
+- operation lease acquisition/release failures;
+- reload/NX import terminal outcomes;
+- publication versions; and
+- Song Select reconciliation outcomes.
 
-Do not add per-file success logs beyond HPA-192 progress.
-
-User-facing examples:
-
-- `Reloading songs: 48 / 100 charts`
-- `Loaded 2 folders, 100 charts; 1 folder unavailable`
-- `Folders saved; no configured folder is currently available`
-- `Song library is busy importing NX scores`
-- `Reload failed; previous song list retained`
-- `Songs were updated but the list could not refresh; restart required`
+Do not add per-file success logs beyond existing HPA-192 progress.
 
 ## Testing Strategy
 
-### Configuration tests
+### Slice 1a configuration tests
 
-- Default config has one managed root and matching `DTXPath`.
-- Indexed roots round-trip in order and rewrite densely.
-- Legacy `DTXPath` migrates and persists immediately.
-- Known legacy `Songs` default migrates to `DTXFiles`.
-- Indexed entries take precedence.
-- Gaps, malformed indexes, duplicate indexes, and blanks behave as specified.
-- Root comparer is ignore-case on Windows/macOS and ordinal on Linux.
-- Chart canonical comparer remains ordinal.
-- Parent/child overlap is rejected symmetrically.
-- Physical aliases are documented but unresolved.
-- Custom missing roots are not created.
-- The managed default is created when restored.
-- Tests explicitly prove removal of the current unconditional custom-root
-  `EnsureDirectorySafe` behavior.
-- Persistence failure restores prior state and emits no event.
-- Successful update emits immutable old/new snapshots once.
-- Persistence statuses are distinct.
-- Downgrade mirror behavior is documented and serialization remains stable.
+- default/mirror behavior;
+- indexed round-trip and dense rewrite;
+- section-agnostic parsing remains unchanged;
+- second LoadConfig clears roots before parse;
+- legacy migration;
+- malformed/duplicate indexes;
+- missing custom paths are never created;
+- managed default creation;
+- atomic persistence rollback;
+- deferred-save marker clears only for the matching path; and
+- immutable event snapshots.
 
-### SongManager root-policy tests
+### Slice 1b root and SongManager tests
 
-- `SetCurrentSearchPaths` directly deduplicates case aliases under
-  `SongRootPolicy` and preserves first occurrence/order.
-- Its copied snapshot cannot be externally mutated.
-- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and
-  `NeedsEnumerationAsync` receive the aligned deduplicated roots.
-- Fresh enumeration and cache hierarchy behavior agree on root identity.
-- Linux case-distinct roots remain distinct.
+- both comparer modes run on every platform through the injected seam;
+- first-occurrence/order deduplication;
+- ignore-case and ordinal overlap matrices;
+- macOS-style case-differing parent/child rejection;
+- no use of `Path.GetRelativePath` for overlap policy;
+- SetCurrentSearchPaths empty input clears active roots;
+- PublishEmptyLibrary installs one coherent empty version;
+- RootSongs returns a stable copied snapshot;
+- filter projection remains safe during concurrent publication;
+- bookmark reconciliation remains safe during concurrent publication;
+- roots and active paths share one version;
+- startup cache/database callers use the same policy;
+- importer short-circuits before persistence/publication when batch active roots
+  are empty; and
+- authoritative unavailable counts come from root-failure batch errors.
 
-### Config and panel tests
+### Slice 2 UI/picker tests
 
-- System exposes **Song Folders**.
-- Singular/plural summaries are correct.
-- Panel uses an isolated draft.
-- Add/remove/reorder/Apply/Cancel/Back are deterministic.
-- Async picker cancellation/failure does not mutate the draft.
-- Stale picker completion cannot update an inactive panel.
-- Structural errors block; availability warnings may be applied.
-- Last root cannot be removed without replacement.
-- Config's delegate is the only `SetSongRoots` caller.
-- Busy changed-root Apply does not persist.
-- Persistence failure releases the lease and starts no reload.
-- `Saved` precedes `Closed` after success.
-- Throws at each reservation-handoff point cannot orphan the lease.
-- Key panels still work through overlay polymorphism.
-- macOS permission/authorization failure maps to Failed, while normal picker
-  cancellation maps to Cancelled.
+- menu and singular/plural summaries;
+- isolated panel draft;
+- add/remove/reorder/apply/cancel/back;
+- structural errors vs availability warnings;
+- async picker cancellation/failure;
+- stale picker generation;
+- Windows STA boundary;
+- macOS cancellation vs authorization failure; and
+- persisted roots are consumed on restart.
 
-### Reload and lifecycle tests
+### Slice 3a operation/reload tests
 
-- Unchanged roots do not write, acquire, or scan.
-- Reorder-only change invokes one full import.
-- Successful Apply invokes importer once with available roots in order.
-- Unavailable roots do not block available ones.
-- No available roots skip import, retain hierarchy, and release the lease.
-- Apply is rejected without persistence during NX import.
-- NX import is rejected during reload.
-- Lower-level busy maps to user-visible Busy.
-- Leaving Config cancels and observes without blocking.
-- Stale continuations cannot write Config UI.
-- Pre-commit failure/cancellation preserves old hierarchy.
-- Post-commit cancellation cannot suppress publication.
-- Unexpected post-commit publication failure reports partial success.
+- unchanged Apply does not acquire/write/scan;
+- Busy Apply does not persist;
+- one full scan for reorder-only change;
+- lease release on validation/persistence/task-construction/continuation errors;
+- lower-level enumeration Busy mapping;
+- NoAvailableRoots retains old Config hierarchy;
+- batch root failures drive final warning counts;
+- pre-commit cancellation preserves old hierarchy;
+- post-commit cancellation cannot suppress publication;
+- NX import and reload cannot overlap;
+- NX import progress never writes Config UI from a worker;
+- deactivation cancellation is non-blocking; and
+- both task lifecycles dispose CTS and release lease exactly once.
 
-### Song Select publication tests
+### Slice 3b Song Select/integration tests
 
-- Publication while Song Select is active is processed only on the update
-  thread.
-- Root list, active roots, filters, Bookmarks, Recent, preview fallback, and
-  empty-state data use the same publication version.
-- Selection is restored by stable identity when retained.
-- Removed selection resets deterministically and stops preview/status state.
-- Publication while inside a removed box resets to root safely.
-- Publication during Bookmarks or Recent refreshes that tab against active roots.
-- Notifications after deactivation are ignored.
-- Multiple fast publications apply only the newest version.
-
-### Startup and integration tests
-
-- Startup uses `SongRoots`, not compatibility `DTXPath`.
-- Production `DTXPath` reads are absent outside compatibility allowlist.
-- Multiple roots appear in configured order.
-- Root aliases import once under the root comparer.
-- Distinct roots import each chart once.
-- Root N preview fallback uses active roots.
-- Removed-root songs disappear after successful reload but remain stored.
-- Bookmarks/Recent hide off-active entries and restore after re-add.
-- Missing removable root does not block another root.
-- No available roots publish an empty active library without cleanup.
-- Empty states are distinct.
-- Windows and macOS compile only their picker implementation.
-- Existing HPA-192 cancellation, retention, and performance tests stay green.
+- publication callback only records a version;
+- update-thread reconciliation uses one coherent snapshot;
+- concurrent filter iteration cannot observe collection mutation;
+- stable selection/navigation restoration;
+- removed selection stops preview and clears panels;
+- publication inside a removed box returns safely to root;
+- Bookmarks/Recent refresh against active roots;
+- multiple publications apply newest only;
+- notifications after deactivation are ignored;
+- root N preview fallback;
+- removed-root data remains stored and reappears after re-add;
+- empty states are distinct; and
+- Windows/macOS builds remain isolated to their picker implementation.
 
 ## Implementation Slices
 
-Slices are hard dependencies and land in order: **Slice 1 → Slice 2 → Slice
-3**. Each is scoped to at most three engineer days.
+The slices are hard dependencies and land in order.
 
-### Slice 1: Canonical multi-root configuration and consumer migration
+### Slice 1a: Configuration model and persistence
 
-- Add `SongRoots`, indexed INI format, mirror, migration, persistence result,
-  immutable event snapshots, and immediate persistence.
-- Replace unconditional custom-root directory creation with managed-default-only
-  creation and add behavior-removal tests.
-- Add internal `SongRootPolicy` with normalization, explicit comparer, overlap,
-  and availability probing.
-- Align all `SongManager` root deduplication with the policy.
-- Add direct `SetCurrentSearchPaths` and startup cache/database caller coverage.
-- Update startup to consume snapshots and publish empty active state when needed.
-- Audit all production `DTXPath` consumers and add an architecture allowlist
-  test.
-- Add active-root snapshot exposure and multi-root preview fallback.
-- Do not add Config editing UI or live reload.
+- Add `SongRoots`, indexed format, mirror, migration, and load clearing.
+- Add persistence result/event snapshots.
+- Remove custom-root auto-creation.
+- Preserve section-agnostic parsing.
+- Correct pending-save clearing.
+- Add focused config tests.
+
+### Slice 1b: Root policy, SongManager snapshots, and startup consumers
+
+- Add testable `SongRootPolicy`.
+- Add segment-wise overlap detection.
+- Align all SongManager root deduplication.
+- Replace live RootSongs view with copied/versioned snapshots.
+- Add empty publication and remove empty-path early-return behavior.
+- Add authoritative no-active-root enumeration result.
+- Update startup, preview fallback, and runtime consumer audit.
+- Add concurrency and startup/cache-path tests.
 
 ### Slice 2: Cross-platform SongFolderPanel
 
-Depends on Slice 1.
+- Add `IConfigOverlayPanel`.
+- Add asynchronous Windows/macOS/fake pickers.
+- Implement draft editing and Config-owned Apply delegate.
+- Use restart-required status until live reload lands.
+- Add panel and platform tests.
 
-- Add `IConfigOverlayPanel` and adapt key panels.
-- Add asynchronous Windows, macOS, and fake picker implementations.
-- Include macOS consent/authorization UX and result mapping.
-- Replace **DTX Folder** with **Song Folders** and implement draft editing.
-- Commit through Config's single delegate.
-- Show temporary restart-required status after `Updated`.
-- Verify startup consumes persisted roots on next launch.
-- Add panel, threading, privacy-failure, and platform-boundary tests.
+### Slice 3a: Config operation coordinator and live reload
 
-### Slice 3: Live reload and active-stage reconciliation
+- Add atomic scoped lease coordinator.
+- Implement single-method Apply ownership.
+- Add reload service and HPA-192 adaptation.
+- Migrate NX import fully onto the same lifecycle.
+- Add non-blocking cancellation/observation and progress marshalling.
+- Add operation/reload tests.
 
-Depends on Slices 1 and 2.
+### Slice 3b: Active Song Select reconciliation and retained views
 
-- Add `ISongLibraryReloadService`.
-- Add Config mutual exclusion and scoped lease handoff with throw-safe release.
-- Add progress, warnings, non-blocking retirement, commit-to-publish terminal
-  semantics, and failure feedback.
-- Add active-root filtering for Bookmarks/Recent and deliberate empty states.
-- Add update-thread Song Select reconciliation for out-of-band publication,
-  including stable selection/navigation restoration.
-- Verify successful publication, retained old hierarchy on pre-commit failure,
-  post-commit recovery, and removed-root data retention.
-- Add multi-root lifecycle integration tests and Windows/macOS builds.
+- Add publication subscription/version handling.
+- Reconcile hierarchy/navigation/selection on update thread.
+- Refresh filters, Bookmarks, Recent, previews, and empty states coherently.
+- Add concurrent-publication and retained-data integration tests.
+
+Each slice is intended to fit within three engineer days. If Slice 3b expands
+beyond that during planning, split retained-data tab refresh from core hierarchy
+reconciliation rather than broadening one task.
 
 ## Acceptance Criteria
 
-- Existing one-path configurations migrate without library loss.
-- Fresh install has one managed default root.
-- Config adds, removes, and reorders roots on Windows and macOS.
-- Ordered roots survive restart and startup reads them.
-- Root comparison is ignore-case on Windows/macOS and ordinal on Linux; chart
-  canonical identity remains ordinal.
-- `SetCurrentSearchPaths` and startup cache/database paths use the same policy
-  with direct tests.
-- Duplicate and textual parent/child roots cannot be applied.
-- Missing custom roots remain configured and are never auto-created.
-- Removal of the current custom-path `EnsureDirectorySafe` behavior is explicit
-  and tested.
-- Existing auto-created directories are not deleted.
-- The first-root downgrade mirror and its older-build recreation caveat are
-  documented.
-- Unchanged roots do not acquire or scan; any changed ordered list performs at
-  most one full scan.
-- Busy changed-root Apply does not persist.
-- Every available root scans in configured order.
-- NX import and reload cannot run concurrently.
-- Slot handoff is throw-safe and cannot orphan ownership.
-- One unavailable root does not block available roots.
-- Successful reload atomically replaces hierarchy and active roots.
-- Pre-commit failure/cancellation never exposes partial hierarchy.
-- Post-commit cancellation cannot suppress publication.
-- Config deactivation never blocks the game thread.
-- Song Select safely reconciles an out-of-band publication while active.
-- No available root during Apply retains the previous active hierarchy.
-- No available root during startup reaches Title with empty active state and
-  leaves SQLite untouched.
-- Preview fallback works under every active root.
-- Removing a root hides its songs, Bookmarks, and Recent entries while retaining
-  database data.
-- Re-adding restores retained state and active views.
-- Song Select distinguishes unavailable roots from available-but-empty roots.
-- `DTXPath` remains compatibility-only; runtime consumers use configured or
-  active snapshots as appropriate.
-- Physical-target deduplication remains explicitly outside scope.
-- No DTXCreator, parser, schema, or synthetic-root-navigation change is
-  included.
+- Legacy one-root configuration migrates without library loss.
+- Indexed roots persist in order and load repeatedly without accumulation.
+- INI parsing remains section-agnostic.
+- `DTXPath` remains a compatibility mirror only.
+- Missing custom roots are never auto-created.
+- Root comparison supports testable ignore-case and ordinal modes.
+- Duplicate and comparer-aware parent/child roots cannot be applied.
+- Physical-target deduplication remains out of scope.
+- RootSongs never exposes a live mutable-list wrapper.
+- Concurrent publication cannot break filter/bookmark enumeration.
+- Empty publication clears hierarchy and active roots in one version.
+- Startup and every SongManager root path use the same policy.
+- Changed root lists perform at most one full scan; unchanged lists perform none.
+- Config root-failure counts reflect what the enumeration batch actually saw.
+- A no-active-root batch never imports or publishes through normal reload.
+- Config retains the old hierarchy when no root is active.
+- Startup publishes a deliberate empty library without cleanup when no root is
+  active.
+- Busy Apply does not persist.
+- NX import and reload share one throw-safe lifecycle and cannot overlap.
+- Config deactivation never blocks the update thread.
+- Commit-to-publication is non-cancellable.
+- Active Song Select reconciles a new publication on the update thread.
+- Bookmarks/Recent show only active-root rows while retained rows remain stored.
+- Preview fallback works for every active root.
+- Re-adding a root restores retained user data.
+- No DTXCreator, parser, schema, or synthetic-root-navigation change is included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
 **Date:** 2026-08-01  
-**Status:** Draft for review
+**Status:** Revised draft for review
 
 ## Context
 
@@ -23,25 +23,28 @@ The lower-level song system is already substantially multi-root capable:
 
 HPA-191 therefore does not require a database schema change or another song
 import architecture. The work is to make the ordered root list a first-class
-configuration value, expose safe cross-platform editing in Config, and reload
-the active library without routing the game through boot-only startup state.
+configuration value, expose safe cross-platform editing in Config, audit every
+legacy `DTXPath` runtime consumer, and reload the active library without routing
+the game through boot-only startup state.
 
 ## Goals
 
-- Allow the player to add, remove, and reorder song-library roots from the
-  Config stage.
+- Allow the player to add, remove, and reorder song-library roots from Config.
 - Support one or more persisted roots while retaining compatibility with
   existing `DTXPath` configurations.
-- Apply valid changes immediately and perform one live library reload.
+- Apply valid changes immediately and perform at most one live library reload.
 - Preserve the currently published hierarchy until a replacement reload has
   completed successfully.
 - Preserve database records and user-owned data for roots removed from the
   active configuration or temporarily unavailable.
 - Support Windows and macOS folder selection without referencing platform UI
   frameworks from shared game code.
-- Reject configurations that would scan the same subtree more than once.
+- Reject configurations that would scan the same textual subtree more than
+  once under the selected root-comparison policy.
 - Keep startup behavior deterministic when some or all configured roots are
   unavailable.
+- Serialize Config-initiated song-library mutation operations so NX score import
+  and song-folder reload cannot write or rebuild the library concurrently.
 
 ## Non-goals
 
@@ -50,27 +53,34 @@ the active library without routing the game through boot-only startup state.
 - Song database schema changes.
 - Filesystem watchers or automatic reload when a removable drive is mounted.
 - Background rescans after every individual add, remove, or reorder action.
+- A database-only optimization for reorder-only changes; any changed ordered
+  root list performs one full enumeration/import in HPA-191.
 - Editing or creating song files from Config.
 - Synthetic top-level boxes for each configured root.
 - Merging same-named folders or songs across different roots.
 - Deleting retained database records for removed roots.
+- Resolving filesystem aliases to a physical target. Symlinks, junctions, bind
+  mounts, aliases, and case-sensitive macOS volumes can expose the same target
+  through distinct paths; realpath/inode-based deduplication is deferred.
 - General-purpose file-picker infrastructure beyond directory selection.
+- Replacing the macOS AppleScript adapter with a native `NSOpenPanel` helper.
 - Linux-specific picker integration; the configuration and reload contracts
   remain platform-neutral, but HPA-191 targets the existing Windows and macOS
   game projects.
 
 ## Chosen Approach
 
-Add an ordered `SongRoots` collection as the sole runtime source of truth.
-Retain `DTXPath` only as a serialized compatibility mirror of the first root.
-A dedicated Config overlay edits a working copy and commits it only when the
-player selects **Apply**. A platform-specific folder-picker service supplies new
-paths. After the configuration is atomically persisted, a focused song-library
-reload service invokes the existing HPA-192 enumeration/import path once.
+Add an ordered `SongRoots` collection as the sole configured-root source of
+truth. Retain `DTXPath` only as a serialized compatibility mirror of the first
+root. A dedicated Config overlay edits a working copy and commits it only when
+the player selects **Apply**. An asynchronous platform-specific folder-picker
+service supplies new paths. After configuration is atomically persisted, a
+focused song-library reload service invokes the existing HPA-192
+enumeration/import path once.
 
 The old hierarchy remains published until the complete replacement batch has
-committed and been published. A failed or cancelled reload therefore cannot
-leave Song Select displaying a partial library.
+committed and been published. A failed or cancelled pre-commit reload therefore
+cannot leave Song Select displaying a partial library.
 
 Three root states are distinguished throughout the design:
 
@@ -78,33 +88,37 @@ Three root states are distinguished throughout the design:
 - **Available roots:** configured roots that currently exist and pass a minimal
   access probe.
 - **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy. Active roots change only after a successful reload, or during a
-  clean startup that intentionally publishes an empty library.
+  hierarchy. Active roots change only after a successful publication, or during
+  a clean startup that intentionally publishes an empty active library.
 
-This distinction allows removable-drive paths to remain configured without
-pretending they are currently usable.
+Configured roots and active roots may temporarily differ. For example, a player
+can save new roots and then encounter a failed reload; Song Select must continue
+to use the old active-root snapshot until a later reload or startup succeeds.
 
 ## Alternatives Considered
 
 ### Save and require restart
 
 This is the smallest implementation, but it leaves the active library stale
-until the player restarts and gives weak feedback that the change succeeded.
-It is rejected because the existing bulk importer already provides an atomic
-publication boundary suitable for a live reload.
+until restart and gives weak feedback that the change succeeded. It is rejected
+for the final feature because the existing bulk importer provides an atomic
+publication boundary suitable for a live reload. Slice 2 temporarily uses this
+behavior until Slice 3 lands.
 
 ### Transition Config back through StartupStage
 
 This reuses the startup progress screen, but `StartupStage` owns boot-specific
 phase state, activation generations, timing summaries, and exactly-once startup
-telemetry. Re-entering it for a user-initiated configuration operation would
-couple unrelated lifecycles and make telemetry ambiguous. It is rejected.
+telemetry. Re-entering it for a user-initiated operation would couple unrelated
+lifecycles and make telemetry ambiguous. It is rejected.
 
-### Rescan after every list edit
+### Rebuild from SQLite for reorder-only changes
 
-This would repeatedly traverse and persist the same library while the player is
-still composing the desired configuration. It is rejected in favor of a draft
-list and one Apply operation.
+The database hierarchy builder could potentially republish roots in a different
+order without reparsing charts. HPA-191 deliberately does not add that branch.
+Apply is an explicit refresh operation, and one full scan also observes any
+filesystem changes made while the panel was open. A future measured
+optimization may special-case reorder-only changes.
 
 ### Store one delimited `SongRoots=` value
 
@@ -121,20 +135,24 @@ and hand editing. Indexed keys are easier to parse, order, diagnose, and migrate
 public List<string> SongRoots { get; } = new();
 ```
 
-The collection is initialized with `AppPaths.GetDefaultSongsPath()`.
+The property remains get-only. Load, reset, and successful update operations
+clear and refill the existing list rather than replacing the list reference.
+Consumers must never retain or mutate that live collection. Every UI, event,
+reload, and startup boundary receives an immutable copied snapshot.
 
 `DTXPath` remains available for source and downgrade compatibility, but is a
 mirror only:
 
 - After load, reset, or a successful root update, it equals the first canonical
   configured root.
-- Production startup, Config UI, reload, and active-root filtering must consume
-  `SongRoots`, never `DTXPath`.
+- Production startup, Config UI, reload, active-root filtering, previews, and
+  other runtime behavior consume `SongRoots` or the active-root snapshot, never
+  `DTXPath`.
 - Direct legacy mutation of `DTXPath` is not a supported way to change the
   runtime library.
 
 At least one configured root is always required. Availability is not required;
-a single configured path may point to a currently disconnected removable drive.
+a single configured path may point to a disconnected removable drive.
 
 ### Persisted format
 
@@ -153,22 +171,19 @@ Rules:
 2. Roots are loaded in ascending numeric order; gaps are allowed.
 3. Malformed suffixes, blank values, and negative indexes are ignored with a
    warning.
-4. Duplicate indexes use the last parsed value, matching normal INI overwrite
-   expectations, and emit a warning.
-5. Values may contain `=` because `ConfigManager` already splits lines on the
-   first `=` only.
+4. Duplicate indexes use the last parsed value and emit a warning.
+5. Values may contain `=` because `ConfigManager` splits on the first `=` only.
 6. Save rewrites indexes densely from zero.
 7. `DTXPath` is always written as the first root for downgrade compatibility.
-8. `SongRoot.*` entries are the authority whenever at least one structurally
-   valid entry exists.
-9. When no valid indexed entries exist, the loader migrates the legacy
-   `DTXPath` value into a one-element root list.
-10. When neither representation yields a usable path, the managed default root
-    is restored.
+8. `SongRoot.*` entries are authoritative whenever at least one structurally
+   valid indexed entry exists.
+9. When no valid indexed entry exists, load migrates legacy `DTXPath` into a
+   one-element list.
+10. When neither representation yields a valid path, load restores the managed
+    default root.
 
 A successful legacy migration is persisted immediately through the existing
-atomic temp-file replacement so the next launch no longer depends on fallback
-logic.
+atomic temp-file replacement.
 
 ### Legacy path migration
 
@@ -177,7 +192,12 @@ The existing migration from legacy `Songs` defaults to the current managed
 before that value becomes `SongRoots[0]`.
 
 Indexed custom roots are not remapped merely because their final segment is
-named `Songs`; only the known legacy default representations are migrated.
+named `Songs`; only known legacy default representations are migrated.
+
+Previous releases may already have created an empty custom directory while a
+removable or network path was unavailable. HPA-191 stops creating such paths,
+but it does not delete or move directories created by earlier versions. The
+migration is logged; filesystem cleanup is left to the user.
 
 ### Directory creation
 
@@ -186,13 +206,35 @@ is selected or restored as the fallback root.
 
 The game must not create arbitrary custom roots. A missing custom path may be a
 removable drive, network mount, renamed directory, or user error. Creating it
-would hide the problem and could produce unwanted directories on the wrong
+would hide the problem and could produce an unwanted directory on the wrong
 volume.
 
-## Path Identity and Validation
+## Root Path Identity and Validation
 
-All roots are resolved and compared through one shared policy used by config
-load, Config UI, and the setter.
+Root comparison is intentionally distinct from HPA-192 chart identity.
+`SongPathIdentity.CanonicalComparer` remains ordinal and continues to protect
+exact persisted chart identities. HPA-191 does not redefine it as
+platform-aware.
+
+### Shared root policy
+
+Add an internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. It is
+the only path used by Config load, Config UI, `SetSongRoots`, startup,
+`SongManager` defensive root deduplication, and availability probing.
+
+`SongRootPolicy.RootComparer` uses
+`SongPathIdentity.LegacyAliasComparer`:
+
+- Windows and macOS: ordinal ignore-case.
+- Linux and other platforms: ordinal case-sensitive.
+
+This is a deliberate user-facing root policy. On a case-sensitive macOS volume,
+paths that differ only by case are still treated as duplicate configured roots
+for HPA-191. Resolving actual filesystem case or targets is outside scope.
+
+`SongPathIdentity` remains internal. No public API exposure is required because
+`ConfigManager`, stages, `SongManager`, and `SongRootPolicy` live in the same
+assembly. Tests use the repository's existing internal-test access pattern.
 
 ### Canonicalization
 
@@ -201,13 +243,18 @@ For each non-blank input:
 1. Expand supported home-relative forms through `AppPaths`.
 2. Resolve relative legacy paths against the same app-data base used today.
 3. Convert to an absolute full path.
-4. Normalize separators and trailing separators through `SongPathIdentity`.
-5. Compare with `SongPathIdentity.CanonicalComparer`, preserving platform path
-   case behavior.
-6. Persist the canonical absolute value.
+4. Normalize separators and trailing separators through
+   `SongPathIdentity.Normalize`.
+5. Compare roots with `SongRootPolicy.RootComparer`.
+6. Persist the normalized absolute value.
 
 Root order is semantically meaningful. It controls traversal order and the
 ordering of root-level nodes in Song Select.
+
+`SongManager.SetCurrentSearchPaths`, enumeration batch root creation, and other
+defensive deduplication must use `SongRootPolicy.RootComparer`, not
+`SongPathIdentity.CanonicalComparer`, so direct callers cannot reintroduce root
+case aliases that Config rejects.
 
 ### Blocking structural errors
 
@@ -215,18 +262,20 @@ The following prevent Apply and leave the current configuration unchanged:
 
 - No configured roots.
 - Blank or syntactically invalid paths.
-- Canonically duplicate roots.
-- Overlapping roots where either path is an ancestor of the other.
+- Duplicate roots under `SongRootPolicy.RootComparer`.
+- Overlapping roots where either normalized path is an ancestor of the other.
 
-Overlapping roots are rejected because scanning both a parent and its child
-would discover the same charts twice. The policy performs a symmetric
-ancestor check after canonicalization; authored order does not make an overlap
-valid.
+Overlap checks use the same root comparer for path-segment equality. Authored
+order does not make an overlap valid.
 
 Hand-edited invalid configuration must not prevent startup. During load, roots
 are processed in numeric order and the first accepted root wins. Later duplicate
 or overlapping entries are dropped with warnings. If all entries are rejected,
 the managed default is restored.
+
+Symlink, junction, mount, and alias targets are not resolved. Two textually
+different non-overlapping paths that reach the same physical directory may both
+scan in v1.
 
 ### Availability warnings
 
@@ -252,19 +301,13 @@ scan; that failure follows the reload error contract below.
 Replace the read-only **DTX Folder** item with a navigation item named
 **Song Folders**.
 
-Its value summary is:
-
-- `1 folder` for one configured root.
-- `<n> folders` for multiple roots.
-
-The description states that the folders are scanned in the displayed order and
-that Apply reloads the song library once.
+Its value summary is `1 folder` or `<n> folders`. The description states that
+folders are scanned in displayed order and Apply reloads the library once.
 
 ### Overlay abstraction
 
-`ConfigStage` currently models its active overlay as `IKeyAssignPanel`, although
-the lifecycle and drawing contract is generally useful. Introduce
-`IConfigOverlayPanel` containing the common members:
+Introduce `IConfigOverlayPanel` containing the common members currently carried
+by `IKeyAssignPanel`:
 
 - `IsActive`
 - `Closed`
@@ -273,25 +316,42 @@ the lifecycle and drawing contract is generally useful. Introduce
 - `Update(...)`
 - `Draw(...)`
 
-`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving existing key-panel
-contracts. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
-targeted boundary correction required to host a non-key-assignment panel; it is
-not a broader Config UI refactor.
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving its existing
+`Saved`-before-`Closed` contract. `ConfigStage._activePanel` becomes
+`IConfigOverlayPanel`. This is a targeted boundary correction, not a broader UI
+refactor.
 
-### SongFolderPanel
+### SongFolderPanel ownership
 
 `SongFolderPanel` receives:
 
-- An immutable snapshot of configured roots.
+- An immutable configured-root snapshot.
 - `IFolderPickerService`.
 - The shared root validation policy.
+- A commit delegate owned by `ConfigStage`:
 
-It owns a private draft list. Opening, reordering, adding, removing, or
+```csharp
+Func<IReadOnlyList<string>, SongRootUpdateResult> commitRoots
+```
+
+The panel owns a private draft list. Opening, reordering, adding, removing, or
 cancelling does not mutate `ConfigData`.
 
-The panel displays the full selected path and a scrollable ordered list. Long
-paths may be visually ellipsized, but validation and persistence always use the
-complete value.
+On **Apply**:
+
+1. The panel validates its draft.
+2. The panel passes an immutable draft snapshot to the Config-owned delegate.
+3. The delegate is the only caller of `IConfigManager.SetSongRoots`.
+4. Validation or persistence failure is returned to the panel; the panel stays
+   open and shows the error.
+5. On `Updated` or `Unchanged`, the panel stores the immutable committed
+   snapshot, raises `Saved`, then raises `Closed`.
+6. `ConfigStage` reads the committed snapshot during `Saved`. It starts a reload
+   only for `Updated`; `Unchanged` closes without a scan.
+
+The panel never holds `IConfigManager` and never persists roots independently.
+This prevents double commits and keeps event ordering consistent with existing
+Config panels.
 
 Supported actions:
 
@@ -301,55 +361,53 @@ Supported actions:
 - **Apply** — validate and commit the complete draft.
 - **Cancel** — discard the draft and close.
 
-Input behavior follows existing Config conventions:
-
-- Up/Down move selection.
-- Left/Right change the selected action where applicable.
-- Activate executes the highlighted action.
-- Back behaves as Cancel.
-
-Structural errors are shown in the panel and keep it open. Availability warnings
-are shown beside affected roots but do not disable Apply.
-
-A folder-picker cancellation is a no-op. A picker failure displays an error and
-leaves the draft unchanged.
+Structural errors keep the panel open. Availability warnings appear beside
+roots but do not disable Apply. Picker cancellation is a no-op; picker failure
+leaves the draft unchanged and displays an error.
 
 ## Platform Folder Picker
 
-Shared code depends only on:
+Shared code depends on an asynchronous interface:
 
 ```csharp
 public interface IFolderPickerService
 {
-    FolderPickerResult PickFolder(string? initialDirectory);
+    Task<FolderPickerResult> PickFolderAsync(
+        string? initialDirectory,
+        CancellationToken cancellationToken);
 }
 ```
 
 The result distinguishes selected, cancelled, unavailable, and failed outcomes
 and carries an error message only for failure.
 
+While a picker is active, the panel displays a selecting state and ignores
+repeat Add actions. Picker completion is marshalled back to panel state only if
+the panel activation generation is still current.
+
 Platform composition selects the implementation:
 
-- **Windows:** use `System.Windows.Forms.FolderBrowserDialog`, already supported
-  by the Windows project target. The dialog starts from the selected root or the
-  managed default when possible.
-- **macOS:** invoke the native folder chooser through a small `osascript`
-  adapter using `choose folder`, returning its POSIX path. Process arguments are
-  passed without shell interpolation, cancellation is mapped to Cancelled, and
-  non-cancellation failures include stderr in structured logging.
+- **Windows:** `FolderBrowserDialog` is acceptable because the Windows project
+  already enables WinForms. The implementation owns the required STA thread or
+  platform dispatcher; shared game/update code does not assume its thread is
+  STA. The dialog starts from the selected root or managed default when valid.
+- **macOS:** invoke `osascript` with `choose folder`, a clear prompt, and a
+  default location when `initialDirectory` exists. Construct arguments through
+  `ProcessStartInfo.ArgumentList`, never shell interpolation. Await process exit
+  asynchronously, map user cancellation to `Cancelled`, terminate the process
+  on cancellation when safe, and map privacy/automation denial or other
+  non-cancellation failures to `Failed` with stderr in structured logs.
 
-The shared `DTXMania.Game` code must not reference WinForms, AppleScript process
-construction, or other platform UI types. Picker implementations and service
-registration live in platform-specific source files or projects.
-
-Headless tests inject a deterministic fake picker.
+The shared project must not reference WinForms, AppleScript process
+construction, or native picker types. Headless tests inject a deterministic fake
+picker. A future native `NSOpenPanel` helper may replace AppleScript without
+changing the shared interface.
 
 ## Commit and Persistence Flow
 
-Applying roots is an explicit user commit, so it requires stronger semantics
-than an ordinary deferred toggle edit.
+Applying roots is an explicit user commit and requires immediate persistence.
 
-`IConfigManager` gains a typed root update operation returning a result:
+`IConfigManager` gains:
 
 ```csharp
 SongRootUpdateResult SetSongRoots(
@@ -357,115 +415,249 @@ SongRootUpdateResult SetSongRoots(
     IReadOnlyList<string> roots);
 ```
 
+The result contract is:
+
+```csharp
+public enum SongRootUpdateStatus
+{
+    Updated,
+    Unchanged,
+    ValidationFailed,
+    PersistenceFailed
+}
+
+public sealed record SongRootUpdateResult(
+    SongRootUpdateStatus Status,
+    IReadOnlyList<string> CanonicalRoots,
+    IReadOnlyList<SongRootDiagnostic> Diagnostics)
+{
+    public bool IsSuccess =>
+        Status is SongRootUpdateStatus.Updated
+            or SongRootUpdateStatus.Unchanged;
+}
+```
+
+The implementation may adjust concrete type names but must preserve those four
+outcomes and immutable snapshots.
+
 The operation:
 
 1. Validates and canonicalizes the complete list.
-2. Captures the prior `SongRoots` and `DTXPath` values.
-3. Updates both in memory.
-4. Writes the complete config immediately through the existing atomic
-   temp-file replacement.
+2. Captures prior `SongRoots` and `DTXPath` snapshots.
+3. Clears/refills `SongRoots` and updates `DTXPath` in memory.
+4. Writes the complete config immediately through atomic temp-file replacement.
 5. Clears any pending deferred-save marker on success because all current
    settings were written.
-6. Restores the prior in-memory values if persistence fails.
+6. Restores prior in-memory values if persistence fails.
 7. Raises `SongRootsChanged` only after persistence succeeds.
-8. Is a no-op success when the canonical ordered list is unchanged.
+8. Returns `Unchanged` without a write or event when the canonical ordered list
+   is unchanged.
 
-Event subscribers are isolated using the same per-subscriber exception handling
-as existing config events. A subscriber failure does not undo an accepted and
-persisted configuration.
-
-If persistence fails, the panel remains open, the old configuration remains the
-truth, and no reload begins.
+`SongRootsChangedEventArgs` carries copied immutable old and new root snapshots.
+Subscriber exceptions are isolated using existing config-event behavior. A
+subscriber failure cannot undo accepted persisted configuration.
 
 ## Live Library Reload
 
 ### Boundary
 
-Introduce an `ISongLibraryReloadService` abstraction so `ConfigStage` does not
-own raw `SongManager` orchestration and tests do not need the singleton.
+Introduce `ISongLibraryReloadService` so `ConfigStage` does not own raw
+`SongManager` orchestration and tests do not need the singleton.
 
 The production implementation:
 
-- Resolves currently available roots from the persisted configured list.
-- Adapts `EnumerationProgress` to a Config status string.
-- Invokes `SongManager.EnumerateAndImportSongsAsync` once.
-- Returns the successful active-root set, aggregate counts, warnings, or a
-  terminal failure/cancellation result.
-- Allows only one in-flight reload.
+- Resolves available roots from the persisted configured snapshot.
+- Adapts `EnumerationProgress` to Config status.
+- Invokes `SongManager.EnumerateAndImportSongsAsync` exactly once for any
+  changed ordered list, including reorder-only changes.
+- Returns the successful active-root set, aggregate counts, skipped-root
+  warnings, busy, cancellation, partial post-commit failure, or terminal
+  pre-commit failure.
+- Allows one in-flight reload.
 
-It does not create another import path. The existing HPA-192 batch builder,
-bulk transaction, hierarchy finalization, and publication remain authoritative.
+It does not call `NeedsEnumerationAsync` and does not invent a cache or
+reorder-only path. HPA-192 remains the sole importer and publication authority.
 
 ### Apply sequence
 
-1. `SongFolderPanel` validates its draft.
-2. `ConfigManager.SetSongRoots` atomically persists the canonical list.
-3. The panel closes and Config displays a reload status.
-4. The reload service probes all configured roots.
-5. When at least one root is available, one enumeration/import starts with only
+1. `SongFolderPanel` validates and commits its draft.
+2. `ConfigManager.SetSongRoots` atomically persists the canonical ordered list.
+3. `Saved` fires before `Closed`; Config captures the committed snapshot.
+4. `Unchanged` closes with no reload.
+5. `Updated` acquires the Config song-operation slot and displays reload status.
+6. The reload service probes all configured roots.
+7. When at least one root is available, one enumeration/import starts with only
    those roots.
-6. The old hierarchy remains active while discovery and persistence run.
-7. On successful commit, `SongManager.PublishEnumeration` replaces the hierarchy
-   and current active-root snapshot atomically.
-8. Config reports loaded root, chart, logical-song, skipped-root, and error
-   counts.
+8. The old hierarchy remains active while discovery and persistence run.
+9. On successful commit, finalization and publication replace the hierarchy and
+   active-root snapshot atomically.
+10. Config reports folder, chart, unavailable-folder, and error counts. Logical
+    song counts remain structured-log detail rather than user-facing copy.
 
-Unavailable configured roots are omitted from that scan and listed as warnings.
-Their database records are retained because they are outside the active import
-roots.
+Unavailable configured roots are omitted from the scan and listed as warnings.
+Their database records remain outside active import cleanup.
 
-When no configured root is currently available, Config does not invoke the
-importer and does not clear the current hierarchy. The roots remain saved and
-Config reports that the current library was retained until a successful future
-reload or restart.
+When no configured root is available, Config skips the importer and retains the
+current active hierarchy. The roots remain saved and Config reports that the
+current library is retained until a later successful reload or restart.
 
-### Concurrency and lifecycle
+### Config operation mutual exclusion
 
-- A second Apply/reload request is rejected while one reload is in flight.
-- Song-folder editing may be reopened only after the prior reload terminates.
-- Leaving Config cancels the reload and observes its task.
-- The cancellation source is disposed only after the operation terminates,
-  preserving HPA-192's enumeration-slot and cancellation-winddown guarantees.
-- Config deactivation must not block indefinitely waiting for filesystem work.
-- The reload task may complete during a stage transition, but it must not write
-  into disposed Config graphics or panel state. Status publication is guarded
-  by an activation generation or equivalent lifetime token.
+`ConfigStage` owns one operation slot for Config-initiated song-library work:
 
-### Failure and cancellation
+```text
+None | NxScoreImport | SongFolderReload
+```
 
-If discovery, import, or publication fails:
+Both `StartNxScoreImport` and song-folder Apply must acquire this slot before
+starting work and release it only in their terminal continuation.
 
-- The newly persisted configured roots remain saved.
-- The previous active hierarchy and active-root snapshot remain published.
+Required behavior:
+
+- Apply while NX import is running is rejected with a clear status; roots are
+  not re-persisted and no reload starts.
+- NX import while reload is running is rejected with a clear status.
+- A second reload is rejected while reload is active.
+- Existing `SongManager` enumeration-slot rejection is converted to a `Busy`
+  reload result, never an unhandled `InvalidOperationException`.
+- Future Config features that mutate or rebuild the song library must use the
+  same slot.
+
+The operation slot prevents the current NX import and reload paths from racing
+on SQLite and hierarchy refresh. `SongManager` retains its own enumeration slot
+as the lower-level defensive boundary for non-Config callers.
+
+### Cancellation, commit, and publication
+
+The HPA-192 transaction commit through hierarchy publication is treated as a
+non-cancellable terminal section:
+
+- Cancellation is honored during probing, discovery, parsing, matching, and
+  persistence before the database commit.
+- Once the bulk import commits successfully, the caller must not perform another
+  cancellation check before `FinalizePendingNodes` and `PublishEnumeration`.
+- A cancellation request arriving after commit is ignored until publication
+  completes; the result is success, not cancellation.
+- This rule prevents the database from reflecting the new active-root cleanup
+  while the old hierarchy remains published solely because cancellation arrived
+  in the commit-to-publish gap.
+
+If an unexpected finalization or publication exception occurs after commit, the
+old hierarchy remains atomically intact, but the database may already reflect
+the new import. Report a distinct partial-success failure requiring restart;
+do not claim rollback. This is an exceptional recovery path, not normal
+cancellation behavior.
+
+### Config deactivation
+
+Leaving Config requests cancellation for whichever Config song operation owns
+the slot. Deactivation never synchronously waits for filesystem or SQLite work
+on the game/update thread.
+
+Use the same pattern as `StartupStage`:
+
+- Increment an activation generation.
+- Cancel the operation CTS.
+- Attach an execute-synchronously observation continuation.
+- Observe any fault and dispose the CTS only after task termination.
+- Suppress UI/status writes from stale generations.
+
+The game-wide `SongManager` operation may finish after Config deactivates. A
+post-commit reload still finalizes and publishes; only Config-specific visual
+feedback is suppressed.
+
+### Failure classes
+
+Before database commit, failure or cancellation means:
+
+- Persisted configured roots remain saved.
+- Database transaction rolls back.
+- Previous active hierarchy and active-root snapshot remain published.
 - No partial hierarchy is exposed.
-- The player sees a concise failure message explaining that the saved roots will
-  be retried on the next startup or Apply.
-- Detailed exceptions and failed-root diagnostics are logged.
+- Config reports that the saved roots will be retried on startup or Apply.
 
-If cancellation occurs before publication, the same old-hierarchy guarantee
-applies. If the HPA-192 operation has already committed and published before the
-cancellation is observed, that successful publication remains authoritative;
-the status must not claim that the library was rolled back.
+After database commit, cancellation no longer changes the success path. An
+unexpected post-commit publication failure uses the partial-success recovery
+message described above.
 
 ## Startup Integration
 
-`StartupStage` reads a snapshot of `Config.SongRoots`, never `DTXPath`.
+`StartupStage` reads an immutable snapshot of `Config.SongRoots`, never
+`DTXPath`.
 
-Before selecting the cache or enumeration path, startup performs the shared
-availability probe:
+Before cache/enumeration selection, startup performs the shared availability
+probe:
 
 - Available roots are passed to `NeedsEnumerationAsync`, cache hierarchy
   construction, and enumeration.
-- Unavailable roots are logged once with their diagnostics.
-- Root order remains the configured order.
+- Unavailable roots are logged once with diagnostics.
+- Root order remains configured order.
 
-When no configured root is available during a clean startup, startup completes
-successfully with an empty active hierarchy and an empty active-root snapshot.
-It does not delete or stale-clean any database records. The title screen remains
-reachable, and the player can enter Config to repair the paths.
+When no configured root is available during clean startup, startup publishes an
+empty active hierarchy and empty active-root snapshot through a dedicated
+`SongManager` operation that does not import, stale-clean, or delete database
+records. Startup completes and Title remains reachable.
 
-A later successful startup or Apply restores songs from the retained database or
-re-enumerates the returned roots according to the normal load-path decision.
+A later startup or Apply restores songs from retained data or enumeration using
+the normal load decision.
+
+## Runtime Consumer Audit
+
+Slice 1 must grep every production `DTXPath` read and classify it. No runtime
+consumer may silently remain first-root-only.
+
+Known consumers include:
+
+- `StartupStage`: switch to configured `SongRoots` snapshot.
+- `ConfigStage`: replace the read-only DTX Folder item.
+- `SongSelectionStage` / `PreviewImagePanel`: remove the single
+  `SongsRootPath` fallback.
+- Any E2E fixture or runtime helper that supplies the production configuration.
+
+### Preview resolution
+
+The selected chart's normalized absolute `SongChart.FilePath` remains the first
+and authoritative source for its directory.
+
+For legacy nodes whose directory is still relative,
+`PreviewImagePanel.SongsRootPath` becomes an immutable ordered active-root
+snapshot, for example `ActiveSongRootPaths`. The panel tries each active root in
+order. It must not use configured roots because a failed reload can leave the
+old hierarchy and old active roots authoritative.
+
+`SongManager` exposes a copied read-only current-search-path snapshot for
+SongSelection activation and refresh. A preview under root N greater than zero
+must resolve without falling back to root zero.
+
+## Active Views and Retained Data
+
+Removed or unavailable-root rows remain in SQLite, but active Song Select views
+must not surface them after a successful reload excludes that root.
+
+Product rule:
+
+- All Songs uses the published active hierarchy.
+- Bookmarks and Recent filter database-backed results to the current active-root
+  snapshot.
+- If a reload fails and the previous hierarchy stays active, the previous roots'
+  Bookmarks and Recent entries remain visible because those roots are still
+  active.
+- After a successful removal reload, off-root Bookmarks and Recent entries are
+  hidden but retained.
+- Re-adding and successfully publishing the root makes retained entries visible
+  again with their user-owned data intact.
+
+## Empty Library UX
+
+Song Select must show a deliberate empty state rather than a blank list:
+
+- Configured roots exist but none are active/available: **No song folders are
+  currently available. Open Config to reconnect or change them.**
+- At least one active root exists but contains no supported charts: **No songs
+  were found in the active song folders.**
+
+Exact copy may be localized later, but the two conditions remain distinct and
+are covered by logic tests.
 
 ## SongManager and Database Interaction
 
@@ -474,44 +666,44 @@ No database migration is required.
 The existing HPA-192 contracts remain in force:
 
 - Enumeration and persistence receive an ordered root array.
-- Exact duplicate roots are defensively deduplicated again in `SongManager`.
-- Cleanup affects only roots successfully supplied to the import.
+- Root aliases are defensively deduplicated with `SongRootPolicy.RootComparer`.
+- Cleanup affects only roots supplied to the successful import.
 - Charts and songs outside those roots are retained.
-- Bookmarks, all score-speed variants, play counts, recent-play timestamps,
-  ranks, full-combo state, and performance history remain user-owned data.
-- The replacement hierarchy is published only after the transaction commits.
+- Bookmarks, score-speed variants, play counts, recent timestamps, ranks,
+  full-combo state, and performance history remain user-owned.
+- The replacement hierarchy is published only after transaction commit.
 
-HPA-191 prevents overlapping configured roots before they reach `SongManager`.
-The importer is not responsible for inferring which overlapping root the player
-intended.
+HPA-191 prevents textual parent/child overlaps before they reach `SongManager`.
+The importer is not responsible for resolving physical aliases or choosing
+which overlapping root the player intended.
 
 Multiple roots remain flattened into the existing root-level hierarchy in
-configured order. Two roots may legitimately produce boxes or songs with equal
-display titles; identity remains path/database based and the nodes are not
-merged. Adding synthetic per-root containers would change navigation semantics
-and is outside this issue.
+configured order. Equal display titles are allowed; identity remains path and
+database based, and nodes are not merged.
 
 ## Logging and User Feedback
 
 Structured logs include:
 
-- Config migration from `DTXPath` to indexed roots.
+- Migration from `DTXPath` to indexed roots.
 - Dropped malformed, duplicate, or overlapping hand-edited entries.
-- Selected and cancelled folder-picker outcomes at debug level.
-- Picker failures at warning level.
-- Canonical old and new root lists after a successful commit.
+- Canonical old/new root lists after commit.
 - Availability warnings by configured root.
-- Reload start, success, cancellation, and failure with aggregate counts.
+- Picker selected/cancelled outcomes at debug level and failures at warning.
+- Config operation-slot busy decisions.
+- Reload start, success, cancellation, pre-commit failure, and post-commit
+  partial failure with aggregate counts.
 
-Normal logs must not emit per-file success messages beyond the progress behavior
-already owned by HPA-192.
+Normal logs must not emit new per-file success messages beyond HPA-192 progress.
 
-Config displays one concise status line for the current operation, for example:
+Config user-facing examples:
 
 - `Reloading songs: 48 / 100 charts`
 - `Loaded 2 folders, 100 charts; 1 folder unavailable`
 - `Folders saved; no configured folder is currently available`
+- `Song library is busy importing NX scores`
 - `Reload failed; previous song list retained`
+- `Songs were updated but the list could not refresh; restart required`
 
 ## Testing Strategy
 
@@ -519,113 +711,147 @@ Config displays one concise status line for the current operation, for example:
 
 - Default config contains exactly the managed default root and mirrors it to
   `DTXPath`.
-- Indexed roots round-trip in order and are rewritten densely.
+- Indexed roots round-trip in order and rewrite densely.
 - Legacy `DTXPath` migrates to one indexed root and persists immediately.
 - Legacy default `Songs` migration still resolves to `DTXFiles`.
 - Indexed entries take precedence over `DTXPath`.
-- Gaps, malformed indexes, duplicate indexes, and blank values are handled as
+- Gaps, malformed indexes, duplicate indexes, and blank values behave as
   specified.
-- Canonical duplicates are rejected by the setter and dropped safely on load.
+- Root duplicates use `SongRootPolicy.RootComparer`: ignore-case on Windows and
+  macOS, ordinal on Linux.
+- `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
 - Parent/child overlaps are rejected symmetrically.
-- Root comparison follows platform path semantics.
+- Symlink/junction aliases are documented but not resolved.
 - Missing custom roots are not created.
-- The managed default root is created when restored as fallback.
-- Failed config persistence restores the prior in-memory roots and emits no
-  change event.
-- A successful update raises `SongRootsChanged` once after persistence.
+- Managed default root is created when restored.
+- Persistence failure restores old roots and emits no event.
+- Successful update raises one event with immutable snapshots.
+- `Unchanged`, `ValidationFailed`, and `PersistenceFailed` results are distinct.
 
 ### Config and panel tests
 
-- The System category exposes **Song Folders** instead of a read-only path.
-- The count summary uses singular and plural forms.
-- Panel activation starts from an isolated draft.
-- Add, remove, reorder, Apply, Cancel, and Back behavior are deterministic.
-- Picker cancellation and failure do not mutate the draft.
-- Structural errors keep the panel open.
-- Missing paths appear as warnings and may be applied.
-- The last configured root cannot be removed without adding another.
-- Apply does not start a reload when persistence fails.
-- Active overlay polymorphism continues to support existing key panels.
+- System exposes **Song Folders** instead of a read-only path.
+- Singular/plural count summaries are correct.
+- Panel starts from an isolated draft.
+- Add, remove, reorder, Apply, Cancel, and Back are deterministic.
+- Async picker cancellation/failure does not mutate the draft.
+- Stale picker completion cannot update a reactivated/disposed panel.
+- Structural errors keep the panel open; availability warnings may be applied.
+- Last configured root cannot be removed without adding another.
+- Config's commit delegate is the only `SetSongRoots` caller.
+- `Saved` fires before `Closed` after successful commit.
+- Persistence failure keeps the panel open and starts no reload.
+- Active overlay polymorphism continues supporting existing key panels.
 
-### Reload-service tests
+### Operation and reload tests
 
-- One successful Apply triggers exactly one importer call with roots in order.
-- Unavailable roots are skipped without preventing available roots from loading.
-- No available roots skip import and retain the existing hierarchy.
-- Concurrent reload is rejected.
-- Success publishes the new hierarchy and active roots.
-- Failure and pre-publication cancellation preserve the previous hierarchy.
-- Leaving Config cancels and safely observes the operation.
-- Post-publication cancellation is reported as success, not rollback.
+- Unchanged ordered roots perform no write and no scan.
+- Reorder-only changed roots perform exactly one full importer call.
+- One successful Apply invokes importer once with available roots in order.
+- Unavailable roots are skipped without blocking available roots.
+- No available roots skip import and retain existing hierarchy.
+- Apply is rejected while NX import runs.
+- NX import is rejected while reload runs.
+- Lower-level enumeration busy is mapped to a user-visible Busy result.
+- Leaving Config cancels and asynchronously observes the active operation.
+- Stale generation continuations cannot write Config UI state.
+- Pre-commit failure/cancellation preserves old hierarchy.
+- Cancellation after commit cannot suppress publication and reports success.
+- Unexpected post-commit publication failure reports partial success/restart.
 
-### Startup and integration tests
+### Startup and runtime integration tests
 
-- Startup consumes `SongRoots`, not the compatibility `DTXPath` value.
-- Multiple available roots appear in configured order.
+- Startup consumes `SongRoots`, not compatibility `DTXPath`.
+- Every production `DTXPath` consumer is removed or explicitly compatibility-only.
+- Multiple roots appear in configured order.
+- Root aliases are imported once under the selected root comparer.
 - Charts under distinct roots are imported once each.
-- Removed-root songs disappear from the active hierarchy after successful
-  reload but remain in SQLite with scores and bookmarks intact.
-- Re-adding the root restores retained user-owned state.
-- A missing removable-drive root does not block another root.
-- No available roots produce an empty active library without database cleanup.
-- Windows and macOS projects compile with only their own picker implementation.
-- Existing HPA-192 enumeration, cancellation, score-retention, and performance
-  tests remain green.
+- Root N preview fallback resolves using active roots, not configured root zero.
+- Removed-root songs disappear from active hierarchy after success but remain in
+  SQLite with scores/bookmarks intact.
+- Bookmarks and Recent hide off-active-root rows and restore them after re-add.
+- Missing removable root does not block another root.
+- No available roots publish an empty active library without database cleanup.
+- Distinct Song Select empty states are selected correctly.
+- Windows and macOS compile with only their picker implementation.
+- Existing HPA-192 cancellation, retention, and performance tests remain green.
 
 ## Implementation Slices
 
-Each slice is intended to fit within three engineer days and be executable by a
-junior code agent with repository-wide access.
+The slices are hard dependencies and land in order: **Slice 1 → Slice 2 →
+Slice 3**. Each is intended to fit within three engineer days.
 
-### Slice 1: Canonical multi-root configuration
+### Slice 1: Canonical multi-root configuration and consumer migration
 
-- Add `SongRoots`, the indexed INI format, compatibility mirror, migration, and
-  immediate persistence behavior.
-- Add shared canonicalization, overlap validation, and availability probing.
-- Update `IConfigManager`, `ConfigManager`, `ConfigData`, and startup root
-  consumption.
-- Add configuration and startup unit tests.
-- Do not add Config UI or live reload in this slice.
+- Add `SongRoots`, indexed INI format, compatibility mirror, migration, result
+  contract, immutable event snapshots, and immediate persistence.
+- Add internal `SongRootPolicy` with the explicit root comparer, overlap
+  validation, normalization, and availability probing.
+- Align `SongManager` defensive root deduplication with the root policy.
+- Update startup to consume root snapshots and publish an empty active library
+  when no root is available.
+- Audit and migrate all production `DTXPath` consumers, including active-root
+  preview fallback and active-root snapshot exposure.
+- Add configuration, startup, preview, and consumer-audit tests.
+- Do not add Config editing UI or live reload.
 
 ### Slice 2: Cross-platform SongFolderPanel
 
-- Add `IConfigOverlayPanel` and adapt the existing key-panel interface.
-- Add `IFolderPickerService` with Windows, macOS, and fake implementations.
-- Replace **DTX Folder** with **Song Folders** and implement the draft editing
-  panel.
-- Commit through `SetSongRoots`, but show a temporary `restart required` status
-  until Slice 3 supplies live reload.
-- Add panel and platform-boundary tests.
+Depends on Slice 1.
+
+- Add `IConfigOverlayPanel` and adapt key-panel interface.
+- Add asynchronous `IFolderPickerService` with Windows, macOS, and fake
+  implementations.
+- Replace **DTX Folder** with **Song Folders** and implement draft editing.
+- Commit through Config's single commit delegate and `SetSongRoots`.
+- Show temporary `restart required` status after `Updated` until Slice 3.
+- Verify the persisted roots are consumed by Startup on the next launch.
+- Add panel, picker-threading, and platform-boundary tests.
 
 ### Slice 3: Live reload and retained-data integration
 
-- Add `ISongLibraryReloadService` and Config lifecycle coordination.
-- Add progress, unavailable-root summaries, cancellation, and failure feedback.
-- Verify successful publication, old-hierarchy retention, and removed-root data
-  retention.
+Depends on Slices 1 and 2.
+
+- Add `ISongLibraryReloadService`.
+- Add Config operation mutual exclusion shared by NX import and reload.
+- Add progress, unavailable-root summaries, non-blocking cancellation
+  observation, commit-to-publish terminal semantics, and failure feedback.
+- Add active-root filtering for Bookmarks/Recent and deliberate empty-state UX.
+- Verify successful publication, old-hierarchy retention, post-commit recovery,
+  and removed-root data retention.
 - Add multi-root integration tests and Windows/macOS build validation.
 
 ## Acceptance Criteria
 
-- Existing one-path `DTXPath` configurations migrate without losing the library.
+- Existing one-path `DTXPath` configurations migrate without library loss.
 - A fresh install has one managed default song root.
 - Config allows adding, removing, and reordering roots on Windows and macOS.
-- The ordered root list survives restart.
-- Duplicate and parent/child-overlapping roots cannot be applied.
+- Ordered roots survive restart and are read by startup after Slice 2.
+- Root duplicate comparison is explicitly ignore-case on Windows/macOS and
+  ordinal on Linux; chart canonical identity remains ordinal.
+- Duplicate and textual parent/child-overlapping roots cannot be applied.
 - Missing custom roots remain configured and are never created automatically.
-- Applying a changed list performs at most one live scan.
+- Previously auto-created custom directories are not deleted by migration.
+- Unchanged roots do not scan; any changed ordered list performs at most one full
+  scan, including reorder-only changes.
 - Every available root is scanned in configured order.
+- NX import and song reload cannot run concurrently from Config.
+- Busy lower-level enumeration is reported without an unhandled exception.
 - One unavailable root does not prevent available roots from loading.
-- A successful reload replaces the active hierarchy atomically.
-- A failed or cancelled pre-publication reload never exposes a partial hierarchy.
-- When no root is available during Apply, the previous active hierarchy remains
-  visible and the saved configuration is retried later.
-- When no root is available during startup, the game reaches Title with an empty
-  active library and leaves the database untouched.
-- Removing a root removes its songs from active views after a successful reload
-  but preserves their bookmarks, scores, variants, and performance history.
-- Re-adding a root restores retained user data.
-- `DTXPath` remains a compatibility mirror only; runtime code consumes
-  `SongRoots`.
+- A successful reload replaces active hierarchy atomically.
+- Pre-commit failure or cancellation never exposes a partial hierarchy.
+- Cancellation after commit cannot suppress hierarchy publication.
+- Config deactivation never blocks the game thread waiting for reload/import.
+- No available root during Apply retains the previous active hierarchy.
+- No available root during startup reaches Title with an empty active library
+  and leaves SQLite untouched.
+- Preview fallback under any active root resolves correctly.
+- Removing a root hides its songs, Bookmarks, and Recent entries after successful
+  reload while preserving their database records and user-owned data.
+- Re-adding a root restores retained user data and active views.
+- Song Select distinguishes unavailable folders from available-but-empty roots.
+- `DTXPath` remains a compatibility mirror only; every runtime consumer uses
+  configured or active root snapshots as appropriate.
+- Symlink/junction/physical-target deduplication is explicitly outside scope.
 - No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
   included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -2,160 +2,154 @@
 
 **Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
 **Date:** 2026-08-01  
-**Status:** Revised draft for review
+**Status:** Revised after second-pass design review
 
 ## Context
 
-DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath` and
-writes it as `DTXPath=` in `Config.ini`. `ConfigStage` displays that value as a
-read-only **DTX Folder** item. During startup, `StartupStage` wraps the value in
-a one-element string array before passing it into the song-loading pipeline.
+DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath`,
+writes it as `DTXPath=` in `Config.ini`, displays it as a read-only **DTX
+Folder** item in `ConfigStage`, and wraps it in a one-element array during
+startup.
 
 The lower-level song system is already substantially multi-root capable:
 
-- `SongManager` accepts arrays of search roots.
+- `SongManager` accepts ordered arrays of search roots.
 - Enumeration normalizes and deduplicates roots.
 - Root traversal order is preserved in the published hierarchy.
-- HPA-192 bulk import and cleanup are scoped to active roots.
-- Database rows outside active roots are retained, protecting scores,
-  bookmarks, performance history, and other user-owned state when a library is
-  temporarily removed or unavailable.
+- HPA-192 bulk import and stale cleanup are scoped to the active roots supplied
+  to a completed import.
+- Rows outside active roots are retained, protecting bookmarks, score variants,
+  play history, ranks, full-combo state, and performance history when a library
+  is removed or unavailable.
 
-HPA-191 therefore does not require a database schema change or another song
-import architecture. The work is to make the ordered root list a first-class
-configuration value, expose safe cross-platform editing in Config, audit every
-legacy `DTXPath` runtime consumer, and reload the active library without routing
-the game through boot-only startup state.
+HPA-191 therefore does not introduce another importer or a database schema
+migration. It makes the ordered root list a first-class configuration value,
+adds safe Config editing and platform folder selection, migrates every runtime
+consumer away from the single-root compatibility property, and performs one
+atomic live reload without routing the game through boot-only `StartupStage`
+state.
 
 ## Goals
 
-- Allow the player to add, remove, and reorder song-library roots from Config.
-- Support one or more persisted roots while retaining compatibility with
-  existing `DTXPath` configurations.
-- Apply valid changes immediately and perform at most one live library reload.
-- Preserve the currently published hierarchy until a replacement reload has
-  completed successfully.
-- Preserve database records and user-owned data for roots removed from the
-  active configuration or temporarily unavailable.
-- Support Windows and macOS folder selection without referencing platform UI
-  frameworks from shared game code.
-- Reject configurations that would scan the same textual subtree more than
-  once under the selected root-comparison policy.
+- Allow players to add, remove, and reorder song-library roots from Config.
+- Persist one or more ordered roots while migrating existing `DTXPath`
+  configurations without library loss.
+- Apply valid changes immediately and perform at most one live reload.
+- Preserve the currently published hierarchy until a replacement library has
+  committed and published successfully.
+- Preserve database rows and user-owned state for removed or temporarily
+  unavailable roots.
+- Support Windows and macOS folder selection without platform UI dependencies
+  in shared game code.
+- Reject textual duplicate or parent/child root combinations that would scan the
+  same subtree more than once under the selected root-comparison policy.
 - Keep startup deterministic when some or all configured roots are unavailable.
-- Serialize Config-initiated song-library mutation operations so NX score import
-  and song-folder reload cannot write or rebuild the library concurrently.
+- Serialize Config-initiated library mutation operations so NX score import and
+  song-folder reload cannot race.
+- Keep an already-active Song Select stage coherent when a reload publishes
+  after Config has deactivated.
 
 ## Non-goals
 
 - DTXCreator changes.
-- Changes to chart parsing, `set.def`, or `box.def` semantics.
+- Chart parser, `set.def`, or `box.def` semantic changes.
 - Song database schema changes.
-- Filesystem watchers or automatic reload when a removable drive is mounted.
-- Background rescans after every individual add, remove, or reorder action.
-- A database-only optimization for reorder-only changes; any changed ordered
-  root list performs one full enumeration/import in HPA-191.
-- Editing or creating song files from Config.
+- Filesystem watchers or automatic reload when removable media mounts.
+- Rescanning after each individual draft edit.
+- A database-only reorder fast path. Any changed ordered root list performs one
+  full enumeration/import in HPA-191.
+- Editing or creating chart files from Config.
 - Synthetic top-level boxes for each configured root.
-- Merging same-named folders or songs across different roots.
-- Deleting retained database records for removed roots.
-- Resolving filesystem aliases to a physical target. Symlinks, junctions, bind
-  mounts, aliases, and case-sensitive macOS volumes can expose the same target
-  through distinct paths; realpath/inode-based deduplication is deferred.
-- General-purpose file-picker infrastructure beyond directory selection.
+- Merging same-named folders or songs across roots.
+- Deleting retained records for removed roots.
+- Resolving filesystem aliases to physical targets. Symlinks, junctions, bind
+  mounts, aliases, and case-sensitive macOS volumes may expose one target through
+  distinct paths; realpath/inode-based deduplication is deferred.
+- General-purpose file-picker infrastructure beyond folder selection.
 - Replacing the macOS AppleScript adapter with a native `NSOpenPanel` helper.
-- Linux-specific picker integration; the configuration and reload contracts
+- Linux-specific picker integration. The configuration and reload contracts
   remain platform-neutral, but HPA-191 targets the existing Windows and macOS
-  game projects.
+  projects.
 
 ## Chosen Approach
 
 Add an ordered `SongRoots` collection as the sole configured-root source of
-truth. Retain `DTXPath` only as a serialized compatibility mirror of the first
-root. A dedicated Config overlay edits a working copy and commits it only when
-the player selects **Apply**. An asynchronous platform-specific folder-picker
-service supplies new paths. After configuration is atomically persisted, a
-focused song-library reload service invokes the existing HPA-192
-enumeration/import path once.
+truth. Keep `DTXPath` only as a serialized compatibility mirror of the first
+root. A Config overlay edits a private draft and commits through one
+Config-owned delegate. An asynchronous platform picker supplies new paths.
+After the changed list is persisted atomically, a focused reload service invokes
+the existing HPA-192 enumeration/import path once.
 
-The old hierarchy remains published until the complete replacement batch has
-committed and been published. A failed or cancelled pre-commit reload therefore
-cannot leave Song Select displaying a partial library.
+The old hierarchy remains active until the complete replacement batch commits,
+finalizes, and publishes. Failure or cancellation before commit cannot expose a
+partial list.
 
-Three root states are distinguished throughout the design:
+The design distinguishes three root states:
 
-- **Configured roots:** the ordered canonical paths persisted in `Config.ini`.
-- **Available roots:** configured roots that currently exist and pass a minimal
+- **Configured roots:** ordered normalized paths persisted in `Config.ini`.
+- **Available roots:** configured roots that currently exist and pass a shallow
   access probe.
 - **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy. Active roots change only after successful publication, or during a
-  clean startup that intentionally publishes an empty active library.
+  hierarchy.
 
-Configured roots and active roots may temporarily differ. For example, a player
-can save new roots and then encounter a failed reload; Song Select must continue
-to use the old active-root snapshot until a later reload or startup succeeds.
+Configured and active roots may differ after a failed reload. Runtime surfaces
+that represent the published library must use the active-root snapshot, not the
+new configured list.
 
 ## Alternatives Considered
 
 ### Save and require restart
 
-This is the smallest implementation, but it leaves the active library stale
-until restart and gives weak feedback that the change succeeded. It is rejected
-for the final feature because the existing bulk importer provides an atomic
-publication boundary suitable for a live reload. Slice 2 temporarily uses this
-behavior until Slice 3 lands.
+This is the smallest change but leaves the active library stale and provides
+weak confirmation. It is rejected for the completed feature. Slice 2 uses a
+temporary restart-required state until Slice 3 lands.
 
-### Transition Config back through StartupStage
+### Transition Config through StartupStage
 
-This reuses the startup progress screen, but `StartupStage` owns boot-specific
-phase state, activation generations, timing summaries, and exactly-once startup
-telemetry. Re-entering it for a user-initiated operation would couple unrelated
-lifecycles and make telemetry ambiguous. It is rejected.
+`StartupStage` owns boot phases, activation generations, timing summaries, and
+exactly-once startup telemetry. Re-entering it for a user operation would couple
+unrelated lifecycles and make telemetry ambiguous. It is rejected.
 
 ### Rebuild from SQLite for reorder-only changes
 
-The database hierarchy builder could potentially republish roots in a different
-order without reparsing charts. HPA-191 deliberately does not add that branch.
-Apply is an explicit refresh operation, and one full scan also observes any
-filesystem changes made while the panel was open. A future measured
-optimization may special-case reorder-only changes.
+The hierarchy builder could potentially republish roots in a new order without
+parsing charts. HPA-191 deliberately does not add that branch. Apply is an
+explicit refresh and one full scan also observes filesystem changes made while
+the panel was open. A future measured optimization may specialize reorder-only
+changes.
 
-### Store one delimited `SongRoots=` value
+### Store one delimited value
 
-A delimiter would conflict with legal path characters and complicate escaping
-and hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
+A delimiter conflicts with legal path characters and complicates escaping and
+hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
 
 ## Configuration Contract
 
 ### Runtime model
 
-`ConfigData` gains an ordered mutable collection:
+`ConfigData` gains:
 
 ```csharp
 public List<string> SongRoots { get; } = new();
 ```
 
-The property remains get-only. Load, reset, and successful update operations
-clear and refill the existing list rather than replacing the list reference.
-Consumers must never retain or mutate that live collection. Every UI, event,
-reload, and startup boundary receives an immutable copied snapshot.
+The property remains get-only. Load, reset, and successful updates clear and
+refill the existing collection instead of replacing its reference. Consumers
+must never retain or mutate the live list. Startup, UI, events, and reload
+boundaries receive copied immutable snapshots.
 
-`DTXPath` remains available for source and downgrade compatibility, but is a
-mirror only:
+`DTXPath` remains for source and downgrade compatibility only:
 
-- After load, reset, or a successful root update, it equals the first canonical
+- After load, reset, or a successful update, it equals the first normalized
   configured root.
-- Production startup, Config UI, reload, active-root filtering, previews, and
-  other runtime behavior consume `SongRoots` or the active-root snapshot, never
-  `DTXPath`.
-- Direct legacy mutation of `DTXPath` is not a supported way to change the
-  runtime library.
+- Startup, Config, reload, active views, previews, and all other runtime behavior
+  consume configured or active root snapshots instead.
+- Direct mutation of `DTXPath` is not a supported runtime update mechanism.
 
-At least one configured root is always required. Availability is not required;
-a single configured path may point to a disconnected removable drive.
+At least one configured root is required. Availability is not required; the
+only root may be a disconnected removable or network location.
 
 ### Persisted format
-
-`Config.ini` stores roots in explicit order:
 
 ```ini
 [System]
@@ -166,60 +160,73 @@ SongRoot.1=D:\Community Charts
 
 Rules:
 
-1. `SongRoot.<index>` uses a non-negative decimal integer index.
-2. Roots are loaded in ascending numeric order; gaps are allowed.
-3. Malformed suffixes, blank values, and negative indexes are ignored with a
+1. `SongRoot.<index>` uses a non-negative decimal integer.
+2. Entries load in ascending numeric order; gaps are allowed.
+3. Malformed suffixes, negative indexes, and blank values are ignored with a
    warning.
 4. Duplicate indexes use the last parsed value and emit a warning.
-5. Values may contain `=` because `ConfigManager` splits on the first `=` only.
+5. Values may contain `=` because parsing splits on the first `=` only.
 6. Save rewrites indexes densely from zero.
-7. `DTXPath` is always written as the first root for downgrade compatibility.
-8. `SongRoot.*` entries are authoritative whenever at least one structurally
-   valid indexed entry exists.
-9. When no valid indexed entry exists, load migrates legacy `DTXPath` into a
-   one-element list.
-10. When neither representation yields a valid path, load restores the managed
-    default root.
+7. `DTXPath` mirrors the first root.
+8. At least one structurally valid indexed entry makes `SongRoot.*`
+   authoritative.
+9. With no valid indexed entry, load migrates legacy `DTXPath` into a one-root
+   list.
+10. If neither representation yields a valid path, load restores the managed
+    default.
 
-A successful legacy migration is persisted immediately through the existing
+A successful legacy migration is immediately persisted through the existing
 atomic temp-file replacement.
+
+### Downgrade compatibility caveat
+
+The `DTXPath` mirror is best-effort compatibility, not a guarantee that older
+build behavior is safe. If the first root is an unavailable removable or
+network path and the user runs a pre-HPA-191 build, that older build may execute
+its unconditional directory-creation behavior and create an empty directory at
+that path. HPA-191 cannot prevent behavior after a downgrade; ordering a stable
+local root first reduces that risk.
 
 ### Legacy path migration
 
-The existing migration from legacy `Songs` defaults to the current managed
-`DTXFiles` location is retained. It applies to the fallback `DTXPath` value
-before that value becomes `SongRoots[0]`.
+The existing known-default migration from `Songs` to the managed `DTXFiles`
+location remains. It applies to the fallback legacy value before it becomes
+`SongRoots[0]`. Indexed custom roots are not remapped merely because their final
+segment is named `Songs`.
 
-Indexed custom roots are not remapped merely because their final segment is
-named `Songs`; only known legacy default representations are migrated.
+Previous builds may already have created empty custom directories while a
+removable or network root was unavailable. HPA-191 does not delete or move such
+folders.
 
-Previous releases may already have created an empty custom directory while a
-removable or network path was unavailable. HPA-191 stops creating such paths,
-but it does not delete or move directories created by earlier versions. The
-migration is logged; filesystem cleanup is left to the user.
+### Deliberate removal of custom-root auto-creation
 
-### Directory creation
+Today `NormalizeConfigPaths` unconditionally calls
+`EnsureDirectorySafe(Config.DTXPath)`, creating every configured custom path at
+load. Slice 1 deliberately removes that behavior.
 
-The game may create the managed default `AppPaths.GetDefaultSongsPath()` when it
-is selected or restored as the fallback root.
+After HPA-191:
 
-The game must not create arbitrary custom roots. A missing custom path may be a
-removable drive, network mount, renamed directory, or user error. Creating it
-would hide the problem and could produce an unwanted directory on the wrong
-volume.
+- The game may create only `AppPaths.GetDefaultSongsPath()` when the managed
+  default is selected or restored as fallback.
+- Missing custom roots are retained as unavailable configuration values.
+- No load, migration, Apply, startup, or availability probe creates a custom
+  directory.
+- Existing directories created by older versions are left untouched.
+
+This is an intentional product behavior change, not merely an implementation
+detail of the multi-root format.
 
 ## Root Path Identity and Validation
 
-Root comparison is intentionally distinct from HPA-192 chart identity.
-`SongPathIdentity.CanonicalComparer` remains ordinal and continues to protect
-exact persisted chart identities. HPA-191 does not redefine it as
-platform-aware.
+Root identity is intentionally separate from HPA-192 chart identity.
+`SongPathIdentity.CanonicalComparer` remains ordinal for exact persisted chart
+identity.
 
 ### Shared root policy
 
-Add an internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. It is
-the only path used by Config load, Config UI, `SetSongRoots`, startup,
-`SongManager` defensive root deduplication, and availability probing.
+Add internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. Config
+load, Config UI, `SetSongRoots`, startup, defensive `SongManager` root
+deduplication, overlap checks, and availability probing all use this policy.
 
 `SongRootPolicy.RootComparer` uses
 `SongPathIdentity.LegacyAliasComparer`:
@@ -227,86 +234,95 @@ the only path used by Config load, Config UI, `SetSongRoots`, startup,
 - Windows and macOS: ordinal ignore-case.
 - Linux and other platforms: ordinal case-sensitive.
 
-This is a deliberate user-facing root policy. On a case-sensitive macOS volume,
-paths that differ only by case are still treated as duplicate configured roots
-for HPA-191. Resolving actual filesystem case or targets is outside scope.
+On a case-sensitive macOS volume, case-only root variants are still treated as
+duplicates for HPA-191. Physical-case and real-target discovery are out of
+scope.
 
-`SongPathIdentity` remains internal. No public API exposure is required because
-`ConfigManager`, stages, `SongManager`, and `SongRootPolicy` live in the same
-assembly. Tests use the repository's existing internal-test access pattern.
+`SongPathIdentity` remains internal. No public exposure is necessary because the
+policy and consumers live in the shared assembly; tests use the repository's
+internal-test access pattern.
 
 ### Canonicalization
 
 For each non-blank input:
 
 1. Expand supported home-relative forms through `AppPaths`.
-2. Resolve relative legacy paths against the same app-data base used today.
+2. Resolve legacy relative paths against the existing app-data base.
 3. Convert to an absolute full path.
-4. Normalize separators and trailing separators through
+4. Normalize separators and trailing separators with
    `SongPathIdentity.Normalize`.
 5. Compare roots with `SongRootPolicy.RootComparer`.
 6. Persist the normalized absolute value.
 
-Root order is semantically meaningful. It controls traversal order and the
-ordering of root-level nodes in Song Select.
+Root order controls traversal and root-level presentation order.
 
-`SongManager.SetCurrentSearchPaths`, enumeration batch root creation, and other
-defensive deduplication must use `SongRootPolicy.RootComparer`, not
-`SongPathIdentity.CanonicalComparer`, so direct callers cannot reintroduce root
-case aliases that Config rejects.
+### Defensive SongManager alignment
+
+`SongManager.SetCurrentSearchPaths`, enumeration-batch root creation, and every
+other defensive root deduplication point must use
+`SongRootPolicy.RootComparer`, not the ordinal chart comparer. Direct callers
+must not reintroduce aliases that Config rejects.
+
+This is a deliberate behavior change for all `SetCurrentSearchPaths` callers,
+including startup cache/database paths such as `LoadScoreCacheAsync`,
+`BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync`. On Windows
+and macOS, roots differing only by case will now collapse to one root in those
+paths as well as during fresh enumeration.
+
+Slice 1 must add focused coverage for `SetCurrentSearchPaths` behavior and its
+snapshot, plus caller-path tests for cache load, database hierarchy rebuild, and
+enumeration decisions. The comparer change must not rely only on Config-panel
+integration tests.
 
 ### Blocking structural errors
 
-The following prevent Apply and leave the current configuration unchanged:
+Apply is blocked by:
 
-- No configured roots.
+- No roots.
 - Blank or syntactically invalid paths.
-- Duplicate roots under `SongRootPolicy.RootComparer`.
-- Overlapping roots where either normalized path is an ancestor of the other.
+- Duplicates under `SongRootPolicy.RootComparer`.
+- Parent/child overlap in either direction after normalization.
 
-Overlap checks use the same root comparer for path-segment equality. Authored
-order does not make an overlap valid.
+Overlap segment comparison uses the same root comparer. Authored order does not
+make overlap valid.
 
-Hand-edited invalid configuration must not prevent startup. During load, roots
-are processed in numeric order and the first accepted root wins. Later duplicate
-or overlapping entries are dropped with warnings. If all entries are rejected,
-the managed default is restored.
+Hand-edited invalid configuration must not prevent startup. Load processes
+entries in numeric order; the first accepted root wins and later duplicate or
+overlapping entries are dropped with warnings. If all are rejected, the managed
+default is restored.
 
 Symlink, junction, mount, and alias targets are not resolved. Two textually
-different non-overlapping paths that reach the same physical directory may both
+different non-overlapping paths reaching the same physical directory may both
 scan in v1.
 
 ### Availability warnings
 
-Missing and inaccessible paths are warnings, not structural errors. They remain
-configured so removable or network libraries can return later.
+Missing and inaccessible roots are warnings, not structural failures. They stay
+configured so removable and network libraries can return later.
 
-A minimal availability probe must:
+The shallow probe:
 
-- Check that the directory exists.
-- Attempt to begin a shallow directory enumeration to detect obvious access
-  failures without recursively scanning charts.
-- Catch path, I/O, and authorization errors and return a diagnostic instead of
-  throwing.
+- Checks directory existence.
+- Attempts to begin a shallow directory enumeration.
+- Catches path, I/O, and authorization failures and returns a diagnostic.
+- Never recursively scans charts and never creates directories.
 
-Only roots passing this probe are supplied to a live reload or normal startup
-load. A path may still fail later because availability can change during a
-scan; that failure follows the reload error contract below.
+Only available roots are supplied to startup or live reload. A root may still
+fail during scanning if availability changes; that follows the reload failure
+contract.
 
 ## Config User Experience
 
 ### System menu entry
 
-Replace the read-only **DTX Folder** item with a navigation item named
-**Song Folders**.
-
-Its value summary is `1 folder` or `<n> folders`. The description states that
-folders are scanned in displayed order and Apply reloads the library once.
+Replace **DTX Folder** with a navigation item named **Song Folders**. Its value
+is `1 folder` or `<n> folders`. The description says folders are scanned in the
+displayed order and Apply reloads once.
 
 ### Overlay abstraction
 
-Introduce `IConfigOverlayPanel` containing the common members currently carried
-by `IKeyAssignPanel`:
+Introduce `IConfigOverlayPanel` with the common lifecycle currently carried by
+`IKeyAssignPanel`:
 
 - `IsActive`
 - `Closed`
@@ -315,10 +331,9 @@ by `IKeyAssignPanel`:
 - `Update(...)`
 - `Draw(...)`
 
-`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving its existing
-`Saved`-before-`Closed` contract. `ConfigStage._activePanel` becomes
-`IConfigOverlayPanel`. This is a targeted boundary correction, not a broader UI
-refactor.
+`IKeyAssignPanel` inherits it and keeps the existing `Saved`-before-`Closed`
+contract. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
+targeted boundary correction, not a broad UI rewrite.
 
 ### SongFolderPanel ownership
 
@@ -326,44 +341,33 @@ refactor.
 
 - An immutable configured-root snapshot.
 - `IFolderPickerService`.
-- The shared root validation policy.
-- A commit delegate owned by `ConfigStage`:
+- The shared validation policy.
+- A Config-owned commit delegate:
 
 ```csharp
 Func<IReadOnlyList<string>, SongFolderCommitResult> commitRoots
 ```
 
-The panel owns a private draft list. Opening, reordering, adding, removing, or
-cancelling does not mutate `ConfigData`.
+The panel owns a private draft. Add, remove, reorder, Back, and Cancel never
+mutate configuration.
 
-The Config-owned delegate is the only commit owner. For a draft snapshot it:
+The delegate is the only commit owner:
 
-1. Canonicalizes and compares against the current configured snapshot.
-2. Returns `Unchanged` without acquiring an operation slot or writing.
-3. For a changed list, attempts to reserve the Config operation slot as
-   `SongFolderReload` **before** calling `SetSongRoots`.
-4. Returns `Busy` without persisting when NX import or another reload owns the
+1. Canonicalize and compare the draft with the current configured snapshot.
+2. Return `Unchanged` without acquiring a slot or writing.
+3. For a changed list, reserve the Config operation slot as
+   `SongFolderReload` before persistence.
+4. Return `Busy` without persisting if NX import or another reload owns the
    slot.
-5. Calls `IConfigManager.SetSongRoots` only after the slot is reserved.
-6. Releases the slot immediately when validation or persistence fails.
-7. Retains the reserved slot on `Updated` so the `Saved` handler can start the
-   matching reload without a race.
+5. Call `SetSongRoots` only while holding the reservation.
+6. Release the slot immediately on validation or persistence failure.
+7. Retain the reservation on `Updated` for handoff to the reload task.
 
-On **Apply**, the panel passes an immutable draft snapshot to that delegate.
-Validation, persistence, or busy failure keeps the panel open and displays the
-returned diagnostic. On `Updated` or `Unchanged`, the panel stores the immutable
-committed snapshot, raises `Saved`, then raises `Closed`.
+On Apply, failure or `Busy` keeps the panel open with a diagnostic. On `Updated`
+or `Unchanged`, the panel stores an immutable committed snapshot, raises
+`Saved`, then `Closed`.
 
-`ConfigStage` reads the committed snapshot during `Saved`:
-
-- `Unchanged`: no operation slot is held and no reload starts.
-- `Updated`: the reload starts using the already-reserved slot. The handler must
-  either attach the reload task or release the slot before returning; it must
-  not leave a reserved slot orphaned if task construction fails.
-
-The panel never holds `IConfigManager` and never persists roots independently.
-
-The panel-level result distinguishes orchestration from persistence:
+The panel never holds `IConfigManager` and never persists independently.
 
 ```csharp
 public enum SongFolderCommitStatus
@@ -383,19 +387,19 @@ public sealed record SongFolderCommitResult(
 
 Supported actions:
 
-- **Add Folder** — invoke the platform picker and append a unique selection.
-- **Remove** — remove the selected root when at least one draft root remains.
-- **Move Up** / **Move Down** — change scan and display order.
-- **Apply** — validate and commit the complete draft.
-- **Cancel** — discard the draft and close.
+- **Add Folder**
+- **Remove** while one draft root remains
+- **Move Up** / **Move Down**
+- **Apply**
+- **Cancel**
 
-Structural errors keep the panel open. Availability warnings appear beside
-roots but do not disable Apply. Picker cancellation is a no-op; picker failure
-leaves the draft unchanged and displays an error.
+Structural errors keep the panel open. Availability warnings do not disable
+Apply. Picker cancellation is a no-op; picker failure leaves the draft
+unchanged.
 
 ## Platform Folder Picker
 
-Shared code depends on an asynchronous interface:
+Shared code uses:
 
 ```csharp
 public interface IFolderPickerService
@@ -406,30 +410,34 @@ public interface IFolderPickerService
 }
 ```
 
-The result distinguishes selected, cancelled, unavailable, and failed outcomes
-and carries an error message only for failure.
+The result distinguishes Selected, Cancelled, Unavailable, and Failed. While a
+picker is active, repeat Add actions are ignored. Completion updates panel state
+only when its activation generation remains current.
 
-While a picker is active, the panel displays a selecting state and ignores
-repeat Add actions. Picker completion is marshalled back to panel state only if
-the panel activation generation is still current.
+### Windows
 
-Platform composition selects the implementation:
+`FolderBrowserDialog` is acceptable because the Windows project already enables
+WinForms. The platform implementation owns STA dispatch; shared update code does
+not assume it runs on an STA thread. The dialog starts from the selected root or
+managed default when valid.
 
-- **Windows:** `FolderBrowserDialog` is acceptable because the Windows project
-  already enables WinForms. The implementation owns the required STA thread or
-  platform dispatcher; shared game/update code does not assume its thread is
-  STA. The dialog starts from the selected root or managed default when valid.
-- **macOS:** invoke `osascript` with `choose folder`, a clear prompt, and a
-  default location when `initialDirectory` exists. Construct arguments through
-  `ProcessStartInfo.ArgumentList`, never shell interpolation. Await process exit
-  asynchronously, map user cancellation to `Cancelled`, terminate the process
-  on cancellation when safe, and map privacy/automation denial or other
-  non-cancellation failures to `Failed` with stderr in structured logs.
+### macOS
 
-The shared project must not reference WinForms, AppleScript process
-construction, or native picker types. Headless tests inject a deterministic fake
-picker. A future native `NSOpenPanel` helper may replace AppleScript without
-changing the shared interface.
+Invoke `osascript` using Standard Additions `choose folder`, with a clear prompt
+and `default location` when the initial directory exists. Build arguments with
+`ProcessStartInfo.ArgumentList`, never shell interpolation. Await exit
+asynchronously, distinguish the standard user-cancel error, terminate on
+cancellation when safe, and log stderr for non-cancellation failures.
+
+The first invocation may display macOS system consent or privacy UI depending on
+the host process and selected location. The product must not promise a specific
+System Settings pane. Cancellation remains a normal `Cancelled` result;
+permission or authorization denial is `Failed` with a concise user message and
+structured diagnostic.
+
+Shared code must not reference WinForms, AppleScript construction, or native
+picker types. Headless tests inject a deterministic fake. A future
+`NSOpenPanel` helper may replace the adapter without changing the interface.
 
 ## Config Persistence API
 
@@ -440,8 +448,6 @@ SongRootUpdateResult SetSongRoots(
     string configFilePath,
     IReadOnlyList<string> roots);
 ```
-
-This persistence-level result remains independent of Config's `Busy` status:
 
 ```csharp
 public enum SongRootUpdateStatus
@@ -463,270 +469,265 @@ public sealed record SongRootUpdateResult(
 }
 ```
 
-The implementation may adjust concrete type names but must preserve those four
-persistence outcomes and immutable snapshots.
-
-The operation:
+The persistence operation:
 
 1. Validates and canonicalizes the complete list.
 2. Captures prior `SongRoots` and `DTXPath` snapshots.
-3. Clears/refills `SongRoots` and updates `DTXPath` in memory.
-4. Writes the complete config immediately through atomic temp-file replacement.
-5. Clears any pending deferred-save marker on success because all current
-   settings were written.
+3. Clears/refills `SongRoots` and updates the mirror in memory.
+4. Writes the complete config through atomic temp-file replacement.
+5. Clears the deferred-save marker on success because all settings were written.
 6. Restores prior in-memory values if persistence fails.
 7. Raises `SongRootsChanged` only after persistence succeeds.
-8. Returns `Unchanged` without a write or event when the canonical ordered list
-   is unchanged.
+8. Returns `Unchanged` without write or event for an equal ordered list.
 
-`SongRootsChangedEventArgs` carries copied immutable old and new root snapshots.
-Subscriber exceptions are isolated using existing config-event behavior. A
-subscriber failure cannot undo accepted persisted configuration.
+Event args carry copied immutable old/new snapshots. Subscriber exceptions are
+isolated and cannot roll back accepted configuration.
 
 ## Live Library Reload
 
 ### Boundary
 
-Introduce `ISongLibraryReloadService` so `ConfigStage` does not own raw
-`SongManager` orchestration and tests do not need the singleton.
+Introduce `ISongLibraryReloadService` so `ConfigStage` does not directly own raw
+singleton orchestration.
 
-The production implementation:
+The production service:
 
-- Resolves available roots from the persisted configured snapshot.
+- Probes the persisted configured snapshot.
 - Adapts `EnumerationProgress` to Config status.
-- Invokes `SongManager.EnumerateAndImportSongsAsync` exactly once for any
-  changed ordered list, including reorder-only changes.
-- Returns the successful active-root set, aggregate counts, skipped-root
-  warnings, busy, cancellation, partial post-commit failure, or terminal
-  pre-commit failure.
+- Calls `SongManager.EnumerateAndImportSongsAsync` exactly once for every changed
+  ordered list, including reorder-only changes.
+- Returns active roots, aggregate counts, unavailable warnings, Busy,
+  cancellation, pre-commit failure, or post-commit partial failure.
 - Allows one in-flight reload.
 
-It does not call `NeedsEnumerationAsync` and does not invent a cache or
-reorder-only path. HPA-192 remains the sole importer and publication authority.
+It does not call `NeedsEnumerationAsync` or create another cache/reorder path.
 
 ### Apply sequence
 
-1. The panel validates its draft locally.
-2. Config's commit delegate detects `Unchanged` or reserves the
-   `SongFolderReload` operation slot for a changed list.
-3. A busy slot returns `Busy`; roots are not persisted and the panel stays open.
-4. With the slot reserved, `ConfigManager.SetSongRoots` atomically persists the
-   canonical ordered list.
-5. Validation/persistence failure releases the slot and keeps the panel open.
-6. `Updated` stores the committed snapshot and raises `Saved` before `Closed`.
-7. Config's `Saved` handler starts reload using the existing slot reservation.
-8. The reload service probes all configured roots.
-9. When at least one root is available, one enumeration/import starts with only
-   those roots.
-10. The old hierarchy remains active while discovery and persistence run.
-11. On successful commit, finalization and publication replace the hierarchy and
-    active-root snapshot atomically.
-12. Config reports folder, chart, unavailable-folder, and error counts. Logical
-    song counts remain structured-log detail rather than user-facing copy.
+1. Panel validates the draft locally.
+2. Config's delegate returns `Unchanged` or reserves `SongFolderReload`.
+3. A busy slot returns `Busy`; no persistence occurs.
+4. With the slot reserved, `SetSongRoots` persists the canonical list.
+5. Failure releases the slot and keeps the panel open.
+6. `Updated` raises `Saved` before `Closed`.
+7. The `Saved` handler starts reload using the reservation.
+8. Reload probes configured roots.
+9. With at least one available root, it starts one enumeration/import.
+10. The previous hierarchy stays active during discovery and persistence.
+11. Commit, finalization, and publication replace hierarchy and active roots.
+12. Config reports folder, chart, unavailable-folder, and error counts.
 
-Unavailable configured roots are omitted from the scan and listed as warnings.
-Their database records remain outside active import cleanup.
-
-When no configured root is available, Config skips the importer, retains the
-current active hierarchy, reports the warning, and releases the operation slot.
+If no root is available, import is skipped, the previous hierarchy is retained,
+a warning is shown, and the operation slot is released.
 
 ### Config operation mutual exclusion
 
-`ConfigStage` owns one operation slot for Config-initiated song-library work:
+`ConfigStage` owns:
 
 ```text
 None | NxScoreImport | SongFolderReload
 ```
 
-Both `StartNxScoreImport` and changed-root Apply must reserve this slot before
-performing persistence or database work and release it only in their terminal
-continuation.
+NX import and changed-root Apply acquire the same slot. Apply while NX import is
+active returns `Busy` without persistence. NX import while reload is active is
+rejected. A second reload is rejected. Lower-level
+`InvalidOperationException` from an occupied SongManager enumeration slot is
+mapped to a user-visible Busy result.
 
-Required behavior:
+### Throw-safe reservation handoff
 
-- Apply while NX import is running returns `Busy`; roots are not persisted and
-  no reload starts.
-- NX import while reload is running is rejected with a clear status.
-- A second reload is rejected while reload is active.
-- Existing `SongManager` enumeration-slot rejection is converted to a `Busy`
-  reload result, never an unhandled `InvalidOperationException`.
-- Future Config features that mutate or rebuild the song library must use the
-  same slot.
+The reservation-to-task handoff is a strict implementation invariant. Acquiring
+the slot, persisting, raising `Saved`, constructing the reload task, and
+transferring release ownership must use `try/finally` or an equivalent scoped
+lease.
 
-The operation slot prevents the current NX import and reload paths from racing
-on SQLite and hierarchy refresh. `SongManager` retains its own enumeration slot
-as the lower-level defensive boundary for non-Config callers.
+Required ownership rule:
+
+- Before the reload task is attached, synchronous code owns the lease and must
+  release it in `finally` on every exit or exception.
+- Only after the terminal continuation is attached may release ownership move
+  to that continuation.
+- Task-construction, event-subscriber, or continuation-registration failure
+  cannot orphan the slot.
+- The terminal continuation releases exactly once.
+
+A dedicated test injects a throw at each handoff point and verifies the next
+operation can acquire the slot.
 
 ### Cancellation, commit, and publication
 
-The HPA-192 transaction commit through hierarchy publication is treated as a
-non-cancellable terminal section:
+Database commit through hierarchy publication is non-cancellable:
 
 - Cancellation is honored during probing, discovery, parsing, matching, and
-  persistence before database commit.
-- Once bulk import commits successfully, the caller must not perform another
-  cancellation check before `FinalizePendingNodes` and `PublishEnumeration`.
-- A cancellation request arriving after commit is ignored until publication
-  completes; the result is success, not cancellation.
-- This prevents the database from reflecting new active-root cleanup while the
-  old hierarchy remains solely because cancellation arrived in the
-  commit-to-publish gap.
+  persistence before commit.
+- After commit succeeds, no cancellation check occurs before
+  `FinalizePendingNodes` and `PublishEnumeration`.
+- A request arriving after commit is ignored until publication completes and is
+  reported as success.
 
-If an unexpected finalization or publication exception occurs after commit, the
-old hierarchy remains atomically intact, but the database may already reflect
-the new import. Report a distinct partial-success failure requiring restart;
-do not claim rollback.
+This prevents the database from reflecting new active-root cleanup while the
+old hierarchy remains solely because cancellation arrived in the commit-to-
+publish gap.
+
+An unexpected finalization/publication exception after commit reports a distinct
+partial-success/restart-required outcome. It must not claim rollback.
 
 ### Config deactivation
 
-Leaving Config requests cancellation for whichever Config song operation owns
-the slot. Deactivation never synchronously waits for filesystem or SQLite work
-on the game/update thread.
+Leaving Config requests cancellation but never blocks the update thread waiting
+for filesystem or SQLite work.
 
-Use the same pattern as `StartupStage`:
+Use the `StartupStage` retirement pattern:
 
 - Increment an activation generation.
 - Cancel the operation CTS.
 - Attach an execute-synchronously observation continuation.
-- Observe any fault and dispose the CTS only after task termination.
-- Release the Config operation slot in that terminal continuation.
-- Suppress UI/status writes from stale generations.
+- Observe faults and dispose the CTS only after termination.
+- Release the operation lease in the terminal continuation.
+- Suppress Config UI/status writes from stale generations.
 
-The game-wide `SongManager` operation may finish after Config deactivates. A
-post-commit reload still finalizes and publishes; only Config-specific visual
-feedback is suppressed.
-
-### Failure classes
-
-Before database commit, failure or cancellation means:
-
-- Persisted configured roots remain saved when persistence had already
-  succeeded.
-- Database transaction rolls back.
-- Previous active hierarchy and active-root snapshot remain published.
-- No partial hierarchy is exposed.
-- Config reports that saved roots will be retried on startup or Apply.
-
-After database commit, cancellation no longer changes the success path. An
-unexpected post-commit publication failure uses the partial-success recovery
-message described above.
+A post-commit reload may finish and publish after Config deactivates.
 
 ## Startup Integration
 
-`StartupStage` reads an immutable snapshot of `Config.SongRoots`, never
-`DTXPath`.
+`StartupStage` reads an immutable `SongRoots` snapshot, never `DTXPath`.
 
-Before cache/enumeration selection, startup performs the shared availability
-probe:
+Before cache/enumeration selection:
 
-- Available roots are passed to `NeedsEnumerationAsync`, cache hierarchy
-  construction, and enumeration.
-- Unavailable roots are logged once with diagnostics.
-- Root order remains configured order.
+- Probe configured roots.
+- Pass available roots in configured order to `NeedsEnumerationAsync`, cache
+  hierarchy construction, or enumeration.
+- Log unavailable roots once.
 
-When no configured root is available during clean startup, startup publishes an
-empty active hierarchy and empty active-root snapshot through a dedicated
-`SongManager` operation that does not import, stale-clean, or delete database
-records. Startup completes and Title remains reachable.
-
-A later startup or Apply restores songs from retained data or enumeration using
-the normal load decision.
+When no root is available on clean startup, publish an empty active hierarchy
+and empty active-root snapshot through a dedicated SongManager operation that
+does not import, stale-clean, or delete database rows. Startup completes and
+Title remains reachable.
 
 ## Runtime Consumer Audit
 
-Slice 1 must grep every production `DTXPath` read and classify it. No runtime
+Slice 1 must grep and classify every production `DTXPath` read. No runtime
 consumer may silently remain first-root-only.
 
-Known consumers include:
+Known consumers:
 
-- `StartupStage`: switch to configured `SongRoots` snapshot.
-- `ConfigStage`: replace the read-only DTX Folder item.
-- `SongSelectionStage` / `PreviewImagePanel`: remove the single
-  `SongsRootPath` fallback.
-- Any E2E fixture or runtime helper that supplies production configuration.
+- `StartupStage`: configured `SongRoots` snapshot.
+- `ConfigStage`: replace the read-only item.
+- `SongSelectionStage` / `PreviewImagePanel`: active-root fallback snapshot.
+- E2E fixtures and runtime helpers that provide production configuration.
+
+A source-level architecture test or explicit allowlist must fail if a new
+runtime `Config.DTXPath` read is introduced outside serialization/migration
+compatibility code.
 
 ### Preview resolution
 
-The selected chart's normalized absolute `SongChart.FilePath` remains the first
-and authoritative source for its directory.
+The normalized absolute `SongChart.FilePath` is authoritative. For legacy nodes
+with relative directories, replace `PreviewImagePanel.SongsRootPath` with an
+immutable ordered active-root snapshot such as `ActiveSongRootPaths`, trying
+each active root in order.
 
-For legacy nodes whose directory is still relative,
-`PreviewImagePanel.SongsRootPath` becomes an immutable ordered active-root
-snapshot, for example `ActiveSongRootPaths`. The panel tries each active root in
-order. It must not use configured roots because a failed reload can leave the
-old hierarchy and old active roots authoritative.
+Configured roots must not be used for this fallback because failed reload leaves
+the previous active hierarchy authoritative. Root N greater than zero must
+resolve correctly.
 
-`SongManager` exposes a copied read-only current-search-path snapshot for
-SongSelection activation and refresh. A preview under root N greater than zero
-must resolve without falling back to root zero.
+`SongManager` exposes a copied current-search-path snapshot for Song Select
+activation and refresh.
+
+## Active Song Select Publication Handling
+
+A reload can commit and publish after Config deactivates. A player may reach an
+already-active Song Select stage before that terminal publication. Today Song
+Select copies `SongManager.RootSongs` during initialization and does not observe
+later publication, so merely proving that the stale list does not crash is
+insufficient.
+
+HPA-191 requires an update-thread refresh contract:
+
+- Song Select subscribes on activation and unsubscribes on deactivation to a
+  library-published notification. The existing `EnumerationCompleted` event may
+  be used if its post-publication contract is made explicit; otherwise add a
+  dedicated `SongLibraryPublished` event carrying a monotonically increasing
+  publication version and active-root snapshot.
+- The event handler never mutates UI collections. It records a pending version
+  or enqueues a refresh request guarded by the stage activation version.
+- `OnUpdate` snapshots `RootSongs` and active roots and replaces the displayed
+  root list on the game thread.
+- If the current navigation path still exists, restore it by stable path or
+  database identity. Otherwise reset to the root.
+- Preserve the selected chart by stable chart/database identity when possible;
+  otherwise select the first valid item.
+- Stop previews and clear status/history panels when the selected item no longer
+  exists.
+- Rebuild active All Songs, Bookmarks, Recent, filter, breadcrumb, preview-root,
+  and empty-state data from one publication version so the UI never mixes old
+  and new snapshots.
+- Stale or deactivated-stage notifications are ignored.
+
+Integration coverage must publish a replacement library while Song Select is
+active, including while inside a box and while Bookmarks or Recent is selected,
+and verify safe deterministic reconciliation rather than stale display or
+background-thread mutation.
 
 ## Active Views and Retained Data
 
-Removed or unavailable-root rows remain in SQLite, but active Song Select views
-must not surface them after a successful reload excludes that root.
+Removed/unavailable rows stay in SQLite, but active views do not surface them
+after a successful publication excludes their root:
 
-Product rule:
-
-- All Songs uses the published active hierarchy.
-- Bookmarks and Recent filter database-backed results to the current active-root
-  snapshot.
-- If reload fails and the previous hierarchy stays active, previous roots'
-  Bookmarks and Recent entries remain visible because those roots remain active.
-- After successful removal reload, off-root Bookmarks and Recent entries are
-  hidden but retained.
-- Re-adding and successfully publishing the root makes retained entries visible
-  again with user-owned data intact.
+- All Songs uses the active hierarchy.
+- Bookmarks and Recent filter database-backed rows to active roots.
+- If reload fails, old active roots and their entries remain visible.
+- After successful removal, off-root entries are hidden but retained.
+- Successful re-add makes them visible with user data intact.
 
 ## Empty Library UX
 
-Song Select must show a deliberate empty state rather than a blank list:
+Song Select distinguishes:
 
-- No active roots and no configured root is currently available: **No song
-  folders are currently available. Open Config to reconnect or change them.**
-- At least one active root exists but contains no supported charts: **No songs
-  were found in the active song folders.**
+- No active roots and no configured root currently available: **No song folders
+  are currently available. Open Config to reconnect or change them.**
+- At least one active root but no supported charts: **No songs were found in the
+  active song folders.**
 
-Exact copy may be localized later, but the two conditions remain distinct and
-are covered by logic tests.
+Exact wording may be localized later; the conditions remain distinct.
 
 ## SongManager and Database Interaction
 
 No database migration is required.
 
-The existing HPA-192 contracts remain in force:
+HPA-192 contracts remain authoritative:
 
-- Enumeration and persistence receive an ordered root array.
-- Root aliases are defensively deduplicated with `SongRootPolicy.RootComparer`.
-- Cleanup affects only roots supplied to the successful import.
-- Charts and songs outside those roots are retained.
-- Bookmarks, score-speed variants, play counts, recent timestamps, ranks,
-  full-combo state, and performance history remain user-owned.
-- Replacement hierarchy is published only after transaction commit.
+- Enumeration/persistence receive an ordered root array.
+- Root aliases are defensively deduplicated through `SongRootPolicy`.
+- Cleanup affects only roots supplied to a successful import.
+- Off-root charts and songs are retained.
+- User-owned scores, bookmarks, timestamps, ranks, combos, and history are
+  preserved.
+- Publication follows transaction commit.
 
-HPA-191 prevents textual parent/child overlaps before they reach `SongManager`.
-The importer is not responsible for resolving physical aliases or choosing
-which overlapping root the player intended.
+HPA-191 prevents textual overlap before import. The importer does not resolve
+physical aliases.
 
-Multiple roots remain flattened into the existing root-level hierarchy in
-configured order. Equal display titles are allowed; identity remains path and
-database based, and nodes are not merged.
+Multiple roots remain flattened into the current root-level hierarchy. Equal
+display titles are allowed; identity remains path/database based.
 
 ## Logging and User Feedback
 
 Structured logs include:
 
-- Migration from `DTXPath` to indexed roots.
-- Dropped malformed, duplicate, or overlapping hand-edited entries.
-- Canonical old/new root lists after commit.
-- Availability warnings by configured root.
+- `DTXPath` migration and indexed-root parsing warnings.
+- Deliberate suppression of custom-root directory creation.
+- Old/new normalized root snapshots after commit.
+- Availability diagnostics.
 - Picker selected/cancelled outcomes at debug level and failures at warning.
-- Config operation-slot busy decisions.
+- Config operation-slot busy decisions and lease handoff failures.
 - Reload start, success, cancellation, pre-commit failure, and post-commit
-  partial failure with aggregate counts.
+  partial failure.
+- Song Select publication-version refresh and reconciliation outcome.
 
-Normal logs must not emit new per-file success messages beyond HPA-192 progress.
+Do not add per-file success logs beyond HPA-192 progress.
 
-Config user-facing examples:
+User-facing examples:
 
 - `Reloading songs: 48 / 100 charts`
 - `Loaded 2 folders, 100 charts; 1 folder unavailable`
@@ -737,155 +738,189 @@ Config user-facing examples:
 
 ## Testing Strategy
 
-### Configuration unit tests
+### Configuration tests
 
-- Default config contains exactly managed default root and mirrors `DTXPath`.
+- Default config has one managed root and matching `DTXPath`.
 - Indexed roots round-trip in order and rewrite densely.
-- Legacy `DTXPath` migrates to one indexed root and persists immediately.
-- Legacy default `Songs` migration still resolves to `DTXFiles`.
-- Indexed entries take precedence over `DTXPath`.
-- Gaps, malformed indexes, duplicate indexes, and blank values behave as
-  specified.
-- Root duplicates use `SongRootPolicy.RootComparer`: ignore-case on Windows and
-  macOS, ordinal on Linux.
-- `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
-- Parent/child overlaps are rejected symmetrically.
-- Symlink/junction aliases are documented but not resolved.
-- Missing custom roots are not created.
-- Managed default root is created when restored.
-- Persistence failure restores old roots and emits no event.
-- Successful update raises one event with immutable snapshots.
-- Persistence result statuses are distinct.
+- Legacy `DTXPath` migrates and persists immediately.
+- Known legacy `Songs` default migrates to `DTXFiles`.
+- Indexed entries take precedence.
+- Gaps, malformed indexes, duplicate indexes, and blanks behave as specified.
+- Root comparer is ignore-case on Windows/macOS and ordinal on Linux.
+- Chart canonical comparer remains ordinal.
+- Parent/child overlap is rejected symmetrically.
+- Physical aliases are documented but unresolved.
+- Custom missing roots are not created.
+- The managed default is created when restored.
+- Tests explicitly prove removal of the current unconditional custom-root
+  `EnsureDirectorySafe` behavior.
+- Persistence failure restores prior state and emits no event.
+- Successful update emits immutable old/new snapshots once.
+- Persistence statuses are distinct.
+- Downgrade mirror behavior is documented and serialization remains stable.
+
+### SongManager root-policy tests
+
+- `SetCurrentSearchPaths` directly deduplicates case aliases under
+  `SongRootPolicy` and preserves first occurrence/order.
+- Its copied snapshot cannot be externally mutated.
+- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and
+  `NeedsEnumerationAsync` receive the aligned deduplicated roots.
+- Fresh enumeration and cache hierarchy behavior agree on root identity.
+- Linux case-distinct roots remain distinct.
 
 ### Config and panel tests
 
-- System exposes **Song Folders** instead of a read-only path.
-- Singular/plural count summaries are correct.
-- Panel starts from an isolated draft.
-- Add, remove, reorder, Apply, Cancel, and Back are deterministic.
+- System exposes **Song Folders**.
+- Singular/plural summaries are correct.
+- Panel uses an isolated draft.
+- Add/remove/reorder/Apply/Cancel/Back are deterministic.
 - Async picker cancellation/failure does not mutate the draft.
-- Stale picker completion cannot update a reactivated/disposed panel.
-- Structural errors keep panel open; availability warnings may be applied.
-- Last configured root cannot be removed without adding another.
+- Stale picker completion cannot update an inactive panel.
+- Structural errors block; availability warnings may be applied.
+- Last root cannot be removed without replacement.
 - Config's delegate is the only `SetSongRoots` caller.
 - Busy changed-root Apply does not persist.
-- Persistence failure releases the reserved slot, keeps panel open, and starts
-  no reload.
-- `Saved` fires before `Closed` after successful commit.
-- Updated `Saved` handler cannot orphan the reserved slot.
-- Active overlay polymorphism continues supporting key panels.
+- Persistence failure releases the lease and starts no reload.
+- `Saved` precedes `Closed` after success.
+- Throws at each reservation-handoff point cannot orphan the lease.
+- Key panels still work through overlay polymorphism.
+- macOS permission/authorization failure maps to Failed, while normal picker
+  cancellation maps to Cancelled.
 
-### Operation and reload tests
+### Reload and lifecycle tests
 
-- Unchanged ordered roots perform no write, slot acquisition, or scan.
-- Reorder-only changed roots perform exactly one full importer call.
+- Unchanged roots do not write, acquire, or scan.
+- Reorder-only change invokes one full import.
 - Successful Apply invokes importer once with available roots in order.
-- Unavailable roots are skipped without blocking available roots.
-- No available roots skip import, retain hierarchy, and release the slot.
-- Apply is rejected without persistence while NX import runs.
-- NX import is rejected while reload runs.
-- Lower-level enumeration busy maps to a user-visible Busy result.
-- Leaving Config cancels and asynchronously observes active operation.
-- Stale generation continuations cannot write Config UI state.
+- Unavailable roots do not block available ones.
+- No available roots skip import, retain hierarchy, and release the lease.
+- Apply is rejected without persistence during NX import.
+- NX import is rejected during reload.
+- Lower-level busy maps to user-visible Busy.
+- Leaving Config cancels and observes without blocking.
+- Stale continuations cannot write Config UI.
 - Pre-commit failure/cancellation preserves old hierarchy.
-- Cancellation after commit cannot suppress publication and reports success.
-- Unexpected post-commit publication failure reports partial success/restart.
+- Post-commit cancellation cannot suppress publication.
+- Unexpected post-commit publication failure reports partial success.
 
-### Startup and runtime integration tests
+### Song Select publication tests
 
-- Startup consumes `SongRoots`, not compatibility `DTXPath`.
-- Every production `DTXPath` consumer is removed or compatibility-only.
+- Publication while Song Select is active is processed only on the update
+  thread.
+- Root list, active roots, filters, Bookmarks, Recent, preview fallback, and
+  empty-state data use the same publication version.
+- Selection is restored by stable identity when retained.
+- Removed selection resets deterministically and stops preview/status state.
+- Publication while inside a removed box resets to root safely.
+- Publication during Bookmarks or Recent refreshes that tab against active roots.
+- Notifications after deactivation are ignored.
+- Multiple fast publications apply only the newest version.
+
+### Startup and integration tests
+
+- Startup uses `SongRoots`, not compatibility `DTXPath`.
+- Production `DTXPath` reads are absent outside compatibility allowlist.
 - Multiple roots appear in configured order.
-- Root aliases are imported once under selected root comparer.
-- Charts under distinct roots are imported once each.
-- Root N preview fallback uses active roots, not configured root zero.
-- Removed-root songs disappear from active hierarchy after success but remain in
-  SQLite with scores/bookmarks intact.
-- Bookmarks and Recent hide off-active-root rows and restore them after re-add.
+- Root aliases import once under the root comparer.
+- Distinct roots import each chart once.
+- Root N preview fallback uses active roots.
+- Removed-root songs disappear after successful reload but remain stored.
+- Bookmarks/Recent hide off-active entries and restore after re-add.
 - Missing removable root does not block another root.
-- No available roots publish empty active library without database cleanup.
-- Distinct Song Select empty states are selected correctly.
-- Windows and macOS compile with only their picker implementation.
-- Existing HPA-192 cancellation, retention, and performance tests remain green.
+- No available roots publish an empty active library without cleanup.
+- Empty states are distinct.
+- Windows and macOS compile only their picker implementation.
+- Existing HPA-192 cancellation, retention, and performance tests stay green.
 
 ## Implementation Slices
 
-The slices are hard dependencies and land in order: **Slice 1 → Slice 2 →
-Slice 3**. Each is intended to fit within three engineer days.
+Slices are hard dependencies and land in order: **Slice 1 → Slice 2 → Slice
+3**. Each is scoped to at most three engineer days.
 
 ### Slice 1: Canonical multi-root configuration and consumer migration
 
-- Add `SongRoots`, indexed INI format, compatibility mirror, migration,
-  persistence result, immutable event snapshots, and immediate persistence.
-- Add internal `SongRootPolicy` with explicit root comparer, overlap validation,
-  normalization, and availability probing.
-- Align `SongManager` defensive root deduplication with root policy.
-- Update startup to consume snapshots and publish empty active library when no
-  root is available.
-- Audit and migrate all production `DTXPath` consumers, including active-root
-  preview fallback and active-root snapshot exposure.
-- Add configuration, startup, preview, and consumer-audit tests.
+- Add `SongRoots`, indexed INI format, mirror, migration, persistence result,
+  immutable event snapshots, and immediate persistence.
+- Replace unconditional custom-root directory creation with managed-default-only
+  creation and add behavior-removal tests.
+- Add internal `SongRootPolicy` with normalization, explicit comparer, overlap,
+  and availability probing.
+- Align all `SongManager` root deduplication with the policy.
+- Add direct `SetCurrentSearchPaths` and startup cache/database caller coverage.
+- Update startup to consume snapshots and publish empty active state when needed.
+- Audit all production `DTXPath` consumers and add an architecture allowlist
+  test.
+- Add active-root snapshot exposure and multi-root preview fallback.
 - Do not add Config editing UI or live reload.
 
 ### Slice 2: Cross-platform SongFolderPanel
 
 Depends on Slice 1.
 
-- Add `IConfigOverlayPanel` and adapt key-panel interface.
-- Add asynchronous `IFolderPickerService` with Windows, macOS, and fake
-  implementations.
+- Add `IConfigOverlayPanel` and adapt key panels.
+- Add asynchronous Windows, macOS, and fake picker implementations.
+- Include macOS consent/authorization UX and result mapping.
 - Replace **DTX Folder** with **Song Folders** and implement draft editing.
-- Commit through Config's single commit delegate and `SetSongRoots`.
-- Show temporary `restart required` status after `Updated` until Slice 3.
-- Verify persisted roots are consumed by Startup on next launch.
-- Add panel, picker-threading, and platform-boundary tests.
+- Commit through Config's single delegate.
+- Show temporary restart-required status after `Updated`.
+- Verify startup consumes persisted roots on next launch.
+- Add panel, threading, privacy-failure, and platform-boundary tests.
 
-### Slice 3: Live reload and retained-data integration
+### Slice 3: Live reload and active-stage reconciliation
 
 Depends on Slices 1 and 2.
 
 - Add `ISongLibraryReloadService`.
-- Add Config operation mutual exclusion shared by NX import and reload, with
-  reservation before changed-root persistence.
-- Add progress, unavailable-root summaries, non-blocking cancellation
-  observation, commit-to-publish terminal semantics, and failure feedback.
-- Add active-root filtering for Bookmarks/Recent and deliberate empty-state UX.
-- Verify successful publication, old-hierarchy retention, post-commit recovery,
-  and removed-root data retention.
-- Add multi-root integration tests and Windows/macOS build validation.
+- Add Config mutual exclusion and scoped lease handoff with throw-safe release.
+- Add progress, warnings, non-blocking retirement, commit-to-publish terminal
+  semantics, and failure feedback.
+- Add active-root filtering for Bookmarks/Recent and deliberate empty states.
+- Add update-thread Song Select reconciliation for out-of-band publication,
+  including stable selection/navigation restoration.
+- Verify successful publication, retained old hierarchy on pre-commit failure,
+  post-commit recovery, and removed-root data retention.
+- Add multi-root lifecycle integration tests and Windows/macOS builds.
 
 ## Acceptance Criteria
 
-- Existing one-path `DTXPath` configurations migrate without library loss.
-- Fresh install has one managed default song root.
-- Config allows adding, removing, and reordering roots on Windows and macOS.
-- Ordered roots survive restart and are read by startup after Slice 2.
-- Root duplicate comparison is ignore-case on Windows/macOS and ordinal on
-  Linux; chart canonical identity remains ordinal.
-- Duplicate and textual parent/child-overlapping roots cannot be applied.
-- Missing custom roots remain configured and are never created automatically.
-- Previously auto-created custom directories are not deleted by migration.
-- Unchanged roots do not acquire slot or scan; any changed ordered list performs
-  at most one full scan, including reorder-only changes.
-- Busy changed-root Apply does not persist the draft.
-- Every available root is scanned in configured order.
-- NX import and song reload cannot run concurrently from Config.
-- Busy lower-level enumeration is reported without an unhandled exception.
-- One unavailable root does not prevent available roots from loading.
-- Successful reload replaces active hierarchy atomically.
-- Pre-commit failure or cancellation never exposes partial hierarchy.
-- Cancellation after commit cannot suppress hierarchy publication.
-- Config deactivation never blocks game thread waiting for reload/import.
-- No available root during Apply retains previous active hierarchy.
-- No available root during startup reaches Title with empty active library and
+- Existing one-path configurations migrate without library loss.
+- Fresh install has one managed default root.
+- Config adds, removes, and reorders roots on Windows and macOS.
+- Ordered roots survive restart and startup reads them.
+- Root comparison is ignore-case on Windows/macOS and ordinal on Linux; chart
+  canonical identity remains ordinal.
+- `SetCurrentSearchPaths` and startup cache/database paths use the same policy
+  with direct tests.
+- Duplicate and textual parent/child roots cannot be applied.
+- Missing custom roots remain configured and are never auto-created.
+- Removal of the current custom-path `EnsureDirectorySafe` behavior is explicit
+  and tested.
+- Existing auto-created directories are not deleted.
+- The first-root downgrade mirror and its older-build recreation caveat are
+  documented.
+- Unchanged roots do not acquire or scan; any changed ordered list performs at
+  most one full scan.
+- Busy changed-root Apply does not persist.
+- Every available root scans in configured order.
+- NX import and reload cannot run concurrently.
+- Slot handoff is throw-safe and cannot orphan ownership.
+- One unavailable root does not block available roots.
+- Successful reload atomically replaces hierarchy and active roots.
+- Pre-commit failure/cancellation never exposes partial hierarchy.
+- Post-commit cancellation cannot suppress publication.
+- Config deactivation never blocks the game thread.
+- Song Select safely reconciles an out-of-band publication while active.
+- No available root during Apply retains the previous active hierarchy.
+- No available root during startup reaches Title with empty active state and
   leaves SQLite untouched.
-- Preview fallback under any active root resolves correctly.
-- Removing a root hides songs, Bookmarks, and Recent after successful reload
-  while preserving database records and user-owned data.
-- Re-adding a root restores retained user data and active views.
-- Song Select distinguishes unavailable folders from available-but-empty roots.
-- `DTXPath` remains compatibility mirror only; every runtime consumer uses
-  configured or active snapshots as appropriate.
-- Symlink/junction/physical-target deduplication is outside scope.
-- No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
+- Preview fallback works under every active root.
+- Removing a root hides its songs, Bookmarks, and Recent entries while retaining
+  database data.
+- Re-adding restores retained state and active views.
+- Song Select distinguishes unavailable roots from available-but-empty roots.
+- `DTXPath` remains compatibility-only; runtime consumers use configured or
+  active snapshots as appropriate.
+- Physical-target deduplication remains explicitly outside scope.
+- No DTXCreator, parser, schema, or synthetic-root-navigation change is
   included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -1,0 +1,631 @@
+# HPA-191 Configurable Multiple Song Folders Design
+
+**Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
+**Date:** 2026-08-01  
+**Status:** Draft for review
+
+## Context
+
+DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath` and
+writes it as `DTXPath=` in `Config.ini`. `ConfigStage` displays that value as a
+read-only **DTX Folder** item. During startup, `StartupStage` wraps the value in
+a one-element string array before passing it into the song-loading pipeline.
+
+The lower-level song system is already substantially multi-root capable:
+
+- `SongManager` accepts arrays of search roots.
+- Enumeration normalizes and deduplicates roots.
+- Root traversal order is preserved in the published hierarchy.
+- HPA-192 bulk import and cleanup are scoped to active roots.
+- Database rows outside active roots are retained, protecting scores,
+  bookmarks, performance history, and other user-owned state when a library is
+  temporarily removed or unavailable.
+
+HPA-191 therefore does not require a database schema change or another song
+import architecture. The work is to make the ordered root list a first-class
+configuration value, expose safe cross-platform editing in Config, and reload
+the active library without routing the game through boot-only startup state.
+
+## Goals
+
+- Allow the player to add, remove, and reorder song-library roots from the
+  Config stage.
+- Support one or more persisted roots while retaining compatibility with
+  existing `DTXPath` configurations.
+- Apply valid changes immediately and perform one live library reload.
+- Preserve the currently published hierarchy until a replacement reload has
+  completed successfully.
+- Preserve database records and user-owned data for roots removed from the
+  active configuration or temporarily unavailable.
+- Support Windows and macOS folder selection without referencing platform UI
+  frameworks from shared game code.
+- Reject configurations that would scan the same subtree more than once.
+- Keep startup behavior deterministic when some or all configured roots are
+  unavailable.
+
+## Non-goals
+
+- DTXCreator changes.
+- Changes to chart parsing, `set.def`, or `box.def` semantics.
+- Song database schema changes.
+- Filesystem watchers or automatic reload when a removable drive is mounted.
+- Background rescans after every individual add, remove, or reorder action.
+- Editing or creating song files from Config.
+- Synthetic top-level boxes for each configured root.
+- Merging same-named folders or songs across different roots.
+- Deleting retained database records for removed roots.
+- General-purpose file-picker infrastructure beyond directory selection.
+- Linux-specific picker integration; the configuration and reload contracts
+  remain platform-neutral, but HPA-191 targets the existing Windows and macOS
+  game projects.
+
+## Chosen Approach
+
+Add an ordered `SongRoots` collection as the sole runtime source of truth.
+Retain `DTXPath` only as a serialized compatibility mirror of the first root.
+A dedicated Config overlay edits a working copy and commits it only when the
+player selects **Apply**. A platform-specific folder-picker service supplies new
+paths. After the configuration is atomically persisted, a focused song-library
+reload service invokes the existing HPA-192 enumeration/import path once.
+
+The old hierarchy remains published until the complete replacement batch has
+committed and been published. A failed or cancelled reload therefore cannot
+leave Song Select displaying a partial library.
+
+Three root states are distinguished throughout the design:
+
+- **Configured roots:** the ordered canonical paths persisted in `Config.ini`.
+- **Available roots:** configured roots that currently exist and pass a minimal
+  access probe.
+- **Active roots:** roots represented by the currently published `SongManager`
+  hierarchy. Active roots change only after a successful reload, or during a
+  clean startup that intentionally publishes an empty library.
+
+This distinction allows removable-drive paths to remain configured without
+pretending they are currently usable.
+
+## Alternatives Considered
+
+### Save and require restart
+
+This is the smallest implementation, but it leaves the active library stale
+until the player restarts and gives weak feedback that the change succeeded.
+It is rejected because the existing bulk importer already provides an atomic
+publication boundary suitable for a live reload.
+
+### Transition Config back through StartupStage
+
+This reuses the startup progress screen, but `StartupStage` owns boot-specific
+phase state, activation generations, timing summaries, and exactly-once startup
+telemetry. Re-entering it for a user-initiated configuration operation would
+couple unrelated lifecycles and make telemetry ambiguous. It is rejected.
+
+### Rescan after every list edit
+
+This would repeatedly traverse and persist the same library while the player is
+still composing the desired configuration. It is rejected in favor of a draft
+list and one Apply operation.
+
+### Store one delimited `SongRoots=` value
+
+A delimiter would conflict with legal path characters and complicate escaping
+and hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
+
+## Configuration Contract
+
+### Runtime model
+
+`ConfigData` gains an ordered mutable collection:
+
+```csharp
+public List<string> SongRoots { get; } = new();
+```
+
+The collection is initialized with `AppPaths.GetDefaultSongsPath()`.
+
+`DTXPath` remains available for source and downgrade compatibility, but is a
+mirror only:
+
+- After load, reset, or a successful root update, it equals the first canonical
+  configured root.
+- Production startup, Config UI, reload, and active-root filtering must consume
+  `SongRoots`, never `DTXPath`.
+- Direct legacy mutation of `DTXPath` is not a supported way to change the
+  runtime library.
+
+At least one configured root is always required. Availability is not required;
+a single configured path may point to a currently disconnected removable drive.
+
+### Persisted format
+
+`Config.ini` stores roots in explicit order:
+
+```ini
+[System]
+DTXPath=C:\DTX\Main
+SongRoot.0=C:\DTX\Main
+SongRoot.1=D:\Community Charts
+```
+
+Rules:
+
+1. `SongRoot.<index>` uses a non-negative decimal integer index.
+2. Roots are loaded in ascending numeric order; gaps are allowed.
+3. Malformed suffixes, blank values, and negative indexes are ignored with a
+   warning.
+4. Duplicate indexes use the last parsed value, matching normal INI overwrite
+   expectations, and emit a warning.
+5. Values may contain `=` because `ConfigManager` already splits lines on the
+   first `=` only.
+6. Save rewrites indexes densely from zero.
+7. `DTXPath` is always written as the first root for downgrade compatibility.
+8. `SongRoot.*` entries are the authority whenever at least one structurally
+   valid entry exists.
+9. When no valid indexed entries exist, the loader migrates the legacy
+   `DTXPath` value into a one-element root list.
+10. When neither representation yields a usable path, the managed default root
+    is restored.
+
+A successful legacy migration is persisted immediately through the existing
+atomic temp-file replacement so the next launch no longer depends on fallback
+logic.
+
+### Legacy path migration
+
+The existing migration from legacy `Songs` defaults to the current managed
+`DTXFiles` location is retained. It applies to the fallback `DTXPath` value
+before that value becomes `SongRoots[0]`.
+
+Indexed custom roots are not remapped merely because their final segment is
+named `Songs`; only the known legacy default representations are migrated.
+
+### Directory creation
+
+The game may create the managed default `AppPaths.GetDefaultSongsPath()` when it
+is selected or restored as the fallback root.
+
+The game must not create arbitrary custom roots. A missing custom path may be a
+removable drive, network mount, renamed directory, or user error. Creating it
+would hide the problem and could produce unwanted directories on the wrong
+volume.
+
+## Path Identity and Validation
+
+All roots are resolved and compared through one shared policy used by config
+load, Config UI, and the setter.
+
+### Canonicalization
+
+For each non-blank input:
+
+1. Expand supported home-relative forms through `AppPaths`.
+2. Resolve relative legacy paths against the same app-data base used today.
+3. Convert to an absolute full path.
+4. Normalize separators and trailing separators through `SongPathIdentity`.
+5. Compare with `SongPathIdentity.CanonicalComparer`, preserving platform path
+   case behavior.
+6. Persist the canonical absolute value.
+
+Root order is semantically meaningful. It controls traversal order and the
+ordering of root-level nodes in Song Select.
+
+### Blocking structural errors
+
+The following prevent Apply and leave the current configuration unchanged:
+
+- No configured roots.
+- Blank or syntactically invalid paths.
+- Canonically duplicate roots.
+- Overlapping roots where either path is an ancestor of the other.
+
+Overlapping roots are rejected because scanning both a parent and its child
+would discover the same charts twice. The policy performs a symmetric
+ancestor check after canonicalization; authored order does not make an overlap
+valid.
+
+Hand-edited invalid configuration must not prevent startup. During load, roots
+are processed in numeric order and the first accepted root wins. Later duplicate
+or overlapping entries are dropped with warnings. If all entries are rejected,
+the managed default is restored.
+
+### Availability warnings
+
+Missing and inaccessible paths are warnings, not structural errors. They remain
+configured so removable or network libraries can return later.
+
+A minimal availability probe must:
+
+- Check that the directory exists.
+- Attempt to begin a shallow directory enumeration to detect obvious access
+  failures without recursively scanning charts.
+- Catch path, I/O, and authorization errors and return a diagnostic instead of
+  throwing.
+
+Only roots passing this probe are supplied to a live reload or normal startup
+load. A path may still fail later because availability can change during a
+scan; that failure follows the reload error contract below.
+
+## Config User Experience
+
+### System menu entry
+
+Replace the read-only **DTX Folder** item with a navigation item named
+**Song Folders**.
+
+Its value summary is:
+
+- `1 folder` for one configured root.
+- `<n> folders` for multiple roots.
+
+The description states that the folders are scanned in the displayed order and
+that Apply reloads the song library once.
+
+### Overlay abstraction
+
+`ConfigStage` currently models its active overlay as `IKeyAssignPanel`, although
+the lifecycle and drawing contract is generally useful. Introduce
+`IConfigOverlayPanel` containing the common members:
+
+- `IsActive`
+- `Closed`
+- `Saved`
+- `Activate()` / `Deactivate()`
+- `Update(...)`
+- `Draw(...)`
+
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving existing key-panel
+contracts. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
+targeted boundary correction required to host a non-key-assignment panel; it is
+not a broader Config UI refactor.
+
+### SongFolderPanel
+
+`SongFolderPanel` receives:
+
+- An immutable snapshot of configured roots.
+- `IFolderPickerService`.
+- The shared root validation policy.
+
+It owns a private draft list. Opening, reordering, adding, removing, or
+cancelling does not mutate `ConfigData`.
+
+The panel displays the full selected path and a scrollable ordered list. Long
+paths may be visually ellipsized, but validation and persistence always use the
+complete value.
+
+Supported actions:
+
+- **Add Folder** — invoke the platform picker and append a unique selection.
+- **Remove** — remove the selected root when at least one draft root remains.
+- **Move Up** / **Move Down** — change scan and display order.
+- **Apply** — validate and commit the complete draft.
+- **Cancel** — discard the draft and close.
+
+Input behavior follows existing Config conventions:
+
+- Up/Down move selection.
+- Left/Right change the selected action where applicable.
+- Activate executes the highlighted action.
+- Back behaves as Cancel.
+
+Structural errors are shown in the panel and keep it open. Availability warnings
+are shown beside affected roots but do not disable Apply.
+
+A folder-picker cancellation is a no-op. A picker failure displays an error and
+leaves the draft unchanged.
+
+## Platform Folder Picker
+
+Shared code depends only on:
+
+```csharp
+public interface IFolderPickerService
+{
+    FolderPickerResult PickFolder(string? initialDirectory);
+}
+```
+
+The result distinguishes selected, cancelled, unavailable, and failed outcomes
+and carries an error message only for failure.
+
+Platform composition selects the implementation:
+
+- **Windows:** use `System.Windows.Forms.FolderBrowserDialog`, already supported
+  by the Windows project target. The dialog starts from the selected root or the
+  managed default when possible.
+- **macOS:** invoke the native folder chooser through a small `osascript`
+  adapter using `choose folder`, returning its POSIX path. Process arguments are
+  passed without shell interpolation, cancellation is mapped to Cancelled, and
+  non-cancellation failures include stderr in structured logging.
+
+The shared `DTXMania.Game` code must not reference WinForms, AppleScript process
+construction, or other platform UI types. Picker implementations and service
+registration live in platform-specific source files or projects.
+
+Headless tests inject a deterministic fake picker.
+
+## Commit and Persistence Flow
+
+Applying roots is an explicit user commit, so it requires stronger semantics
+than an ordinary deferred toggle edit.
+
+`IConfigManager` gains a typed root update operation returning a result:
+
+```csharp
+SongRootUpdateResult SetSongRoots(
+    string configFilePath,
+    IReadOnlyList<string> roots);
+```
+
+The operation:
+
+1. Validates and canonicalizes the complete list.
+2. Captures the prior `SongRoots` and `DTXPath` values.
+3. Updates both in memory.
+4. Writes the complete config immediately through the existing atomic
+   temp-file replacement.
+5. Clears any pending deferred-save marker on success because all current
+   settings were written.
+6. Restores the prior in-memory values if persistence fails.
+7. Raises `SongRootsChanged` only after persistence succeeds.
+8. Is a no-op success when the canonical ordered list is unchanged.
+
+Event subscribers are isolated using the same per-subscriber exception handling
+as existing config events. A subscriber failure does not undo an accepted and
+persisted configuration.
+
+If persistence fails, the panel remains open, the old configuration remains the
+truth, and no reload begins.
+
+## Live Library Reload
+
+### Boundary
+
+Introduce an `ISongLibraryReloadService` abstraction so `ConfigStage` does not
+own raw `SongManager` orchestration and tests do not need the singleton.
+
+The production implementation:
+
+- Resolves currently available roots from the persisted configured list.
+- Adapts `EnumerationProgress` to a Config status string.
+- Invokes `SongManager.EnumerateAndImportSongsAsync` once.
+- Returns the successful active-root set, aggregate counts, warnings, or a
+  terminal failure/cancellation result.
+- Allows only one in-flight reload.
+
+It does not create another import path. The existing HPA-192 batch builder,
+bulk transaction, hierarchy finalization, and publication remain authoritative.
+
+### Apply sequence
+
+1. `SongFolderPanel` validates its draft.
+2. `ConfigManager.SetSongRoots` atomically persists the canonical list.
+3. The panel closes and Config displays a reload status.
+4. The reload service probes all configured roots.
+5. When at least one root is available, one enumeration/import starts with only
+   those roots.
+6. The old hierarchy remains active while discovery and persistence run.
+7. On successful commit, `SongManager.PublishEnumeration` replaces the hierarchy
+   and current active-root snapshot atomically.
+8. Config reports loaded root, chart, logical-song, skipped-root, and error
+   counts.
+
+Unavailable configured roots are omitted from that scan and listed as warnings.
+Their database records are retained because they are outside the active import
+roots.
+
+When no configured root is currently available, Config does not invoke the
+importer and does not clear the current hierarchy. The roots remain saved and
+Config reports that the current library was retained until a successful future
+reload or restart.
+
+### Concurrency and lifecycle
+
+- A second Apply/reload request is rejected while one reload is in flight.
+- Song-folder editing may be reopened only after the prior reload terminates.
+- Leaving Config cancels the reload and observes its task.
+- The cancellation source is disposed only after the operation terminates,
+  preserving HPA-192's enumeration-slot and cancellation-winddown guarantees.
+- Config deactivation must not block indefinitely waiting for filesystem work.
+- The reload task may complete during a stage transition, but it must not write
+  into disposed Config graphics or panel state. Status publication is guarded
+  by an activation generation or equivalent lifetime token.
+
+### Failure and cancellation
+
+If discovery, import, or publication fails:
+
+- The newly persisted configured roots remain saved.
+- The previous active hierarchy and active-root snapshot remain published.
+- No partial hierarchy is exposed.
+- The player sees a concise failure message explaining that the saved roots will
+  be retried on the next startup or Apply.
+- Detailed exceptions and failed-root diagnostics are logged.
+
+If cancellation occurs before publication, the same old-hierarchy guarantee
+applies. If the HPA-192 operation has already committed and published before the
+cancellation is observed, that successful publication remains authoritative;
+the status must not claim that the library was rolled back.
+
+## Startup Integration
+
+`StartupStage` reads a snapshot of `Config.SongRoots`, never `DTXPath`.
+
+Before selecting the cache or enumeration path, startup performs the shared
+availability probe:
+
+- Available roots are passed to `NeedsEnumerationAsync`, cache hierarchy
+  construction, and enumeration.
+- Unavailable roots are logged once with their diagnostics.
+- Root order remains the configured order.
+
+When no configured root is available during a clean startup, startup completes
+successfully with an empty active hierarchy and an empty active-root snapshot.
+It does not delete or stale-clean any database records. The title screen remains
+reachable, and the player can enter Config to repair the paths.
+
+A later successful startup or Apply restores songs from the retained database or
+re-enumerates the returned roots according to the normal load-path decision.
+
+## SongManager and Database Interaction
+
+No database migration is required.
+
+The existing HPA-192 contracts remain in force:
+
+- Enumeration and persistence receive an ordered root array.
+- Exact duplicate roots are defensively deduplicated again in `SongManager`.
+- Cleanup affects only roots successfully supplied to the import.
+- Charts and songs outside those roots are retained.
+- Bookmarks, all score-speed variants, play counts, recent-play timestamps,
+  ranks, full-combo state, and performance history remain user-owned data.
+- The replacement hierarchy is published only after the transaction commits.
+
+HPA-191 prevents overlapping configured roots before they reach `SongManager`.
+The importer is not responsible for inferring which overlapping root the player
+intended.
+
+Multiple roots remain flattened into the existing root-level hierarchy in
+configured order. Two roots may legitimately produce boxes or songs with equal
+display titles; identity remains path/database based and the nodes are not
+merged. Adding synthetic per-root containers would change navigation semantics
+and is outside this issue.
+
+## Logging and User Feedback
+
+Structured logs include:
+
+- Config migration from `DTXPath` to indexed roots.
+- Dropped malformed, duplicate, or overlapping hand-edited entries.
+- Selected and cancelled folder-picker outcomes at debug level.
+- Picker failures at warning level.
+- Canonical old and new root lists after a successful commit.
+- Availability warnings by configured root.
+- Reload start, success, cancellation, and failure with aggregate counts.
+
+Normal logs must not emit per-file success messages beyond the progress behavior
+already owned by HPA-192.
+
+Config displays one concise status line for the current operation, for example:
+
+- `Reloading songs: 48 / 100 charts`
+- `Loaded 2 folders, 100 charts; 1 folder unavailable`
+- `Folders saved; no configured folder is currently available`
+- `Reload failed; previous song list retained`
+
+## Testing Strategy
+
+### Configuration unit tests
+
+- Default config contains exactly the managed default root and mirrors it to
+  `DTXPath`.
+- Indexed roots round-trip in order and are rewritten densely.
+- Legacy `DTXPath` migrates to one indexed root and persists immediately.
+- Legacy default `Songs` migration still resolves to `DTXFiles`.
+- Indexed entries take precedence over `DTXPath`.
+- Gaps, malformed indexes, duplicate indexes, and blank values are handled as
+  specified.
+- Canonical duplicates are rejected by the setter and dropped safely on load.
+- Parent/child overlaps are rejected symmetrically.
+- Root comparison follows platform path semantics.
+- Missing custom roots are not created.
+- The managed default root is created when restored as fallback.
+- Failed config persistence restores the prior in-memory roots and emits no
+  change event.
+- A successful update raises `SongRootsChanged` once after persistence.
+
+### Config and panel tests
+
+- The System category exposes **Song Folders** instead of a read-only path.
+- The count summary uses singular and plural forms.
+- Panel activation starts from an isolated draft.
+- Add, remove, reorder, Apply, Cancel, and Back behavior are deterministic.
+- Picker cancellation and failure do not mutate the draft.
+- Structural errors keep the panel open.
+- Missing paths appear as warnings and may be applied.
+- The last configured root cannot be removed without adding another.
+- Apply does not start a reload when persistence fails.
+- Active overlay polymorphism continues to support existing key panels.
+
+### Reload-service tests
+
+- One successful Apply triggers exactly one importer call with roots in order.
+- Unavailable roots are skipped without preventing available roots from loading.
+- No available roots skip import and retain the existing hierarchy.
+- Concurrent reload is rejected.
+- Success publishes the new hierarchy and active roots.
+- Failure and pre-publication cancellation preserve the previous hierarchy.
+- Leaving Config cancels and safely observes the operation.
+- Post-publication cancellation is reported as success, not rollback.
+
+### Startup and integration tests
+
+- Startup consumes `SongRoots`, not the compatibility `DTXPath` value.
+- Multiple available roots appear in configured order.
+- Charts under distinct roots are imported once each.
+- Removed-root songs disappear from the active hierarchy after successful
+  reload but remain in SQLite with scores and bookmarks intact.
+- Re-adding the root restores retained user-owned state.
+- A missing removable-drive root does not block another root.
+- No available roots produce an empty active library without database cleanup.
+- Windows and macOS projects compile with only their own picker implementation.
+- Existing HPA-192 enumeration, cancellation, score-retention, and performance
+  tests remain green.
+
+## Implementation Slices
+
+Each slice is intended to fit within three engineer days and be executable by a
+junior code agent with repository-wide access.
+
+### Slice 1: Canonical multi-root configuration
+
+- Add `SongRoots`, the indexed INI format, compatibility mirror, migration, and
+  immediate persistence behavior.
+- Add shared canonicalization, overlap validation, and availability probing.
+- Update `IConfigManager`, `ConfigManager`, `ConfigData`, and startup root
+  consumption.
+- Add configuration and startup unit tests.
+- Do not add Config UI or live reload in this slice.
+
+### Slice 2: Cross-platform SongFolderPanel
+
+- Add `IConfigOverlayPanel` and adapt the existing key-panel interface.
+- Add `IFolderPickerService` with Windows, macOS, and fake implementations.
+- Replace **DTX Folder** with **Song Folders** and implement the draft editing
+  panel.
+- Commit through `SetSongRoots`, but show a temporary `restart required` status
+  until Slice 3 supplies live reload.
+- Add panel and platform-boundary tests.
+
+### Slice 3: Live reload and retained-data integration
+
+- Add `ISongLibraryReloadService` and Config lifecycle coordination.
+- Add progress, unavailable-root summaries, cancellation, and failure feedback.
+- Verify successful publication, old-hierarchy retention, and removed-root data
+  retention.
+- Add multi-root integration tests and Windows/macOS build validation.
+
+## Acceptance Criteria
+
+- Existing one-path `DTXPath` configurations migrate without losing the library.
+- A fresh install has one managed default song root.
+- Config allows adding, removing, and reordering roots on Windows and macOS.
+- The ordered root list survives restart.
+- Duplicate and parent/child-overlapping roots cannot be applied.
+- Missing custom roots remain configured and are never created automatically.
+- Applying a changed list performs at most one live scan.
+- Every available root is scanned in configured order.
+- One unavailable root does not prevent available roots from loading.
+- A successful reload replaces the active hierarchy atomically.
+- A failed or cancelled pre-publication reload never exposes a partial hierarchy.
+- When no root is available during Apply, the previous active hierarchy remains
+  visible and the saved configuration is retried later.
+- When no root is available during startup, the game reaches Title with an empty
+  active library and leaves the database untouched.
+- Removing a root removes its songs from active views after a successful reload
+  but preserves their bookmarks, scores, variants, and performance history.
+- Re-adding a root restores retained user data.
+- `DTXPath` remains a compatibility mirror only; runtime code consumes
+  `SongRoots`.
+- No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
+  included.


### PR DESCRIPTION
## Summary

Adds the finalized HPA-191 design specification and an executable implementation plan for configurable multiple song-library roots.

## Documentation

- Design: `docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md`
- Implementation plan: `docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md`

## Implementation sequence

The plan uses five hard-ordered, independently reviewable slices:

1. **1a — Configuration model and persistence**
   - Indexed `SongRoot.N` format, migration, repeated-load clearing, managed-default-only creation, and deferred-save correctness.
2. **1b — Root policy and SongManager snapshots**
   - Testable comparer modes, segment-wise overlap checks, copied/versioned snapshots, empty publication, startup and preview consumer migration.
3. **2 — Cross-platform SongFolderPanel**
   - Generalized Config overlay, isolated draft editing, and asynchronous Windows/macOS folder pickers.
4. **3a — Config operation coordinator and live reload**
   - One scoped lifecycle for root reload and NX score import, HPA-192 result mapping, update-thread progress, and non-blocking cancellation.
5. **3b — Active Song Select reconciliation**
   - Update-thread publication handling, stable navigation/selection restoration, active-root Bookmarks/Recent, preview roots, and empty states.

Each slice includes exact files, interfaces, red/green commands, explicit commit boundaries, and a review gate. Each remains scoped below three engineer days.

## Branch strategy

This PR remains documentation-only. After it merges, implementation starts from updated `main` on a fresh branch and is published as a separate implementation PR with the five slice commits retained for review and bisection.

## Plan self-review

- Every design acceptance criterion maps to a slice and test gate.
- Both root comparer branches are testable on every CI host.
- Publication version increments only during publication.
- Zero-active-root results retain a non-null empty import result.
- Commit commands stage explicit files only.
- No undefined cross-slice interfaces or placeholder steps remain.

## Impact

Documentation only. No production code, tests, or database schema changes are included.

Linear: https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders