### PR TITLE
feat: configure ordered song folders with live reload

### DIFF
--- a/DTXMania.Game/DTXMania.Game.Mac.csproj
+++ b/DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -11,6 +11,11 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Platform/Windows/WindowsFolderPickerService.cs" />
+    <Compile Remove="Platform/FolderPickerServiceFactory.Windows.cs" />
+  </ItemGroup>
   
   <ItemGroup>
     <None Remove="Icon.ico" />

--- a/DTXMania.Game/DTXMania.Game.Windows.csproj
+++ b/DTXMania.Game/DTXMania.Game.Windows.csproj
@@ -13,6 +13,11 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Platform/Mac/MacFolderPickerService.cs" />
+    <Compile Remove="Platform/FolderPickerServiceFactory.Mac.cs" />
+  </ItemGroup>
   
   
   <ItemGroup>

--- a/DTXMania.Game/Lib/Config/ConfigData.cs
+++ b/DTXMania.Game/Lib/Config/ConfigData.cs
@@ -8,7 +8,30 @@ namespace DTXMania.Game.Lib.Config
         // System settings
         public string DTXManiaVersion { get; set; } = "NX1.5.0-MG";
         public string SkinPath { get; set; } = AppPaths.GetDefaultSystemSkinRoot();
-        public string DTXPath { get; set; } = AppPaths.GetDefaultSongsPath();
+
+        private string _dtxPath = AppPaths.GetDefaultSongsPath();
+
+        /// <summary>
+        /// The primary song-library path. Setting this keeps the first
+        /// <see cref="SongRoots"/> entry in sync when it is still tracking the
+        /// previous value, so object-initializer assignments such as
+        /// <c>new ConfigData { DTXPath = "/x" }</c> cannot leave
+        /// <c>SongRoots[0]</c> stale. Multi-root configurations (where
+        /// <c>SongRoots[0]</c> no longer equals the prior DTXPath) are left
+        /// untouched.
+        /// </summary>
+        public string DTXPath
+        {
+            get => _dtxPath;
+            set
+            {
+                var previous = _dtxPath;
+                _dtxPath = value;
+                if (SongRoots.Count > 0 && SongRoots[0] == previous)
+                    SongRoots[0] = value;
+            }
+        }
+
         public List<string> SongRoots { get; } = new();
 
         public ConfigData()

--- a/DTXMania.Game/Lib/Config/ConfigData.cs
+++ b/DTXMania.Game/Lib/Config/ConfigData.cs
@@ -9,6 +9,12 @@ namespace DTXMania.Game.Lib.Config
         public string DTXManiaVersion { get; set; } = "NX1.5.0-MG";
         public string SkinPath { get; set; } = AppPaths.GetDefaultSystemSkinRoot();
         public string DTXPath { get; set; } = AppPaths.GetDefaultSongsPath();
+        public List<string> SongRoots { get; } = new();
+
+        public ConfigData()
+        {
+            SongRoots.Add(DTXPath);
+        }
 
         // Skin settings
         public bool UseBoxDefSkin { get; set; } = true;

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -28,6 +29,14 @@ namespace DTXMania.Game.Lib.Config
         };
 
         private const string MidiVelocityPrefix = "MidiVelocity.";
+        private const string SongRootPrefix = "SongRoot.";
+
+        private enum SongRootsLoadSource
+        {
+            Indexed,
+            LegacyDTXPath,
+            ManagedDefault,
+        }
 
         /// <summary>
         /// Logical token persisted in Config.ini to represent the bundled default
@@ -87,6 +96,7 @@ namespace DTXMania.Game.Lib.Config
             _loadedConfigPath = filePath;
             EnsureConfigDirectory(filePath);
             Config.MidiVelocityThresholds.Clear();
+            Config.SongRoots.Clear();
             if (!File.Exists(filePath))
             {
                 NormalizeConfigPaths(baseDir);
@@ -95,6 +105,8 @@ namespace DTXMania.Game.Lib.Config
             }
 
             var lines = File.ReadAllLines(filePath, Encoding.UTF8);
+            var indexedSongRoots = new Dictionary<int, string>();
+            string? legacyDtxPath = null;
 
             foreach (var line in lines)
             {
@@ -110,8 +122,11 @@ namespace DTXMania.Game.Lib.Config
                 var key = parts[0].Trim();
                 var value = parts[1].Trim();
 
-                ParseConfigLine(key, value);
+                ParseConfigLine(key, value, indexedSongRoots, ref legacyDtxPath);
             }
+
+            var songRootsLoadSource = FinalizeSongRoots(indexedSongRoots, legacyDtxPath);
+            var songRootsMigrated = songRootsLoadSource != SongRootsLoadSource.Indexed;
 
             // Capture the pre-normalization SkinPath so we can detect whether
             // NormalizeConfigPaths migrated it (e.g. absolute bundled path →
@@ -121,27 +136,36 @@ namespace DTXMania.Game.Lib.Config
             // token's relocation-survival guarantee.
             var skinPathBeforeNormalization = Config.SkinPath;
 
-            NormalizeConfigPaths(baseDir);
+            NormalizeConfigPaths(baseDir, songRootsLoadSource == SongRootsLoadSource.LegacyDTXPath);
 
             var skinPathMigrated = !string.Equals(
                 skinPathBeforeNormalization, Config.SkinPath,
                 AppPaths.SkinPathComparison);
 
-            if (skinPathMigrated)
+            if (skinPathMigrated || songRootsMigrated)
             {
                 try
                 {
                     SaveConfig(filePath);
-                    _logger.LogInformation(
-                        "Migrated SkinPath from '{OldPath}' to '{NewPath}' and persisted the change to the config file.",
-                        skinPathBeforeNormalization, Config.SkinPath);
+                    if (skinPathMigrated)
+                    {
+                        _logger.LogInformation(
+                            "Migrated SkinPath from '{OldPath}' to '{NewPath}' and persisted the change to the config file.",
+                            skinPathBeforeNormalization, Config.SkinPath);
+                    }
+
+                    if (songRootsMigrated)
+                    {
+                        _logger.LogInformation(
+                            "Persisted SongRoot migration using {SongRootCount} configured root(s).",
+                            Config.SongRoots.Count);
+                    }
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex,
-                        "Failed to persist SkinPath migration from '{OldPath}' to '{NewPath}'. " +
-                        "In-memory value is correct; the file will be updated on the next save.",
-                        skinPathBeforeNormalization, Config.SkinPath);
+                        "Failed to persist configuration migration. In-memory values are correct; " +
+                        "the file will be updated on the next save.");
                 }
             }
 
@@ -364,8 +388,15 @@ namespace DTXMania.Game.Lib.Config
             }
         }
 
-        private void ParseConfigLine(string key, string value)
+        private void ParseConfigLine(
+            string key,
+            string value,
+            Dictionary<int, string> indexedSongRoots,
+            ref string? legacyDtxPath)
         {
+            if (TryCaptureIndexedSongRoot(key, value, indexedSongRoots))
+                return;
+
             switch (key)
             {
                 case "DTXManiaVersion":
@@ -375,7 +406,7 @@ namespace DTXMania.Game.Lib.Config
                     Config.SkinPath = value;
                     break;
                 case "DTXPath":
-                    Config.DTXPath = value;
+                    legacyDtxPath = value;
                     break;
                 case "UseBoxDefSkin":
                     Config.UseBoxDefSkin = value.ToLower() == "true";
@@ -490,9 +521,80 @@ namespace DTXMania.Game.Lib.Config
             }
         }
 
+        private bool TryCaptureIndexedSongRoot(
+            string key,
+            string value,
+            Dictionary<int, string> indexedSongRoots)
+        {
+            if (!key.StartsWith(SongRootPrefix, StringComparison.Ordinal))
+                return false;
+
+            var indexText = key.Substring(SongRootPrefix.Length);
+            if (!int.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index))
+            {
+                _logger.LogWarning(
+                    "Ignoring malformed SongRoot entry '{Key}={Value}': index must be a non-negative decimal integer.",
+                    key,
+                    value);
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                _logger.LogWarning(
+                    "Ignoring blank SongRoot entry '{Key}'.",
+                    key);
+                return true;
+            }
+
+            if (indexedSongRoots.ContainsKey(index))
+            {
+                _logger.LogWarning(
+                    "SongRoot index {Index} appeared more than once; using the last value.",
+                    index);
+            }
+
+            indexedSongRoots[index] = value;
+            return true;
+        }
+
+        private SongRootsLoadSource FinalizeSongRoots(
+            IReadOnlyDictionary<int, string> indexedSongRoots,
+            string? legacyDtxPath)
+        {
+            if (indexedSongRoots.Count > 0)
+            {
+                foreach (var root in indexedSongRoots.OrderBy(pair => pair.Key).Select(pair => pair.Value))
+                {
+                    Config.SongRoots.Add(root);
+                }
+
+                Config.DTXPath = Config.SongRoots[0];
+                return SongRootsLoadSource.Indexed;
+            }
+
+            if (!string.IsNullOrWhiteSpace(legacyDtxPath))
+            {
+                Config.SongRoots.Add(legacyDtxPath);
+                Config.DTXPath = legacyDtxPath;
+                return SongRootsLoadSource.LegacyDTXPath;
+            }
+
+            var defaultSongsPath = AppPaths.GetDefaultSongsPath();
+            Config.SongRoots.Add(defaultSongsPath);
+            Config.DTXPath = defaultSongsPath;
+            return SongRootsLoadSource.ManagedDefault;
+        }
+
         public void SaveConfig(string filePath)
         {
             EnsureConfigDirectory(filePath);
+            var songRoots = Config.SongRoots.ToArray();
+            if (songRoots.Length > 0)
+            {
+                Config.DTXPath = songRoots[0];
+            }
+
             var sb = new StringBuilder();
             sb.AppendLine("; DTXMania Configuration File");
             sb.AppendLine($"; Generated: {DateTime.Now}");
@@ -502,6 +604,10 @@ namespace DTXMania.Game.Lib.Config
             sb.AppendLine($"DTXManiaVersion={Config.DTXManiaVersion}");
             sb.AppendLine($"SkinPath={Config.SkinPath}");
             sb.AppendLine($"DTXPath={Config.DTXPath}");
+            for (var index = 0; index < songRoots.Length; index++)
+            {
+                sb.AppendLine($"{SongRootPrefix}{index}={songRoots[index]}");
+            }
             sb.AppendLine();
 
             sb.AppendLine("[Skin]");
@@ -579,6 +685,7 @@ namespace DTXMania.Game.Lib.Config
             var tempFile = filePath + ".tmp";
             File.WriteAllText(tempFile, sb.ToString(), Encoding.UTF8);
             File.Move(tempFile, filePath, overwrite: true);
+            ClearMatchingPendingSavePath(filePath);
         }
 
         public void ResetToDefaults()
@@ -775,7 +882,6 @@ namespace DTXMania.Game.Lib.Config
             try
             {
                 SaveConfig(path);
-                _pendingSavePath = null;
             }
             catch (Exception ex)
             {
@@ -790,6 +896,32 @@ namespace DTXMania.Game.Lib.Config
         private void MarkDirty(string? path = null)
         {
             _pendingSavePath = path ?? _loadedConfigPath ?? _pendingSavePath;
+        }
+
+        private void ClearMatchingPendingSavePath(string savedPath)
+        {
+            if (_pendingSavePath == null)
+                return;
+
+            try
+            {
+                var pendingPath = Path.GetFullPath(_pendingSavePath);
+                var normalizedSavedPath = Path.GetFullPath(savedPath);
+                if (string.Equals(
+                    NormalizePathForComparison(pendingPath),
+                    NormalizePathForComparison(normalizedSavedPath),
+                    AppPaths.SkinPathComparison))
+                {
+                    _pendingSavePath = null;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Could not compare pending config path '{PendingPath}' with saved path '{SavedPath}'; retaining the pending save marker.",
+                    _pendingSavePath,
+                    savedPath);
+            }
         }
 
         /// <summary>
@@ -1134,25 +1266,34 @@ namespace DTXMania.Game.Lib.Config
                 || string.Equals(normalized, "./Songs", StringComparison.OrdinalIgnoreCase);
         }
 
-        private void NormalizeConfigPaths(string baseDir)
+        private void NormalizeConfigPaths(string baseDir, bool migrateLegacySongsPath = false)
         {
             var defaultSystemSkinRoot = AppPaths.GetDefaultSystemSkinRoot();
             var defaultSongsPath = AppPaths.GetDefaultSongsPath();
-            var shouldMigrateLegacySongsPath = IsLegacyDefaultSongsPath(Config.DTXPath, defaultSongsPath);
-
-            if (shouldMigrateLegacySongsPath)
-            {
-                _logger.LogInformation(
-                    "Migrating legacy DTXPath '{LegacyPath}' to '{DefaultSongsPath}'",
-                    Config.DTXPath,
-                    defaultSongsPath);
-            }
 
             // Honor configured paths first, fallback to defaults if not set
             Config.SystemSkinRoot = AppPaths.ResolvePathOrDefault(Config.SystemSkinRoot, defaultSystemSkinRoot);
-            Config.DTXPath = shouldMigrateLegacySongsPath
-                ? defaultSongsPath
-                : AppPaths.ResolvePathOrDefault(Config.DTXPath, defaultSongsPath);
+
+            if (Config.SongRoots.Count == 0)
+            {
+                Config.SongRoots.Add(defaultSongsPath);
+            }
+
+            if (migrateLegacySongsPath && IsLegacyDefaultSongsPath(Config.SongRoots[0], defaultSongsPath))
+            {
+                _logger.LogInformation(
+                    "Migrating legacy DTXPath '{LegacyPath}' to '{DefaultSongsPath}'",
+                    Config.SongRoots[0],
+                    defaultSongsPath);
+                Config.SongRoots[0] = defaultSongsPath;
+            }
+
+            for (var index = 0; index < Config.SongRoots.Count; index++)
+            {
+                Config.SongRoots[index] = AppPaths.ResolvePathOrDefault(Config.SongRoots[index], defaultSongsPath);
+            }
+
+            Config.DTXPath = Config.SongRoots[0];
 
             // SkinPath: persist the "Default" token when the configured path is
             // empty, the app-data default, or a validating bundled root candidate.
@@ -1190,7 +1331,13 @@ namespace DTXMania.Game.Lib.Config
             }
 
             EnsureDirectorySafe(Config.SystemSkinRoot);
-            EnsureDirectorySafe(Config.DTXPath);
+            if (Config.SongRoots.Any(root => string.Equals(
+                NormalizePathForComparison(root),
+                NormalizePathForComparison(defaultSongsPath),
+                AppPaths.SkinPathComparison)))
+            {
+                EnsureDirectorySafe(defaultSongsPath);
+            }
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -147,13 +147,24 @@ namespace DTXMania.Game.Lib.Config
             // token's relocation-survival guarantee.
             var skinPathBeforeNormalization = Config.SkinPath;
 
+            // Capture the pre-normalization SongRoots so we can detect whether
+            // NormalizeConfigPaths discarded malformed entries, replaced them
+            // with resolved paths, or inserted the managed default. Those
+            // corrections must be persisted alongside skin/SongRoot migrations
+            // so a corrupted or stale SongRoot.* line does not survive a
+            // relocation-triggered reload.
+            var songRootsBeforeNormalization = Config.SongRoots.ToList();
+
             NormalizeConfigPaths(baseDir, songRootsLoadSource == SongRootsLoadSource.LegacyDTXPath);
 
             var skinPathMigrated = !string.Equals(
                 skinPathBeforeNormalization, Config.SkinPath,
                 AppPaths.SkinPathComparison);
 
-            if (skinPathMigrated || songRootsMigrated)
+            var songRootsCorrected = !SongRootsSequenceEqual(
+                songRootsBeforeNormalization, Config.SongRoots);
+
+            if (skinPathMigrated || songRootsMigrated || songRootsCorrected)
             {
                 try
                 {
@@ -169,6 +180,13 @@ namespace DTXMania.Game.Lib.Config
                     {
                         _logger.LogInformation(
                             "Persisted SongRoot migration using {SongRootCount} configured root(s).",
+                            Config.SongRoots.Count);
+                    }
+
+                    if (songRootsCorrected && !songRootsMigrated)
+                    {
+                        _logger.LogInformation(
+                            "NormalizeConfigPaths corrected {SongRootCount} SongRoot entry/entries; persisting the updated values to the config file.",
                             Config.SongRoots.Count);
                     }
                 }
@@ -961,6 +979,24 @@ namespace DTXMania.Game.Lib.Config
             if (string.IsNullOrEmpty(path))
                 return string.Empty;
             return path.Replace('\\', '/').TrimEnd('/');
+        }
+
+        /// <summary>
+        /// Compares two SongRoot lists element-by-element using the platform's
+        /// path comparison so that discarded, replaced, or inserted entries are
+        /// detected after <see cref="NormalizeConfigPaths"/> runs.
+        /// </summary>
+        private static bool SongRootsSequenceEqual(
+            IReadOnlyList<string> first, IReadOnlyList<string> second)
+        {
+            if (first.Count != second.Count)
+                return false;
+            for (var i = 0; i < first.Count; i++)
+            {
+                if (!string.Equals(first[i], second[i], AppPaths.SkinPathComparison))
+                    return false;
+            }
+            return true;
         }
 
         /// <inheritdoc/>

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Stage.KeyAssign;
 using DTXMania.Game.Lib.Utilities;
 using Microsoft.Extensions.Logging;
@@ -1261,9 +1262,9 @@ namespace DTXMania.Game.Lib.Config
                 Path.Combine(Path.GetDirectoryName(defaultSongsPath) ?? string.Empty, "Songs"));
 
             // Only match the specific legacy defaults, not every path ending in "Songs".
-            return string.Equals(normalized, legacyDefaultSongsPath, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(normalized, "Songs", StringComparison.OrdinalIgnoreCase)
-                || string.Equals(normalized, "./Songs", StringComparison.OrdinalIgnoreCase);
+            return SongPathIdentity.LegacyAliasComparer.Equals(normalized, legacyDefaultSongsPath)
+                || SongPathIdentity.LegacyAliasComparer.Equals(normalized, "Songs")
+                || SongPathIdentity.LegacyAliasComparer.Equals(normalized, "./Songs");
         }
 
         private void NormalizeConfigPaths(string baseDir, bool migrateLegacySongsPath = false)
@@ -1331,10 +1332,9 @@ namespace DTXMania.Game.Lib.Config
             }
 
             EnsureDirectorySafe(Config.SystemSkinRoot);
-            if (Config.SongRoots.Any(root => string.Equals(
+            if (Config.SongRoots.Any(root => SongPathIdentity.LegacyAliasComparer.Equals(
                 NormalizePathForComparison(root),
-                NormalizePathForComparison(defaultSongsPath),
-                AppPaths.SkinPathComparison)))
+                NormalizePathForComparison(defaultSongsPath))))
             {
                 EnsureDirectorySafe(defaultSongsPath);
             }

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -54,6 +54,7 @@ namespace DTXMania.Game.Lib.Config
         }
 
         private readonly ILogger<ConfigManager> _logger;
+        private readonly SongRootPolicy _songRootPolicy;
         public ConfigData Config { get; private set; }
 
         /// <summary>
@@ -68,7 +69,16 @@ namespace DTXMania.Game.Lib.Config
         private string? _loadedConfigPath;
 
         public ConfigManager(ILogger<ConfigManager>? logger = null)
+            : this(SongRootPolicy.ForCurrentPlatform(), logger)
         {
+        }
+
+        internal ConfigManager(
+            SongRootPolicy songRootPolicy,
+            ILogger<ConfigManager>? logger = null)
+        {
+            _songRootPolicy = songRootPolicy ??
+                throw new ArgumentNullException(nameof(songRootPolicy));
             _logger = logger ?? NullLogger<ConfigManager>.Instance;
             Config = new ConfigData();
         }
@@ -699,6 +709,86 @@ namespace DTXMania.Game.Lib.Config
         public event EventHandler<EventArgs>? KeyBindingsChanged;
 
         public event EventHandler<EventArgs>? SystemKeyBindingsChanged;
+
+        public event EventHandler<SongRootsChangedEventArgs>? SongRootsChanged;
+
+        /// <summary>
+        /// Persists an ordered set of validated song-library roots immediately. A failed
+        /// write restores the exact in-memory roots and legacy compatibility mirror.
+        /// </summary>
+        public SongRootUpdateResult SetSongRoots(
+            string configFilePath,
+            IReadOnlyList<string> roots)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(configFilePath);
+            ArgumentNullException.ThrowIfNull(roots);
+
+            var validation = _songRootPolicy.Validate(roots);
+            if (!validation.IsValid)
+            {
+                return new SongRootUpdateResult(
+                    SongRootUpdateStatus.ValidationFailed,
+                    validation.CanonicalRoots,
+                    validation.Diagnostics);
+            }
+
+            var oldRoots = Config.SongRoots.ToArray();
+            var oldCanonicalRoots = _songRootPolicy.Validate(oldRoots)
+                .CanonicalRoots;
+            if (oldCanonicalRoots.SequenceEqual(
+                validation.CanonicalRoots,
+                _songRootPolicy.Comparer))
+            {
+                return new SongRootUpdateResult(
+                    SongRootUpdateStatus.Unchanged,
+                    validation.CanonicalRoots,
+                    validation.Diagnostics);
+            }
+
+            var oldDtxPath = Config.DTXPath;
+            Config.SongRoots.Clear();
+            Config.SongRoots.AddRange(validation.CanonicalRoots);
+            Config.DTXPath = validation.CanonicalRoots.FirstOrDefault() ?? string.Empty;
+
+            try
+            {
+                SaveConfig(configFilePath);
+            }
+            catch (Exception ex)
+            {
+                Config.SongRoots.Clear();
+                Config.SongRoots.AddRange(oldRoots);
+                Config.DTXPath = oldDtxPath;
+                _logger.LogError(
+                    ex,
+                    "Failed to persist song roots to {Path}; restored the in-memory configuration.",
+                    configFilePath);
+
+                var diagnostics = validation.Diagnostics
+                    .Concat(
+                    [
+                        new SongRootDiagnostic(
+                            configFilePath,
+                            $"Could not persist song roots: {ex.Message}",
+                            IsWarning: false),
+                    ])
+                    .ToArray();
+                return new SongRootUpdateResult(
+                    SongRootUpdateStatus.PersistenceFailed,
+                    validation.CanonicalRoots,
+                    diagnostics);
+            }
+
+            RaiseEvent(
+                SongRootsChanged,
+                new SongRootsChangedEventArgs(
+                    oldCanonicalRoots,
+                    validation.CanonicalRoots));
+            return new SongRootUpdateResult(
+                SongRootUpdateStatus.Updated,
+                validation.CanonicalRoots,
+                validation.Diagnostics);
+        }
 
         public void SetScrollSpeed(string configFilePath, int percent)
         {

--- a/DTXMania.Game/Lib/Config/ConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/ConfigManager.cs
@@ -1379,10 +1379,46 @@ namespace DTXMania.Game.Lib.Config
                 Config.SongRoots[0] = defaultSongsPath;
             }
 
+            // Resolve each persisted root, discarding entries whose stored value
+            // is malformed (e.g. contains illegal path characters or a NUL).
+            // ResolvePathOrDefault eventually calls Path.GetFullPath, which throws
+            // for such values; without per-entry recovery a single corrupted
+            // SongRoot.* line would abort LoadConfig entirely and prevent the
+            // application from starting. Invalid entries are logged and dropped;
+            // when no valid root survives, the managed default restores a usable
+            // library root so configuration loading always completes.
+            var resolvedSongRoots = new List<string>(Config.SongRoots.Count);
             for (var index = 0; index < Config.SongRoots.Count; index++)
             {
-                Config.SongRoots[index] = AppPaths.ResolvePathOrDefault(Config.SongRoots[index], defaultSongsPath);
+                var persistedRoot = Config.SongRoots[index];
+                try
+                {
+                    resolvedSongRoots.Add(
+                        AppPaths.ResolvePathOrDefault(persistedRoot, defaultSongsPath));
+                }
+                catch (Exception ex) when (
+                    ex is ArgumentException or PathTooLongException
+                        or NotSupportedException or IOException
+                        or UnauthorizedAccessException
+                        or System.Security.SecurityException)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Discarding malformed SongRoot entry '{PersistedRoot}' that could not be resolved to an absolute path.",
+                        persistedRoot);
+                }
             }
+
+            if (resolvedSongRoots.Count == 0)
+            {
+                _logger.LogWarning(
+                    "No configured SongRoot entries resolved to a valid path; " +
+                    "falling back to the managed default songs root.");
+                resolvedSongRoots.Add(defaultSongsPath);
+            }
+
+            Config.SongRoots.Clear();
+            Config.SongRoots.AddRange(resolvedSongRoots);
 
             Config.DTXPath = Config.SongRoots[0];
 

--- a/DTXMania.Game/Lib/Config/IConfigManager.cs
+++ b/DTXMania.Game/Lib/Config/IConfigManager.cs
@@ -33,6 +33,25 @@ namespace DTXMania.Game.Lib.Config
         event EventHandler<EventArgs>? SystemKeyBindingsChanged;
 
         /// <summary>
+        /// Raised after a validated song-root edit has been persisted successfully.
+        /// </summary>
+        event EventHandler<SongRootsChangedEventArgs>? SongRootsChanged
+        {
+            add { }
+            remove { }
+        }
+
+        /// <summary>
+        /// Validates, persists, and publishes an ordered song-root update. Existing
+        /// interface implementations that do not own persisted song roots can opt out.
+        /// </summary>
+        SongRootUpdateResult SetSongRoots(
+            string configFilePath,
+            IReadOnlyList<string> roots) =>
+            throw new NotSupportedException(
+                "This configuration manager does not support song-root updates.");
+
+        /// <summary>
         /// Sets the scroll speed (percent), snapping to the nearest allowed step and
         /// clamping to the allowed range. Persists to the given file path and raises
         /// ScrollSpeedChanged when the value actually changes.

--- a/DTXMania.Game/Lib/Config/SongRootConfigModels.cs
+++ b/DTXMania.Game/Lib/Config/SongRootConfigModels.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DTXMania.Game.Lib.Config
+{
+    public enum SongRootUpdateStatus
+    {
+        Updated,
+        Unchanged,
+        ValidationFailed,
+        PersistenceFailed,
+    }
+
+    public sealed record SongRootDiagnostic(
+        string Path,
+        string Message,
+        bool IsWarning);
+
+    public sealed record SongRootUpdateResult
+    {
+        public SongRootUpdateStatus Status { get; }
+        public IReadOnlyList<string> CanonicalRoots { get; }
+        public IReadOnlyList<SongRootDiagnostic> Diagnostics { get; }
+
+        public SongRootUpdateResult(
+            SongRootUpdateStatus status,
+            IReadOnlyList<string> canonicalRoots,
+            IReadOnlyList<SongRootDiagnostic> diagnostics)
+        {
+            ArgumentNullException.ThrowIfNull(canonicalRoots);
+            ArgumentNullException.ThrowIfNull(diagnostics);
+
+            Status = status;
+            CanonicalRoots = Array.AsReadOnly(canonicalRoots.ToArray());
+            Diagnostics = Array.AsReadOnly(diagnostics.ToArray());
+        }
+
+        public void Deconstruct(
+            out SongRootUpdateStatus status,
+            out IReadOnlyList<string> canonicalRoots,
+            out IReadOnlyList<SongRootDiagnostic> diagnostics)
+        {
+            status = Status;
+            canonicalRoots = CanonicalRoots;
+            diagnostics = Diagnostics;
+        }
+    }
+
+    public sealed class SongRootsChangedEventArgs : EventArgs
+    {
+        public IReadOnlyList<string> OldRoots { get; }
+        public IReadOnlyList<string> NewRoots { get; }
+
+        public SongRootsChangedEventArgs(
+            IReadOnlyList<string> oldRoots,
+            IReadOnlyList<string> newRoots)
+        {
+            ArgumentNullException.ThrowIfNull(oldRoots);
+            ArgumentNullException.ThrowIfNull(newRoots);
+
+            OldRoots = Array.AsReadOnly(oldRoots.ToArray());
+            NewRoots = Array.AsReadOnly(newRoots.ToArray());
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs
@@ -140,6 +140,18 @@ namespace DTXMania.Game.Lib.Song.Components
         }
 
         /// <summary>
+        /// Clears the selected-song presentation when a library publication removes the
+        /// previous chart. This releases its texture immediately so a stale preimage cannot
+        /// survive while Song Select resets to the replacement list.
+        /// </summary>
+        public void ClearSelectedSong()
+        {
+            _currentSong = null;
+            ResetDisplayDelay();
+            ReleaseCurrentPreviewTexture();
+        }
+
+        /// <summary>
         /// Update timing and delay logic (called from stage)
         /// </summary>
         public override void Update(double deltaTime)

--- a/DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs
+++ b/DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs
@@ -46,8 +46,9 @@ namespace DTXMania.Game.Lib.Song.Components
         private double _displayDelay = 0.0;
         private const double DISPLAY_DELAY_SECONDS = 0.5; // 500ms delay before showing preview
 
-        // Configured songs root path (e.g., DTXFiles or Songs directory)
-        private string _songsRootPath;
+        // Published active song roots, ordered by the library snapshot that supplied
+        // the selected node. This is intentionally a copied collection.
+        private IReadOnlyList<string> _activeSongRootPaths = Array.Empty<string>();
 
         #endregion
 
@@ -79,13 +80,14 @@ namespace DTXMania.Game.Lib.Song.Components
         }
 
         /// <summary>
-        /// Configured songs root path (e.g., DTXFiles or Songs directory)
-        /// Used for resolving relative song directory paths
+        /// Ordered active song roots used only as a fallback for relative chart paths.
+        /// Absolute chart paths remain authoritative.
         /// </summary>
-        public string SongsRootPath
+        public IReadOnlyList<string> ActiveSongRootPaths
         {
-            get => _songsRootPath;
-            set => _songsRootPath = value;
+            get => _activeSongRootPaths;
+            set => _activeSongRootPaths = Array.AsReadOnly(
+                (value ?? Array.Empty<string>()).ToArray());
         }
 
         #endregion
@@ -463,76 +465,73 @@ namespace DTXMania.Game.Lib.Song.Components
         /// </summary>
         private string ResolveSongDirectoryPath(string songDirectory)
         {
-            // Convert to absolute path if needed - handle both relative and already absolute paths
-            if (!System.IO.Path.IsPathRooted(songDirectory))
+            // An absolute chart path comes from the selected score and must not be
+            // remapped through a potentially newer library-root snapshot.
+            if (System.IO.Path.IsPathRooted(songDirectory))
+                return songDirectory;
+
+            // Relative legacy metadata is resolved against the roots that were active
+            // for this published library, in configured order.
+            try
             {
-                // Try to resolve relative path from current working directory or known song directories
-                try
+                var workingDir = Environment.CurrentDirectory;
+                var possiblePaths = new List<string>();
+                foreach (var activeRoot in _activeSongRootPaths)
                 {
-                    var workingDir = Environment.CurrentDirectory;
-
-                    // Build list of possible paths, including configured songs root
-                    // Note: Path.GetFullPath(songDirectory) already resolves relative to current/working directory
-                    var possiblePaths = new List<string>
+                    if (!string.IsNullOrWhiteSpace(activeRoot))
                     {
-                        System.IO.Path.GetFullPath(songDirectory) // From current/working directory
-                    };
-
-                    // Add configured songs root path if available (e.g., DTXFiles or legacy Songs)
-                    if (!string.IsNullOrEmpty(_songsRootPath))
-                    {
-                        possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(_songsRootPath, songDirectory)));
-                    }
-
-                    // Add fallback paths for backward compatibility
-                    possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "DTXFiles", songDirectory))); // From DTXFiles folder
-                    possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "..", "DTXFiles", songDirectory))); // Parent DTXFiles folder
-                    possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "Songs", songDirectory))); // Legacy Songs folder
-                    possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "..", "Songs", songDirectory))); // Parent legacy Songs folder
-
-                    foreach (var testPath in possiblePaths)
-                    {
-                        if (System.IO.Directory.Exists(testPath))
-                        {
-                            songDirectory = testPath;
-                            break;
-                        }
+                        possiblePaths.Add(System.IO.Path.GetFullPath(
+                            System.IO.Path.Combine(activeRoot, songDirectory)));
                     }
                 }
-                catch (Exception ex)
+
+                // Preserve prior convenience fallbacks after the authoritative
+                // published roots have been exhausted.
+                possiblePaths.Add(System.IO.Path.GetFullPath(songDirectory));
+                possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "DTXFiles", songDirectory)));
+                possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "..", "DTXFiles", songDirectory)));
+                possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "Songs", songDirectory)));
+                possiblePaths.Add(System.IO.Path.GetFullPath(System.IO.Path.Combine(workingDir, "..", "Songs", songDirectory)));
+
+                foreach (var testPath in possiblePaths)
                 {
-                    // Working directory can be unavailable (e.g., deleted temp dirs in tests).
-                    // First try configured SongsRootPath, then base-directory anchored resolution.
-                    System.Diagnostics.Debug.WriteLine(
-                        $"PreviewImagePanel: Primary path resolution failed for '{songDirectory}': {ex.Message}");
+                    if (System.IO.Directory.Exists(testPath))
+                    {
+                        return testPath;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // Working directory can be unavailable (e.g., deleted temp dirs in
+                // tests). Preserve a deterministic root-first fallback in that case.
+                System.Diagnostics.Debug.WriteLine(
+                    $"PreviewImagePanel: Path resolution failed for '{songDirectory}': {ex.Message}");
+                foreach (var activeRoot in _activeSongRootPaths)
+                {
                     try
                     {
-                        if (!string.IsNullOrEmpty(_songsRootPath))
-                        {
-                            var fromSongsRoot = System.IO.Path.GetFullPath(System.IO.Path.Combine(_songsRootPath, songDirectory));
-                            if (System.IO.Directory.Exists(fromSongsRoot))
-                            {
-                                songDirectory = fromSongsRoot;
-                                return songDirectory;
-                            }
-                        }
-
-                        songDirectory = System.IO.Path.GetFullPath(songDirectory);
+                        var fromActiveRoot = System.IO.Path.GetFullPath(
+                            System.IO.Path.Combine(activeRoot, songDirectory));
+                        if (System.IO.Directory.Exists(fromActiveRoot))
+                            return fromActiveRoot;
                     }
-                    catch (Exception ex2)
+                    catch (Exception fallbackException)
                     {
                         System.Diagnostics.Debug.WriteLine(
-                            $"PreviewImagePanel: SongsRootPath fallback failed for '{songDirectory}': {ex2.Message}");
-                        try
-                        {
-                            songDirectory = System.IO.Path.GetFullPath(System.IO.Path.Combine(AppContext.BaseDirectory, songDirectory));
-                        }
-                        catch (Exception ex3)
-                        {
-                            System.Diagnostics.Debug.WriteLine(
-                                $"PreviewImagePanel: All resolution attempts failed for '{songDirectory}': {ex3.Message}");
-                        }
+                            $"PreviewImagePanel: Active-root fallback failed for '{songDirectory}': {fallbackException.Message}");
                     }
+                }
+
+                try
+                {
+                    return System.IO.Path.GetFullPath(
+                        System.IO.Path.Combine(AppContext.BaseDirectory, songDirectory));
+                }
+                catch (Exception fallbackException)
+                {
+                    System.Diagnostics.Debug.WriteLine(
+                        $"PreviewImagePanel: Base-directory fallback failed for '{songDirectory}': {fallbackException.Message}");
                 }
             }
 

--- a/DTXMania.Game/Lib/Song/DTXChartParser.cs
+++ b/DTXMania.Game/Lib/Song/DTXChartParser.cs
@@ -24,6 +24,17 @@ namespace DTXMania.Game.Lib.Song
         private static readonly string[] _supportedExtensions = { ".dtx", ".gda", ".g2d", ".bms", ".bme", ".bml" };
         private static bool _encodingProviderRegistered;
 
+        /// <summary>
+        /// The set of chart file extensions this parser accepts, without the
+        /// leading dot (e.g. ".dtx", ".gda"). Exposed so filesystem-scan helpers
+        /// (cache-freshness counts, change detection) enumerate exactly the same
+        /// formats as full enumeration, which filters via
+        /// <see cref="IsSupportedFile"/>. Without this, counting only "*.dtx"
+        /// permanently mismatches libraries containing .gda/.g2d/.bms/.bme/.bml
+        /// charts and forces a full rescan on every startup.
+        /// </summary>
+        public static IReadOnlyCollection<string> SupportedExtensions => _supportedExtensions;
+
         #endregion
 
         #region Constants

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -1921,6 +1921,43 @@ namespace DTXMania.Game.Lib.Song.Entities
         }
 
         /// <summary>
+        /// Returns the <see cref="SongChart.Id"/> and <see cref="SongChart.FilePath"/>
+        /// of every chart whose file path resides under one of <paramref name="roots"/>
+        /// (root-containment uses <see cref="SongPathIdentity"/>, mirroring
+        /// SongManager's active-chart rule). Used by the cache-freshness
+        /// file-existence check so charts belonging to removed (retained) roots are
+        /// not flagged as missing on every startup. Returns an empty list for an
+        /// empty root set.
+        /// </summary>
+        public async Task<IReadOnlyList<(int Id, string FilePath)>> GetActiveChartsAsync(
+            IReadOnlyList<string> roots)
+        {
+            if (roots == null || roots.Count == 0)
+                return Array.Empty<(int, string)>();
+
+            var normalizedRoots = roots
+                .Select(SongPathIdentity.Normalize)
+                .ToArray();
+            using var context = CreateContext();
+            var charts = await context.SongCharts
+                .AsNoTracking()
+                .Select(chart => new { chart.Id, chart.FilePath })
+                .ToListAsync();
+            var active = new List<(int Id, string FilePath)>(charts.Count);
+            foreach (var chart in charts)
+            {
+                if (!string.IsNullOrEmpty(chart.FilePath) &&
+                    SongPathIdentity.TryNormalize(chart.FilePath, out var normalized) &&
+                    normalizedRoots.Any(root =>
+                        SongPathIdentity.IsUnderRoot(normalized, root)))
+                {
+                    active.Add((chart.Id, chart.FilePath));
+                }
+            }
+            return active;
+        }
+
+        /// <summary>
         /// Counts <see cref="SongChart"/> rows whose <see cref="SongChart.FilePath"/>
         /// resides under one of <paramref name="roots"/> (root-containment uses
         /// <see cref="SongPathIdentity"/>, mirroring SongManager's active-chart
@@ -2203,6 +2240,15 @@ namespace DTXMania.Game.Lib.Song.Entities
                 // Additive schema upgrade: playback-speed-scoped scores, pitch history,
                 // and durable save receipts.
                 await EnsurePlaybackSpeedScoreScopeAsync(context);
+
+                // Additive schema upgrade: enumeration-freshness metadata. The
+                // cache-freshness check previously derived the last enumeration time
+                // from the database file's last-write time, which any SaveChangesAsync
+                // (bookmark toggle, score save) advances. Persisting an explicit
+                // LastSuccessfulEnumerationUtc value that is updated only after a
+                // successful enumeration avoids later chart edits being masked by an
+                // unrelated database write.
+                await EnsureEnumerationMetadataTableAsync(context);
             }
             finally
             {
@@ -2243,6 +2289,97 @@ namespace DTXMania.Game.Lib.Song.Entities
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not create version table: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Key under which the last successful enumeration timestamp is stored in
+        /// <see cref="__EnumerationMetadata"/>. The value is an ISO 8601 UTC string.
+        /// </summary>
+        private const string LastSuccessfulEnumerationKey = "LastSuccessfulEnumerationUtc";
+
+        /// <summary>
+        /// Ensures the <c>__EnumerationMetadata</c> key/value table exists. Created
+        /// idempotently for both fresh and pre-existing databases via
+        /// <c>CREATE TABLE IF NOT EXISTS</c> (the table is intentionally not modeled
+        /// on <see cref="SongDbContext"/>, so <c>EnsureCreated</c> does not create
+        /// it). The table stores the <see cref="LastSuccessfulEnumerationKey"/>
+        /// timestamp used by the cache-freshness check instead of the database
+        /// file's last-write time.
+        /// </summary>
+        private async Task EnsureEnumerationMetadataTableAsync(SongDbContext context)
+        {
+            try
+            {
+                await context.Database.ExecuteSqlRawAsync(@"
+                    CREATE TABLE IF NOT EXISTS __EnumerationMetadata (
+                        Key TEXT PRIMARY KEY,
+                        Value TEXT NOT NULL
+                    )");
+            }
+            catch (Exception ex)
+            {
+                // Swallow-only is intentional: a failed metadata table must not abort
+                // initialization. The cache-freshness check treats a missing timestamp
+                // as "first-time enumeration" and rescans, which is always safe.
+                System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not create enumeration metadata table: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Returns the UTC timestamp of the last successful enumeration, or null
+        /// when no enumeration has been recorded (fresh database, missing table, or
+        /// unparseable value). Never throws: any storage error is treated as
+        /// "no enumeration recorded" so the caller falls back to a full scan.
+        /// </summary>
+        public async Task<DateTime?> GetLastSuccessfulEnumerationUtcAsync()
+        {
+            try
+            {
+                using var context = CreateContext();
+                var value = await context.Database.SqlQueryRaw<string>(
+                    "SELECT Value FROM __EnumerationMetadata WHERE Key = {0} LIMIT 1",
+                    LastSuccessfulEnumerationKey).ToListAsync();
+                var raw = value.FirstOrDefault();
+                if (string.IsNullOrEmpty(raw) ||
+                    !DateTime.TryParse(raw, null,
+                        System.Globalization.DateTimeStyles.RoundtripKind,
+                        out var parsed))
+                {
+                    return null;
+                }
+                return parsed.ToUniversalTime();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not read last enumeration timestamp: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Persists the UTC timestamp of the most recent successful enumeration.
+        /// Called only after an <see cref="SongEnumerationOutcome.ImportedAndPublished"/>
+        /// result so unrelated <c>SaveChangesAsync</c> calls (bookmark toggles, score
+        /// saves) cannot advance the recorded enumeration time and mask later chart
+        /// edits.
+        /// </summary>
+        public async Task SetLastSuccessfulEnumerationUtcAsync(DateTime utc)
+        {
+            try
+            {
+                using var context = CreateContext();
+                await context.Database.ExecuteSqlRawAsync(
+                    "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
+                    LastSuccessfulEnumerationKey,
+                    utc.ToUniversalTime().ToString("o"));
+            }
+            catch (Exception ex)
+            {
+                // Swallow-only: a failed write leaves the previous timestamp in
+                // place (or none), which only makes the next freshness check more
+                // conservative. Never abort the post-enumeration path over metadata.
+                System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not persist last enumeration timestamp: {ex.Message}");
             }
         }
 

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -1921,19 +1921,25 @@ namespace DTXMania.Game.Lib.Song.Entities
         }
 
         /// <summary>
-        /// Counts <see cref="SongScoreEntity"/> rows whose chart's
-        /// <see cref="SongChart.FilePath"/> resides under one of
-        /// <paramref name="roots"/>, mirroring the active-chart containment rule
-        /// used by <see cref="GetActiveChartIdsAsync"/>. This is the
-        /// active-root-scoped counterpart to the global
-        /// <see cref="DatabaseStats.ScoreCount"/> returned by
-        /// <see cref="GetDatabaseStatsAsync"/>: cache-freshness checks must count
-        /// only the active root set, otherwise retained rows belonging to a
-        /// removed root make the filesystem and database counts diverge forever
-        /// and force a full rescan on every startup. Returns 0 for an empty root
-        /// set or when no active charts have scores.
+        /// Counts <see cref="SongChart"/> rows whose <see cref="SongChart.FilePath"/>
+        /// resides under one of <paramref name="roots"/> (root-containment uses
+        /// <see cref="SongPathIdentity"/>, mirroring SongManager's active-chart
+        /// rule). This is the active-root-scoped chart count compared against the
+        /// filesystem chart-file count by the cache-freshness check.
+        /// <para>
+        /// IMPORTANT: this must count <em>charts</em>, not <see cref="SongScoreEntity"/>
+        /// rows. A single chart has one-to-many <see cref="SongScoreEntity"/> rows
+        /// (uniqueness = ChartId + Instrument + PlaySpeedPercent): import seeds
+        /// DRUMS/GUITAR/BASS rows, and each distinct play speed adds another. Once a
+        /// player records results at multiple speeds or instruments, the score-row
+        /// count permanently exceeds the chart-file count and forces a full rescan
+        /// on every startup. Counting charts keeps the database side of the
+        /// cache-freshness comparison aligned with the filesystem contract (one
+        /// file = one chart).
+        /// </para>
+        /// Returns 0 for an empty root set or when no active charts exist.
         /// </summary>
-        public async Task<int> GetActiveScoreCountAsync(IReadOnlyList<string> roots)
+        public async Task<int> GetActiveChartCountAsync(IReadOnlyList<string> roots)
         {
             if (roots == null || roots.Count == 0)
                 return 0;
@@ -1967,12 +1973,10 @@ namespace DTXMania.Game.Lib.Song.Entities
                 }
             }
 
-            if (activeChartIds.Count == 0)
-                return 0;
-
-            return await context.SongScores
-                .AsNoTracking()
-                .CountAsync(score => activeChartIds.Contains(score.ChartId));
+            // Count active charts, NOT score rows: one chart file maps to many
+            // SongScore rows across instrument and play-speed variants, so the
+            // score count would never match the filesystem file count.
+            return activeChartIds.Count;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -2471,12 +2471,12 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// values are written or none are — a crash or failure mid-write cannot
         /// leave the global timestamp committed while per-root rows are absent.
         /// <para>
-        /// The read path's legacy fallback applies the global watermark to every
-        /// root when zero per-root rows are found. Without atomicity, a partial
-        /// write (global committed, per-root missing) would cause that fallback
-        /// to assign another root's newer timestamp to a returning root and hide
-        /// its edits. This method eliminates that window by committing both the
-        /// global key and every per-root key together.
+        /// The read path treats a missing per-root watermark as "needs
+        /// enumeration" (a conservative full rescan). Without atomicity, a
+        /// partial write (global committed, per-root missing) would force that
+        /// conservative rescan on every startup until per-root rows catch up.
+        /// This method eliminates that window by committing both the global key
+        /// and every per-root key together.
         /// </para>
         /// <para>
         /// Returns <c>true</c> on success, <c>false</c> on failure. A failed

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -1921,6 +1921,61 @@ namespace DTXMania.Game.Lib.Song.Entities
         }
 
         /// <summary>
+        /// Counts <see cref="SongScoreEntity"/> rows whose chart's
+        /// <see cref="SongChart.FilePath"/> resides under one of
+        /// <paramref name="roots"/>, mirroring the active-chart containment rule
+        /// used by <see cref="GetActiveChartIdsAsync"/>. This is the
+        /// active-root-scoped counterpart to the global
+        /// <see cref="DatabaseStats.ScoreCount"/> returned by
+        /// <see cref="GetDatabaseStatsAsync"/>: cache-freshness checks must count
+        /// only the active root set, otherwise retained rows belonging to a
+        /// removed root make the filesystem and database counts diverge forever
+        /// and force a full rescan on every startup. Returns 0 for an empty root
+        /// set or when no active charts have scores.
+        /// </summary>
+        public async Task<int> GetActiveScoreCountAsync(IReadOnlyList<string> roots)
+        {
+            if (roots == null || roots.Count == 0)
+                return 0;
+
+            // Normalize defensively so blank or malformed roots (which
+            // CountDTXFilesAsync also skips) do not abort the count. Mirrors the
+            // active-root pre-normalization in ImportSongsAsync.
+            var normalizedRoots = roots
+                .Select(root =>
+                {
+                    SongPathIdentity.TryNormalize(root, out var normalized);
+                    return normalized;
+                })
+                .Where(r => !string.IsNullOrEmpty(r))
+                .ToArray();
+            if (normalizedRoots.Length == 0)
+                return 0;
+            using var context = CreateContext();
+            var charts = await context.SongCharts
+                .AsNoTracking()
+                .Select(chart => new { chart.Id, chart.FilePath })
+                .ToListAsync();
+            var activeChartIds = new HashSet<int>();
+            foreach (var chart in charts)
+            {
+                if (SongPathIdentity.TryNormalize(chart.FilePath, out var normalized) &&
+                    normalizedRoots.Any(root =>
+                        SongPathIdentity.IsUnderRoot(normalized, root)))
+                {
+                    activeChartIds.Add(chart.Id);
+                }
+            }
+
+            if (activeChartIds.Count == 0)
+                return 0;
+
+            return await context.SongScores
+                .AsNoTracking()
+                .CountAsync(score => activeChartIds.Contains(score.ChartId));
+        }
+
+        /// <summary>
         /// Sets or clears the bookmark flag on a song. No-op if the song id is not found.
         /// </summary>
         public async Task SetBookmarkAsync(int songId, bool bookmarked)

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -1899,9 +1899,19 @@ namespace DTXMania.Game.Lib.Song.Entities
             if (roots == null || roots.Count == 0)
                 return Array.Empty<int>();
 
+            // Normalize defensively so blank or malformed roots do not abort the
+            // query. Mirrors the active-root pre-normalization in
+            // GetActiveChartCountAsync.
             var normalizedRoots = roots
-                .Select(SongPathIdentity.Normalize)
+                .Select(root =>
+                {
+                    SongPathIdentity.TryNormalize(root, out var normalized);
+                    return normalized;
+                })
+                .Where(r => !string.IsNullOrEmpty(r))
                 .ToArray();
+            if (normalizedRoots.Length == 0)
+                return Array.Empty<int>();
             using var context = CreateContext();
             var charts = await context.SongCharts
                 .AsNoTracking()
@@ -1935,9 +1945,19 @@ namespace DTXMania.Game.Lib.Song.Entities
             if (roots == null || roots.Count == 0)
                 return Array.Empty<(int, string)>();
 
+            // Normalize defensively so blank or malformed roots (which
+            // CountDTXFilesAsync also skips) do not abort the lookup. Mirrors
+            // the active-root pre-normalization in GetActiveChartCountAsync.
             var normalizedRoots = roots
-                .Select(SongPathIdentity.Normalize)
+                .Select(root =>
+                {
+                    SongPathIdentity.TryNormalize(root, out var normalized);
+                    return normalized;
+                })
+                .Where(r => !string.IsNullOrEmpty(r))
                 .ToArray();
+            if (normalizedRoots.Length == 0)
+                return Array.Empty<(int, string)>();
             using var context = CreateContext();
             var charts = await context.SongCharts
                 .AsNoTracking()
@@ -2298,8 +2318,22 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// </summary>
         private const string LastSuccessfulEnumerationKey = "LastSuccessfulEnumerationUtc";
 
-        private const string LastSuccessfulEnumerationRootKeyPrefix =
+        /// <summary>
+        /// Key prefix for per-root enumeration watermarks stored in
+        /// <see cref="__EnumerationMetadata"/>. Exposed as internal so tests
+        /// can build the same wildcard delete filter without hardcoding the
+        /// literal. The full key is built by <see cref="BuildRootWatermarkKey"/>.
+        /// </summary>
+        internal const string LastSuccessfulEnumerationRootKeyPrefix =
             "LastSuccessfulEnumerationUtc:Root:";
+
+        /// <summary>
+        /// Builds the per-root watermark key for a normalized root. Centralized
+        /// so the read/write/atomic-write sites cannot drift from each other.
+        /// </summary>
+        private static string BuildRootWatermarkKey(string normalizedRoot) =>
+            LastSuccessfulEnumerationRootKeyPrefix +
+                SongPathIdentity.GetStableRootKey(normalizedRoot);
 
         /// <summary>
         /// Ensures the <c>__EnumerationMetadata</c> key/value table exists. Created
@@ -2375,7 +2409,7 @@ namespace DTXMania.Game.Lib.Song.Entities
                 using var context = CreateContext();
                 var value = await context.Database.SqlQueryRaw<string>(
                     "SELECT Value FROM __EnumerationMetadata WHERE Key = {0} LIMIT 1",
-                    LastSuccessfulEnumerationRootKeyPrefix + SongPathIdentity.GetStableRootKey(normalizedRoot))
+                    BuildRootWatermarkKey(normalizedRoot))
                     .ToListAsync();
                 var raw = value.FirstOrDefault();
                 if (string.IsNullOrEmpty(raw) ||
@@ -2452,7 +2486,7 @@ namespace DTXMania.Game.Lib.Song.Entities
 
                     await context.Database.ExecuteSqlRawAsync(
                         "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
-                        LastSuccessfulEnumerationRootKeyPrefix + SongPathIdentity.GetStableRootKey(normalizedRoot),
+                        BuildRootWatermarkKey(normalizedRoot),
                         value);
                 }
             }
@@ -2511,7 +2545,7 @@ namespace DTXMania.Game.Lib.Song.Entities
 
                         await context.Database.ExecuteSqlRawAsync(
                             "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
-                            LastSuccessfulEnumerationRootKeyPrefix + SongPathIdentity.GetStableRootKey(normalizedRoot),
+                            BuildRootWatermarkKey(normalizedRoot),
                             value).ConfigureAwait(false);
                     }
                 }

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -2375,7 +2375,7 @@ namespace DTXMania.Game.Lib.Song.Entities
                 using var context = CreateContext();
                 var value = await context.Database.SqlQueryRaw<string>(
                     "SELECT Value FROM __EnumerationMetadata WHERE Key = {0} LIMIT 1",
-                    LastSuccessfulEnumerationRootKeyPrefix + normalizedRoot)
+                    LastSuccessfulEnumerationRootKeyPrefix + SongPathIdentity.GetStableRootKey(normalizedRoot))
                     .ToListAsync();
                 var raw = value.FirstOrDefault();
                 if (string.IsNullOrEmpty(raw) ||
@@ -2428,6 +2428,11 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// Persists the same enumeration watermark for each canonical root that
         /// participated in the successful scan. Roots omitted from the list keep
         /// their previous watermark, which is required for partial multi-root scans.
+        /// <para>
+        /// Each root key is built with <see cref="SongPathIdentity.GetStableRootKey"/>
+        /// so that a casing-only change in configuration cannot make a root's
+        /// watermark appear absent on case-insensitive platforms (Windows, macOS).
+        /// </para>
         /// </summary>
         public async Task SetLastSuccessfulEnumerationUtcAsync(
             IReadOnlyList<string> canonicalRoots,
@@ -2447,7 +2452,7 @@ namespace DTXMania.Game.Lib.Song.Entities
 
                     await context.Database.ExecuteSqlRawAsync(
                         "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
-                        LastSuccessfulEnumerationRootKeyPrefix + normalizedRoot,
+                        LastSuccessfulEnumerationRootKeyPrefix + SongPathIdentity.GetStableRootKey(normalizedRoot),
                         value);
                 }
             }
@@ -2457,6 +2462,68 @@ namespace DTXMania.Game.Lib.Song.Entities
                 // none), so the next freshness check remains conservative.
                 System.Diagnostics.Debug.WriteLine(
                     $"SongDatabaseService: Warning - Could not persist root enumeration timestamps: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Atomically persists the global enumeration watermark and every
+        /// active-root watermark in a single database transaction. Either all
+        /// values are written or none are — a crash or failure mid-write cannot
+        /// leave the global timestamp committed while per-root rows are absent.
+        /// <para>
+        /// The read path's legacy fallback applies the global watermark to every
+        /// root when zero per-root rows are found. Without atomicity, a partial
+        /// write (global committed, per-root missing) would cause that fallback
+        /// to assign another root's newer timestamp to a returning root and hide
+        /// its edits. This method eliminates that window by committing both the
+        /// global key and every per-root key together.
+        /// </para>
+        /// <para>
+        /// Returns <c>true</c> on success, <c>false</c> on failure. A failed
+        /// write leaves the previous watermark in place (or none), which only
+        /// makes the next freshness check more conservative — it never creates
+        /// a partial state.
+        /// </para>
+        /// </summary>
+        public async Task<bool> SetEnumerationWatermarkAtomicallyAsync(
+            DateTime utc,
+            IReadOnlyList<string> canonicalRoots)
+        {
+            try
+            {
+                using var context = CreateContext();
+                await using var transaction =
+                    await context.Database.BeginTransactionAsync().ConfigureAwait(false);
+
+                var value = utc.ToUniversalTime().ToString("o");
+
+                await context.Database.ExecuteSqlRawAsync(
+                    "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
+                    LastSuccessfulEnumerationKey,
+                    value).ConfigureAwait(false);
+
+                if (canonicalRoots != null && canonicalRoots.Count > 0)
+                {
+                    foreach (var canonicalRoot in canonicalRoots)
+                    {
+                        if (!SongPathIdentity.TryNormalize(canonicalRoot, out var normalizedRoot))
+                            continue;
+
+                        await context.Database.ExecuteSqlRawAsync(
+                            "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
+                            LastSuccessfulEnumerationRootKeyPrefix + SongPathIdentity.GetStableRootKey(normalizedRoot),
+                            value).ConfigureAwait(false);
+                    }
+                }
+
+                await transaction.CommitAsync().ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongDatabaseService: Warning - Could not atomically persist enumeration watermark: {ex.Message}");
+                return false;
             }
         }
 

--- a/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
+++ b/DTXMania.Game/Lib/Song/Entities/SongDatabaseService.cs
@@ -2298,6 +2298,9 @@ namespace DTXMania.Game.Lib.Song.Entities
         /// </summary>
         private const string LastSuccessfulEnumerationKey = "LastSuccessfulEnumerationUtc";
 
+        private const string LastSuccessfulEnumerationRootKeyPrefix =
+            "LastSuccessfulEnumerationUtc:Root:";
+
         /// <summary>
         /// Ensures the <c>__EnumerationMetadata</c> key/value table exists. Created
         /// idempotently for both fresh and pre-existing databases via
@@ -2358,6 +2361,44 @@ namespace DTXMania.Game.Lib.Song.Entities
         }
 
         /// <summary>
+        /// Returns the UTC timestamp recorded for a canonical song root, or null
+        /// when that root has not been included in a successful enumeration.
+        /// </summary>
+        public async Task<DateTime?> GetLastSuccessfulEnumerationUtcAsync(
+            string canonicalRoot)
+        {
+            try
+            {
+                if (!SongPathIdentity.TryNormalize(canonicalRoot, out var normalizedRoot))
+                    return null;
+
+                using var context = CreateContext();
+                var value = await context.Database.SqlQueryRaw<string>(
+                    "SELECT Value FROM __EnumerationMetadata WHERE Key = {0} LIMIT 1",
+                    LastSuccessfulEnumerationRootKeyPrefix + normalizedRoot)
+                    .ToListAsync();
+                var raw = value.FirstOrDefault();
+                if (string.IsNullOrEmpty(raw) ||
+                    !DateTime.TryParse(
+                        raw,
+                        null,
+                        DateTimeStyles.RoundtripKind,
+                        out var parsed))
+                {
+                    return null;
+                }
+
+                return parsed.ToUniversalTime();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongDatabaseService: Warning - Could not read root enumeration timestamp: {ex.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Persists the UTC timestamp of the most recent successful enumeration.
         /// Called only after an <see cref="SongEnumerationOutcome.ImportedAndPublished"/>
         /// result so unrelated <c>SaveChangesAsync</c> calls (bookmark toggles, score
@@ -2380,6 +2421,42 @@ namespace DTXMania.Game.Lib.Song.Entities
                 // place (or none), which only makes the next freshness check more
                 // conservative. Never abort the post-enumeration path over metadata.
                 System.Diagnostics.Debug.WriteLine($"SongDatabaseService: Warning - Could not persist last enumeration timestamp: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Persists the same enumeration watermark for each canonical root that
+        /// participated in the successful scan. Roots omitted from the list keep
+        /// their previous watermark, which is required for partial multi-root scans.
+        /// </summary>
+        public async Task SetLastSuccessfulEnumerationUtcAsync(
+            IReadOnlyList<string> canonicalRoots,
+            DateTime utc)
+        {
+            if (canonicalRoots == null || canonicalRoots.Count == 0)
+                return;
+
+            try
+            {
+                using var context = CreateContext();
+                var value = utc.ToUniversalTime().ToString("o");
+                foreach (var canonicalRoot in canonicalRoots)
+                {
+                    if (!SongPathIdentity.TryNormalize(canonicalRoot, out var normalizedRoot))
+                        continue;
+
+                    await context.Database.ExecuteSqlRawAsync(
+                        "INSERT OR REPLACE INTO __EnumerationMetadata (Key, Value) VALUES ({0}, {1})",
+                        LastSuccessfulEnumerationRootKeyPrefix + normalizedRoot,
+                        value);
+                }
+            }
+            catch (Exception ex)
+            {
+                // A failed root watermark leaves the previous value in place (or
+                // none), so the next freshness check remains conservative.
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongDatabaseService: Warning - Could not persist root enumeration timestamps: {ex.Message}");
             }
         }
 

--- a/DTXMania.Game/Lib/Song/SongEnumerationBusyException.cs
+++ b/DTXMania.Game/Lib/Song/SongEnumerationBusyException.cs
@@ -1,0 +1,32 @@
+#nullable enable
+
+using System;
+
+namespace DTXMania.Game.Lib.Song
+{
+    /// <summary>
+    /// Thrown when song enumeration is requested while another enumeration is
+    /// already in progress. Derives from <see cref="InvalidOperationException"/>
+    /// so existing handlers that catch <c>InvalidOperationException</c> continue
+    /// to classify this condition, while callers that need to distinguish a busy
+    /// enumeration from other invalid-operation failures can catch this type
+    /// directly instead of string-matching the message.
+    /// </summary>
+    public sealed class SongEnumerationBusyException : InvalidOperationException
+    {
+        public SongEnumerationBusyException()
+            : base("Song enumeration is already in progress.")
+        {
+        }
+
+        public SongEnumerationBusyException(string message)
+            : base(message)
+        {
+        }
+
+        public SongEnumerationBusyException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/SongImportModels.cs
+++ b/DTXMania.Game/Lib/Song/SongImportModels.cs
@@ -106,6 +106,42 @@ namespace DTXMania.Game.Lib.Song
         NoActiveRoots,
     }
 
+    /// <summary>
+    /// Identifies the live-library phase that failed after the database import
+    /// had already committed. Callers must not present this as a rollback.
+    /// </summary>
+    public enum SongEnumerationPostCommitPhase
+    {
+        Finalization,
+        Publication,
+    }
+
+    /// <summary>
+    /// Signals an HPA-192 failure after the import transaction committed but
+    /// before its in-memory library publication completed. The captured batch
+    /// lets callers retain accurate root-failure diagnostics while reporting
+    /// the operation as partial success requiring recovery/restart.
+    /// </summary>
+    public sealed class SongEnumerationPostCommitException : Exception
+    {
+        internal SongEnumerationPostCommitException(
+            SongEnumerationPostCommitPhase phase,
+            SongEnumerationBatch batch,
+            SongBulkImportResult import,
+            Exception innerException)
+            : base($"Song enumeration {phase.ToString().ToLowerInvariant()} failed after database commit.",
+                innerException)
+        {
+            Phase = phase;
+            Batch = batch ?? throw new ArgumentNullException(nameof(batch));
+            Import = import ?? throw new ArgumentNullException(nameof(import));
+        }
+
+        public SongEnumerationPostCommitPhase Phase { get; }
+        public SongEnumerationBatch Batch { get; }
+        public SongBulkImportResult Import { get; }
+    }
+
     public sealed record SongEnumerationResult(
         SongEnumerationOutcome Outcome,
         SongEnumerationBatch Batch,

--- a/DTXMania.Game/Lib/Song/SongImportModels.cs
+++ b/DTXMania.Game/Lib/Song/SongImportModels.cs
@@ -34,8 +34,8 @@ namespace DTXMania.Game.Lib.Song
     /// </summary>
     internal sealed record ChartInventoryEntry(
         string Path,
-        DateTime LastWriteTime,
-        DateTime CreationTime);
+        DateTime LastWriteTimeUtc,
+        DateTime CreationTimeUtc);
 
     /// <summary>
     /// The result of a single filesystem walk over the active song roots that

--- a/DTXMania.Game/Lib/Song/SongImportModels.cs
+++ b/DTXMania.Game/Lib/Song/SongImportModels.cs
@@ -27,6 +27,40 @@ namespace DTXMania.Game.Lib.Song
         string Message,
         bool IsRootFailure);
 
+    /// <summary>
+    /// One filesystem entry (chart file, set.def, or directory) collected by the
+    /// shared chart-inventory scanner, with the timestamps the cache-freshness
+    /// change check compares against the last successful enumeration time.
+    /// </summary>
+    internal sealed record ChartInventoryEntry(
+        string Path,
+        DateTime LastWriteTime,
+        DateTime CreationTime);
+
+    /// <summary>
+    /// The result of a single filesystem walk over the active song roots that
+    /// mirrors full enumeration's directory and set.def discovery rules. Used by
+    /// both the chart-file count and the mtime change check so they agree with
+    /// what full enumeration would import (set.def-referenced charts only, no
+    /// unreferenced/backup charts; case-insensitive extension matching) and so
+    /// the active roots are walked once instead of once per extension per pass.
+    /// <para>
+    /// <see cref="Charts"/> holds exactly the chart files full enumeration would
+    /// import (deduplicated by normalized path so overlapping roots or a set.def
+    /// referencing the same file from two difficulties cannot double-count).
+    /// <see cref="SetDefinitions"/> holds every <c>set.def</c> discovered (its
+    /// modification signals a rescan even when referenced charts are unchanged).
+    /// <see cref="Directories"/> holds every directory visited for the directory
+    /// mtime change signal.
+    /// </para>
+    /// </summary>
+    internal sealed class ChartInventory
+    {
+        public List<ChartInventoryEntry> Charts { get; } = new();
+        public List<ChartInventoryEntry> SetDefinitions { get; } = new();
+        public List<ChartInventoryEntry> Directories { get; } = new();
+    }
+
     internal enum SongBulkImportMilestone
     {
         PreloadStarted,

--- a/DTXMania.Game/Lib/Song/SongImportModels.cs
+++ b/DTXMania.Game/Lib/Song/SongImportModels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using DTXMania.Game.Lib.Song.Entities;
 
 namespace DTXMania.Game.Lib.Song
@@ -80,10 +81,47 @@ namespace DTXMania.Game.Lib.Song
         int StaleCharts,
         int StaleSongs,
         TimeSpan PersistenceDuration,
-        TimeSpan CleanupDuration);
+        TimeSpan CleanupDuration)
+    {
+        private static readonly IReadOnlyDictionary<string, SongChart> EmptyCharts =
+            new ReadOnlyDictionary<string, SongChart>(
+                new Dictionary<string, SongChart>(StringComparer.Ordinal));
+
+        public static SongBulkImportResult Empty { get; } = new(
+            EmptyCharts,
+            Added: 0,
+            Updated: 0,
+            Preserved: 0,
+            Skipped: 0,
+            Conflicts: 0,
+            StaleCharts: 0,
+            StaleSongs: 0,
+            PersistenceDuration: TimeSpan.Zero,
+            CleanupDuration: TimeSpan.Zero);
+    }
+
+    public enum SongEnumerationOutcome
+    {
+        ImportedAndPublished,
+        NoActiveRoots,
+    }
 
     public sealed record SongEnumerationResult(
+        SongEnumerationOutcome Outcome,
         SongEnumerationBatch Batch,
         SongBulkImportResult Import,
-        TimeSpan HierarchyDuration);
+        TimeSpan HierarchyDuration)
+    {
+        public SongEnumerationResult(
+            SongEnumerationBatch batch,
+            SongBulkImportResult import,
+            TimeSpan hierarchyDuration)
+            : this(
+                SongEnumerationOutcome.ImportedAndPublished,
+                batch,
+                import,
+                hierarchyDuration)
+        {
+        }
+    }
 }

--- a/DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs
+++ b/DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DTXMania.Game.Lib.Song
+{
+    /// <summary>
+    /// Immutable-at-publication view of the song library. The lists are copied at
+    /// construction so a subsequent publication cannot mutate a reader's view.
+    /// </summary>
+    public sealed record SongLibrarySnapshot
+    {
+        public SongLibrarySnapshot(
+            long Version,
+            IReadOnlyList<SongListNode> RootSongs,
+            IReadOnlyList<string> ActiveRoots,
+            int EnumeratedFileCount,
+            int DiscoveredScoreCount)
+        {
+            ArgumentNullException.ThrowIfNull(RootSongs);
+            ArgumentNullException.ThrowIfNull(ActiveRoots);
+
+            this.Version = Version;
+            this.RootSongs = Array.AsReadOnly(RootSongs.ToArray());
+            this.ActiveRoots = Array.AsReadOnly(ActiveRoots.ToArray());
+            this.EnumeratedFileCount = EnumeratedFileCount;
+            this.DiscoveredScoreCount = DiscoveredScoreCount;
+        }
+
+        public long Version { get; }
+        public IReadOnlyList<SongListNode> RootSongs { get; }
+        public IReadOnlyList<string> ActiveRoots { get; }
+        public int EnumeratedFileCount { get; }
+        public int DiscoveredScoreCount { get; }
+
+        public void Deconstruct(
+            out long Version,
+            out IReadOnlyList<SongListNode> RootSongs,
+            out IReadOnlyList<string> ActiveRoots,
+            out int EnumeratedFileCount,
+            out int DiscoveredScoreCount)
+        {
+            Version = this.Version;
+            RootSongs = this.RootSongs;
+            ActiveRoots = this.ActiveRoots;
+            EnumeratedFileCount = this.EnumeratedFileCount;
+            DiscoveredScoreCount = this.DiscoveredScoreCount;
+        }
+    }
+
+    public sealed class SongLibraryPublishedEventArgs : EventArgs
+    {
+        public SongLibraryPublishedEventArgs(SongLibrarySnapshot snapshot)
+        {
+            Snapshot = snapshot ?? throw new ArgumentNullException(nameof(snapshot));
+        }
+
+        public SongLibrarySnapshot Snapshot { get; }
+    }
+}

--- a/DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs
+++ b/DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs
@@ -13,20 +13,20 @@ namespace DTXMania.Game.Lib.Song
     public sealed record SongLibrarySnapshot
     {
         public SongLibrarySnapshot(
-            long Version,
-            IReadOnlyList<SongListNode> RootSongs,
-            IReadOnlyList<string> ActiveRoots,
-            int EnumeratedFileCount,
-            int DiscoveredScoreCount)
+            long version,
+            IReadOnlyList<SongListNode> rootSongs,
+            IReadOnlyList<string> activeRoots,
+            int enumeratedFileCount,
+            int discoveredScoreCount)
         {
-            ArgumentNullException.ThrowIfNull(RootSongs);
-            ArgumentNullException.ThrowIfNull(ActiveRoots);
+            ArgumentNullException.ThrowIfNull(rootSongs);
+            ArgumentNullException.ThrowIfNull(activeRoots);
 
-            this.Version = Version;
-            this.RootSongs = Array.AsReadOnly(RootSongs.ToArray());
-            this.ActiveRoots = Array.AsReadOnly(ActiveRoots.ToArray());
-            this.EnumeratedFileCount = EnumeratedFileCount;
-            this.DiscoveredScoreCount = DiscoveredScoreCount;
+            Version = version;
+            RootSongs = Array.AsReadOnly(rootSongs.ToArray());
+            ActiveRoots = Array.AsReadOnly(activeRoots.ToArray());
+            EnumeratedFileCount = enumeratedFileCount;
+            DiscoveredScoreCount = discoveredScoreCount;
         }
 
         public long Version { get; }
@@ -36,17 +36,17 @@ namespace DTXMania.Game.Lib.Song
         public int DiscoveredScoreCount { get; }
 
         public void Deconstruct(
-            out long Version,
-            out IReadOnlyList<SongListNode> RootSongs,
-            out IReadOnlyList<string> ActiveRoots,
-            out int EnumeratedFileCount,
-            out int DiscoveredScoreCount)
+            out long version,
+            out IReadOnlyList<SongListNode> rootSongs,
+            out IReadOnlyList<string> activeRoots,
+            out int enumeratedFileCount,
+            out int discoveredScoreCount)
         {
-            Version = this.Version;
-            RootSongs = this.RootSongs;
-            ActiveRoots = this.ActiveRoots;
-            EnumeratedFileCount = this.EnumeratedFileCount;
-            DiscoveredScoreCount = this.DiscoveredScoreCount;
+            version = Version;
+            rootSongs = RootSongs;
+            activeRoots = ActiveRoots;
+            enumeratedFileCount = EnumeratedFileCount;
+            discoveredScoreCount = DiscoveredScoreCount;
         }
     }
 

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -4135,6 +4135,13 @@ namespace DTXMania.Game.Lib.Song
         /// for the roots in the successful batch so a partial multi-root scan
         /// cannot advance another root's watermark. Unrelated database writes
         /// (bookmark toggles, score saves) cannot advance either value.
+        /// <para>
+        /// The global and per-root watermarks are written as one atomic database
+        /// transaction. A crash or failure mid-write cannot leave the global
+        /// timestamp committed while per-root rows are absent, which would
+        /// otherwise cause the legacy fallback to assign another root's newer
+        /// timestamp to a returning root and hide its edits.
+        /// </para>
         /// </summary>
         private async Task SetEnumerationWatermarkAsync(
             IReadOnlyList<string> activeRoots,
@@ -4144,11 +4151,20 @@ namespace DTXMania.Game.Lib.Song
             {
                 if (_databaseService == null) return;
 
-                await _databaseService.SetLastSuccessfulEnumerationUtcAsync(startUtc);
-                await _databaseService.SetLastSuccessfulEnumerationUtcAsync(
-                    activeRoots,
-                    startUtc);
-                Debug.WriteLine($"SongManager: Enumeration watermark persisted at {startUtc:yyyy-MM-dd HH:mm:ss} UTC (scan start)");
+                var success = await _databaseService
+                    .SetEnumerationWatermarkAtomicallyAsync(startUtc, activeRoots)
+                    .ConfigureAwait(false);
+                if (success)
+                {
+                    Debug.WriteLine($"SongManager: Enumeration watermark persisted at {startUtc:yyyy-MM-dd HH:mm:ss} UTC (scan start)");
+                }
+                else
+                {
+                    // A failed write leaves the previous watermark in place (or
+                    // none), so the next freshness check remains conservative.
+                    // No partial state is possible because the write is atomic.
+                    Debug.WriteLine($"SongManager: Enumeration watermark write failed; previous watermark retained.");
+                }
             }
             catch (Exception ex)
             {

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -71,6 +71,10 @@ namespace DTXMania.Game.Lib.Song
         private CancellationTokenSource? _enumCancellation;
         private SongDatabaseService? _databaseService;
         private string[] _currentSearchPaths = Array.Empty<string>();
+        private long _publicationVersion;
+
+        internal SongRootPolicy RootPolicy { get; set; } =
+            SongRootPolicy.ForCurrentPlatform();
 
         internal Func<string, Task<(SongEntity song, SongChart chart)>>
             ParseSongEntitiesCoreAsync { get; set; } =
@@ -156,21 +160,11 @@ namespace DTXMania.Game.Lib.Song
             }
         }
 
-        private void SetCurrentSearchPaths(string[] searchPaths)
+        internal void SetCurrentSearchPaths(IReadOnlyList<string> searchPaths)
         {
-            if (searchPaths == null || searchPaths.Length == 0)
-                return;
-
-            // Normalize once, retaining only successful results, then dedupe.
-            var normalized = new List<string>(searchPaths.Length);
-            foreach (var path in searchPaths)
-            {
-                if (SongPathIdentity.TryNormalize(path, out var normalizedPath))
-                    normalized.Add(normalizedPath);
-            }
-
-            var distinct = normalized
-                .Distinct(SongPathIdentity.CanonicalComparer)
+            ArgumentNullException.ThrowIfNull(searchPaths);
+            var distinct = RootPolicy.Validate(searchPaths)
+                .CanonicalRoots
                 .ToArray();
 
             // Assign under the same lock used by GetCurrentSearchPathsSnapshot,
@@ -194,13 +188,17 @@ namespace DTXMania.Game.Lib.Song
         /// </summary>
         public IReadOnlyList<SongListNode> RootSongs
         {
-            get
-            {
-                lock (_lockObject)
-                {
-                    return _rootSongs.AsReadOnly();
-                }
-            }
+            get => GetLibrarySnapshot().RootSongs;
+        }
+
+        /// <summary>
+        /// Gets a stable, versioned view of the currently published library.
+        /// Reading never changes the publication version.
+        /// </summary>
+        public SongLibrarySnapshot GetLibrarySnapshot()
+        {
+            lock (_lockObject)
+                return CreateSnapshotLocked();
         }
 
         /// <summary>
@@ -269,6 +267,12 @@ namespace DTXMania.Game.Lib.Song
         /// Fired when enumeration completes
         /// </summary>
         public event EventHandler? EnumerationCompleted;
+
+        /// <summary>
+        /// Fired after a complete library snapshot has been published. Subscribers run
+        /// outside the manager lock and always receive one coherent hierarchy/root view.
+        /// </summary>
+        public event EventHandler<SongLibraryPublishedEventArgs>? SongLibraryPublished;
 
         #endregion
 
@@ -390,7 +394,6 @@ namespace DTXMania.Game.Lib.Song
         {
             try
             {
-                SetCurrentSearchPaths(searchPaths);
                 var db = GetDatabaseServiceSnapshot();
                 if (db == null)
                 {
@@ -452,9 +455,12 @@ namespace DTXMania.Game.Lib.Song
                 cancellationToken,
                 observer: null,
                 linked).ConfigureAwait(false);
-            await UpdateEnumerationTimestampAsync().ConfigureAwait(false);
+            if (result.Outcome == SongEnumerationOutcome.ImportedAndPublished)
+                await UpdateEnumerationTimestampAsync().ConfigureAwait(false);
 
-            return (result.Batch.Candidates.Count, true);
+            return (
+                result.Batch.Candidates.Count,
+                result.Outcome == SongEnumerationOutcome.ImportedAndPublished);
         }
 
         /// <summary>
@@ -525,8 +531,6 @@ namespace DTXMania.Game.Lib.Song
         /// </summary>
         public async Task BuildSongListFromDatabasePublicAsync(string[] searchPaths)
         {
-            SetCurrentSearchPaths(searchPaths);
-
             await BuildHierarchyFromDatabaseOnceAsync(searchPaths).ConfigureAwait(false);
         }
 
@@ -744,6 +748,17 @@ namespace DTXMania.Game.Lib.Song
                         "An incomplete enumeration cannot be imported.");
                 }
 
+                if (batch.ActiveRoots.Count == 0)
+                {
+                    result = new SongEnumerationResult(
+                        SongEnumerationOutcome.NoActiveRoots,
+                        batch,
+                        SongBulkImportResult.Empty,
+                        TimeSpan.Zero);
+                    outcome = StartupOperationOutcome.Success;
+                    return result;
+                }
+
                 var import = await ImportSongsCoreAsync(
                     database,
                     new SongBulkImportRequest(
@@ -759,6 +774,7 @@ namespace DTXMania.Game.Lib.Song
                 PublishEnumeration(batch);
 
                 result = new SongEnumerationResult(
+                    SongEnumerationOutcome.ImportedAndPublished,
                     batch,
                     import,
                     hierarchy.Elapsed);
@@ -875,64 +891,48 @@ namespace DTXMania.Game.Lib.Song
             public List<string> OrderedChartPaths { get; } = new();
         }
 
-        private static SongEnumerationBatchBuilder CreateBatchBuilder(
+        private SongEnumerationBatchBuilder CreateBatchBuilder(
             IEnumerable<string> searchPaths)
         {
             ArgumentNullException.ThrowIfNull(searchPaths);
-            var validRoots = new List<string>();
+            var configuredRoots = searchPaths.ToArray();
+            var validation = RootPolicy.Validate(configuredRoots);
             var errors = new List<SongEnumerationError>();
-            foreach (var path in searchPaths)
+            foreach (var diagnostic in validation.Diagnostics)
             {
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    var blankError = new SongEnumerationError(
-                        path ?? string.Empty,
-                        "A configured song root is blank.",
-                        IsRootFailure: true);
-                    errors.Add(blankError);
-                    Debug.WriteLine(
-                        $"SongManager: skipping blank song root: {blankError.Message}");
+                if (diagnostic.IsWarning)
                     continue;
-                }
 
-                string normalized;
-                try
-                {
-                    normalized = SongPathIdentity.Normalize(path);
-                }
-                catch (Exception ex) when (
-                    ex is ArgumentException or NotSupportedException
-                        or System.IO.PathTooLongException)
-                {
-                    var normalizeError = new SongEnumerationError(
-                        path,
-                        $"Configured song root path is invalid: {ex.Message}",
-                        IsRootFailure: true);
-                    errors.Add(normalizeError);
-                    Debug.WriteLine(
-                        $"SongManager: skipping invalid song root: {normalizeError.Message}");
-                    continue;
-                }
-
-                if (!Directory.Exists(normalized))
-                {
-                    var missingError = new SongEnumerationError(
-                        normalized,
-                        $"Configured song root does not exist: {normalized}",
-                        IsRootFailure: true);
-                    errors.Add(missingError);
-                    Debug.WriteLine(
-                        $"SongManager: skipping missing song root: {missingError.Message}");
-                    continue;
-                }
-
-                validRoots.Add(normalized);
+                var error = new SongEnumerationError(
+                    diagnostic.Path,
+                    diagnostic.Message,
+                    IsRootFailure: true);
+                errors.Add(error);
+                Debug.WriteLine($"SongManager: skipping song root: {error.Message}");
             }
 
-            var distinctRoots = validRoots
-                .Distinct(SongPathIdentity.CanonicalComparer)
-                .ToArray();
-            return new SongEnumerationBatchBuilder(distinctRoots, errors);
+            var activeRoots = new List<string>();
+            foreach (var normalizedRoot in validation.CanonicalRoots)
+            {
+                var availability = RootPolicy.Probe(normalizedRoot);
+                if (availability == SongRootAvailability.Available)
+                {
+                    activeRoots.Add(normalizedRoot);
+                    continue;
+                }
+
+                var message = availability == SongRootAvailability.Missing
+                    ? $"Configured song root does not exist: {normalizedRoot}"
+                    : $"Configured song root is inaccessible: {normalizedRoot}";
+                var error = new SongEnumerationError(
+                    normalizedRoot,
+                    message,
+                    IsRootFailure: true);
+                errors.Add(error);
+                Debug.WriteLine($"SongManager: skipping song root: {error.Message}");
+            }
+
+            return new SongEnumerationBatchBuilder(activeRoots, errors);
         }
 
         private async Task EnumerateDirectoryIntoBatchAsync(
@@ -1454,23 +1454,66 @@ namespace DTXMania.Game.Lib.Song
 
         internal void PublishEnumeration(SongEnumerationBatch batch)
         {
+            ArgumentNullException.ThrowIfNull(batch);
+            SongLibrarySnapshot snapshot;
             lock (_lockObject)
             {
                 _rootSongs.Clear();
                 _rootSongs.AddRange(batch.RootNodes);
-                _currentSearchPaths = batch.ActiveRoots.ToArray();
+                _currentSearchPaths = RootPolicy.Validate(batch.ActiveRoots)
+                    .CanonicalRoots
+                    .ToArray();
                 EnumeratedFileCount = batch.DiscoveredChartPaths.Count;
                 // Count discovered difficulty charts, not grouped logical songs:
                 // a multi-difficulty set contributes one PendingSong but one
                 // candidate per chart, and the contract is "number of discovered
                 // scores" (mirroring the legacy per-chart increment).
                 DiscoveredScoreCount = batch.Candidates.Count;
+                _publicationVersion++;
+                snapshot = CreateSnapshotLocked();
             }
 
+            SafeInvoke(
+                SongLibraryPublished,
+                this,
+                new SongLibraryPublishedEventArgs(snapshot),
+                nameof(SongLibraryPublished));
             foreach (var song in FlattenScoreNodes(batch.RootNodes))
                 SafeInvoke(SongDiscovered, this, new SongDiscoveredEventArgs(song), nameof(SongDiscovered));
             SafeInvoke(EnumerationCompleted, this, EventArgs.Empty, nameof(EnumerationCompleted));
         }
+
+        /// <summary>
+        /// Publishes an explicit empty library. Startup uses this to distinguish an
+        /// intentionally empty accepted-root set from a failed or unfinished enumeration.
+        /// </summary>
+        public void PublishEmptyLibrary()
+        {
+            SongLibrarySnapshot snapshot;
+            lock (_lockObject)
+            {
+                _rootSongs.Clear();
+                _currentSearchPaths = Array.Empty<string>();
+                EnumeratedFileCount = 0;
+                DiscoveredScoreCount = 0;
+                _publicationVersion++;
+                snapshot = CreateSnapshotLocked();
+            }
+
+            SafeInvoke(
+                SongLibraryPublished,
+                this,
+                new SongLibraryPublishedEventArgs(snapshot),
+                nameof(SongLibraryPublished));
+        }
+
+        private SongLibrarySnapshot CreateSnapshotLocked() =>
+            new(
+                _publicationVersion,
+                Array.AsReadOnly(_rootSongs.ToArray()),
+                Array.AsReadOnly(_currentSearchPaths.ToArray()),
+                EnumeratedFileCount,
+                DiscoveredScoreCount);
 
         // Subscribers run independently so that one throwing handler cannot
         // suppress later handlers, cannot stop EnumerationCompleted, and —
@@ -1560,23 +1603,14 @@ namespace DTXMania.Game.Lib.Song
             {
                 var newRootNodes = new List<SongListNode>();
                 var allSongs = await db.GetSongsAsync().ConfigureAwait(false);
+                var configuredRoots = RootPolicy.Validate(searchPaths)
+                    .CanonicalRoots;
+                var availableRoots = configuredRoots
+                    .Where(root => RootPolicy.Probe(root) == SongRootAvailability.Available)
+                    .ToArray();
 
-                foreach (var searchPath in searchPaths)
+                foreach (var normalizedRoot in availableRoots)
                 {
-                    if (string.IsNullOrEmpty(searchPath) || !Directory.Exists(searchPath))
-                    {
-                        Debug.WriteLine($"SongManager: Skipping invalid path during database rebuild: {searchPath}");
-                        continue;
-                    }
-
-                    // Normalize the search-path root once instead of re-normalizing
-                    // it for every chart via IsUnderRoot.
-                    if (!SongPathIdentity.TryNormalize(searchPath, out var normalizedRoot))
-                    {
-                        Debug.WriteLine($"SongManager: Skipping unnormalizable path during database rebuild: {searchPath}");
-                        continue;
-                    }
-
                     // Get all charts that belong to this search path
                     var relevantCharts = allSongs
                         .SelectMany(song => song.Charts
@@ -1591,21 +1625,37 @@ namespace DTXMania.Game.Lib.Song
                         .ToList();
 
                     // Build the folder hierarchy structure from file paths
-                    var pathNodes = await BuildHierarchyFromCharts(searchPath, relevantCharts);
+                    var pathNodes = await BuildHierarchyFromCharts(normalizedRoot, relevantCharts);
                     newRootNodes.AddRange(pathNodes);
                 }
 
-                // Update root songs list
-                lock (_lockObject)
-                {
-                    _rootSongs.Clear();
-                    _rootSongs.AddRange(newRootNodes);
-                }
+                PublishDatabaseHierarchy(newRootNodes, configuredRoots);
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"SongManager: Error building song list from database: {ex.Message}");
             }
+        }
+
+        private void PublishDatabaseHierarchy(
+            IReadOnlyList<SongListNode> rootNodes,
+            IReadOnlyList<string> activeRoots)
+        {
+            SongLibrarySnapshot snapshot;
+            lock (_lockObject)
+            {
+                _rootSongs.Clear();
+                _rootSongs.AddRange(rootNodes);
+                _currentSearchPaths = activeRoots.ToArray();
+                _publicationVersion++;
+                snapshot = CreateSnapshotLocked();
+            }
+
+            SafeInvoke(
+                SongLibraryPublished,
+                this,
+                new SongLibraryPublishedEventArgs(snapshot),
+                nameof(SongLibraryPublished));
         }
 
         /// <summary>
@@ -3270,7 +3320,6 @@ namespace DTXMania.Game.Lib.Song
         {
             try
             {
-                SetCurrentSearchPaths(searchPaths);
                 if (forceEnumeration)
                 {
                     Debug.WriteLine("SongManager: Force enumeration requested");
@@ -3295,7 +3344,14 @@ namespace DTXMania.Game.Lib.Song
                 Debug.WriteLine($"SongManager: Database contains {stats.SongCount} songs, checking for filesystem changes...");
 
                 // Check for filesystem changes by comparing directory modification times
-                var changeDetected = await DetectFilesystemChangesAsync(searchPaths);
+                // Cache freshness must evaluate the same canonical root set as database
+                // hierarchy rebuilds and filesystem enumeration. Otherwise duplicate or
+                // overlapping configured roots can double-count charts here while the
+                // published library only contains one root identity.
+                var canonicalRoots = RootPolicy.Validate(searchPaths)
+                    .CanonicalRoots
+                    .ToArray();
+                var changeDetected = await DetectFilesystemChangesAsync(canonicalRoots);
                 if (changeDetected)
                 {
                     Debug.WriteLine("SongManager: Filesystem changes detected, enumeration needed");
@@ -4006,6 +4062,7 @@ namespace DTXMania.Game.Lib.Song
         /// </summary>
         public void Clear()
         {
+            SongLibrarySnapshot snapshot;
             lock (_lockObject)
             {
                 // Cancel any ongoing enumeration first
@@ -4018,6 +4075,9 @@ namespace DTXMania.Game.Lib.Song
                 _databaseService?.Dispose();
                 _databaseService = null;
                 _currentSearchPaths = Array.Empty<string>();
+                EnumeratedFileCount = 0;
+                DiscoveredScoreCount = 0;
+                _publicationVersion++;
                 ParseSongEntitiesCoreAsync =
                     DTXChartParser.ParseSongEntitiesAsync;
                 EnumerateFilesCore = Directory.EnumerateFiles;
@@ -4031,9 +4091,15 @@ namespace DTXMania.Game.Lib.Song
                 BuildEnumerationBatchCoreAsync =
                     (searchPaths, progress, token) =>
                         BuildEnumerationBatchAsync(searchPaths, progress, token);
+                RootPolicy = SongRootPolicy.ForCurrentPlatform();
+                snapshot = CreateSnapshotLocked();
             }
-            DiscoveredScoreCount = 0;
-            EnumeratedFileCount = 0;
+
+            SafeInvoke(
+                SongLibraryPublished,
+                this,
+                new SongLibraryPublishedEventArgs(snapshot),
+                nameof(SongLibraryPublished));
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -504,8 +504,6 @@ namespace DTXMania.Game.Lib.Song
                 cancellationToken,
                 observer: null,
                 linked).ConfigureAwait(false);
-            if (result.Outcome == SongEnumerationOutcome.ImportedAndPublished)
-                await UpdateEnumerationTimestampAsync().ConfigureAwait(false);
 
             return (
                 result.Batch.Candidates.Count,
@@ -776,6 +774,16 @@ namespace DTXMania.Game.Lib.Song
         {
             SongEnumerationResult? result = null;
             var outcome = StartupOperationOutcome.Failure;
+
+            // Capture the enumeration start as the freshness watermark. It is
+            // persisted only after successful publication so that any file edit
+            // during the (possibly long) scan remains newer than the watermark
+            // and triggers the next refresh. Using the completion time instead
+            // would mask mid-scan edits: a file parsed early and then modified
+            // while other roots are still scanning would have an mtime older
+            // than the completion-time watermark and be silently ignored.
+            var enumerationStartedUtc = DateTime.UtcNow;
+
             try
             {
                 // The cancellation check and database snapshot must run inside
@@ -853,6 +861,14 @@ namespace DTXMania.Game.Lib.Song
                     import,
                     hierarchy.Elapsed);
                 outcome = StartupOperationOutcome.Success;
+
+                // Persist the START watermark (not the completion time) so that
+                // mid-scan edits remain newer than the watermark and are detected
+                // by the next freshness check. NoActiveRoots and failure paths
+                // do not update the watermark: nothing was enumerated.
+                await SetEnumerationWatermarkAsync(enumerationStartedUtc)
+                    .ConfigureAwait(false);
+
                 return result;
             }
             catch (OperationCanceledException)
@@ -3634,8 +3650,8 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Detects filesystem changes in song directories by walking the active
-        /// roots once via the shared chart-inventory scanner.
+        /// Detects filesystem changes in song directories by walking the
+        /// available roots once via the shared chart-inventory scanner.
         /// </summary>
         private async Task<bool> DetectFilesystemChangesAsync(string[] searchPaths)
         {
@@ -3649,29 +3665,50 @@ namespace DTXMania.Game.Lib.Song
                     return true; // First time enumeration
                 }
 
-                Debug.WriteLine($"SongManager: Last enumeration was at {lastEnumerationTime:yyyy-MM-dd HH:mm:ss}");
+                Debug.WriteLine($"SongManager: Last enumeration was at {lastEnumerationTime:yyyy-MM-dd HH:mm:ss} UTC");
 
-                // Walk the active roots once, mirroring full enumeration's directory
-                // and set.def discovery rules. The inventory yields exactly the chart
-                // files enumeration would import (set.def-referenced charts only in a
-                // set.def directory; case-insensitive extension matching) plus the
-                // set.def and directory mtimes used by the change check below. This
-                // replaces the previous per-extension recursive globs (six walks for
-                // counting plus seven for timestamp checking per root).
+                // Probe canonical roots once and carry only currently available
+                // roots through every downstream check. A missing or inaccessible
+                // configured root is a diagnostic condition, NOT a filesystem
+                // change: a full scan cannot make the root available, and
+                // treating its absence as a change whenever another root has
+                // charts forces a perpetual rescan on every startup. When the
+                // root returns (external drive reattached, network share
+                // mounted), the count mismatch between the filesystem inventory
+                // — now including it — and the scoped database count naturally
+                // triggers a refresh.
+                var availableRoots = new List<string>(searchPaths.Length);
+                foreach (var searchPath in searchPaths)
+                {
+                    if (string.IsNullOrEmpty(searchPath))
+                        continue;
+                    if (Directory.Exists(searchPath))
+                        availableRoots.Add(searchPath);
+                    else
+                        Debug.WriteLine($"SongManager: Configured root unavailable, skipping freshness check: {searchPath}");
+                }
+
+                // Walk the available roots once, mirroring full enumeration's
+                // directory and set.def discovery rules. The inventory yields
+                // exactly the chart files enumeration would import (set.def-
+                // referenced charts only in a set.def directory; case-insensitive
+                // extension matching) plus the set.def and directory mtimes used
+                // by the change check below.
                 var inventory = await ScanChartInventoryAsync(
-                    searchPaths, CancellationToken.None).ConfigureAwait(false);
+                    availableRoots.ToArray(), CancellationToken.None).ConfigureAwait(false);
 
-                // File count mismatch is a reliable indicator of added/removed charts.
-                // Both counts are scoped to the same active root set: the inventory is
-                // restricted to these searchPaths, so the database count must be too.
-                // The global chart count would include retained rows belonging to a
-                // removed root, which can never match the scoped filesystem count and
-                // would force a full rescan on every startup. The database side counts
-                // charts (one row per chart file), not score rows, so it matches the
-                // one-file-per-chart filesystem contract even when a chart has many
-                // score variants.
+                // File count mismatch is a reliable indicator of added/removed
+                // charts. Both counts are scoped to the same available root set:
+                // the inventory is restricted to these roots, so the database
+                // count must be too. The global chart count would include
+                // retained rows belonging to a removed or unavailable root,
+                // which can never match the scoped filesystem count and would
+                // force a full rescan on every startup. The database side counts
+                // charts (one row per chart file), not score rows, so it matches
+                // the one-file-per-chart filesystem contract even when a chart
+                // has many score variants.
                 var currentFileCount = inventory.Charts.Count;
-                var databaseChartCount = await GetActiveDatabaseChartCountAsync(searchPaths);
+                var databaseChartCount = await GetActiveDatabaseChartCountAsync(availableRoots);
 
                 Debug.WriteLine($"SongManager: Current chart files: {currentFileCount}, Database charts: {databaseChartCount}");
 
@@ -3681,39 +3718,19 @@ namespace DTXMania.Game.Lib.Song
                     return true;
                 }
 
-                // A configured root that no longer exists (deleted/unmounted/detached)
-                // is a change when the database still holds charts: those charts may be
-                // unreachable from the filesystem. The count mismatch above already
-                // catches the case where the missing root had charts, but check
-                // explicitly to preserve the conservative rescan whenever any
-                // configured root is absent and the active library is non-empty.
-                foreach (var searchPath in searchPaths)
-                {
-                    if (string.IsNullOrEmpty(searchPath))
-                        continue;
-                    if (!Directory.Exists(Path.GetFullPath(searchPath)) && databaseChartCount > 0)
-                    {
-                        Debug.WriteLine($"SongManager: Configured root missing: {searchPath}");
-                        return true;
-                    }
-                }
-
-                // Check if files in database still exist at their recorded paths (detects moves).
-                // Scoped to the same active roots as the file/DB counts above so retained
-                // charts belonging to a removed root are not flagged as missing.
-                var filesMovedOrDeleted = await CheckDatabaseFilesStillExist(searchPaths);
+                // Check if files in database still exist at their recorded paths
+                // (detects moves). Scoped to the same available roots as the
+                // file/DB counts above so retained charts belonging to a removed
+                // or unavailable root are not flagged as missing.
+                var filesMovedOrDeleted = await CheckDatabaseFilesStillExist(availableRoots);
                 if (filesMovedOrDeleted)
                 {
                     Debug.WriteLine($"SongManager: Some files have been moved or deleted since last enumeration");
                     return true;
                 }
 
-                // A missing configured root with database rows is a change (e.g. an
-                // external song drive was detached). The inventory skips non-existent
-                // roots, so its chart count is 0 for that root while the scoped database
-                // count is > 0 — already caught by the count mismatch above. Check the
-                // remaining roots' mtimes against the last enumeration time using the
-                // single inventory walk.
+                // Check the available roots' mtimes against the last enumeration
+                // time using the single inventory walk.
                 if (InventoryHasChangesSince(inventory, lastEnumerationTime.Value))
                 {
                     Debug.WriteLine("SongManager: Changes detected in song directories");
@@ -3831,8 +3848,8 @@ namespace DTXMania.Game.Lib.Song
             var dirInfo = new DirectoryInfo(directoryPath);
             inventory.Directories.Add(new ChartInventoryEntry(
                 SongPathIdentity.Normalize(directoryPath),
-                dirInfo.LastWriteTime,
-                dirInfo.CreationTime));
+                dirInfo.LastWriteTimeUtc,
+                dirInfo.CreationTimeUtc));
 
             var setDefPath = Path.Combine(directoryPath, "set.def");
             if (File.Exists(setDefPath))
@@ -3843,8 +3860,8 @@ namespace DTXMania.Game.Lib.Song
                 var setDefInfo = new FileInfo(setDefPath);
                 inventory.SetDefinitions.Add(new ChartInventoryEntry(
                     SongPathIdentity.Normalize(setDefPath),
-                    setDefInfo.LastWriteTime,
-                    setDefInfo.CreationTime));
+                    setDefInfo.LastWriteTimeUtc,
+                    setDefInfo.CreationTimeUtc));
                 foreach (var chartPath in EnumerateSetDefReferencedCharts(
                     setDefPath, cancellationToken))
                 {
@@ -3854,8 +3871,8 @@ namespace DTXMania.Game.Lib.Song
                     var chartInfo = new FileInfo(chartPath);
                     inventory.Charts.Add(new ChartInventoryEntry(
                         chartPath,
-                        chartInfo.LastWriteTime,
-                        chartInfo.CreationTime));
+                        chartInfo.LastWriteTimeUtc,
+                        chartInfo.CreationTimeUtc));
                 }
                 return;
             }
@@ -3877,8 +3894,8 @@ namespace DTXMania.Game.Lib.Song
                 var fileInfo = new FileInfo(file);
                 inventory.Charts.Add(new ChartInventoryEntry(
                     file,
-                    fileInfo.LastWriteTime,
-                    fileInfo.CreationTime));
+                    fileInfo.LastWriteTimeUtc,
+                    fileInfo.CreationTimeUtc));
             }
 
             foreach (var subdirectory in EnumerateDirectoriesCore(directoryPath)
@@ -3977,6 +3994,13 @@ namespace DTXMania.Game.Lib.Song
         /// enumeration time from it would let an unrelated write mask later chart
         /// edits when the file count is unchanged. A null result means no
         /// enumeration has been recorded yet and forces a first-time scan.
+        /// </para>
+        /// <para>
+        /// Returns UTC directly. The inventory walker uses
+        /// <c>LastWriteTimeUtc</c>/<c>CreationTimeUtc</c>, so the comparison is
+        /// UTC-vs-UTC — no local-time conversion that would break under DST or
+        /// timezone shifts.
+        /// </para>
         /// </summary>
         private async Task<DateTime?> GetLastEnumerationTimestampAsync()
         {
@@ -3995,14 +4019,8 @@ namespace DTXMania.Game.Lib.Song
                     return null;
                 }
 
-                // Convert to local time before returning: downstream change detection
-                // compares this against FileInfo/DirectoryInfo LastWriteTime values,
-                // which are returned in local time. Comparing a UTC DateTime directly
-                // against a Local DateTime would mis-order them by the timezone offset
-                // on non-UTC systems and report every file as modified (or never).
-                var localTimestamp = timestamp.Value.ToLocalTime();
-                Debug.WriteLine($"SongManager: Last successful enumeration at {localTimestamp:yyyy-MM-dd HH:mm:ss} (local)");
-                return localTimestamp;
+                Debug.WriteLine($"SongManager: Last successful enumeration at {timestamp.Value:yyyy-MM-dd HH:mm:ss} UTC");
+                return timestamp;
             }
             catch (Exception ex)
             {
@@ -4013,22 +4031,27 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Persists the enumeration timestamp after a successful enumeration. The
-        /// value is updated only here (after ImportedAndPublished) so unrelated
-        /// database writes cannot advance it.
+        /// Persists the enumeration watermark after a successful
+        /// <see cref="SongEnumerationOutcome.ImportedAndPublished"/> result.
+        /// The watermark is the START of filesystem traversal (captured in
+        /// <see cref="EnumerateAndImportSongsCoreAsync"/>), not the completion
+        /// time, so that files edited during the scan remain newer than the
+        /// watermark and trigger the next freshness check. Updated only here so
+        /// unrelated database writes (bookmark toggles, score saves) cannot
+        /// advance it.
         /// </summary>
-        private async Task UpdateEnumerationTimestampAsync()
+        private async Task SetEnumerationWatermarkAsync(DateTime startUtc)
         {
             try
             {
                 if (_databaseService == null) return;
 
-                await _databaseService.SetLastSuccessfulEnumerationUtcAsync(DateTime.UtcNow);
-                Debug.WriteLine($"SongManager: Enumeration timestamp persisted at {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
+                await _databaseService.SetLastSuccessfulEnumerationUtcAsync(startUtc);
+                Debug.WriteLine($"SongManager: Enumeration watermark persisted at {startUtc:yyyy-MM-dd HH:mm:ss} UTC (scan start)");
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"SongManager: Error updating enumeration timestamp: {ex.Message}");
+                Debug.WriteLine($"SongManager: Error updating enumeration watermark: {ex.Message}");
             }
         }
 

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -132,6 +132,11 @@ namespace DTXMania.Game.Lib.Song
         private static readonly Regex SpacedCommandPattern = new Regex(@"#\s*([A-Z\s]+?)\s+(.*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex ExcessiveSpacesPattern = new Regex(@"\s+", RegexOptions.Compiled);
 
+        // Back off the persisted scan-start watermark to account for filesystems
+        // that round modification times down to a coarse resolution.
+        private static readonly TimeSpan EnumerationWatermarkBackoff =
+            TimeSpan.FromSeconds(5);
+
         #endregion
 
         #region Public Properties
@@ -775,14 +780,15 @@ namespace DTXMania.Game.Lib.Song
             SongEnumerationResult? result = null;
             var outcome = StartupOperationOutcome.Failure;
 
-            // Capture the enumeration start as the freshness watermark. It is
-            // persisted only after successful publication so that any file edit
-            // during the (possibly long) scan remains newer than the watermark
-            // and triggers the next refresh. Using the completion time instead
-            // would mask mid-scan edits: a file parsed early and then modified
-            // while other roots are still scanning would have an mtime older
-            // than the completion-time watermark and be silently ignored.
-            var enumerationStartedUtc = DateTime.UtcNow;
+            // Capture a conservatively backed-off enumeration start as the
+            // freshness watermark. It is persisted only after successful
+            // publication so that any file edit during the (possibly long) scan
+            // remains newer than the watermark and triggers the next refresh.
+            // Using the completion time instead would mask mid-scan edits: a
+            // file parsed early and then modified while other roots are still
+            // scanning would have an mtime older than the completion-time
+            // watermark and be silently ignored.
+            var enumerationStartedUtc = DateTime.UtcNow - EnumerationWatermarkBackoff;
 
             try
             {
@@ -862,11 +868,13 @@ namespace DTXMania.Game.Lib.Song
                     hierarchy.Elapsed);
                 outcome = StartupOperationOutcome.Success;
 
-                // Persist the START watermark (not the completion time) so that
-                // mid-scan edits remain newer than the watermark and are detected
-                // by the next freshness check. NoActiveRoots and failure paths
-                // do not update the watermark: nothing was enumerated.
-                await SetEnumerationWatermarkAsync(enumerationStartedUtc)
+                // Persist the backed-off START watermark (not the completion time)
+                // so that mid-scan edits remain newer than the watermark and are
+                // detected by the next freshness check. NoActiveRoots and failure
+                // paths do not update the watermark: nothing was enumerated.
+                await SetEnumerationWatermarkAsync(
+                    batch.ActiveRoots,
+                    enumerationStartedUtc)
                     .ConfigureAwait(false);
 
                 return result;
@@ -3674,15 +3682,14 @@ namespace DTXMania.Game.Lib.Song
                 // treating its absence as a change whenever another root has
                 // charts forces a perpetual rescan on every startup. When the
                 // root returns (external drive reattached, network share
-                // mounted), the count mismatch between the filesystem inventory
-                // — now including it — and the scoped database count naturally
-                // triggers a refresh.
+                // mounted), its retained watermark is used to detect edits even
+                // when the chart count still matches the retained database rows.
                 var availableRoots = new List<string>(searchPaths.Length);
                 foreach (var searchPath in searchPaths)
                 {
                     if (string.IsNullOrEmpty(searchPath))
                         continue;
-                    if (Directory.Exists(searchPath))
+                    if (RootPolicy.Probe(searchPath) == SongRootAvailability.Available)
                         availableRoots.Add(searchPath);
                     else
                         Debug.WriteLine($"SongManager: Configured root unavailable, skipping freshness check: {searchPath}");
@@ -3729,9 +3736,16 @@ namespace DTXMania.Game.Lib.Song
                     return true;
                 }
 
-                // Check the available roots' mtimes against the last enumeration
-                // time using the single inventory walk.
-                if (InventoryHasChangesSince(inventory, lastEnumerationTime.Value))
+                // Check each available root against its own last successful
+                // watermark. A root omitted from a partial scan has no new
+                // watermark, so its return is conservatively treated as a change.
+                var rootWatermarks = await GetRootEnumerationWatermarksAsync(
+                    availableRoots,
+                    lastEnumerationTime.Value).ConfigureAwait(false);
+                if (InventoryHasChangesSince(
+                        inventory,
+                        availableRoots,
+                        rootWatermarks))
                 {
                     Debug.WriteLine("SongManager: Changes detected in song directories");
                     return true;
@@ -3748,16 +3762,43 @@ namespace DTXMania.Game.Lib.Song
             }
         }
 
+        private async Task<IReadOnlyDictionary<string, DateTime>>
+            GetRootEnumerationWatermarksAsync(
+                IReadOnlyList<string> availableRoots,
+                DateTime legacyWatermark)
+        {
+            var watermarks = new Dictionary<string, DateTime>(
+                SongPathIdentity.CanonicalComparer);
+            var database = GetDatabaseServiceSnapshot();
+            if (database == null)
+                return watermarks;
+
+            foreach (var root in availableRoots)
+            {
+                var watermark = await database
+                    .GetLastSuccessfulEnumerationUtcAsync(root)
+                    .ConfigureAwait(false);
+                if (watermark.HasValue)
+                    watermarks[root] = watermark.Value;
+            }
+
+            // Databases created before per-root watermarks only have the global
+            // value. Use it as a one-time migration fallback; once any root
+            // watermark exists, an omitted root must remain missing so a return
+            // after a partial scan cannot inherit another root's newer time.
+            if (watermarks.Count == 0)
+            {
+                foreach (var root in availableRoots)
+                    watermarks[root] = legacyWatermark;
+            }
+
+            return watermarks;
+        }
+
         /// <summary>
         /// Counts the chart files full enumeration would import across the active
-        /// roots, by delegating to the shared <see cref="ScanChartInventoryAsync"/>.
-        /// This matches enumeration's directory and set.def discovery rules: in a
-        /// set.def directory only the referenced charts are counted (not loose or
-        /// backup charts), and extension matching is case-insensitive via
-        /// <see cref="DTXChartParser.IsSupportedFile"/> so uppercase chart files
-        /// (e.g. CHART.DTX) are counted on case-sensitive filesystems. The previous
-        /// recursive-glob counter mismatched both cases and forced a permanent
-        /// rescan.
+        /// roots by delegating to the shared inventory scanner. Kept as a private
+        /// compatibility seam for existing coverage of the inventory contract.
         /// </summary>
         private async Task<int> CountDTXFilesAsync(string[] searchPaths)
         {
@@ -3771,35 +3812,40 @@ namespace DTXMania.Game.Lib.Song
             catch (Exception ex)
             {
                 Debug.WriteLine($"SongManager: Error counting chart files: {ex.Message}");
-                return -1; // Return invalid count to trigger enumeration
+                return -1;
             }
         }
 
         /// <summary>
-        /// Checks a single root directory for new or modified chart/set.def/directory
-        /// entries since <paramref name="lastEnumerationTime"/> by delegating to the
-        /// shared <see cref="ScanChartInventoryAsync"/>. Mirrors enumeration's
-        /// discovery rules (set.def-referenced charts only; case-insensitive
-        /// extensions; the set.def file itself is watched so label/reference edits
-        /// trigger a rescan even when referenced charts are unchanged). A missing or
-        /// unreadable directory assumes changes, matching the previous behavior.
+        /// Checks one root against a supplied watermark using the shared inventory
+        /// scanner. Kept as a private compatibility seam for existing coverage of
+        /// the inventory contract; live freshness checks use per-root watermarks.
         /// </summary>
-        private async Task<bool> CheckDirectoryForChangesAsync(string directoryPath, DateTime lastEnumerationTime)
+        private async Task<bool> CheckDirectoryForChangesAsync(
+            string directoryPath,
+            DateTime lastEnumerationTime)
         {
             try
             {
                 if (string.IsNullOrEmpty(directoryPath) || !Directory.Exists(directoryPath))
-                    return true; // Missing root with database rows is a change.
+                    return true;
 
                 var inventory = await ScanChartInventoryAsync(
                     new[] { directoryPath }, CancellationToken.None).ConfigureAwait(false);
-                return InventoryHasChangesSince(inventory, lastEnumerationTime);
+                var normalizedRoot = SongPathIdentity.Normalize(directoryPath);
+                return InventoryHasChangesSince(
+                    inventory,
+                    new[] { normalizedRoot },
+                    new Dictionary<string, DateTime>(SongPathIdentity.CanonicalComparer)
+                    {
+                        [normalizedRoot] = lastEnumerationTime
+                    });
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"SongManager: Error checking directory {directoryPath}: {ex.Message}");
                 Debug.WriteLine($"SongManager: Stack trace: {ex.StackTrace}");
-                return true; // Assume changes on error
+                return true;
             }
         }
 
@@ -3942,18 +3988,34 @@ namespace DTXMania.Game.Lib.Song
 
         /// <summary>
         /// Returns true if any directory, set.def, or chart in
-        /// <paramref name="inventory"/> was created or modified after
-        /// <paramref name="lastEnumerationTime"/>. Mirrors the per-entry checks
-        /// previously spread across <c>CheckDirectoryForChangesAsync</c> and
-        /// <c>CheckSubdirectoriesForChangesAsync</c>, but evaluated over a single
-        /// inventory walk instead of one recursive walk per extension.
+        /// <paramref name="inventory"/> was created or modified after the
+        /// watermark for its containing root. Mirrors the per-entry checks
+        /// previously spread across multiple recursive checks, but evaluated over
+        /// a single inventory walk instead of one recursive walk per extension.
         /// </summary>
         private static bool InventoryHasChangesSince(
-            ChartInventory inventory, DateTime lastEnumerationTime)
+            ChartInventory inventory,
+            IReadOnlyList<string> activeRoots,
+            IReadOnlyDictionary<string, DateTime> rootWatermarks)
         {
+            foreach (var root in activeRoots)
+            {
+                if (!rootWatermarks.ContainsKey(root))
+                {
+                    Debug.WriteLine(
+                        $"SongManager: No enumeration watermark found for returning root: {root}");
+                    return true;
+                }
+            }
+
             foreach (var dir in inventory.Directories)
             {
-                if (dir.LastWriteTime > lastEnumerationTime)
+                if (TryGetRootWatermark(
+                        dir.Path,
+                        activeRoots,
+                        rootWatermarks,
+                        out var watermark) &&
+                    dir.LastWriteTime > watermark)
                 {
                     Debug.WriteLine($"SongManager: Directory modified: {dir.Path} at {dir.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
                     return true;
@@ -3962,8 +4024,13 @@ namespace DTXMania.Game.Lib.Song
 
             foreach (var setDef in inventory.SetDefinitions)
             {
-                if (setDef.CreationTime > lastEnumerationTime ||
-                    setDef.LastWriteTime > lastEnumerationTime)
+                if (TryGetRootWatermark(
+                        setDef.Path,
+                        activeRoots,
+                        rootWatermarks,
+                        out var watermark) &&
+                    (setDef.CreationTime > watermark ||
+                     setDef.LastWriteTime > watermark))
                 {
                     Debug.WriteLine($"SongManager: set.def modified: {setDef.Path} at {setDef.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
                     return true;
@@ -3972,16 +4039,44 @@ namespace DTXMania.Game.Lib.Song
 
             foreach (var chart in inventory.Charts)
             {
-                if (chart.CreationTime > lastEnumerationTime ||
-                    chart.LastWriteTime > lastEnumerationTime)
+                if (TryGetRootWatermark(
+                        chart.Path,
+                        activeRoots,
+                        rootWatermarks,
+                        out var watermark) &&
+                    (chart.CreationTime > watermark ||
+                     chart.LastWriteTime > watermark))
                 {
-                    var reason = chart.CreationTime > lastEnumerationTime ? "new" : "modified";
+                    var reason = chart.CreationTime > watermark ? "new" : "modified";
                     Debug.WriteLine($"SongManager: {reason.ToUpper()} chart detected: {chart.Path} at {chart.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
                     return true;
                 }
             }
 
             return false;
+        }
+
+        private static bool TryGetRootWatermark(
+            string path,
+            IReadOnlyList<string> activeRoots,
+            IReadOnlyDictionary<string, DateTime> rootWatermarks,
+            out DateTime watermark)
+        {
+            watermark = default;
+            string? containingRoot = null;
+            foreach (var root in activeRoots)
+            {
+                if (!SongPathIdentity.IsUnderNormalizedRoot(path, root) ||
+                    (containingRoot != null && root.Length <= containingRoot.Length))
+                {
+                    continue;
+                }
+
+                containingRoot = root;
+            }
+
+            return containingRoot != null &&
+                rootWatermarks.TryGetValue(containingRoot, out watermark);
         }
 
         /// <summary>
@@ -4033,20 +4128,26 @@ namespace DTXMania.Game.Lib.Song
         /// <summary>
         /// Persists the enumeration watermark after a successful
         /// <see cref="SongEnumerationOutcome.ImportedAndPublished"/> result.
-        /// The watermark is the START of filesystem traversal (captured in
-        /// <see cref="EnumerateAndImportSongsCoreAsync"/>), not the completion
-        /// time, so that files edited during the scan remain newer than the
-        /// watermark and trigger the next freshness check. Updated only here so
-        /// unrelated database writes (bookmark toggles, score saves) cannot
-        /// advance it.
+        /// The watermark is the backed-off START of filesystem traversal
+        /// (captured in <see cref="EnumerateAndImportSongsCoreAsync"/>), not the
+        /// completion time, so that files edited during the scan remain newer
+        /// than the watermark and trigger the next freshness check. Updated only
+        /// for the roots in the successful batch so a partial multi-root scan
+        /// cannot advance another root's watermark. Unrelated database writes
+        /// (bookmark toggles, score saves) cannot advance either value.
         /// </summary>
-        private async Task SetEnumerationWatermarkAsync(DateTime startUtc)
+        private async Task SetEnumerationWatermarkAsync(
+            IReadOnlyList<string> activeRoots,
+            DateTime startUtc)
         {
             try
             {
                 if (_databaseService == null) return;
 
                 await _databaseService.SetLastSuccessfulEnumerationUtcAsync(startUtc);
+                await _databaseService.SetLastSuccessfulEnumerationUtcAsync(
+                    activeRoots,
+                    startUtc);
                 Debug.WriteLine($"SongManager: Enumeration watermark persisted at {startUtc:yyyy-MM-dd HH:mm:ss} UTC (scan start)");
             }
             catch (Exception ex)

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -3933,66 +3933,85 @@ namespace DTXMania.Game.Lib.Song
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var dirInfo = new DirectoryInfo(directoryPath);
-            inventory.Directories.Add(new ChartInventoryEntry(
-                SongPathIdentity.Normalize(directoryPath),
-                dirInfo.LastWriteTimeUtc,
-                dirInfo.CreationTimeUtc));
-
-            var setDefPath = Path.Combine(directoryPath, "set.def");
-            if (File.Exists(setDefPath))
+            // Wrap this directory's access (DirectoryInfo construction and
+            // file/directory enumeration) so an inaccessible or unreadable
+            // directory skips itself while its siblings continue scanning.
+            // OperationCanceledException is NOT caught here, so cancellation
+            // from ThrowIfCancellationRequested (above and in the loops below)
+            // propagates unchanged.
+            try
             {
-                // set.def directory: only referenced charts are imported; loose
-                // charts and subdirectories are NOT scanned (enumeration returns
-                // early after ParseSetDefinitionIntoBatchAsync).
-                var setDefInfo = new FileInfo(setDefPath);
-                inventory.SetDefinitions.Add(new ChartInventoryEntry(
-                    SongPathIdentity.Normalize(setDefPath),
-                    setDefInfo.LastWriteTimeUtc,
-                    setDefInfo.CreationTimeUtc));
-                foreach (var chartPath in EnumerateSetDefReferencedCharts(
-                    setDefPath, cancellationToken))
+                var dirInfo = new DirectoryInfo(directoryPath);
+                inventory.Directories.Add(new ChartInventoryEntry(
+                    SongPathIdentity.Normalize(directoryPath),
+                    dirInfo.LastWriteTimeUtc,
+                    dirInfo.CreationTimeUtc));
+
+                var setDefPath = Path.Combine(directoryPath, "set.def");
+                if (File.Exists(setDefPath))
+                {
+                    // set.def directory: only referenced charts are imported; loose
+                    // charts and subdirectories are NOT scanned (enumeration returns
+                    // early after ParseSetDefinitionIntoBatchAsync).
+                    var setDefInfo = new FileInfo(setDefPath);
+                    inventory.SetDefinitions.Add(new ChartInventoryEntry(
+                        SongPathIdentity.Normalize(setDefPath),
+                        setDefInfo.LastWriteTimeUtc,
+                        setDefInfo.CreationTimeUtc));
+                    foreach (var chartPath in EnumerateSetDefReferencedCharts(
+                        setDefPath, cancellationToken))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        if (!seenCharts.Add(chartPath))
+                            continue;
+                        var chartInfo = new FileInfo(chartPath);
+                        inventory.Charts.Add(new ChartInventoryEntry(
+                            chartPath,
+                            chartInfo.LastWriteTimeUtc,
+                            chartInfo.CreationTimeUtc));
+                    }
+                    return;
+                }
+
+                // No set.def: collect loose supported charts (case-insensitive via
+                // IsSupportedFile, matching full enumeration) and recurse into all
+                // subdirectories. Boxes are organizational only and do not filter
+                // charts, so they are recursed like any other directory.
+                foreach (var file in EnumerateFilesCore(directoryPath)
+                    .Where(DTXChartParser.IsSupportedFile)
+                    .Select(SongPathIdentity.Normalize)
+                    .OrderBy(path => path, SongPathIdentity.CanonicalComparer))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    if (!seenCharts.Add(chartPath))
+                    if (!File.Exists(file))
                         continue;
-                    var chartInfo = new FileInfo(chartPath);
+                    if (!seenCharts.Add(file))
+                        continue;
+                    var fileInfo = new FileInfo(file);
                     inventory.Charts.Add(new ChartInventoryEntry(
-                        chartPath,
-                        chartInfo.LastWriteTimeUtc,
-                        chartInfo.CreationTimeUtc));
+                        file,
+                        fileInfo.LastWriteTimeUtc,
+                        fileInfo.CreationTimeUtc));
                 }
-                return;
-            }
 
-            // No set.def: collect loose supported charts (case-insensitive via
-            // IsSupportedFile, matching full enumeration) and recurse into all
-            // subdirectories. Boxes are organizational only and do not filter
-            // charts, so they are recursed like any other directory.
-            foreach (var file in EnumerateFilesCore(directoryPath)
-                .Where(DTXChartParser.IsSupportedFile)
-                .Select(SongPathIdentity.Normalize)
-                .OrderBy(path => path, SongPathIdentity.CanonicalComparer))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (!File.Exists(file))
-                    continue;
-                if (!seenCharts.Add(file))
-                    continue;
-                var fileInfo = new FileInfo(file);
-                inventory.Charts.Add(new ChartInventoryEntry(
-                    file,
-                    fileInfo.LastWriteTimeUtc,
-                    fileInfo.CreationTimeUtc));
+                foreach (var subdirectory in EnumerateDirectoriesCore(directoryPath)
+                    .Select(SongPathIdentity.Normalize)
+                    .OrderBy(path => path, SongPathIdentity.CanonicalComparer))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ScanChartInventoryDirectory(
+                        subdirectory, inventory, seenCharts, cancellationToken);
+                }
             }
-
-            foreach (var subdirectory in EnumerateDirectoriesCore(directoryPath)
-                .Select(SongPathIdentity.Normalize)
-                .OrderBy(path => path, SongPathIdentity.CanonicalComparer))
+            catch (UnauthorizedAccessException ex)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-                ScanChartInventoryDirectory(
-                    subdirectory, inventory, seenCharts, cancellationToken);
+                Debug.WriteLine(
+                    $"SongManager: Skipping inaccessible directory during inventory scan: {directoryPath}: {ex.Message}");
+            }
+            catch (IOException ex)
+            {
+                Debug.WriteLine(
+                    $"SongManager: Skipping unreadable directory during inventory scan: {directoryPath}: {ex.Message}");
             }
         }
 
@@ -4067,9 +4086,9 @@ namespace DTXMania.Game.Lib.Song
                         activeRoots,
                         rootWatermarks,
                         out var watermark) &&
-                    dir.LastWriteTime > watermark)
+                    dir.LastWriteTimeUtc > watermark)
                 {
-                    Debug.WriteLine($"SongManager: Directory modified: {dir.Path} at {dir.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
+                    Debug.WriteLine($"SongManager: Directory modified: {dir.Path} at {dir.LastWriteTimeUtc:yyyy-MM-dd HH:mm:ss}");
                     return true;
                 }
             }
@@ -4081,10 +4100,10 @@ namespace DTXMania.Game.Lib.Song
                         activeRoots,
                         rootWatermarks,
                         out var watermark) &&
-                    (setDef.CreationTime > watermark ||
-                     setDef.LastWriteTime > watermark))
+                    (setDef.CreationTimeUtc > watermark ||
+                     setDef.LastWriteTimeUtc > watermark))
                 {
-                    Debug.WriteLine($"SongManager: set.def modified: {setDef.Path} at {setDef.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
+                    Debug.WriteLine($"SongManager: set.def modified: {setDef.Path} at {setDef.LastWriteTimeUtc:yyyy-MM-dd HH:mm:ss}");
                     return true;
                 }
             }
@@ -4096,11 +4115,11 @@ namespace DTXMania.Game.Lib.Song
                         activeRoots,
                         rootWatermarks,
                         out var watermark) &&
-                    (chart.CreationTime > watermark ||
-                     chart.LastWriteTime > watermark))
+                    (chart.CreationTimeUtc > watermark ||
+                     chart.LastWriteTimeUtc > watermark))
                 {
-                    var reason = chart.CreationTime > watermark ? "new" : "modified";
-                    Debug.WriteLine($"SongManager: {reason.ToUpper()} chart detected: {chart.Path} at {chart.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
+                    var reason = chart.CreationTimeUtc > watermark ? "new" : "modified";
+                    Debug.WriteLine($"SongManager: {reason.ToUpper()} chart detected: {chart.Path} at {chart.LastWriteTimeUtc:yyyy-MM-dd HH:mm:ss}");
                     return true;
                 }
             }
@@ -4115,18 +4134,7 @@ namespace DTXMania.Game.Lib.Song
             out DateTime watermark)
         {
             watermark = default;
-            string? containingRoot = null;
-            foreach (var root in activeRoots)
-            {
-                if (!SongPathIdentity.IsUnderNormalizedRoot(path, root) ||
-                    (containingRoot != null && root.Length <= containingRoot.Length))
-                {
-                    continue;
-                }
-
-                containingRoot = root;
-            }
-
+            var containingRoot = FindContainingRoot(path, activeRoots);
             return containingRoot != null &&
                 rootWatermarks.TryGetValue(containingRoot, out watermark);
         }
@@ -4262,9 +4270,10 @@ namespace DTXMania.Game.Lib.Song
         {
             try
             {
-                if (_databaseService == null) return;
+                var databaseService = GetDatabaseServiceSnapshot();
+                if (databaseService == null) return;
 
-                var success = await _databaseService
+                var success = await databaseService
                     .SetEnumerationWatermarkAtomicallyAsync(startUtc, activeRoots)
                     .ConfigureAwait(false);
                 if (success)

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -71,6 +71,7 @@ namespace DTXMania.Game.Lib.Song
         private CancellationTokenSource? _enumCancellation;
         private SongDatabaseService? _databaseService;
         private string[] _currentSearchPaths = Array.Empty<string>();
+        private string[] _pendingSearchPaths = Array.Empty<string>();
         private long _publicationVersion;
 
         internal SongRootPolicy RootPolicy { get; set; } =
@@ -167,12 +168,18 @@ namespace DTXMania.Game.Lib.Song
                 .CanonicalRoots
                 .ToArray();
 
-            // Assign under the same lock used by GetCurrentSearchPathsSnapshot,
-            // RefreshSongListFromDatabaseAsync, PublishEnumeration, and Clear so
-            // readers never observe a torn _currentSearchPaths reference.
+            // A non-empty set is input for a future database rebuild, not a partial
+            // publication. Publishing roots without matching hierarchy/count data
+            // would make a snapshot internally inconsistent.
+            if (distinct.Length == 0)
+            {
+                PublishEmptyLibrary();
+                return;
+            }
+
             lock (_lockObject)
             {
-                _currentSearchPaths = distinct;
+                _pendingSearchPaths = distinct;
             }
         }
 
@@ -544,7 +551,9 @@ namespace DTXMania.Game.Lib.Song
             string[] searchPaths;
             lock (_lockObject)
             {
-                searchPaths = _currentSearchPaths.ToArray();
+                searchPaths = _pendingSearchPaths.Length > 0
+                    ? _pendingSearchPaths.ToArray()
+                    : _currentSearchPaths.ToArray();
             }
 
             if (searchPaths.Length > 0)
@@ -1460,9 +1469,11 @@ namespace DTXMania.Game.Lib.Song
             {
                 _rootSongs.Clear();
                 _rootSongs.AddRange(batch.RootNodes);
-                _currentSearchPaths = RootPolicy.Validate(batch.ActiveRoots)
+                var activeRoots = RootPolicy.Validate(batch.ActiveRoots)
                     .CanonicalRoots
                     .ToArray();
+                _currentSearchPaths = activeRoots;
+                _pendingSearchPaths = activeRoots.ToArray();
                 EnumeratedFileCount = batch.DiscoveredChartPaths.Count;
                 // Count discovered difficulty charts, not grouped logical songs:
                 // a multi-difficulty set contributes one PendingSong but one
@@ -1494,6 +1505,7 @@ namespace DTXMania.Game.Lib.Song
             {
                 _rootSongs.Clear();
                 _currentSearchPaths = Array.Empty<string>();
+                _pendingSearchPaths = Array.Empty<string>();
                 EnumeratedFileCount = 0;
                 DiscoveredScoreCount = 0;
                 _publicationVersion++;
@@ -1609,6 +1621,15 @@ namespace DTXMania.Game.Lib.Song
                     .Where(root => RootPolicy.Probe(root) == SongRootAvailability.Available)
                     .ToArray();
 
+                if (availableRoots.Length == 0)
+                {
+                    Debug.WriteLine(
+                        "SongManager: Database hierarchy refresh skipped — no active search roots.");
+                    return;
+                }
+
+                var activeChartCount = 0;
+
                 foreach (var normalizedRoot in availableRoots)
                 {
                     // Get all charts that belong to this search path
@@ -1624,12 +1645,17 @@ namespace DTXMania.Game.Lib.Song
                             .Select(chart => (song, chart)))
                         .ToList();
 
+                    activeChartCount += relevantCharts.Count;
+
                     // Build the folder hierarchy structure from file paths
                     var pathNodes = await BuildHierarchyFromCharts(normalizedRoot, relevantCharts);
                     newRootNodes.AddRange(pathNodes);
                 }
 
-                PublishDatabaseHierarchy(newRootNodes, configuredRoots);
+                PublishDatabaseHierarchy(
+                    newRootNodes,
+                    availableRoots,
+                    activeChartCount);
             }
             catch (Exception ex)
             {
@@ -1639,7 +1665,8 @@ namespace DTXMania.Game.Lib.Song
 
         private void PublishDatabaseHierarchy(
             IReadOnlyList<SongListNode> rootNodes,
-            IReadOnlyList<string> activeRoots)
+            IReadOnlyList<string> activeRoots,
+            int activeChartCount)
         {
             SongLibrarySnapshot snapshot;
             lock (_lockObject)
@@ -1647,6 +1674,9 @@ namespace DTXMania.Game.Lib.Song
                 _rootSongs.Clear();
                 _rootSongs.AddRange(rootNodes);
                 _currentSearchPaths = activeRoots.ToArray();
+                _pendingSearchPaths = _currentSearchPaths.ToArray();
+                EnumeratedFileCount = activeChartCount;
+                DiscoveredScoreCount = activeChartCount;
                 _publicationVersion++;
                 snapshot = CreateSnapshotLocked();
             }
@@ -4075,6 +4105,7 @@ namespace DTXMania.Game.Lib.Song
                 _databaseService?.Dispose();
                 _databaseService = null;
                 _currentSearchPaths = Array.Empty<string>();
+                _pendingSearchPaths = Array.Empty<string>();
                 EnumeratedFileCount = 0;
                 DiscoveredScoreCount = 0;
                 _publicationVersion++;

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -3466,42 +3466,47 @@ namespace DTXMania.Game.Lib.Song
 
         /// <summary>
         /// Checks if files in the database still exist at their recorded paths
-        /// This detects when files have been moved or deleted
+        /// This detects when files have been moved or deleted.
+        /// <para>
+        /// Only charts whose <see cref="SongChart.FilePath"/> resides under one of
+        /// <paramref name="activeRoots"/> are checked. Charts belonging to removed
+        /// (retained) roots are intentionally skipped: their files are expected to be
+        /// absent from the active root set, and flagging them as missing would force a
+        /// full rescan on every startup. This mirrors the active-root scoping already
+        /// applied to the filesystem and database chart counts in
+        /// <see cref="DetectFilesystemChangesAsync"/>.
         /// </summary>
-        private async Task<bool> CheckDatabaseFilesStillExist()
+        private async Task<bool> CheckDatabaseFilesStillExist(IReadOnlyList<string> activeRoots)
         {
             try
             {
                 if (_databaseService == null)
                     return false;
 
-                var allSongs = await _databaseService.GetSongsAsync();
+                var charts = await _databaseService.GetActiveChartsAsync(activeRoots);
                 int missingFiles = 0;
                 int updatedFiles = 0;
                 int totalFiles = 0;
 
-                foreach (var song in allSongs.Where(s => s.Charts != null))
+                foreach (var chart in charts)
                 {
-                    foreach (var chart in song.Charts!)
+                    totalFiles++;
+                    if (!string.IsNullOrEmpty(chart.FilePath) && !File.Exists(chart.FilePath))
                     {
-                        totalFiles++;
-                        if (!string.IsNullOrEmpty(chart.FilePath) && !File.Exists(chart.FilePath))
+                        // File is missing from recorded path - try to find it in new location
+                        string? newPath = await FindMovedFileAsync(chart.FilePath);
+
+                        if (!string.IsNullOrEmpty(newPath))
                         {
-                            // File is missing from recorded path - try to find it in new location
-                            string? newPath = await FindMovedFileAsync(chart.FilePath);
-                            
-                            if (!string.IsNullOrEmpty(newPath))
-                            {
-                                // Found the file in a new location - update database
-                                Debug.WriteLine($"SongManager: File moved detected: '{chart.FilePath}' -> '{newPath}'");
-                                await UpdateChartFilePathAsync(chart.Id, newPath);
-                                updatedFiles++;
-                            }
-                            else
-                            {
-                                missingFiles++;
-                                Debug.WriteLine($"SongManager: Missing file detected: {chart.FilePath}");
-                            }
+                            // Found the file in a new location - update database
+                            Debug.WriteLine($"SongManager: File moved detected: '{chart.FilePath}' -> '{newPath}'");
+                            await UpdateChartFilePathAsync(chart.Id, newPath);
+                            updatedFiles++;
+                        }
+                        else
+                        {
+                            missingFiles++;
+                            Debug.WriteLine($"SongManager: Missing file detected: {chart.FilePath}");
                         }
                     }
                 }
@@ -3629,7 +3634,8 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Detects filesystem changes in song directories
+        /// Detects filesystem changes in song directories by walking the active
+        /// roots once via the shared chart-inventory scanner.
         /// </summary>
         private async Task<bool> DetectFilesystemChangesAsync(string[] searchPaths)
         {
@@ -3645,69 +3651,73 @@ namespace DTXMania.Game.Lib.Song
 
                 Debug.WriteLine($"SongManager: Last enumeration was at {lastEnumerationTime:yyyy-MM-dd HH:mm:ss}");
 
-                // First, check if file counts have changed - this is a reliable indicator.
-                // Both counts must be scoped to the same active root set: the filesystem
-                // count is restricted to these searchPaths, so the database count must be
-                // too. The global chart count would include retained rows belonging to a
-                // removed root, which can never match the scoped filesystem count and would
-                // force a full rescan on every startup. The database side counts charts
-                // (one row per chart file), not score rows, so it matches the one-file-
-                // per-chart filesystem contract even when a chart has many score variants.
-                var currentFileCount = await CountDTXFilesAsync(searchPaths);
+                // Walk the active roots once, mirroring full enumeration's directory
+                // and set.def discovery rules. The inventory yields exactly the chart
+                // files enumeration would import (set.def-referenced charts only in a
+                // set.def directory; case-insensitive extension matching) plus the
+                // set.def and directory mtimes used by the change check below. This
+                // replaces the previous per-extension recursive globs (six walks for
+                // counting plus seven for timestamp checking per root).
+                var inventory = await ScanChartInventoryAsync(
+                    searchPaths, CancellationToken.None).ConfigureAwait(false);
+
+                // File count mismatch is a reliable indicator of added/removed charts.
+                // Both counts are scoped to the same active root set: the inventory is
+                // restricted to these searchPaths, so the database count must be too.
+                // The global chart count would include retained rows belonging to a
+                // removed root, which can never match the scoped filesystem count and
+                // would force a full rescan on every startup. The database side counts
+                // charts (one row per chart file), not score rows, so it matches the
+                // one-file-per-chart filesystem contract even when a chart has many
+                // score variants.
+                var currentFileCount = inventory.Charts.Count;
                 var databaseChartCount = await GetActiveDatabaseChartCountAsync(searchPaths);
-                
+
                 Debug.WriteLine($"SongManager: Current chart files: {currentFileCount}, Database charts: {databaseChartCount}");
-                
+
                 if (currentFileCount != databaseChartCount)
                 {
                     Debug.WriteLine($"SongManager: File count mismatch detected - files: {currentFileCount}, database: {databaseChartCount}");
                     return true;
                 }
 
-                // Check if files in database still exist at their recorded paths (detects moves)
-                var filesMovedOrDeleted = await CheckDatabaseFilesStillExist();
+                // A configured root that no longer exists (deleted/unmounted/detached)
+                // is a change when the database still holds charts: those charts may be
+                // unreachable from the filesystem. The count mismatch above already
+                // catches the case where the missing root had charts, but check
+                // explicitly to preserve the conservative rescan whenever any
+                // configured root is absent and the active library is non-empty.
+                foreach (var searchPath in searchPaths)
+                {
+                    if (string.IsNullOrEmpty(searchPath))
+                        continue;
+                    if (!Directory.Exists(Path.GetFullPath(searchPath)) && databaseChartCount > 0)
+                    {
+                        Debug.WriteLine($"SongManager: Configured root missing: {searchPath}");
+                        return true;
+                    }
+                }
+
+                // Check if files in database still exist at their recorded paths (detects moves).
+                // Scoped to the same active roots as the file/DB counts above so retained
+                // charts belonging to a removed root are not flagged as missing.
+                var filesMovedOrDeleted = await CheckDatabaseFilesStillExist(searchPaths);
                 if (filesMovedOrDeleted)
                 {
                     Debug.WriteLine($"SongManager: Some files have been moved or deleted since last enumeration");
                     return true;
                 }
 
-                // Check each search path for changes
-                foreach (var searchPath in searchPaths)
+                // A missing configured root with database rows is a change (e.g. an
+                // external song drive was detached). The inventory skips non-existent
+                // roots, so its chart count is 0 for that root while the scoped database
+                // count is > 0 — already caught by the count mismatch above. Check the
+                // remaining roots' mtimes against the last enumeration time using the
+                // single inventory walk.
+                if (InventoryHasChangesSince(inventory, lastEnumerationTime.Value))
                 {
-                    if (string.IsNullOrEmpty(searchPath))
-                    {
-                        Debug.WriteLine($"SongManager: Search path is null or empty, skipping");
-                        continue;
-                    }
-
-                    var fullPath = Path.GetFullPath(searchPath);
-                    Debug.WriteLine($"SongManager: Checking search path: {fullPath}");
-
-                    if (!Directory.Exists(fullPath))
-                    {
-                        Debug.WriteLine($"SongManager: Search path doesn't exist: {fullPath}");
-                        // If the directory doesn't exist but we have songs in DB, this is a change
-                        var songCount = await GetDatabaseScoreCountAsync();
-                        if (songCount > 0)
-                        {
-                            Debug.WriteLine($"SongManager: Directory missing but database has {songCount} songs - change detected");
-                            return true;
-                        }
-                        continue;
-                    }
-
-                    // Check if directory or its contents have been modified since last enumeration
-                    var hasChanges = await CheckDirectoryForChangesAsync(fullPath, lastEnumerationTime.Value);
-                    if (hasChanges)
-                    {
-                        Debug.WriteLine($"SongManager: Changes detected in {fullPath}");
-                        return true;
-                    }
-                    else
-                    {
-                        Debug.WriteLine($"SongManager: No changes detected in {fullPath}");
-                    }
+                    Debug.WriteLine("SongManager: Changes detected in song directories");
+                    return true;
                 }
 
                 Debug.WriteLine("SongManager: No changes detected in any search path");
@@ -3722,37 +3732,24 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Counts supported chart files in all search paths. Uses the same
-        /// extension set as <see cref="DTXChartParser.IsSupportedFile"/> so the
-        /// count matches what full enumeration would import. Counting only
-        /// "*.dtx" would permanently mismatch libraries containing .gda/.g2d/
-        /// .bms/.bme/.bml charts and force a full rescan on every startup.
+        /// Counts the chart files full enumeration would import across the active
+        /// roots, by delegating to the shared <see cref="ScanChartInventoryAsync"/>.
+        /// This matches enumeration's directory and set.def discovery rules: in a
+        /// set.def directory only the referenced charts are counted (not loose or
+        /// backup charts), and extension matching is case-insensitive via
+        /// <see cref="DTXChartParser.IsSupportedFile"/> so uppercase chart files
+        /// (e.g. CHART.DTX) are counted on case-sensitive filesystems. The previous
+        /// recursive-glob counter mismatched both cases and forced a permanent
+        /// rescan.
         /// </summary>
         private async Task<int> CountDTXFilesAsync(string[] searchPaths)
         {
-            int totalCount = 0;
             try
             {
-                // Build the glob patterns once from the canonical supported set.
-                var searchPatterns = DTXChartParser.SupportedExtensions
-                    .Select(ext => "*" + ext)
-                    .ToArray();
-                foreach (var searchPath in searchPaths.Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path)))
-                {
-                    // Use async enumeration to avoid blocking
-                    await Task.Run(() =>
-                    {
-                        int pathCount = 0;
-                        foreach (var pattern in searchPatterns)
-                        {
-                            pathCount += Directory.EnumerateFiles(searchPath, pattern, SearchOption.AllDirectories).Count();
-                        }
-                        totalCount += pathCount;
-                        Debug.WriteLine($"SongManager: Found {pathCount} supported chart files in {searchPath}");
-                    });
-                }
-                Debug.WriteLine($"SongManager: Total supported chart files found: {totalCount}");
-                return totalCount;
+                var inventory = await ScanChartInventoryAsync(
+                    searchPaths, CancellationToken.None).ConfigureAwait(false);
+                Debug.WriteLine($"SongManager: Inventory counted {inventory.Charts.Count} chart files");
+                return inventory.Charts.Count;
             }
             catch (Exception ex)
             {
@@ -3762,77 +3759,24 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Recursively checks a directory for changes since the last enumeration
+        /// Checks a single root directory for new or modified chart/set.def/directory
+        /// entries since <paramref name="lastEnumerationTime"/> by delegating to the
+        /// shared <see cref="ScanChartInventoryAsync"/>. Mirrors enumeration's
+        /// discovery rules (set.def-referenced charts only; case-insensitive
+        /// extensions; the set.def file itself is watched so label/reference edits
+        /// trigger a rescan even when referenced charts are unchanged). A missing or
+        /// unreadable directory assumes changes, matching the previous behavior.
         /// </summary>
         private async Task<bool> CheckDirectoryForChangesAsync(string directoryPath, DateTime lastEnumerationTime)
         {
             try
             {
-                var dirInfo = new DirectoryInfo(directoryPath);
-                Debug.WriteLine($"SongManager: Checking directory: {directoryPath}");
-                Debug.WriteLine($"SongManager: Directory last write time: {dirInfo.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
-                Debug.WriteLine($"SongManager: Comparing against: {lastEnumerationTime:yyyy-MM-dd HH:mm:ss}");
-                
-                // Check if the directory itself was modified
-                if (dirInfo.LastWriteTime > lastEnumerationTime)
-                {
-                    Debug.WriteLine($"SongManager: Directory modified: {directoryPath} at {dirInfo.LastWriteTime:yyyy-MM-dd HH:mm:ss} (after {lastEnumerationTime:yyyy-MM-dd HH:mm:ss})");
-                    return true;
-                }
+                if (string.IsNullOrEmpty(directoryPath) || !Directory.Exists(directoryPath))
+                    return true; // Missing root with database rows is a change.
 
-                // Check for new or modified chart/SET files using async enumeration.
-                // The chart extension set must match DTXChartParser.SupportedExtensions
-                // so modifications to .gda/.g2d/.bms/.bme/.bml charts are detected when
-                // the total file count is unchanged; "*.set" covers SET.def changes.
-                var chartPatterns = DTXChartParser.SupportedExtensions
-                    .Select(ext => "*" + ext)
-                    .Append("*.set")
-                    .ToArray();
-                int totalFilesChecked = 0;
-                int modifiedFilesFound = 0;
-
-                foreach (var extension in chartPatterns)
-                {
-                    Debug.WriteLine($"SongManager: Scanning for {extension} files in {directoryPath}");
-                    
-                    // Use async enumeration to avoid blocking
-                    var hasChanges = await Task.Run(() =>
-                    {
-                        int extensionFileCount = 0;
-                        foreach (var filePath in Directory.EnumerateFiles(directoryPath, extension, SearchOption.AllDirectories))
-                        {
-                            extensionFileCount++;
-                            totalFilesChecked++;
-                            
-                            var fileInfo = new FileInfo(filePath);
-                            var fileIsNew = fileInfo.CreationTime > lastEnumerationTime;
-                            var fileIsModified = fileInfo.LastWriteTime > lastEnumerationTime;
-                            
-                            if (fileIsNew || fileIsModified)
-                            {
-                                modifiedFilesFound++;
-                                var reason = fileIsNew ? "new" : "modified";
-                                var timestamp = fileIsNew ? fileInfo.CreationTime : fileInfo.LastWriteTime;
-                                Debug.WriteLine($"SongManager: {reason.ToUpper()} file detected: {filePath}");
-                                Debug.WriteLine($"SongManager: File timestamp: {timestamp:yyyy-MM-dd HH:mm:ss} vs enumeration: {lastEnumerationTime:yyyy-MM-dd HH:mm:ss}");
-                                return true;
-                            }
-                        }
-                        Debug.WriteLine($"SongManager: Found {extensionFileCount} {extension} files");
-                        return false;
-                    });
-                    
-                    if (hasChanges) return true;
-                }
-
-                Debug.WriteLine($"SongManager: Checked {totalFilesChecked} files, found {modifiedFilesFound} modified files");
-
-                // Check subdirectories recursively (but limit depth to avoid infinite loops)
-                var subdirChanges = await CheckSubdirectoriesForChangesAsync(directoryPath, lastEnumerationTime, 0, 10);
-                if (subdirChanges) return true;
-
-                Debug.WriteLine($"SongManager: No changes detected in {directoryPath}");
-                return false;
+                var inventory = await ScanChartInventoryAsync(
+                    new[] { directoryPath }, CancellationToken.None).ConfigureAwait(false);
+                return InventoryHasChangesSince(inventory, lastEnumerationTime);
             }
             catch (Exception ex)
             {
@@ -3843,104 +3787,196 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Recursively checks subdirectories with depth limit
+        /// Walks the active song roots once, mirroring full enumeration's
+        /// directory and set.def discovery rules, and returns the chart inventory
+        /// that would be imported plus the set.def and directory mtimes used by
+        /// the change check. Replaces the previous per-extension recursive globs
+        /// (six walks for counting plus seven for timestamp checking per root)
+        /// with a single walk per root.
+        /// <para>
+        /// Traversal matches <see cref="EnumerateDirectoryIntoBatchAsync"/>: a
+        /// directory containing <c>set.def</c> contributes only the set.def's
+        /// referenced charts (and is not recursed); a directory without one
+        /// contributes its loose supported charts and recurses into all
+        /// subdirectories. Chart paths are deduplicated by normalized path so
+        /// overlapping roots or a set.def referencing one file from two
+        /// difficulties cannot double-count.
+        /// </para>
         /// </summary>
-        private async Task<bool> CheckSubdirectoriesForChangesAsync(string directoryPath, DateTime lastEnumerationTime, int currentDepth, int maxDepth)
+        private Task<ChartInventory> ScanChartInventoryAsync(
+            string[] searchPaths, CancellationToken cancellationToken)
         {
-            if (currentDepth >= maxDepth)
+            return Task.Run(() =>
             {
-                Debug.WriteLine($"SongManager: Maximum depth {maxDepth} reached for {directoryPath}");
-                return false;
-            }
-
-            try
-            {
-                // Use async enumeration for directories
-                var hasChanges = await Task.Run(() =>
+                var inventory = new ChartInventory();
+                var seenCharts = new HashSet<string>(SongPathIdentity.CanonicalComparer);
+                foreach (var root in searchPaths
+                    .Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path)))
                 {
-                    var subdirectoryPaths = Directory.EnumerateDirectories(directoryPath).ToList();
-                    Debug.WriteLine($"SongManager: Checking {subdirectoryPaths.Count} subdirectories in {directoryPath} (depth {currentDepth})");
-
-                    foreach (var subdirPath in subdirectoryPaths)
-                    {
-                        var subdirInfo = new DirectoryInfo(subdirPath);
-                        
-                        // Skip hidden directories and common non-song directories
-                        if (subdirInfo.Name.StartsWith(".") || 
-                            subdirInfo.Name.Equals("System", StringComparison.OrdinalIgnoreCase) ||
-                            subdirInfo.Name.Equals("Cache", StringComparison.OrdinalIgnoreCase))
-                        {
-                            Debug.WriteLine($"SongManager: Skipping directory: {subdirInfo.Name}");
-                            continue;
-                        }
-
-                        Debug.WriteLine($"SongManager: Checking subdirectory: {subdirPath}");
-                        Debug.WriteLine($"SongManager: Subdirectory last write time: {subdirInfo.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
-
-                        if (subdirInfo.LastWriteTime > lastEnumerationTime)
-                        {
-                            Debug.WriteLine($"SongManager: Subdirectory modified: {subdirPath} at {subdirInfo.LastWriteTime:yyyy-MM-dd HH:mm:ss} (after {lastEnumerationTime:yyyy-MM-dd HH:mm:ss})");
-                            return true;
-                        }
-
-                        // Check for DTX files directly in this subdirectory using enumeration
-                        var dtxFileCount = 0;
-                        foreach (var dtxFilePath in Directory.EnumerateFiles(subdirPath, "*.dtx", SearchOption.TopDirectoryOnly))
-                        {
-                            dtxFileCount++;
-                            var dtxFileInfo = new FileInfo(dtxFilePath);
-                            
-                            if (dtxFileInfo.CreationTime > lastEnumerationTime || dtxFileInfo.LastWriteTime > lastEnumerationTime)
-                            {
-                                var reason = dtxFileInfo.CreationTime > lastEnumerationTime ? "new" : "modified";
-                                var timestamp = dtxFileInfo.CreationTime > lastEnumerationTime ? dtxFileInfo.CreationTime : dtxFileInfo.LastWriteTime;
-                                Debug.WriteLine($"SongManager: {reason.ToUpper()} DTX file in subdirectory: {dtxFilePath}");
-                                Debug.WriteLine($"SongManager: File timestamp: {timestamp:yyyy-MM-dd HH:mm:ss} vs enumeration: {lastEnumerationTime:yyyy-MM-dd HH:mm:ss}");
-                                return true;
-                            }
-                        }
-                        
-                        if (dtxFileCount > 0)
-                        {
-                            Debug.WriteLine($"SongManager: Found {dtxFileCount} DTX files in {subdirPath}");
-                        }
-                    }
-                    return false;
-                });
-                
-                if (hasChanges) return true;
-
-                // Now recursively check each subdirectory
-                foreach (var subdirPath in Directory.EnumerateDirectories(directoryPath))
-                {
-                    var subdirInfo = new DirectoryInfo(subdirPath);
-                    
-                    // Skip hidden directories and common non-song directories
-                    if (subdirInfo.Name.StartsWith(".") || 
-                        subdirInfo.Name.Equals("System", StringComparison.OrdinalIgnoreCase) ||
-                        subdirInfo.Name.Equals("Cache", StringComparison.OrdinalIgnoreCase))
-                    {
-                        continue;
-                    }
-
-                    // Recursively check subdirectory
-                    var subdirHasChanges = await CheckSubdirectoriesForChangesAsync(subdirPath, lastEnumerationTime, currentDepth + 1, maxDepth);
-                    if (subdirHasChanges) return true;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    ScanChartInventoryDirectory(
+                        root, inventory, seenCharts, cancellationToken);
                 }
+                return inventory;
+            }, cancellationToken);
+        }
 
-                Debug.WriteLine($"SongManager: No changes found in subdirectories of {directoryPath}");
-                return false;
-            }
-            catch (Exception ex)
+        private void ScanChartInventoryDirectory(
+            string directoryPath,
+            ChartInventory inventory,
+            HashSet<string> seenCharts,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var dirInfo = new DirectoryInfo(directoryPath);
+            inventory.Directories.Add(new ChartInventoryEntry(
+                SongPathIdentity.Normalize(directoryPath),
+                dirInfo.LastWriteTime,
+                dirInfo.CreationTime));
+
+            var setDefPath = Path.Combine(directoryPath, "set.def");
+            if (File.Exists(setDefPath))
             {
-                Debug.WriteLine($"SongManager: Error checking subdirectories of {directoryPath}: {ex.Message}");
-                Debug.WriteLine($"SongManager: Stack trace: {ex.StackTrace}");
-                return true; // Assume changes on error
+                // set.def directory: only referenced charts are imported; loose
+                // charts and subdirectories are NOT scanned (enumeration returns
+                // early after ParseSetDefinitionIntoBatchAsync).
+                var setDefInfo = new FileInfo(setDefPath);
+                inventory.SetDefinitions.Add(new ChartInventoryEntry(
+                    SongPathIdentity.Normalize(setDefPath),
+                    setDefInfo.LastWriteTime,
+                    setDefInfo.CreationTime));
+                foreach (var chartPath in EnumerateSetDefReferencedCharts(
+                    setDefPath, cancellationToken))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!seenCharts.Add(chartPath))
+                        continue;
+                    var chartInfo = new FileInfo(chartPath);
+                    inventory.Charts.Add(new ChartInventoryEntry(
+                        chartPath,
+                        chartInfo.LastWriteTime,
+                        chartInfo.CreationTime));
+                }
+                return;
+            }
+
+            // No set.def: collect loose supported charts (case-insensitive via
+            // IsSupportedFile, matching full enumeration) and recurse into all
+            // subdirectories. Boxes are organizational only and do not filter
+            // charts, so they are recursed like any other directory.
+            foreach (var file in EnumerateFilesCore(directoryPath)
+                .Where(DTXChartParser.IsSupportedFile)
+                .Select(SongPathIdentity.Normalize)
+                .OrderBy(path => path, SongPathIdentity.CanonicalComparer))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!File.Exists(file))
+                    continue;
+                if (!seenCharts.Add(file))
+                    continue;
+                var fileInfo = new FileInfo(file);
+                inventory.Charts.Add(new ChartInventoryEntry(
+                    file,
+                    fileInfo.LastWriteTime,
+                    fileInfo.CreationTime));
+            }
+
+            foreach (var subdirectory in EnumerateDirectoriesCore(directoryPath)
+                .Select(SongPathIdentity.Normalize)
+                .OrderBy(path => path, SongPathIdentity.CanonicalComparer))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ScanChartInventoryDirectory(
+                    subdirectory, inventory, seenCharts, cancellationToken);
             }
         }
 
         /// <summary>
-        /// Gets the timestamp of the last enumeration from the database
+        /// Resolves the chart file paths a <c>set.def</c> references (and that
+        /// exist on disk and are supported), mirroring
+        /// <see cref="ParseSetDefinitionIntoBatchAsync"/>. Reuses the shared
+        /// <see cref="ReadSetDefLines"/> encoding chain and
+        /// <see cref="ParseSetDefContent"/> so the inventory never drifts from
+        /// what full enumeration imports.
+        /// </summary>
+        private IEnumerable<string> EnumerateSetDefReferencedCharts(
+            string setDefPath, CancellationToken cancellationToken)
+        {
+            var directory = Path.GetDirectoryName(setDefPath) ?? "";
+            var lines = ReadSetDefLines(setDefPath);
+            if (lines == null)
+                yield break;
+
+            var (_, difficulties) = ParseSetDefContent(lines, cancellationToken);
+            var emitted = new HashSet<string>(SongPathIdentity.CanonicalComparer);
+            foreach (var (_, fileName) in difficulties.Values)
+            {
+                if (string.IsNullOrWhiteSpace(fileName))
+                    continue;
+                var path = SongPathIdentity.Normalize(Path.Combine(directory, fileName));
+                if (DTXChartParser.IsSupportedFile(path) &&
+                    File.Exists(path) &&
+                    emitted.Add(path))
+                {
+                    yield return path;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns true if any directory, set.def, or chart in
+        /// <paramref name="inventory"/> was created or modified after
+        /// <paramref name="lastEnumerationTime"/>. Mirrors the per-entry checks
+        /// previously spread across <c>CheckDirectoryForChangesAsync</c> and
+        /// <c>CheckSubdirectoriesForChangesAsync</c>, but evaluated over a single
+        /// inventory walk instead of one recursive walk per extension.
+        /// </summary>
+        private static bool InventoryHasChangesSince(
+            ChartInventory inventory, DateTime lastEnumerationTime)
+        {
+            foreach (var dir in inventory.Directories)
+            {
+                if (dir.LastWriteTime > lastEnumerationTime)
+                {
+                    Debug.WriteLine($"SongManager: Directory modified: {dir.Path} at {dir.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
+                    return true;
+                }
+            }
+
+            foreach (var setDef in inventory.SetDefinitions)
+            {
+                if (setDef.CreationTime > lastEnumerationTime ||
+                    setDef.LastWriteTime > lastEnumerationTime)
+                {
+                    Debug.WriteLine($"SongManager: set.def modified: {setDef.Path} at {setDef.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
+                    return true;
+                }
+            }
+
+            foreach (var chart in inventory.Charts)
+            {
+                if (chart.CreationTime > lastEnumerationTime ||
+                    chart.LastWriteTime > lastEnumerationTime)
+                {
+                    var reason = chart.CreationTime > lastEnumerationTime ? "new" : "modified";
+                    Debug.WriteLine($"SongManager: {reason.ToUpper()} chart detected: {chart.Path} at {chart.LastWriteTime:yyyy-MM-dd HH:mm:ss}");
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the timestamp of the last successful enumeration from the database.
+        /// <para>
+        /// The timestamp is an explicitly persisted
+        /// <c>LastSuccessfulEnumerationUtc</c> metadata value, NOT the database
+        /// file's last-write time. The file mtime advances on every
+        /// <c>SaveChangesAsync</c> (bookmark toggle, score save), so deriving the
+        /// enumeration time from it would let an unrelated write mask later chart
+        /// edits when the file count is unchanged. A null result means no
+        /// enumeration has been recorded yet and forces a first-time scan.
         /// </summary>
         private async Task<DateTime?> GetLastEnumerationTimestampAsync()
         {
@@ -3952,35 +3988,21 @@ namespace DTXMania.Game.Lib.Song
                     return null;
                 }
 
-                var dbPath = _databaseService.DatabasePath;
-                Debug.WriteLine($"SongManager: Checking database path: {dbPath}");
-
-                if (!File.Exists(dbPath))
+                var timestamp = await _databaseService.GetLastSuccessfulEnumerationUtcAsync();
+                if (timestamp == null)
                 {
-                    Debug.WriteLine($"SongManager: Database file doesn't exist: {dbPath}");
+                    Debug.WriteLine("SongManager: No last enumeration timestamp recorded - first time enumeration");
                     return null;
                 }
 
-                var dbInfo = new FileInfo(dbPath);
-                var lastWriteTime = dbInfo.LastWriteTime;
-                Debug.WriteLine($"SongManager: Database last write time: {lastWriteTime:yyyy-MM-dd HH:mm:ss}");
-
-                // Check if the database actually has songs
-                var songCount = await GetDatabaseScoreCountAsync();
-                Debug.WriteLine($"SongManager: Database contains {songCount} songs");
-
-                if (songCount == 0)
-                {
-                    Debug.WriteLine("SongManager: Database is empty, treating as no enumeration done");
-                    return null;
-                }
-
-                // Use database modification time, but subtract a small buffer to ensure we catch recent changes
-                // This is important because filesystem timestamps might have slight differences
-                var timestampWithBuffer = lastWriteTime.AddMinutes(-1);
-                Debug.WriteLine($"SongManager: Using enumeration timestamp with 1-minute buffer: {timestampWithBuffer:yyyy-MM-dd HH:mm:ss}");
-                
-                return timestampWithBuffer;
+                // Convert to local time before returning: downstream change detection
+                // compares this against FileInfo/DirectoryInfo LastWriteTime values,
+                // which are returned in local time. Comparing a UTC DateTime directly
+                // against a Local DateTime would mis-order them by the timezone offset
+                // on non-UTC systems and report every file as modified (or never).
+                var localTimestamp = timestamp.Value.ToLocalTime();
+                Debug.WriteLine($"SongManager: Last successful enumeration at {localTimestamp:yyyy-MM-dd HH:mm:ss} (local)");
+                return localTimestamp;
             }
             catch (Exception ex)
             {
@@ -3991,7 +4013,9 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Updates the enumeration timestamp in the database
+        /// Persists the enumeration timestamp after a successful enumeration. The
+        /// value is updated only here (after ImportedAndPublished) so unrelated
+        /// database writes cannot advance it.
         /// </summary>
         private async Task UpdateEnumerationTimestampAsync()
         {
@@ -3999,9 +4023,8 @@ namespace DTXMania.Game.Lib.Song
             {
                 if (_databaseService == null) return;
 
-                // This could be enhanced to store enumeration metadata in a dedicated table
-                // For now, the database modification time serves as the enumeration timestamp
-                Debug.WriteLine($"SongManager: Enumeration timestamp updated to {DateTime.Now}");
+                await _databaseService.SetLastSuccessfulEnumerationUtcAsync(DateTime.UtcNow);
+                Debug.WriteLine($"SongManager: Enumeration timestamp persisted at {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC");
             }
             catch (Exception ex)
             {

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -3784,8 +3784,7 @@ namespace DTXMania.Game.Lib.Song
                 // watermark. A root omitted from a partial scan has no new
                 // watermark, so its return is conservatively treated as a change.
                 var rootWatermarks = await GetRootEnumerationWatermarksAsync(
-                    availableRoots,
-                    lastEnumerationTime.Value).ConfigureAwait(false);
+                    availableRoots).ConfigureAwait(false);
                 if (InventoryHasChangesSince(
                         inventory,
                         availableRoots,
@@ -3808,8 +3807,7 @@ namespace DTXMania.Game.Lib.Song
 
         private async Task<IReadOnlyDictionary<string, DateTime>>
             GetRootEnumerationWatermarksAsync(
-                IReadOnlyList<string> availableRoots,
-                DateTime legacyWatermark)
+                IReadOnlyList<string> availableRoots)
         {
             var watermarks = new Dictionary<string, DateTime>(
                 SongPathIdentity.CanonicalComparer);
@@ -3826,16 +3824,16 @@ namespace DTXMania.Game.Lib.Song
                     watermarks[root] = watermark.Value;
             }
 
-            // Databases created before per-root watermarks only have the global
-            // value. Use it as a one-time migration fallback; once any root
-            // watermark exists, an omitted root must remain missing so a return
-            // after a partial scan cannot inherit another root's newer time.
-            if (watermarks.Count == 0)
-            {
-                foreach (var root in availableRoots)
-                    watermarks[root] = legacyWatermark;
-            }
-
+            // A missing per-root watermark must remain missing. Assigning the
+            // legacy global timestamp to a root that was never successfully
+            // enumerated (or that returned after a partial scan where another
+            // root advanced the global value) would hide stale content: the
+            // root's retained rows and file mtimes would compare clean against
+            // a watermark it never earned, so NeedsEnumerationAsync would
+            // return false and never retry the failed parse. The conservative
+            // behavior — treat a missing watermark as "needs enumeration" —
+            // costs one full scan to initialize per-root metadata on a legacy
+            // database, then never triggers again.
             return watermarks;
         }
 
@@ -4254,8 +4252,8 @@ namespace DTXMania.Game.Lib.Song
         /// The global and per-root watermarks are written as one atomic database
         /// transaction. A crash or failure mid-write cannot leave the global
         /// timestamp committed while per-root rows are absent, which would
-        /// otherwise cause the legacy fallback to assign another root's newer
-        /// timestamp to a returning root and hide its edits.
+        /// otherwise force a conservative full rescan on every startup until
+        /// the per-root rows catch up.
         /// </para>
         /// </summary>
         private async Task SetEnumerationWatermarkAsync(

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -1263,6 +1263,7 @@ namespace DTXMania.Game.Lib.Song
             }
 
             var directory = Path.GetDirectoryName(setDefPath) ?? "";
+            var normalizedSetDefDirectory = SongPathIdentity.Normalize(directory);
             var groupKey = SongPathIdentity.ForSetDefinition(setDefPath);
             SongListNode? placeholder = null;
             var orderedPaths = new List<string>();
@@ -1277,6 +1278,17 @@ namespace DTXMania.Game.Lib.Song
                 if (string.IsNullOrWhiteSpace(fileName))
                     continue;
 
+                // Reject absolute set.def chart references outright.
+                // Path.Combine silently overrides the set.def directory when
+                // the second argument is rooted, which would let an absolute
+                // path point anywhere on disk.
+                if (Path.IsPathRooted(fileName))
+                {
+                    Debug.WriteLine(
+                        $"SongManager: Rejecting absolute set.def chart reference: {fileName}");
+                    continue;
+                }
+
                 var path = SongPathIdentity.Normalize(
                     Path.Combine(directory, fileName));
                 if (!DTXChartParser.IsSupportedFile(path) ||
@@ -1285,16 +1297,23 @@ namespace DTXMania.Game.Lib.Song
                     continue;
                 }
 
-                // Reject set.def chart references that escape the active-root
-                // boundary (../ traversal or absolute paths). Without this, an
-                // escaped reference is counted by the filesystem inventory but
-                // excluded by the database freshness count (which scopes to
-                // active roots), producing a permanent count mismatch and
-                // perpetual rescans.
-                if (!IsPathUnderAnyRoot(path, builder.ActiveRoots))
+                // Reject set.def chart references that escape the directory
+                // containing the set.def. A reference like
+                // ../Sibling/chart.dtx (still inside the active root) creates a
+                // duplicate placeholder: one under the set.def's directory, one
+                // under the chart's own directory. Both resolve to the single
+                // persisted chart in the freshly published hierarchy, but on a
+                // cached restart the chart is placed only by its physical
+                // path, so the duplicate/misplaced node disappears — an
+                // inconsistency between fresh publish and cached
+                // reconstruction. Valid child paths (e.g. charts/basic.dtx)
+                // are permitted.
+                if (!SongPathIdentity.IsUnderNormalizedRoot(
+                        path,
+                        normalizedSetDefDirectory))
                 {
                     Debug.WriteLine(
-                        $"SongManager: Rejecting set.def chart reference outside active roots: {path}");
+                        $"SongManager: Rejecting set.def chart reference outside its directory: {path}");
                     continue;
                 }
 
@@ -3898,19 +3917,12 @@ namespace DTXMania.Game.Lib.Song
             {
                 var inventory = new ChartInventory();
                 var seenCharts = new HashSet<string>(SongPathIdentity.CanonicalComparer);
-                // Pre-normalize the available roots once so every set.def
-                // containment check reuses the same normalized set without
-                // re-normalizing per chart reference.
-                var normalizedRoots = searchPaths
-                    .Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path))
-                    .Select(SongPathIdentity.Normalize)
-                    .ToArray();
                 foreach (var root in searchPaths
                     .Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path)))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     ScanChartInventoryDirectory(
-                        root, inventory, seenCharts, normalizedRoots, cancellationToken);
+                        root, inventory, seenCharts, cancellationToken);
                 }
                 return inventory;
             }, cancellationToken);
@@ -3920,7 +3932,6 @@ namespace DTXMania.Game.Lib.Song
             string directoryPath,
             ChartInventory inventory,
             HashSet<string> seenCharts,
-            IReadOnlyList<string> normalizedRoots,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -3942,7 +3953,7 @@ namespace DTXMania.Game.Lib.Song
                     setDefInfo.LastWriteTimeUtc,
                     setDefInfo.CreationTimeUtc));
                 foreach (var chartPath in EnumerateSetDefReferencedCharts(
-                    setDefPath, normalizedRoots, cancellationToken))
+                    setDefPath, cancellationToken))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     if (!seenCharts.Add(chartPath))
@@ -3983,27 +3994,28 @@ namespace DTXMania.Game.Lib.Song
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 ScanChartInventoryDirectory(
-                    subdirectory, inventory, seenCharts, normalizedRoots, cancellationToken);
+                    subdirectory, inventory, seenCharts, cancellationToken);
             }
         }
 
         /// <summary>
         /// Resolves the chart file paths a <c>set.def</c> references (and that
-        /// exist on disk, are supported, and remain within an active root),
-        /// mirroring <see cref="ParseSetDefinitionIntoBatchAsync"/>. Reuses the
-        /// shared <see cref="ReadSetDefLines"/> encoding chain and
+        /// exist on disk, are supported, and remain within the directory
+        /// containing the set.def), mirroring
+        /// <see cref="ParseSetDefinitionIntoBatchAsync"/>. Reuses the shared
+        /// <see cref="ReadSetDefLines"/> encoding chain and
         /// <see cref="ParseSetDefContent"/> so the inventory never drifts from
-        /// what full enumeration imports. References that escape the active-root
-        /// boundary via <c>../</c> traversal or absolute paths are rejected so
-        /// the inventory count matches the database freshness count (which
-        /// scopes to active roots).
+        /// what full enumeration imports. References that escape the set.def's
+        /// directory via <c>../</c> traversal or absolute paths are rejected so
+        /// the inventory count matches the database freshness count and no
+        /// duplicate placeholders are created.
         /// </summary>
         private IEnumerable<string> EnumerateSetDefReferencedCharts(
             string setDefPath,
-            IReadOnlyList<string> normalizedRoots,
             CancellationToken cancellationToken)
         {
             var directory = Path.GetDirectoryName(setDefPath) ?? "";
+            var normalizedSetDefDirectory = SongPathIdentity.Normalize(directory);
             var lines = ReadSetDefLines(setDefPath);
             if (lines == null)
                 yield break;
@@ -4014,10 +4026,13 @@ namespace DTXMania.Game.Lib.Song
             {
                 if (string.IsNullOrWhiteSpace(fileName))
                     continue;
+                if (Path.IsPathRooted(fileName))
+                    continue;
                 var path = SongPathIdentity.Normalize(Path.Combine(directory, fileName));
                 if (DTXChartParser.IsSupportedFile(path) &&
                     File.Exists(path) &&
-                    IsPathUnderAnyRoot(path, normalizedRoots) &&
+                    SongPathIdentity.IsUnderNormalizedRoot(
+                        path, normalizedSetDefDirectory) &&
                     emitted.Add(path))
                 {
                     yield return path;
@@ -4116,30 +4131,6 @@ namespace DTXMania.Game.Lib.Song
 
             return containingRoot != null &&
                 rootWatermarks.TryGetValue(containingRoot, out watermark);
-        }
-
-        /// <summary>
-        /// Checks whether a normalized chart path is contained within any of
-        /// the supplied normalized active roots. Used to reject <c>set.def</c>
-        /// <c>#LnFILE</c> references that escape the active-root boundary via
-        /// <c>../</c> traversal or absolute paths — such references would be
-        /// counted by the filesystem inventory but excluded by the database
-        /// freshness count (which scopes to active roots), producing a
-        /// permanent count mismatch and perpetual rescans.
-        /// </summary>
-        private static bool IsPathUnderAnyRoot(
-            string normalizedPath,
-            IReadOnlyList<string> normalizedRoots)
-        {
-            if (normalizedRoots.Count == 0)
-                return false;
-
-            foreach (var root in normalizedRoots)
-            {
-                if (SongPathIdentity.IsUnderNormalizedRoot(normalizedPath, root))
-                    return true;
-            }
-            return false;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -244,15 +244,16 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Number of score rows in the database whose charts reside under one of
+        /// Number of chart rows in the database whose files reside under one of
         /// <paramref name="activeRoots"/>. This is the active-root-scoped
-        /// counterpart to <see cref="GetDatabaseScoreCountAsync"/>: cache
-        /// freshness checks compare it against the filesystem file count, which is
-        /// also scoped to the active roots. Using the global count instead would
-        /// count retained rows belonging to a removed root and force a full
-        /// rescan on every subsequent startup.
+        /// counterpart to the global chart count: cache freshness checks compare
+        /// it against the filesystem chart-file count, which is also scoped to the
+        /// active roots. Using the global count instead would count retained rows
+        /// belonging to a removed root and force a full rescan on every subsequent
+        /// startup. Counts charts (not score rows) so the database side matches
+        /// the one-file-per-chart filesystem contract.
         /// </summary>
-        internal async Task<int> GetActiveDatabaseScoreCountAsync(
+        internal async Task<int> GetActiveDatabaseChartCountAsync(
             IReadOnlyList<string> activeRoots)
         {
             // Copy reference under lock to avoid race with Clear()
@@ -265,7 +266,7 @@ namespace DTXMania.Game.Lib.Song
             if (dbService == null) return 0;
             try
             {
-                return await dbService.GetActiveScoreCountAsync(activeRoots);
+                return await dbService.GetActiveChartCountAsync(activeRoots);
             }
             catch
             {
@@ -3647,17 +3648,19 @@ namespace DTXMania.Game.Lib.Song
                 // First, check if file counts have changed - this is a reliable indicator.
                 // Both counts must be scoped to the same active root set: the filesystem
                 // count is restricted to these searchPaths, so the database count must be
-                // too. The global score count would include retained rows belonging to a
+                // too. The global chart count would include retained rows belonging to a
                 // removed root, which can never match the scoped filesystem count and would
-                // force a full rescan on every startup.
+                // force a full rescan on every startup. The database side counts charts
+                // (one row per chart file), not score rows, so it matches the one-file-
+                // per-chart filesystem contract even when a chart has many score variants.
                 var currentFileCount = await CountDTXFilesAsync(searchPaths);
-                var databaseSongCount = await GetActiveDatabaseScoreCountAsync(searchPaths);
+                var databaseChartCount = await GetActiveDatabaseChartCountAsync(searchPaths);
                 
-                Debug.WriteLine($"SongManager: Current DTX files: {currentFileCount}, Database songs: {databaseSongCount}");
+                Debug.WriteLine($"SongManager: Current chart files: {currentFileCount}, Database charts: {databaseChartCount}");
                 
-                if (currentFileCount != databaseSongCount)
+                if (currentFileCount != databaseChartCount)
                 {
-                    Debug.WriteLine($"SongManager: File count mismatch detected - files: {currentFileCount}, database: {databaseSongCount}");
+                    Debug.WriteLine($"SongManager: File count mismatch detected - files: {currentFileCount}, database: {databaseChartCount}");
                     return true;
                 }
 
@@ -3719,29 +3722,41 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
-        /// Counts DTX files in all search paths
+        /// Counts supported chart files in all search paths. Uses the same
+        /// extension set as <see cref="DTXChartParser.IsSupportedFile"/> so the
+        /// count matches what full enumeration would import. Counting only
+        /// "*.dtx" would permanently mismatch libraries containing .gda/.g2d/
+        /// .bms/.bme/.bml charts and force a full rescan on every startup.
         /// </summary>
         private async Task<int> CountDTXFilesAsync(string[] searchPaths)
         {
             int totalCount = 0;
             try
             {
+                // Build the glob patterns once from the canonical supported set.
+                var searchPatterns = DTXChartParser.SupportedExtensions
+                    .Select(ext => "*" + ext)
+                    .ToArray();
                 foreach (var searchPath in searchPaths.Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path)))
                 {
                     // Use async enumeration to avoid blocking
                     await Task.Run(() =>
                     {
-                        int pathCount = Directory.EnumerateFiles(searchPath, "*.dtx", SearchOption.AllDirectories).Count();
+                        int pathCount = 0;
+                        foreach (var pattern in searchPatterns)
+                        {
+                            pathCount += Directory.EnumerateFiles(searchPath, pattern, SearchOption.AllDirectories).Count();
+                        }
                         totalCount += pathCount;
-                        Debug.WriteLine($"SongManager: Found {pathCount} DTX files in {searchPath}");
+                        Debug.WriteLine($"SongManager: Found {pathCount} supported chart files in {searchPath}");
                     });
                 }
-                Debug.WriteLine($"SongManager: Total DTX files found: {totalCount}");
+                Debug.WriteLine($"SongManager: Total supported chart files found: {totalCount}");
                 return totalCount;
             }
             catch (Exception ex)
             {
-                Debug.WriteLine($"SongManager: Error counting DTX files: {ex.Message}");
+                Debug.WriteLine($"SongManager: Error counting chart files: {ex.Message}");
                 return -1; // Return invalid count to trigger enumeration
             }
         }
@@ -3765,12 +3780,18 @@ namespace DTXMania.Game.Lib.Song
                     return true;
                 }
 
-                // Check for new or modified DTX/SET files using async enumeration
-                var dtxExtensions = new[] { "*.dtx", "*.set" };
+                // Check for new or modified chart/SET files using async enumeration.
+                // The chart extension set must match DTXChartParser.SupportedExtensions
+                // so modifications to .gda/.g2d/.bms/.bme/.bml charts are detected when
+                // the total file count is unchanged; "*.set" covers SET.def changes.
+                var chartPatterns = DTXChartParser.SupportedExtensions
+                    .Select(ext => "*" + ext)
+                    .Append("*.set")
+                    .ToArray();
                 int totalFilesChecked = 0;
                 int modifiedFilesFound = 0;
 
-                foreach (var extension in dtxExtensions)
+                foreach (var extension in chartPatterns)
                 {
                     Debug.WriteLine($"SongManager: Scanning for {extension} files in {directoryPath}");
                     

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -230,12 +230,42 @@ namespace DTXMania.Game.Lib.Song
             {
                 dbService = _databaseService;
             }
-            
+
             if (dbService == null) return 0;
             try
             {
                 var stats = await dbService.GetDatabaseStatsAsync();
                 return stats.ScoreCount;
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Number of score rows in the database whose charts reside under one of
+        /// <paramref name="activeRoots"/>. This is the active-root-scoped
+        /// counterpart to <see cref="GetDatabaseScoreCountAsync"/>: cache
+        /// freshness checks compare it against the filesystem file count, which is
+        /// also scoped to the active roots. Using the global count instead would
+        /// count retained rows belonging to a removed root and force a full
+        /// rescan on every subsequent startup.
+        /// </summary>
+        internal async Task<int> GetActiveDatabaseScoreCountAsync(
+            IReadOnlyList<string> activeRoots)
+        {
+            // Copy reference under lock to avoid race with Clear()
+            SongDatabaseService? dbService;
+            lock (_lockObject)
+            {
+                dbService = _databaseService;
+            }
+
+            if (dbService == null) return 0;
+            try
+            {
+                return await dbService.GetActiveScoreCountAsync(activeRoots);
             }
             catch
             {
@@ -3614,9 +3644,14 @@ namespace DTXMania.Game.Lib.Song
 
                 Debug.WriteLine($"SongManager: Last enumeration was at {lastEnumerationTime:yyyy-MM-dd HH:mm:ss}");
 
-                // First, check if file counts have changed - this is a reliable indicator
+                // First, check if file counts have changed - this is a reliable indicator.
+                // Both counts must be scoped to the same active root set: the filesystem
+                // count is restricted to these searchPaths, so the database count must be
+                // too. The global score count would include retained rows belonging to a
+                // removed root, which can never match the scoped filesystem count and would
+                // force a full rescan on every startup.
                 var currentFileCount = await CountDTXFilesAsync(searchPaths);
-                var databaseSongCount = await GetDatabaseScoreCountAsync();
+                var databaseSongCount = await GetActiveDatabaseScoreCountAsync(searchPaths);
                 
                 Debug.WriteLine($"SongManager: Current DTX files: {currentFileCount}, Database songs: {databaseSongCount}");
                 

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -726,8 +726,7 @@ namespace DTXMania.Game.Lib.Song
             // a concurrent enumeration surfaces as InvalidOperationException.
             if (!TryBeginEnumeration(cancellationToken, out var linked))
             {
-                throw new InvalidOperationException(
-                    "Song enumeration is already in progress.");
+                throw new SongEnumerationBusyException();
             }
             return EnumerateAndImportSongsCoreAsync(
                 searchPaths,
@@ -1557,8 +1556,8 @@ namespace DTXMania.Game.Lib.Song
         private SongLibrarySnapshot CreateSnapshotLocked() =>
             new(
                 _publicationVersion,
-                Array.AsReadOnly(_rootSongs.ToArray()),
-                Array.AsReadOnly(_currentSearchPaths.ToArray()),
+                _rootSongs,
+                _currentSearchPaths,
                 EnumeratedFileCount,
                 DiscoveredScoreCount);
 

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -60,6 +60,9 @@ namespace DTXMania.Game.Lib.Song
             // batches (e.g. an incomplete batch) without subclassing.
             BuildEnumerationBatchCoreAsync = (searchPaths, progress, token) =>
                 BuildEnumerationBatchAsync(searchPaths, progress, token);
+            FinalizePendingNodesCore = (batch, chartsByPath) =>
+                FinalizePendingNodes(batch, chartsByPath);
+            PublishEnumerationCore = PublishEnumeration;
         }
 
         #endregion
@@ -105,6 +108,14 @@ namespace DTXMania.Game.Lib.Song
             IProgress<EnumerationProgress>?,
             CancellationToken,
             Task<SongEnumerationBatch>> BuildEnumerationBatchCoreAsync
+            { get; set; }
+
+        internal Action<
+            SongEnumerationBatch,
+            IReadOnlyDictionary<string, SongChart>> FinalizePendingNodesCore
+            { get; set; }
+
+        internal Action<SongEnumerationBatch> PublishEnumerationCore
             { get; set; }
 
         internal Func<SongDatabaseService, Task<DatabaseStats?>>
@@ -778,9 +789,33 @@ namespace DTXMania.Game.Lib.Song
                     linked.Token).ConfigureAwait(false);
 
                 var hierarchy = Stopwatch.StartNew();
-                FinalizePendingNodes(batch, import.ChartsByPath);
+                try
+                {
+                    FinalizePendingNodesCore(batch, import.ChartsByPath);
+                }
+                catch (Exception exception)
+                {
+                    hierarchy.Stop();
+                    throw new SongEnumerationPostCommitException(
+                        SongEnumerationPostCommitPhase.Finalization,
+                        batch,
+                        import,
+                        exception);
+                }
+
                 hierarchy.Stop();
-                PublishEnumeration(batch);
+                try
+                {
+                    PublishEnumerationCore(batch);
+                }
+                catch (Exception exception)
+                {
+                    throw new SongEnumerationPostCommitException(
+                        SongEnumerationPostCommitPhase.Publication,
+                        batch,
+                        import,
+                        exception);
+                }
 
                 result = new SongEnumerationResult(
                     SongEnumerationOutcome.ImportedAndPublished,
@@ -4122,6 +4157,9 @@ namespace DTXMania.Game.Lib.Song
                 BuildEnumerationBatchCoreAsync =
                     (searchPaths, progress, token) =>
                         BuildEnumerationBatchAsync(searchPaths, progress, token);
+                FinalizePendingNodesCore = (batch, chartsByPath) =>
+                    FinalizePendingNodes(batch, chartsByPath);
+                PublishEnumerationCore = PublishEnumeration;
                 RootPolicy = SongRootPolicy.ForCurrentPlatform();
                 snapshot = CreateSnapshotLocked();
             }

--- a/DTXMania.Game/Lib/Song/SongManager.cs
+++ b/DTXMania.Game/Lib/Song/SongManager.cs
@@ -872,10 +872,22 @@ namespace DTXMania.Game.Lib.Song
                 // so that mid-scan edits remain newer than the watermark and are
                 // detected by the next freshness check. NoActiveRoots and failure
                 // paths do not update the watermark: nothing was enumerated.
-                await SetEnumerationWatermarkAsync(
-                    batch.ActiveRoots,
-                    enumerationStartedUtc)
-                    .ConfigureAwait(false);
+                //
+                // Roots with recoverable (non-root) errors are excluded: a
+                // recoverable error (file parse failure, set.def read failure)
+                // leaves the chart's old database row preserved but unupdated.
+                // Advancing that root's watermark would make the next freshness
+                // check see matching counts and a watermark newer than the file's
+                // mtime, silently accepting stale content. Leaving the watermark
+                // dirty forces a rescan that retries the failed parse.
+                var rootsToAdvance = GetRootsWithoutRecoverableErrors(batch);
+                if (rootsToAdvance.Count > 0)
+                {
+                    await SetEnumerationWatermarkAsync(
+                        rootsToAdvance,
+                        enumerationStartedUtc)
+                        .ConfigureAwait(false);
+                }
 
                 return result;
             }
@@ -1270,6 +1282,19 @@ namespace DTXMania.Game.Lib.Song
                 if (!DTXChartParser.IsSupportedFile(path) ||
                     !File.Exists(path))
                 {
+                    continue;
+                }
+
+                // Reject set.def chart references that escape the active-root
+                // boundary (../ traversal or absolute paths). Without this, an
+                // escaped reference is counted by the filesystem inventory but
+                // excluded by the database freshness count (which scopes to
+                // active roots), producing a permanent count mismatch and
+                // perpetual rescans.
+                if (!IsPathUnderAnyRoot(path, builder.ActiveRoots))
+                {
+                    Debug.WriteLine(
+                        $"SongManager: Rejecting set.def chart reference outside active roots: {path}");
                     continue;
                 }
 
@@ -3873,12 +3898,19 @@ namespace DTXMania.Game.Lib.Song
             {
                 var inventory = new ChartInventory();
                 var seenCharts = new HashSet<string>(SongPathIdentity.CanonicalComparer);
+                // Pre-normalize the available roots once so every set.def
+                // containment check reuses the same normalized set without
+                // re-normalizing per chart reference.
+                var normalizedRoots = searchPaths
+                    .Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path))
+                    .Select(SongPathIdentity.Normalize)
+                    .ToArray();
                 foreach (var root in searchPaths
                     .Where(path => !string.IsNullOrEmpty(path) && Directory.Exists(path)))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     ScanChartInventoryDirectory(
-                        root, inventory, seenCharts, cancellationToken);
+                        root, inventory, seenCharts, normalizedRoots, cancellationToken);
                 }
                 return inventory;
             }, cancellationToken);
@@ -3888,6 +3920,7 @@ namespace DTXMania.Game.Lib.Song
             string directoryPath,
             ChartInventory inventory,
             HashSet<string> seenCharts,
+            IReadOnlyList<string> normalizedRoots,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -3909,7 +3942,7 @@ namespace DTXMania.Game.Lib.Song
                     setDefInfo.LastWriteTimeUtc,
                     setDefInfo.CreationTimeUtc));
                 foreach (var chartPath in EnumerateSetDefReferencedCharts(
-                    setDefPath, cancellationToken))
+                    setDefPath, normalizedRoots, cancellationToken))
                 {
                     cancellationToken.ThrowIfCancellationRequested();
                     if (!seenCharts.Add(chartPath))
@@ -3950,20 +3983,25 @@ namespace DTXMania.Game.Lib.Song
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 ScanChartInventoryDirectory(
-                    subdirectory, inventory, seenCharts, cancellationToken);
+                    subdirectory, inventory, seenCharts, normalizedRoots, cancellationToken);
             }
         }
 
         /// <summary>
         /// Resolves the chart file paths a <c>set.def</c> references (and that
-        /// exist on disk and are supported), mirroring
-        /// <see cref="ParseSetDefinitionIntoBatchAsync"/>. Reuses the shared
-        /// <see cref="ReadSetDefLines"/> encoding chain and
+        /// exist on disk, are supported, and remain within an active root),
+        /// mirroring <see cref="ParseSetDefinitionIntoBatchAsync"/>. Reuses the
+        /// shared <see cref="ReadSetDefLines"/> encoding chain and
         /// <see cref="ParseSetDefContent"/> so the inventory never drifts from
-        /// what full enumeration imports.
+        /// what full enumeration imports. References that escape the active-root
+        /// boundary via <c>../</c> traversal or absolute paths are rejected so
+        /// the inventory count matches the database freshness count (which
+        /// scopes to active roots).
         /// </summary>
         private IEnumerable<string> EnumerateSetDefReferencedCharts(
-            string setDefPath, CancellationToken cancellationToken)
+            string setDefPath,
+            IReadOnlyList<string> normalizedRoots,
+            CancellationToken cancellationToken)
         {
             var directory = Path.GetDirectoryName(setDefPath) ?? "";
             var lines = ReadSetDefLines(setDefPath);
@@ -3979,6 +4017,7 @@ namespace DTXMania.Game.Lib.Song
                 var path = SongPathIdentity.Normalize(Path.Combine(directory, fileName));
                 if (DTXChartParser.IsSupportedFile(path) &&
                     File.Exists(path) &&
+                    IsPathUnderAnyRoot(path, normalizedRoots) &&
                     emitted.Add(path))
                 {
                     yield return path;
@@ -4080,6 +4119,54 @@ namespace DTXMania.Game.Lib.Song
         }
 
         /// <summary>
+        /// Checks whether a normalized chart path is contained within any of
+        /// the supplied normalized active roots. Used to reject <c>set.def</c>
+        /// <c>#LnFILE</c> references that escape the active-root boundary via
+        /// <c>../</c> traversal or absolute paths — such references would be
+        /// counted by the filesystem inventory but excluded by the database
+        /// freshness count (which scopes to active roots), producing a
+        /// permanent count mismatch and perpetual rescans.
+        /// </summary>
+        private static bool IsPathUnderAnyRoot(
+            string normalizedPath,
+            IReadOnlyList<string> normalizedRoots)
+        {
+            if (normalizedRoots.Count == 0)
+                return false;
+
+            foreach (var root in normalizedRoots)
+            {
+                if (SongPathIdentity.IsUnderNormalizedRoot(normalizedPath, root))
+                    return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Finds the most specific (longest) normalized active root that
+        /// contains the supplied normalized path, or <c>null</c> if the path is
+        /// not beneath any root. Used to map a recoverable enumeration error
+        /// (file parse failure, set.def read failure) to the root whose
+        /// watermark must NOT advance so the next freshness check retries it.
+        /// </summary>
+        private static string? FindContainingRoot(
+            string normalizedPath,
+            IReadOnlyList<string> normalizedRoots)
+        {
+            string? containingRoot = null;
+            foreach (var root in normalizedRoots)
+            {
+                if (!SongPathIdentity.IsUnderNormalizedRoot(normalizedPath, root) ||
+                    (containingRoot != null && root.Length <= containingRoot.Length))
+                {
+                    continue;
+                }
+                containingRoot = root;
+            }
+            return containingRoot;
+        }
+
+        /// <summary>
         /// Gets the timestamp of the last successful enumeration from the database.
         /// <para>
         /// The timestamp is an explicitly persisted
@@ -4123,6 +4210,43 @@ namespace DTXMania.Game.Lib.Song
                 Debug.WriteLine($"SongManager: Stack trace: {ex.StackTrace}");
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Returns the subset of <paramref name="batch"/>'s active roots that
+        /// had NO recoverable (non-root) enumeration errors. Roots with
+        /// recoverable errors (file parse failures, set.def read failures) are
+        /// excluded so their watermarks are not advanced, forcing the next
+        /// freshness check to rescan and retry the failed operation rather than
+        /// silently accepting stale content.
+        /// </summary>
+        private static IReadOnlyList<string> GetRootsWithoutRecoverableErrors(
+            SongEnumerationBatch batch)
+        {
+            if (batch.Errors.Count == 0)
+                return batch.ActiveRoots;
+
+            var dirtyRoots = new HashSet<string>(SongPathIdentity.CanonicalComparer);
+            foreach (var error in batch.Errors)
+            {
+                if (error.IsRootFailure)
+                    continue;
+                var containingRoot = FindContainingRoot(
+                    error.Path, batch.ActiveRoots);
+                if (containingRoot != null)
+                {
+                    dirtyRoots.Add(containingRoot);
+                    Debug.WriteLine(
+                        $"SongManager: Suppressing watermark advance for root with recoverable error: {containingRoot} ({error.Message})");
+                }
+            }
+
+            if (dirtyRoots.Count == 0)
+                return batch.ActiveRoots;
+
+            return batch.ActiveRoots
+                .Where(root => !dirtyRoots.Contains(root))
+                .ToArray();
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/SongPathIdentity.cs
+++ b/DTXMania.Game/Lib/Song/SongPathIdentity.cs
@@ -14,6 +14,35 @@ namespace DTXMania.Game.Lib.Song
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
 
+        /// <summary>
+        /// Whether path identity is case-sensitive on the current platform.
+        /// Windows and macOS default to case-insensitive filesystems; Linux and
+        /// other Unix systems are case-sensitive. Mirrors the comparer selected
+        /// by <see cref="SongRootPolicy.ForCurrentPlatform"/>.
+        /// </summary>
+        public static bool IsCaseSensitive =>
+            !OperatingSystem.IsWindows() && !OperatingSystem.IsMacOS();
+
+        /// <summary>
+        /// Produces a stable root identity key from an already-normalized root
+        /// path. On case-insensitive platforms (Windows, macOS) the key is
+        /// lowercased so that differently-cased paths representing the same
+        /// configured root produce the same storage key. On case-sensitive
+        /// platforms the path is returned unchanged.
+        /// <para>
+        /// This must be used consistently for per-root watermark storage and
+        /// lookup so that a casing-only change in configuration cannot make a
+        /// root's watermark appear absent.
+        /// </para>
+        /// </summary>
+        public static string GetStableRootKey(string normalizedRoot)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(normalizedRoot);
+            return IsCaseSensitive
+                ? normalizedRoot
+                : normalizedRoot.ToLowerInvariant();
+        }
+
         public static string Normalize(string path)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(path);

--- a/DTXMania.Game/Lib/Song/SongRootPolicy.cs
+++ b/DTXMania.Game/Lib/Song/SongRootPolicy.cs
@@ -1,0 +1,291 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Utilities;
+
+namespace DTXMania.Game.Lib.Song
+{
+    internal enum SongRootAvailability
+    {
+        Available,
+        Missing,
+        Inaccessible,
+    }
+
+    /// <summary>
+    /// The canonicalization and identity policy for configured song-library roots.
+    /// Keeping this logic in one place prevents config, enumeration, and cache rebuilds
+    /// from disagreeing about equivalent or overlapping directories.
+    /// </summary>
+    internal sealed class SongRootPolicy
+    {
+        private readonly StringComparer _comparer;
+
+        internal SongRootPolicy(StringComparer comparer)
+        {
+            _comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
+        }
+
+        internal static SongRootPolicy ForCurrentPlatform() =>
+            new(CreateComparer(
+                OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()));
+
+        internal static StringComparer CreateComparer(bool ignoreCase) =>
+            ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        internal StringComparer Comparer => _comparer;
+
+        internal SongRootValidationResult Validate(IReadOnlyList<string> roots)
+        {
+            ArgumentNullException.ThrowIfNull(roots);
+
+            var canonicalRoots = new List<string>(roots.Count);
+            var diagnostics = new List<SongRootDiagnostic>();
+            foreach (var configuredRoot in roots)
+            {
+                if (string.IsNullOrWhiteSpace(configuredRoot))
+                {
+                    diagnostics.Add(new SongRootDiagnostic(
+                        configuredRoot ?? string.Empty,
+                        "A configured song root is blank.",
+                        IsWarning: false));
+                    continue;
+                }
+
+                if (!TryNormalize(configuredRoot, out var normalizedRoot, out var error))
+                {
+                    diagnostics.Add(new SongRootDiagnostic(
+                        configuredRoot,
+                        $"Configured song root path is invalid: {error}",
+                        IsWarning: false));
+                    continue;
+                }
+
+                if (canonicalRoots.Any(existing => PathsEqual(existing, normalizedRoot)))
+                {
+                    diagnostics.Add(new SongRootDiagnostic(
+                        normalizedRoot,
+                        "A configured song root duplicates an earlier root.",
+                        IsWarning: false));
+                    continue;
+                }
+
+                if (canonicalRoots.Any(existing =>
+                    IsAncestor(existing, normalizedRoot) ||
+                    IsAncestor(normalizedRoot, existing)))
+                {
+                    diagnostics.Add(new SongRootDiagnostic(
+                        normalizedRoot,
+                        "A configured song root overlaps an earlier root.",
+                        IsWarning: false));
+                    continue;
+                }
+
+                canonicalRoots.Add(normalizedRoot);
+
+                switch (Probe(normalizedRoot))
+                {
+                    case SongRootAvailability.Missing:
+                        diagnostics.Add(new SongRootDiagnostic(
+                            normalizedRoot,
+                            $"Configured song root does not exist: {normalizedRoot}",
+                            IsWarning: true));
+                        break;
+                    case SongRootAvailability.Inaccessible:
+                        diagnostics.Add(new SongRootDiagnostic(
+                            normalizedRoot,
+                            $"Configured song root is inaccessible: {normalizedRoot}",
+                            IsWarning: true));
+                        break;
+                }
+            }
+
+            return new SongRootValidationResult(canonicalRoots, diagnostics);
+        }
+
+        /// <summary>
+        /// Returns whether <paramref name="parent"/> is a strict ancestor of
+        /// <paramref name="child"/>. It deliberately compares path segments rather than
+        /// using relative-path text so a root such as /Songs never matches /SongsBackup.
+        /// </summary>
+        internal bool IsAncestor(string parent, string child)
+        {
+            if (!TryNormalize(parent, out var normalizedParent, out _) ||
+                !TryNormalize(child, out var normalizedChild, out _))
+            {
+                return false;
+            }
+
+            var parentSegments = Split(normalizedParent);
+            var childSegments = Split(normalizedChild);
+            if (!_comparer.Equals(parentSegments.Volume, childSegments.Volume) ||
+                parentSegments.Segments.Count >= childSegments.Segments.Count)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < parentSegments.Segments.Count; index++)
+            {
+                if (!_comparer.Equals(
+                    parentSegments.Segments[index],
+                    childSegments.Segments[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal SongRootAvailability Probe(string normalizedRoot)
+        {
+            try
+            {
+                return Directory.Exists(normalizedRoot)
+                    ? SongRootAvailability.Available
+                    : SongRootAvailability.Missing;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return SongRootAvailability.Inaccessible;
+            }
+            catch (IOException)
+            {
+                return SongRootAvailability.Inaccessible;
+            }
+            catch (System.Security.SecurityException)
+            {
+                return SongRootAvailability.Inaccessible;
+            }
+        }
+
+        private bool PathsEqual(string first, string second)
+        {
+            var firstSegments = Split(first);
+            var secondSegments = Split(second);
+            if (!_comparer.Equals(firstSegments.Volume, secondSegments.Volume) ||
+                firstSegments.Segments.Count != secondSegments.Segments.Count)
+            {
+                return false;
+            }
+
+            for (var index = 0; index < firstSegments.Segments.Count; index++)
+            {
+                if (!_comparer.Equals(
+                    firstSegments.Segments[index],
+                    secondSegments.Segments[index]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool TryNormalize(
+            string path,
+            out string normalized,
+            out string error)
+        {
+            try
+            {
+                normalized = IsWindowsDrivePath(path)
+                    ? NormalizeWindowsDrivePath(path)
+                    : SongPathIdentity.Normalize(AppPaths.ResolvePath(
+                        path,
+                        AppPaths.GetAppDataRoot()));
+                error = string.Empty;
+                return true;
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException or NotSupportedException or PathTooLongException
+                    or IOException or UnauthorizedAccessException
+                    or System.Security.SecurityException)
+            {
+                normalized = string.Empty;
+                error = exception.Message;
+                return false;
+            }
+        }
+
+        private static bool IsWindowsDrivePath(string path) =>
+            path.Length >= 3 &&
+            char.IsLetter(path[0]) &&
+            path[1] == ':' &&
+            (path[2] == '\\' || path[2] == '/');
+
+        // Windows-like roots are accepted as configuration data on every host. This
+        // lets the policy's injected comparer be tested independently of the host OS.
+        private static string NormalizeWindowsDrivePath(string path)
+        {
+            var parts = path.Substring(3)
+                .Replace('/', '\\')
+                .Split('\\', StringSplitOptions.RemoveEmptyEntries);
+            var segments = new List<string>(parts.Length);
+            foreach (var part in parts)
+            {
+                if (part == ".")
+                    continue;
+                if (part == "..")
+                {
+                    if (segments.Count > 0)
+                        segments.RemoveAt(segments.Count - 1);
+                    continue;
+                }
+
+                segments.Add(part);
+            }
+
+            var prefix = path.Substring(0, 2);
+            return segments.Count == 0
+                ? prefix + "\\"
+                : prefix + "\\" + string.Join("\\", segments);
+        }
+
+        private static PathSegments Split(string normalizedPath)
+        {
+            if (IsWindowsDrivePath(normalizedPath))
+            {
+                var segments = normalizedPath.Length <= 3
+                    ? Array.Empty<string>()
+                    : normalizedPath.Substring(3)
+                        .Split('\\', StringSplitOptions.RemoveEmptyEntries);
+                return new PathSegments(normalizedPath.Substring(0, 2), segments);
+            }
+
+            return new PathSegments(
+                Path.DirectorySeparatorChar.ToString(),
+                normalizedPath.Split(
+                    Path.DirectorySeparatorChar,
+                    StringSplitOptions.RemoveEmptyEntries));
+        }
+
+        private sealed record PathSegments(
+            string Volume,
+            IReadOnlyList<string> Segments);
+    }
+
+    internal sealed class SongRootValidationResult
+    {
+        internal SongRootValidationResult(
+            IReadOnlyList<string> canonicalRoots,
+            IReadOnlyList<SongRootDiagnostic> diagnostics)
+        {
+            ArgumentNullException.ThrowIfNull(canonicalRoots);
+            ArgumentNullException.ThrowIfNull(diagnostics);
+
+            CanonicalRoots = Array.AsReadOnly(canonicalRoots.ToArray());
+            Diagnostics = Array.AsReadOnly(diagnostics.ToArray());
+        }
+
+        internal IReadOnlyList<string> CanonicalRoots { get; }
+
+        internal IReadOnlyList<SongRootDiagnostic> Diagnostics { get; }
+
+        internal bool IsValid => Diagnostics.All(diagnostic => diagnostic.IsWarning);
+    }
+}

--- a/DTXMania.Game/Lib/Song/SongRootPolicy.cs
+++ b/DTXMania.Game/Lib/Song/SongRootPolicy.cs
@@ -167,9 +167,18 @@ namespace DTXMania.Game.Lib.Song
                 if (!Directory.Exists(normalizedRoot))
                     return SongRootAvailability.Missing;
 
-                // Force a real directory read. EnumerateFileSystemEntries touches
-                // the directory's metadata/ACL rather than just stat-ing it.
-                _ = Directory.EnumerateFileSystemEntries(normalizedRoot);
+                // Force a real directory read. EnumerateFileSystemEntries is
+                // documented as lazy: constructing the enumerable alone is not
+                // guaranteed to open the directory on every runtime, so advance
+                // the enumerator once to force the ACL/read check inside this
+                // try block. (On .NET 8 macOS construction already throws, but
+                // MoveNext makes the eager-read contract runtime-independent.)
+                // MoveNext returns false for an empty but readable directory;
+                // only whether it throws matters here.
+                using var entries = Directory
+                    .EnumerateFileSystemEntries(normalizedRoot)
+                    .GetEnumerator();
+                _ = entries.MoveNext();
                 return SongRootAvailability.Available;
             }
             catch (UnauthorizedAccessException)

--- a/DTXMania.Game/Lib/Song/SongRootPolicy.cs
+++ b/DTXMania.Game/Lib/Song/SongRootPolicy.cs
@@ -43,6 +43,19 @@ namespace DTXMania.Game.Lib.Song
         {
             ArgumentNullException.ThrowIfNull(roots);
 
+            if (roots.Count == 0)
+            {
+                return new SongRootValidationResult(
+                    Array.Empty<string>(),
+                    new[]
+                    {
+                        new SongRootDiagnostic(
+                            string.Empty,
+                            "At least one configured song root is required.",
+                            IsWarning: false),
+                    });
+            }
+
             var canonicalRoots = new List<string>(roots.Count);
             var diagnostics = new List<SongRootDiagnostic>();
             foreach (var configuredRoot in roots)

--- a/DTXMania.Game/Lib/Song/SongRootPolicy.cs
+++ b/DTXMania.Game/Lib/Song/SongRootPolicy.cs
@@ -156,11 +156,21 @@ namespace DTXMania.Game.Lib.Song
 
         internal SongRootAvailability Probe(string normalizedRoot)
         {
+            // Directory.Exists swallows access exceptions internally and returns
+            // false for both missing and inaccessible directories, so the catch
+            // blocks below would never fire from Exists alone. Distinguish the
+            // two by attempting a read access on a directory that Exists reports
+            // as present: an inaccessible root surfaces as Inaccessible rather
+            // than being misreported as Missing.
             try
             {
-                return Directory.Exists(normalizedRoot)
-                    ? SongRootAvailability.Available
-                    : SongRootAvailability.Missing;
+                if (!Directory.Exists(normalizedRoot))
+                    return SongRootAvailability.Missing;
+
+                // Force a real directory read. EnumerateFileSystemEntries touches
+                // the directory's metadata/ACL rather than just stat-ing it.
+                _ = Directory.EnumerateFileSystemEntries(normalizedRoot);
+                return SongRootAvailability.Available;
             }
             catch (UnauthorizedAccessException)
             {

--- a/DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs
+++ b/DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs
@@ -1,0 +1,124 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DTXMania.Game.Lib.Stage.Config;
+
+internal enum ConfigSongOperationKind
+{
+    NxScoreImport,
+    SongFolderReload
+}
+
+/// <summary>
+/// The exclusive ownership token for one Config-stage song operation.
+/// Only the coordinator that granted the lease can release it, and repeated
+/// disposal is intentionally harmless so every terminal path can use finally.
+/// </summary>
+internal sealed class ConfigSongOperationLease : IDisposable
+{
+    private Action<ConfigSongOperationLease>? _release;
+    private int _disposed;
+
+    internal ConfigSongOperationLease(
+        ConfigSongOperationKind kind,
+        Action<ConfigSongOperationLease> release)
+    {
+        Kind = kind;
+        _release = release ?? throw new ArgumentNullException(nameof(release));
+    }
+
+    public ConfigSongOperationKind Kind { get; }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        var release = Interlocked.Exchange(ref _release, null);
+        release?.Invoke(this);
+    }
+}
+
+/// <summary>
+/// Serializes long-running song operations initiated by Config. The coordinator
+/// deliberately owns only mutual exclusion; persistence and UI state remain
+/// owned by <see cref="ConfigStage"/>.
+/// </summary>
+internal sealed class ConfigSongOperationCoordinator
+{
+    private ConfigSongOperationLease? _activeLease;
+
+    internal bool IsBusy => Volatile.Read(ref _activeLease) != null;
+
+    internal ConfigSongOperationLease? TryAcquire(ConfigSongOperationKind kind)
+    {
+        var lease = new ConfigSongOperationLease(kind, Release);
+        return Interlocked.CompareExchange(ref _activeLease, lease, null) == null
+            ? lease
+            : null;
+    }
+
+    /// <summary>
+    /// Transfers a lease to an operation's terminal continuation. If a custom
+    /// registrar fails synchronously, a fallback continuation still retains the
+    /// lease until the already-created operation task actually terminates.
+    /// </summary>
+    internal void RegisterTerminalContinuation(
+        ConfigSongOperationLease lease,
+        Task operation,
+        Action<Task> terminalObservation,
+        Func<Task, Action<Task>, Task>? continuationRegistrar = null)
+    {
+        ArgumentNullException.ThrowIfNull(lease);
+        ArgumentNullException.ThrowIfNull(operation);
+        ArgumentNullException.ThrowIfNull(terminalObservation);
+
+        Action<Task> complete = completed =>
+        {
+            try
+            {
+                terminalObservation(completed);
+            }
+            finally
+            {
+                lease.Dispose();
+            }
+        };
+
+        try
+        {
+            if (continuationRegistrar == null)
+            {
+                _ = operation.ContinueWith(
+                    complete,
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+            }
+            else
+            {
+                _ = continuationRegistrar(operation, complete);
+            }
+        }
+        catch
+        {
+            // Registration normally cannot fail, but a task may already be
+            // executing when an injected/specialized registrar does. Keep its
+            // lease until that task ends; releasing here would allow overlap.
+            _ = operation.ContinueWith(
+                complete,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            throw;
+        }
+    }
+
+    private void Release(ConfigSongOperationLease lease)
+    {
+        _ = Interlocked.CompareExchange(ref _activeLease, null, lease);
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs
+++ b/DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs
@@ -1,0 +1,115 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Config;
+
+namespace DTXMania.Game.Lib.Stage.Config
+{
+    /// <summary>Outcome of a native folder-selection request.</summary>
+    public enum FolderPickerStatus
+    {
+        Selected,
+        Cancelled,
+        Unavailable,
+        Failed,
+    }
+
+    /// <summary>
+    /// Immutable result of a native folder-selection request. Only a successful
+    /// <see cref="FolderPickerStatus.Selected"/> result carries a usable path.
+    /// </summary>
+    public sealed record FolderPickerResult
+    {
+        public FolderPickerResult(
+            FolderPickerStatus status,
+            string? path = null,
+            string? message = null)
+        {
+            if (status == FolderPickerStatus.Selected && string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(
+                    "A selected folder result requires a non-empty path.",
+                    nameof(path));
+            }
+
+            if (status != FolderPickerStatus.Selected && path != null)
+            {
+                throw new ArgumentException(
+                    "Only a selected folder result may provide a path.",
+                    nameof(path));
+            }
+
+            Status = status;
+            Path = path;
+            Message = message;
+        }
+
+        public FolderPickerStatus Status { get; }
+
+        public string? Path { get; }
+
+        public string? Message { get; }
+
+        public static FolderPickerResult Selected(string path) =>
+            new(FolderPickerStatus.Selected, path);
+
+        public static FolderPickerResult Cancelled() =>
+            new(FolderPickerStatus.Cancelled);
+
+        public static FolderPickerResult Unavailable(string? message = null) =>
+            new(FolderPickerStatus.Unavailable, message: message);
+
+        public static FolderPickerResult Failed(string? message = null) =>
+            new(FolderPickerStatus.Failed, message: message);
+    }
+
+    /// <summary>Provides the native folder picker for the current platform.</summary>
+    public interface IFolderPickerService
+    {
+        Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Result of the Config-owned apply handoff. This is intentionally separate
+    /// from the persisted <see cref="SongRootUpdateStatus"/> contract so later
+    /// operation coordination can add transient states without changing
+    /// <c>IConfigManager</c>.
+    /// </summary>
+    internal sealed record SongFolderApplyResult
+    {
+        internal SongFolderApplyResult(
+            SongFolderApplyStatus status,
+            IReadOnlyList<string> canonicalRoots,
+            IReadOnlyList<SongRootDiagnostic> diagnostics)
+        {
+            ArgumentNullException.ThrowIfNull(canonicalRoots);
+            ArgumentNullException.ThrowIfNull(diagnostics);
+
+            Status = status;
+            CanonicalRoots = Array.AsReadOnly(canonicalRoots.ToArray());
+            Diagnostics = Array.AsReadOnly(diagnostics.ToArray());
+        }
+
+        internal SongFolderApplyStatus Status { get; }
+
+        internal IReadOnlyList<string> CanonicalRoots { get; }
+
+        internal IReadOnlyList<SongRootDiagnostic> Diagnostics { get; }
+    }
+
+    internal enum SongFolderApplyStatus
+    {
+        Updated,
+        Unchanged,
+        Busy,
+        ValidationFailed,
+        PersistenceFailed,
+        Started,
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs
+++ b/DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs
@@ -1,0 +1,38 @@
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.Resources;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+
+namespace DTXMania.Game.Lib.Stage.Config
+{
+    /// <summary>
+    /// A configuration overlay that temporarily owns input and rendering within
+    /// <see cref="DTXMania.Game.Lib.Stage.ConfigStage"/>.
+    /// </summary>
+    public interface IConfigOverlayPanel
+    {
+        bool IsActive { get; }
+
+        /// <summary>Raised after the overlay has committed its edits.</summary>
+        event EventHandler? Saved;
+
+        /// <summary>Raised when the overlay closes, whether saved or cancelled.</summary>
+        event EventHandler? Closed;
+
+        void Activate();
+
+        void Deactivate();
+
+        void Update(double deltaTime, KeyboardState current, KeyboardState previous);
+
+        void Draw(
+            SpriteBatch spriteBatch,
+            IFont? font,
+            IFont? boldFont,
+            Texture2D? whitePixel,
+            int virtualWidth,
+            int virtualHeight);
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
@@ -1,0 +1,564 @@
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+
+namespace DTXMania.Game.Lib.Stage.Config
+{
+    /// <summary>
+    /// Config overlay for editing the ordered configured-song-folder list. The
+    /// panel owns only a draft; Config owns persistence through the injected
+    /// apply delegate.
+    /// </summary>
+    internal sealed class SongFolderPanel : IConfigOverlayPanel
+    {
+        private enum ActionRow
+        {
+            AddFolder,
+            Remove,
+            MoveUp,
+            MoveDown,
+            Apply,
+            Cancel,
+        }
+
+        private static readonly ActionRow[] Actions =
+        {
+            ActionRow.AddFolder,
+            ActionRow.Remove,
+            ActionRow.MoveUp,
+            ActionRow.MoveDown,
+            ActionRow.Apply,
+            ActionRow.Cancel,
+        };
+
+        private static readonly Color BackdropColor = new(0, 0, 0, 200);
+        private static readonly Color BoardColor = new(14, 16, 34, 236);
+        private static readonly Color BoardBorderColor = new(74, 62, 150, 235);
+        private static readonly Color RowColor = new(30, 34, 60, 220);
+        private static readonly Color SelectionColor = new(120, 92, 30, 190);
+        private static readonly Color PrimaryTextColor = new(235, 238, 248);
+        private static readonly Color SelectedTextColor = new(255, 238, 120);
+        private static readonly Color WarningTextColor = new(255, 196, 96);
+        private static readonly Color ErrorTextColor = new(255, 96, 96);
+
+        private IReadOnlyList<string> _configuredRoots;
+        private readonly IFolderPickerService _folderPicker;
+        private readonly SongRootPolicy _rootPolicy;
+        private readonly Func<IReadOnlyList<string>, SongFolderApplyResult> _apply;
+        private readonly List<string> _draftRoots = new();
+        private readonly ConcurrentQueue<PickerCompletion> _pickerCompletions = new();
+
+        private CancellationTokenSource? _pickerCancellation;
+        private int _activationGeneration;
+        private int _selectedIndex;
+        private int _selectedRootIndex;
+
+        internal SongFolderPanel(
+            IReadOnlyList<string> configuredRoots,
+            IFolderPickerService folderPicker,
+            SongRootPolicy rootPolicy,
+            Func<IReadOnlyList<string>, SongFolderApplyResult> apply)
+        {
+            ArgumentNullException.ThrowIfNull(configuredRoots);
+            ArgumentNullException.ThrowIfNull(folderPicker);
+            ArgumentNullException.ThrowIfNull(rootPolicy);
+            ArgumentNullException.ThrowIfNull(apply);
+
+            if (configuredRoots.Count == 0)
+            {
+                throw new ArgumentException(
+                    "At least one configured song folder is required.",
+                    nameof(configuredRoots));
+            }
+
+            _configuredRoots = Array.AsReadOnly(configuredRoots.ToArray());
+            _folderPicker = folderPicker;
+            _rootPolicy = rootPolicy;
+            _apply = apply;
+        }
+
+        public bool IsActive { get; private set; }
+
+        public event EventHandler? Saved;
+
+        public event EventHandler? Closed;
+
+        /// <summary>Copied snapshot used by rendering and diagnostic consumers.</summary>
+        internal IReadOnlyList<string> DraftRoots => Array.AsReadOnly(_draftRoots.ToArray());
+
+        /// <summary>Non-blocking warning or error currently shown by the overlay.</summary>
+        internal string? StatusMessage { get; private set; }
+
+        /// <summary>Most recent Config-owned apply outcome for the stage event handler.</summary>
+        internal SongFolderApplyStatus? LastApplyStatus { get; private set; }
+
+        public void Activate()
+        {
+            CancelPendingPicker();
+            IncrementActivationGeneration();
+
+            _draftRoots.Clear();
+            _draftRoots.AddRange(_configuredRoots);
+            _selectedIndex = 0;
+            _selectedRootIndex = 0;
+            LastApplyStatus = null;
+            IsActive = true;
+            SetValidationStatus(_rootPolicy.Validate(_draftRoots));
+        }
+
+        public void Deactivate()
+        {
+            if (!IsActive)
+                return;
+
+            IsActive = false;
+            IncrementActivationGeneration();
+            CancelPendingPicker();
+        }
+
+        public void Update(double deltaTime, KeyboardState current, KeyboardState previous)
+        {
+            DrainPickerCompletions();
+            if (!IsActive)
+                return;
+
+            if (IsBackPressed(current, previous))
+            {
+                CancelAndClose();
+                return;
+            }
+
+            if (_pickerCancellation != null)
+                return;
+
+            if (IsJustPressed(current, previous, Keys.Up))
+            {
+                _selectedIndex = (_selectedIndex - 1 + RowCount) % RowCount;
+                RememberSelectedRoot();
+            }
+            else if (IsJustPressed(current, previous, Keys.Down))
+            {
+                _selectedIndex = (_selectedIndex + 1) % RowCount;
+                RememberSelectedRoot();
+            }
+            else if (IsJustPressed(current, previous, Keys.Enter))
+            {
+                ActivateSelectedRow();
+            }
+        }
+
+        public void Draw(
+            SpriteBatch spriteBatch,
+            IFont? font,
+            IFont? boldFont,
+            Texture2D? whitePixel,
+            int virtualWidth,
+            int virtualHeight)
+        {
+            if (!IsActive || spriteBatch == null)
+                return;
+
+            const int boardWidth = 760;
+            const int boardHeight = 560;
+            const int rowHeight = 38;
+            const int rowPadding = 20;
+            var boardX = (virtualWidth - boardWidth) / 2;
+            var boardY = (virtualHeight - boardHeight) / 2;
+
+            if (whitePixel != null)
+            {
+                spriteBatch.Draw(whitePixel,
+                    new Rectangle(0, 0, virtualWidth, virtualHeight), BackdropColor);
+                spriteBatch.Draw(whitePixel,
+                    new Rectangle(boardX - 4, boardY - 4, boardWidth + 8, boardHeight + 8),
+                    BoardBorderColor);
+                spriteBatch.Draw(whitePixel,
+                    new Rectangle(boardX, boardY, boardWidth, boardHeight), BoardColor);
+            }
+
+            const string title = "SONG FOLDERS";
+            DrawCenteredText(spriteBatch, boldFont ?? font, title, virtualWidth, boardY + 20, PrimaryTextColor);
+
+            var y = boardY + 74;
+            for (var rootIndex = 0; rootIndex < _draftRoots.Count; rootIndex++)
+            {
+                DrawRow(spriteBatch, font, boldFont, whitePixel, boardX, y, boardWidth, rowHeight,
+                    rootIndex, _draftRoots[rootIndex]);
+                y += rowHeight;
+            }
+
+            y += 10;
+            for (var actionIndex = 0; actionIndex < Actions.Length; actionIndex++)
+            {
+                var rowIndex = _draftRoots.Count + actionIndex;
+                DrawRow(spriteBatch, font, boldFont, whitePixel, boardX, y, boardWidth, rowHeight,
+                    rowIndex, GetActionLabel(Actions[actionIndex]));
+                y += rowHeight;
+            }
+
+            if (!string.IsNullOrWhiteSpace(StatusMessage))
+            {
+                var color = IsWarningStatus() ? WarningTextColor : ErrorTextColor;
+                font?.DrawString(spriteBatch, StatusMessage,
+                    new Vector2(boardX + rowPadding, boardY + boardHeight - 64), color);
+            }
+
+            var instruction = _pickerCancellation == null
+                ? "UP/DOWN: Navigate | ENTER: Select | ESC: Cancel"
+                : "Waiting for folder picker... ESC: Cancel";
+            DrawCenteredText(spriteBatch, font, instruction, virtualWidth,
+                boardY + boardHeight - 34, PrimaryTextColor);
+        }
+
+        private int RowCount => _draftRoots.Count + Actions.Length;
+
+        private void ActivateSelectedRow()
+        {
+            if (_selectedIndex < _draftRoots.Count)
+            {
+                _selectedRootIndex = _selectedIndex;
+                return;
+            }
+
+            var actionIndex = _selectedIndex - _draftRoots.Count;
+            if (actionIndex < 0 || actionIndex >= Actions.Length)
+                return;
+
+            switch (Actions[actionIndex])
+            {
+                case ActionRow.AddFolder:
+                    BeginFolderPicker();
+                    break;
+                case ActionRow.Remove:
+                    RemoveSelectedRoot();
+                    break;
+                case ActionRow.MoveUp:
+                    MoveSelectedRoot(-1);
+                    break;
+                case ActionRow.MoveDown:
+                    MoveSelectedRoot(1);
+                    break;
+                case ActionRow.Apply:
+                    ApplyDraft();
+                    break;
+                case ActionRow.Cancel:
+                    CancelAndClose();
+                    break;
+            }
+        }
+
+        private void BeginFolderPicker()
+        {
+            if (_pickerCancellation != null)
+                return;
+
+            var cancellation = new CancellationTokenSource();
+            _pickerCancellation = cancellation;
+            StatusMessage = null;
+            var initialDirectory = _selectedRootIndex >= 0 && _selectedRootIndex < _draftRoots.Count
+                ? _draftRoots[_selectedRootIndex]
+                : null;
+            _ = CompletePickerAsync(_activationGeneration, cancellation, initialDirectory);
+        }
+
+        private async Task CompletePickerAsync(
+            int generation,
+            CancellationTokenSource cancellation,
+            string? initialDirectory)
+        {
+            FolderPickerResult result;
+            try
+            {
+                result = await _folderPicker
+                    .PickFolderAsync(initialDirectory, cancellation.Token)
+                    .ConfigureAwait(false);
+                result ??= FolderPickerResult.Failed("The folder picker returned no result.");
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                result = FolderPickerResult.Cancelled();
+            }
+            catch (Exception exception)
+            {
+                result = FolderPickerResult.Failed(exception.Message);
+            }
+
+            _pickerCompletions.Enqueue(new PickerCompletion(generation, cancellation, result));
+        }
+
+        private void DrainPickerCompletions()
+        {
+            while (_pickerCompletions.TryDequeue(out var completion))
+            {
+                var isCurrent = IsActive &&
+                                completion.Generation == _activationGeneration &&
+                                ReferenceEquals(completion.Cancellation, _pickerCancellation);
+                if (!isCurrent)
+                {
+                    completion.Cancellation.Dispose();
+                    continue;
+                }
+
+                _pickerCancellation = null;
+                completion.Cancellation.Dispose();
+                ApplyPickerResult(completion.Result);
+            }
+        }
+
+        private void ApplyPickerResult(FolderPickerResult result)
+        {
+            switch (result.Status)
+            {
+                case FolderPickerStatus.Selected:
+                    AddSelectedFolder(result.Path!);
+                    return;
+                case FolderPickerStatus.Cancelled:
+                    StatusMessage = null;
+                    return;
+                case FolderPickerStatus.Unavailable:
+                    StatusMessage = result.Message ?? "Folder picker is unavailable.";
+                    return;
+                case FolderPickerStatus.Failed:
+                    StatusMessage = result.Message ?? "Folder picker failed.";
+                    return;
+                default:
+                    StatusMessage = "Folder picker returned an unknown result.";
+                    return;
+            }
+        }
+
+        private void AddSelectedFolder(string selectedPath)
+        {
+            var proposedRoots = new List<string>(_draftRoots) { selectedPath };
+            var validation = _rootPolicy.Validate(proposedRoots);
+            if (!validation.IsValid)
+            {
+                SetValidationStatus(validation);
+                return;
+            }
+
+            _draftRoots.Clear();
+            _draftRoots.AddRange(validation.CanonicalRoots);
+            _selectedRootIndex = _draftRoots.Count - 1;
+            _selectedIndex = _selectedRootIndex;
+            SetValidationStatus(validation);
+        }
+
+        private void RemoveSelectedRoot()
+        {
+            if (_draftRoots.Count <= 1)
+            {
+                StatusMessage = "At least one song folder is required.";
+                return;
+            }
+
+            var rootIndex = Math.Clamp(_selectedRootIndex, 0, _draftRoots.Count - 1);
+            _draftRoots.RemoveAt(rootIndex);
+            _selectedRootIndex = Math.Min(rootIndex, _draftRoots.Count - 1);
+            _selectedIndex = _selectedRootIndex;
+            SetValidationStatus(_rootPolicy.Validate(_draftRoots));
+        }
+
+        private void MoveSelectedRoot(int direction)
+        {
+            var rootIndex = Math.Clamp(_selectedRootIndex, 0, _draftRoots.Count - 1);
+            var targetIndex = rootIndex + direction;
+            if (targetIndex < 0 || targetIndex >= _draftRoots.Count)
+                return;
+
+            (_draftRoots[rootIndex], _draftRoots[targetIndex]) =
+                (_draftRoots[targetIndex], _draftRoots[rootIndex]);
+            _selectedRootIndex = targetIndex;
+        }
+
+        private void ApplyDraft()
+        {
+            var validation = _rootPolicy.Validate(_draftRoots);
+            if (!validation.IsValid)
+            {
+                SetValidationStatus(validation);
+                return;
+            }
+
+            SongFolderApplyResult result;
+            try
+            {
+                result = _apply(validation.CanonicalRoots);
+            }
+            catch (Exception exception)
+            {
+                LastApplyStatus = SongFolderApplyStatus.PersistenceFailed;
+                StatusMessage = exception.Message;
+                return;
+            }
+
+            LastApplyStatus = result.Status;
+            switch (result.Status)
+            {
+                case SongFolderApplyStatus.Updated:
+                    _configuredRoots = Array.AsReadOnly(result.CanonicalRoots.ToArray());
+                    CommitAndClose();
+                    return;
+                case SongFolderApplyStatus.Unchanged:
+                    CloseSilently();
+                    return;
+                case SongFolderApplyStatus.Busy:
+                case SongFolderApplyStatus.ValidationFailed:
+                case SongFolderApplyStatus.PersistenceFailed:
+                    StatusMessage = GetDiagnosticMessage(result.Diagnostics, "Could not save song folders.");
+                    return;
+                case SongFolderApplyStatus.Started:
+                    // Slice 2 has no live reload. A later Config-owned coordinator
+                    // may use this status to drive progress without changing this
+                    // panel's persistence boundary.
+                    StatusMessage = "Song-folder update has started.";
+                    return;
+                default:
+                    StatusMessage = "Could not save song folders.";
+                    return;
+            }
+        }
+
+        private void CommitAndClose()
+        {
+            Deactivate();
+            Saved?.Invoke(this, EventArgs.Empty);
+            Closed?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void CloseSilently()
+        {
+            Deactivate();
+            Closed?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void CancelAndClose()
+        {
+            LastApplyStatus = null;
+            CloseSilently();
+        }
+
+        private void RememberSelectedRoot()
+        {
+            if (_selectedIndex < _draftRoots.Count)
+                _selectedRootIndex = _selectedIndex;
+        }
+
+        private void SetValidationStatus(SongRootValidationResult validation)
+        {
+            StatusMessage = GetDiagnosticMessage(validation.Diagnostics, fallback: null);
+        }
+
+        private bool IsWarningStatus()
+        {
+            if (string.IsNullOrWhiteSpace(StatusMessage))
+                return false;
+
+            return _rootPolicy.Validate(_draftRoots).Diagnostics.Any(diagnostic =>
+                diagnostic.IsWarning && diagnostic.Message == StatusMessage);
+        }
+
+        private static string? GetDiagnosticMessage(
+            IReadOnlyList<SongRootDiagnostic> diagnostics,
+            string? fallback)
+        {
+            return diagnostics.FirstOrDefault(diagnostic => !diagnostic.IsWarning)?.Message
+                ?? diagnostics.FirstOrDefault()?.Message
+                ?? fallback;
+        }
+
+        private void CancelPendingPicker()
+        {
+            var cancellation = _pickerCancellation;
+            _pickerCancellation = null;
+            if (cancellation == null)
+                return;
+
+            cancellation.Cancel();
+        }
+
+        private void IncrementActivationGeneration()
+        {
+            unchecked
+            {
+                _activationGeneration++;
+            }
+        }
+
+        private static bool IsBackPressed(KeyboardState current, KeyboardState previous) =>
+            IsJustPressed(current, previous, Keys.Escape) ||
+            IsJustPressed(current, previous, Keys.Back);
+
+        private static bool IsJustPressed(KeyboardState current, KeyboardState previous, Keys key) =>
+            current.IsKeyDown(key) && !previous.IsKeyDown(key);
+
+        private static string GetActionLabel(ActionRow action) => action switch
+        {
+            ActionRow.AddFolder => "Add Folder",
+            ActionRow.Remove => "Remove",
+            ActionRow.MoveUp => "Move Up",
+            ActionRow.MoveDown => "Move Down",
+            ActionRow.Apply => "Apply",
+            ActionRow.Cancel => "Cancel",
+            _ => string.Empty,
+        };
+
+        private void DrawRow(
+            SpriteBatch spriteBatch,
+            IFont? font,
+            IFont? boldFont,
+            Texture2D? whitePixel,
+            int boardX,
+            int y,
+            int boardWidth,
+            int rowHeight,
+            int rowIndex,
+            string label)
+        {
+            var selected = rowIndex == _selectedIndex;
+            if (whitePixel != null)
+            {
+                spriteBatch.Draw(whitePixel,
+                    new Rectangle(boardX + 20, y, boardWidth - 40, rowHeight - 4),
+                    selected ? SelectionColor : RowColor);
+            }
+
+            var displayLabel = rowIndex < _draftRoots.Count
+                ? $"{rowIndex + 1}. {label}"
+                : label;
+            (selected ? boldFont ?? font : font)?.DrawString(spriteBatch, displayLabel,
+                new Vector2(boardX + 36, y + 8), selected ? SelectedTextColor : PrimaryTextColor);
+        }
+
+        private static void DrawCenteredText(
+            SpriteBatch spriteBatch,
+            IFont? font,
+            string text,
+            int virtualWidth,
+            int y,
+            Color color)
+        {
+            if (font == null)
+                return;
+
+            var size = font.MeasureString(text);
+            font.DrawString(spriteBatch, text, new Vector2((virtualWidth - size.X) / 2f, y), color);
+        }
+
+        private sealed record PickerCompletion(
+            int Generation,
+            CancellationTokenSource Cancellation,
+            FolderPickerResult Result);
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
@@ -71,6 +71,7 @@ namespace DTXMania.Game.Lib.Stage.Config
         private int _selectedIndex;
         private int _selectedRootIndex;
         private int _firstVisibleRowIndex;
+        private bool _statusIsWarning;
 
         internal SongFolderPanel(
             IReadOnlyList<string> configuredRoots,
@@ -234,7 +235,7 @@ namespace DTXMania.Game.Lib.Stage.Config
 
             if (!string.IsNullOrWhiteSpace(StatusMessage))
             {
-                var color = IsWarningStatus() ? WarningTextColor : ErrorTextColor;
+                var color = _statusIsWarning ? WarningTextColor : ErrorTextColor;
                 font?.DrawString(spriteBatch, StatusMessage,
                     new Vector2(boardX + RowPadding, boardY + BoardHeight - 64), color);
             }
@@ -290,7 +291,7 @@ namespace DTXMania.Game.Lib.Stage.Config
 
             var cancellation = new CancellationTokenSource();
             _pickerCancellation = cancellation;
-            StatusMessage = null;
+            SetStatusMessage(null);
             var initialDirectory = _selectedRootIndex >= 0 && _selectedRootIndex < _draftRoots.Count
                 ? _draftRoots[_selectedRootIndex]
                 : null;
@@ -349,16 +350,16 @@ namespace DTXMania.Game.Lib.Stage.Config
                     AddSelectedFolder(result.Path!);
                     return;
                 case FolderPickerStatus.Cancelled:
-                    StatusMessage = null;
+                    SetStatusMessage(null);
                     return;
                 case FolderPickerStatus.Unavailable:
-                    StatusMessage = result.Message ?? "Folder picker is unavailable.";
+                    SetStatusMessage(result.Message ?? "Folder picker is unavailable.");
                     return;
                 case FolderPickerStatus.Failed:
-                    StatusMessage = result.Message ?? "Folder picker failed.";
+                    SetStatusMessage(result.Message ?? "Folder picker failed.");
                     return;
                 default:
-                    StatusMessage = "Folder picker returned an unknown result.";
+                    SetStatusMessage("Folder picker returned an unknown result.");
                     return;
             }
         }
@@ -385,7 +386,7 @@ namespace DTXMania.Game.Lib.Stage.Config
         {
             if (_draftRoots.Count <= 1)
             {
-                StatusMessage = "At least one song folder is required.";
+                SetStatusMessage("At least one song folder is required.");
                 return;
             }
 
@@ -426,7 +427,7 @@ namespace DTXMania.Game.Lib.Stage.Config
             catch (Exception exception)
             {
                 LastApplyStatus = SongFolderApplyStatus.PersistenceFailed;
-                StatusMessage = exception.Message;
+                SetStatusMessage(exception.Message);
                 return;
             }
 
@@ -443,16 +444,17 @@ namespace DTXMania.Game.Lib.Stage.Config
                 case SongFolderApplyStatus.Busy:
                 case SongFolderApplyStatus.ValidationFailed:
                 case SongFolderApplyStatus.PersistenceFailed:
-                    StatusMessage = GetDiagnosticMessage(result.Diagnostics, "Could not save song folders.");
+                    SetStatusFromDiagnostics(result.Diagnostics, "Could not save song folders.");
                     return;
                 case SongFolderApplyStatus.Started:
-                    // Slice 2 has no live reload. A later Config-owned coordinator
-                    // may use this status to drive progress without changing this
-                    // panel's persistence boundary.
-                    StatusMessage = "Song-folder update has started.";
+                    // Config has already persisted the roots and transferred reload ownership
+                    // to its coordinator. Treat this as the same committed panel boundary as
+                    // Updated so progress can continue behind the closed overlay.
+                    _configuredRoots = Array.AsReadOnly(result.CanonicalRoots.ToArray());
+                    CommitAndClose();
                     return;
                 default:
-                    StatusMessage = "Could not save song folders.";
+                    SetStatusMessage("Could not save song folders.");
                     return;
             }
         }
@@ -499,25 +501,24 @@ namespace DTXMania.Game.Lib.Stage.Config
 
         private void SetValidationStatus(SongRootValidationResult validation)
         {
-            StatusMessage = GetDiagnosticMessage(validation.Diagnostics, fallback: null);
+            SetStatusFromDiagnostics(validation.Diagnostics, fallback: null);
         }
 
-        private bool IsWarningStatus()
-        {
-            if (string.IsNullOrWhiteSpace(StatusMessage))
-                return false;
-
-            return _rootPolicy.Validate(_draftRoots).Diagnostics.Any(diagnostic =>
-                diagnostic.IsWarning && diagnostic.Message == StatusMessage);
-        }
-
-        private static string? GetDiagnosticMessage(
+        private void SetStatusFromDiagnostics(
             IReadOnlyList<SongRootDiagnostic> diagnostics,
             string? fallback)
         {
-            return diagnostics.FirstOrDefault(diagnostic => !diagnostic.IsWarning)?.Message
-                ?? diagnostics.FirstOrDefault()?.Message
-                ?? fallback;
+            var diagnostic = diagnostics.FirstOrDefault(candidate => !candidate.IsWarning)
+                ?? diagnostics.FirstOrDefault();
+            SetStatusMessage(
+                diagnostic?.Message ?? fallback,
+                diagnostic?.IsWarning ?? false);
+        }
+
+        private void SetStatusMessage(string? message, bool isWarning = false)
+        {
+            StatusMessage = message;
+            _statusIsWarning = !string.IsNullOrWhiteSpace(message) && isWarning;
         }
 
         private void CancelPendingPicker()

--- a/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
@@ -393,7 +393,12 @@ namespace DTXMania.Game.Lib.Stage.Config
             var rootIndex = Math.Clamp(_selectedRootIndex, 0, _draftRoots.Count - 1);
             _draftRoots.RemoveAt(rootIndex);
             _selectedRootIndex = Math.Min(rootIndex, _draftRoots.Count - 1);
-            _selectedIndex = _selectedRootIndex;
+            // Keep the cursor on the Remove action row so the user can press
+            // Remove again to delete the next root, matching MoveSelectedRoot's
+            // repeatable interaction. The action rows shift down by one after a
+            // removal, so recompute the Remove row index against the new count.
+            _selectedIndex = _draftRoots.Count +
+                Array.IndexOf(Actions, ActionRow.Remove);
             EnsureSelectedRowVisible();
             SetValidationStatus(_rootPolicy.Validate(_draftRoots));
         }

--- a/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
@@ -52,6 +52,13 @@ namespace DTXMania.Game.Lib.Stage.Config
         private static readonly Color WarningTextColor = new(255, 196, 96);
         private static readonly Color ErrorTextColor = new(255, 96, 96);
 
+        private const int BoardWidth = 760;
+        private const int BoardHeight = 560;
+        private const int RowHeight = 38;
+        private const int RowPadding = 20;
+        private const int RowViewportTopOffset = 74;
+        private const int ViewportRowCapacity = 9;
+
         private IReadOnlyList<string> _configuredRoots;
         private readonly IFolderPickerService _folderPicker;
         private readonly SongRootPolicy _rootPolicy;
@@ -63,6 +70,7 @@ namespace DTXMania.Game.Lib.Stage.Config
         private int _activationGeneration;
         private int _selectedIndex;
         private int _selectedRootIndex;
+        private int _firstVisibleRowIndex;
 
         internal SongFolderPanel(
             IReadOnlyList<string> configuredRoots,
@@ -103,6 +111,18 @@ namespace DTXMania.Game.Lib.Stage.Config
         /// <summary>Most recent Config-owned apply outcome for the stage event handler.</summary>
         internal SongFolderApplyStatus? LastApplyStatus { get; private set; }
 
+        /// <summary>First row currently rendered in the bounded panel viewport.</summary>
+        internal int FirstVisibleRowIndex => _firstVisibleRowIndex;
+
+        /// <summary>Number of complete rows rendered in the panel viewport.</summary>
+        internal int VisibleRowCapacity => ViewportRowCapacity;
+
+        /// <summary>Current keyboard selection in the root/action row sequence.</summary>
+        internal int SelectedRowIndex => _selectedIndex;
+
+        /// <summary>Total root and action rows available to keyboard navigation.</summary>
+        internal int TotalRowCount => RowCount;
+
         public void Activate()
         {
             CancelPendingPicker();
@@ -112,6 +132,7 @@ namespace DTXMania.Game.Lib.Stage.Config
             _draftRoots.AddRange(_configuredRoots);
             _selectedIndex = 0;
             _selectedRootIndex = 0;
+            _firstVisibleRowIndex = 0;
             LastApplyStatus = null;
             IsActive = true;
             SetValidationStatus(_rootPolicy.Validate(_draftRoots));
@@ -146,11 +167,13 @@ namespace DTXMania.Game.Lib.Stage.Config
             {
                 _selectedIndex = (_selectedIndex - 1 + RowCount) % RowCount;
                 RememberSelectedRoot();
+                EnsureSelectedRowVisible();
             }
             else if (IsJustPressed(current, previous, Keys.Down))
             {
                 _selectedIndex = (_selectedIndex + 1) % RowCount;
                 RememberSelectedRoot();
+                EnsureSelectedRowVisible();
             }
             else if (IsJustPressed(current, previous, Keys.Enter))
             {
@@ -169,56 +192,58 @@ namespace DTXMania.Game.Lib.Stage.Config
             if (!IsActive || spriteBatch == null)
                 return;
 
-            const int boardWidth = 760;
-            const int boardHeight = 560;
-            const int rowHeight = 38;
-            const int rowPadding = 20;
-            var boardX = (virtualWidth - boardWidth) / 2;
-            var boardY = (virtualHeight - boardHeight) / 2;
+            var boardX = (virtualWidth - BoardWidth) / 2;
+            var boardY = (virtualHeight - BoardHeight) / 2;
 
             if (whitePixel != null)
             {
                 spriteBatch.Draw(whitePixel,
                     new Rectangle(0, 0, virtualWidth, virtualHeight), BackdropColor);
                 spriteBatch.Draw(whitePixel,
-                    new Rectangle(boardX - 4, boardY - 4, boardWidth + 8, boardHeight + 8),
+                    new Rectangle(boardX - 4, boardY - 4, BoardWidth + 8, BoardHeight + 8),
                     BoardBorderColor);
                 spriteBatch.Draw(whitePixel,
-                    new Rectangle(boardX, boardY, boardWidth, boardHeight), BoardColor);
+                    new Rectangle(boardX, boardY, BoardWidth, BoardHeight), BoardColor);
             }
 
             const string title = "SONG FOLDERS";
             DrawCenteredText(spriteBatch, boldFont ?? font, title, virtualWidth, boardY + 20, PrimaryTextColor);
 
-            var y = boardY + 74;
-            for (var rootIndex = 0; rootIndex < _draftRoots.Count; rootIndex++)
+            var firstVisibleRow = Math.Clamp(_firstVisibleRowIndex, 0,
+                Math.Max(0, RowCount - ViewportRowCapacity));
+            var lastVisibleRowExclusive = Math.Min(RowCount, firstVisibleRow + ViewportRowCapacity);
+            var y = boardY + RowViewportTopOffset;
+
+            // The panel uses a complete-row viewport rather than an arbitrary root limit.
+            // Only rows inside this board region are drawn, so folders/actions outside the
+            // viewport cannot overlap the status or instruction areas below it.
+            for (var rowIndex = firstVisibleRow; rowIndex < lastVisibleRowExclusive; rowIndex++)
             {
-                DrawRow(spriteBatch, font, boldFont, whitePixel, boardX, y, boardWidth, rowHeight,
-                    rootIndex, _draftRoots[rootIndex]);
-                y += rowHeight;
+                DrawRow(spriteBatch, font, boldFont, whitePixel, boardX, y, BoardWidth, RowHeight,
+                    rowIndex, GetRowLabel(rowIndex));
+                y += RowHeight;
             }
 
-            y += 10;
-            for (var actionIndex = 0; actionIndex < Actions.Length; actionIndex++)
-            {
-                var rowIndex = _draftRoots.Count + actionIndex;
-                DrawRow(spriteBatch, font, boldFont, whitePixel, boardX, y, boardWidth, rowHeight,
-                    rowIndex, GetActionLabel(Actions[actionIndex]));
-                y += rowHeight;
-            }
+            if (firstVisibleRow > 0)
+                font?.DrawString(spriteBatch, "More above ↑",
+                    new Vector2(boardX + RowPadding, boardY + 52), WarningTextColor);
+            if (lastVisibleRowExclusive < RowCount)
+                font?.DrawString(spriteBatch, "More below ↓",
+                    new Vector2(boardX + RowPadding, boardY + RowViewportTopOffset +
+                        (ViewportRowCapacity * RowHeight) + 4), WarningTextColor);
 
             if (!string.IsNullOrWhiteSpace(StatusMessage))
             {
                 var color = IsWarningStatus() ? WarningTextColor : ErrorTextColor;
                 font?.DrawString(spriteBatch, StatusMessage,
-                    new Vector2(boardX + rowPadding, boardY + boardHeight - 64), color);
+                    new Vector2(boardX + RowPadding, boardY + BoardHeight - 64), color);
             }
 
             var instruction = _pickerCancellation == null
                 ? "UP/DOWN: Navigate | ENTER: Select | ESC: Cancel"
                 : "Waiting for folder picker... ESC: Cancel";
             DrawCenteredText(spriteBatch, font, instruction, virtualWidth,
-                boardY + boardHeight - 34, PrimaryTextColor);
+                boardY + BoardHeight - 34, PrimaryTextColor);
         }
 
         private int RowCount => _draftRoots.Count + Actions.Length;
@@ -352,6 +377,7 @@ namespace DTXMania.Game.Lib.Stage.Config
             _draftRoots.AddRange(validation.CanonicalRoots);
             _selectedRootIndex = _draftRoots.Count - 1;
             _selectedIndex = _selectedRootIndex;
+            EnsureSelectedRowVisible();
             SetValidationStatus(validation);
         }
 
@@ -367,6 +393,7 @@ namespace DTXMania.Game.Lib.Stage.Config
             _draftRoots.RemoveAt(rootIndex);
             _selectedRootIndex = Math.Min(rootIndex, _draftRoots.Count - 1);
             _selectedIndex = _selectedRootIndex;
+            EnsureSelectedRowVisible();
             SetValidationStatus(_rootPolicy.Validate(_draftRoots));
         }
 
@@ -455,6 +482,21 @@ namespace DTXMania.Game.Lib.Stage.Config
                 _selectedRootIndex = _selectedIndex;
         }
 
+        private void EnsureSelectedRowVisible()
+        {
+            if (_selectedIndex < _firstVisibleRowIndex)
+            {
+                _firstVisibleRowIndex = _selectedIndex;
+            }
+            else if (_selectedIndex >= _firstVisibleRowIndex + ViewportRowCapacity)
+            {
+                _firstVisibleRowIndex = _selectedIndex - ViewportRowCapacity + 1;
+            }
+
+            _firstVisibleRowIndex = Math.Clamp(_firstVisibleRowIndex, 0,
+                Math.Max(0, RowCount - ViewportRowCapacity));
+        }
+
         private void SetValidationStatus(SongRootValidationResult validation)
         {
             StatusMessage = GetDiagnosticMessage(validation.Diagnostics, fallback: null);
@@ -513,6 +555,10 @@ namespace DTXMania.Game.Lib.Stage.Config
             ActionRow.Cancel => "Cancel",
             _ => string.Empty,
         };
+
+        private string GetRowLabel(int rowIndex) => rowIndex < _draftRoots.Count
+            ? _draftRoots[rowIndex]
+            : GetActionLabel(Actions[rowIndex - _draftRoots.Count]);
 
         private void DrawRow(
             SpriteBatch spriteBatch,

--- a/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs
@@ -408,6 +408,7 @@ namespace DTXMania.Game.Lib.Stage.Config
             (_draftRoots[rootIndex], _draftRoots[targetIndex]) =
                 (_draftRoots[targetIndex], _draftRoots[rootIndex]);
             _selectedRootIndex = targetIndex;
+            SetValidationStatus(_rootPolicy.Validate(_draftRoots));
         }
 
         private void ApplyDraft()

--- a/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs
@@ -26,8 +26,9 @@ internal enum SongLibraryReloadOutcome
 
 /// <summary>
 /// Immutable Config-facing summary of an HPA-192 enumeration/import attempt.
-/// An unsuccessful pre-commit result always retains the previously published
-/// song hierarchy; only a completed HPA-192 publication reports Published.
+/// An unsuccessful pre-commit result retains the previously published song
+/// hierarchy. A post-commit failure must instead require recovery/restart,
+/// because the database and live snapshot may no longer agree.
 /// </summary>
 internal sealed record SongLibraryReloadResult(
     SongLibraryReloadOutcome Outcome,
@@ -40,8 +41,7 @@ internal sealed record SongLibraryReloadResult(
         SongLibraryReloadOutcome.Busy or
         SongLibraryReloadOutcome.NoActiveRoots or
         SongLibraryReloadOutcome.Cancelled or
-        SongLibraryReloadOutcome.Failed or
-        SongLibraryReloadOutcome.PartialSuccessRestartRequired;
+        SongLibraryReloadOutcome.Failed;
 
     internal bool RequiresRestart =>
         Outcome == SongLibraryReloadOutcome.PartialSuccessRestartRequired;
@@ -61,26 +61,6 @@ internal sealed record ConfigSongOperationUpdate(
     ConfigSongOperationKind Kind,
     string Status,
     bool IsTerminal);
-
-/// <summary>
-/// Marks a failure that happened after HPA-192 committed the database but
-/// before its live publication could be completed. Config must not describe
-/// this as a rollback: the next restart can rebuild from the committed rows.
-/// </summary>
-internal sealed class SongLibraryReloadPostCommitPublicationException : Exception
-{
-    internal SongLibraryReloadPostCommitPublicationException(string message)
-        : base(message)
-    {
-    }
-
-    internal SongLibraryReloadPostCommitPublicationException(
-        string message,
-        Exception innerException)
-        : base(message, innerException)
-    {
-    }
-}
 
 internal interface ISongLibraryReloadService
 {

--- a/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs
@@ -1,0 +1,91 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DTXMania.Game.Lib.Stage.Config;
+
+/// <summary>Immutable progress produced while rebuilding configured song roots.</summary>
+internal sealed record SongLibraryReloadProgress(
+    string CurrentOperation,
+    int ProcessedCount,
+    int DiscoveredSongs,
+    string CurrentFile,
+    string CurrentDirectory);
+
+internal enum SongLibraryReloadOutcome
+{
+    Busy,
+    Published,
+    NoActiveRoots,
+    Cancelled,
+    Failed,
+    PartialSuccessRestartRequired,
+}
+
+/// <summary>
+/// Immutable Config-facing summary of an HPA-192 enumeration/import attempt.
+/// An unsuccessful pre-commit result always retains the previously published
+/// song hierarchy; only a completed HPA-192 publication reports Published.
+/// </summary>
+internal sealed record SongLibraryReloadResult(
+    SongLibraryReloadOutcome Outcome,
+    int UnavailableRootCount,
+    int EnumeratedFileCount,
+    int DiscoveredScoreCount,
+    string? FailureMessage = null)
+{
+    internal bool RetainsCurrentSnapshot => Outcome is
+        SongLibraryReloadOutcome.Busy or
+        SongLibraryReloadOutcome.NoActiveRoots or
+        SongLibraryReloadOutcome.Cancelled or
+        SongLibraryReloadOutcome.Failed or
+        SongLibraryReloadOutcome.PartialSuccessRestartRequired;
+
+    internal bool RequiresRestart =>
+        Outcome == SongLibraryReloadOutcome.PartialSuccessRestartRequired;
+}
+
+/// <summary>Immutable worker result consumed by ConfigStage on its update thread.</summary>
+internal sealed record ConfigSongOperationCompletion(string Status);
+
+/// <summary>
+/// Immutable status handoff from a background song operation to ConfigStage's
+/// update thread. Holding the lease lets the update thread avoid clearing a
+/// newer operation that started after an older terminal callback queued.
+/// </summary>
+internal sealed record ConfigSongOperationUpdate(
+    int ActivationGeneration,
+    ConfigSongOperationLease Lease,
+    ConfigSongOperationKind Kind,
+    string Status,
+    bool IsTerminal);
+
+/// <summary>
+/// Marks a failure that happened after HPA-192 committed the database but
+/// before its live publication could be completed. Config must not describe
+/// this as a rollback: the next restart can rebuild from the committed rows.
+/// </summary>
+internal sealed class SongLibraryReloadPostCommitPublicationException : Exception
+{
+    internal SongLibraryReloadPostCommitPublicationException(string message)
+        : base(message)
+    {
+    }
+
+    internal SongLibraryReloadPostCommitPublicationException(
+        string message,
+        Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+internal interface ISongLibraryReloadService
+{
+    Task<SongLibraryReloadResult> ReloadAsync(
+        IReadOnlyList<string> configuredRoots,
+        IProgress<SongLibraryReloadProgress>? progress,
+        System.Threading.CancellationToken cancellationToken);
+}

--- a/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs
@@ -16,9 +16,6 @@ namespace DTXMania.Game.Lib.Stage.Config;
 /// </summary>
 internal sealed class SongLibraryReloadService : ISongLibraryReloadService
 {
-    private const string EnumerationBusyMessage =
-        "Song enumeration is already in progress.";
-
     private readonly Func<
         IReadOnlyList<string>,
         IProgress<EnumerationProgress>?,
@@ -87,11 +84,7 @@ internal sealed class SongLibraryReloadService : ISongLibraryReloadService
                     "The song library reload ended with an unknown outcome."),
             };
         }
-        catch (InvalidOperationException exception) when (
-            string.Equals(
-                exception.Message,
-                EnumerationBusyMessage,
-                StringComparison.Ordinal))
+        catch (SongEnumerationBusyException exception)
         {
             return new SongLibraryReloadResult(
                 SongLibraryReloadOutcome.Busy,

--- a/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs
@@ -1,0 +1,152 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+
+namespace DTXMania.Game.Lib.Stage.Config;
+
+/// <summary>
+/// Config-scoped adapter over HPA-192's one-pass enumerate/import/publication
+/// operation. It maps terminal outcomes without attempting a second hierarchy
+/// refresh or publishing an empty library for unavailable configured roots.
+/// </summary>
+internal sealed class SongLibraryReloadService : ISongLibraryReloadService
+{
+    private const string EnumerationBusyMessage =
+        "Song enumeration is already in progress.";
+
+    private readonly Func<
+        IReadOnlyList<string>,
+        IProgress<EnumerationProgress>?,
+        CancellationToken,
+        Task<SongEnumerationResult>> _enumerateAndImportAsync;
+
+    internal SongLibraryReloadService()
+        : this((roots, progress, token) =>
+            SongManager.Instance.EnumerateAndImportSongsAsync(
+                roots.ToArray(),
+                progress,
+                token))
+    {
+    }
+
+    internal SongLibraryReloadService(
+        Func<
+            IReadOnlyList<string>,
+            IProgress<EnumerationProgress>?,
+            CancellationToken,
+            Task<SongEnumerationResult>> enumerateAndImportAsync)
+    {
+        _enumerateAndImportAsync = enumerateAndImportAsync
+            ?? throw new ArgumentNullException(nameof(enumerateAndImportAsync));
+    }
+
+    public async Task<SongLibraryReloadResult> ReloadAsync(
+        IReadOnlyList<string> configuredRoots,
+        IProgress<SongLibraryReloadProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(configuredRoots);
+
+        var enumerationProgress = progress == null
+            ? null
+            : new ReloadProgressAdapter(progress);
+
+        try
+        {
+            // This is intentionally the only HPA-192 call. Its successful
+            // return already means the database commit, hierarchy finalization,
+            // and immutable snapshot publication all completed in order.
+            var result = await _enumerateAndImportAsync(
+                configuredRoots,
+                enumerationProgress,
+                cancellationToken).ConfigureAwait(false);
+            var unavailableRootCount = result.Batch.Errors.Count(
+                error => error.IsRootFailure);
+
+            return result.Outcome switch
+            {
+                SongEnumerationOutcome.ImportedAndPublished => new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.Published,
+                    unavailableRootCount,
+                    result.Batch.DiscoveredChartPaths.Count,
+                    result.Batch.Candidates.Count),
+                SongEnumerationOutcome.NoActiveRoots => new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.NoActiveRoots,
+                    unavailableRootCount,
+                    result.Batch.DiscoveredChartPaths.Count,
+                    result.Batch.Candidates.Count),
+                _ => new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.Failed,
+                    unavailableRootCount,
+                    result.Batch.DiscoveredChartPaths.Count,
+                    result.Batch.Candidates.Count,
+                    "The song library reload ended with an unknown outcome."),
+            };
+        }
+        catch (InvalidOperationException exception) when (
+            string.Equals(
+                exception.Message,
+                EnumerationBusyMessage,
+                StringComparison.Ordinal))
+        {
+            return new SongLibraryReloadResult(
+                SongLibraryReloadOutcome.Busy,
+                UnavailableRootCount: 0,
+                EnumeratedFileCount: 0,
+                DiscoveredScoreCount: 0,
+                exception.Message);
+        }
+        catch (OperationCanceledException)
+        {
+            return new SongLibraryReloadResult(
+                SongLibraryReloadOutcome.Cancelled,
+                UnavailableRootCount: 0,
+                EnumeratedFileCount: 0,
+                DiscoveredScoreCount: 0);
+        }
+        catch (SongLibraryReloadPostCommitPublicationException exception)
+        {
+            return new SongLibraryReloadResult(
+                SongLibraryReloadOutcome.PartialSuccessRestartRequired,
+                UnavailableRootCount: 0,
+                EnumeratedFileCount: 0,
+                DiscoveredScoreCount: 0,
+                exception.GetBaseException().Message);
+        }
+        catch (Exception exception)
+        {
+            return new SongLibraryReloadResult(
+                SongLibraryReloadOutcome.Failed,
+                UnavailableRootCount: 0,
+                EnumeratedFileCount: 0,
+                DiscoveredScoreCount: 0,
+                exception.GetBaseException().Message);
+        }
+    }
+
+    private sealed class ReloadProgressAdapter : IProgress<EnumerationProgress>
+    {
+        private readonly IProgress<SongLibraryReloadProgress> _progress;
+
+        public ReloadProgressAdapter(IProgress<SongLibraryReloadProgress> progress)
+        {
+            _progress = progress;
+        }
+
+        public void Report(EnumerationProgress value)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _progress.Report(new SongLibraryReloadProgress(
+                value.CurrentOperation,
+                value.ProcessedCount,
+                value.DiscoveredSongs,
+                value.CurrentFile,
+                value.CurrentDirectory));
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs
+++ b/DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs
@@ -65,8 +65,7 @@ internal sealed class SongLibraryReloadService : ISongLibraryReloadService
                 configuredRoots,
                 enumerationProgress,
                 cancellationToken).ConfigureAwait(false);
-            var unavailableRootCount = result.Batch.Errors.Count(
-                error => error.IsRootFailure);
+            var unavailableRootCount = CountUnavailableRoots(result.Batch);
 
             return result.Outcome switch
             {
@@ -101,6 +100,15 @@ internal sealed class SongLibraryReloadService : ISongLibraryReloadService
                 DiscoveredScoreCount: 0,
                 exception.Message);
         }
+        catch (SongEnumerationPostCommitException exception)
+        {
+            return new SongLibraryReloadResult(
+                SongLibraryReloadOutcome.PartialSuccessRestartRequired,
+                CountUnavailableRoots(exception.Batch),
+                exception.Batch.DiscoveredChartPaths.Count,
+                exception.Batch.Candidates.Count,
+                exception.GetBaseException().Message);
+        }
         catch (OperationCanceledException)
         {
             return new SongLibraryReloadResult(
@@ -108,15 +116,6 @@ internal sealed class SongLibraryReloadService : ISongLibraryReloadService
                 UnavailableRootCount: 0,
                 EnumeratedFileCount: 0,
                 DiscoveredScoreCount: 0);
-        }
-        catch (SongLibraryReloadPostCommitPublicationException exception)
-        {
-            return new SongLibraryReloadResult(
-                SongLibraryReloadOutcome.PartialSuccessRestartRequired,
-                UnavailableRootCount: 0,
-                EnumeratedFileCount: 0,
-                DiscoveredScoreCount: 0,
-                exception.GetBaseException().Message);
         }
         catch (Exception exception)
         {
@@ -127,6 +126,12 @@ internal sealed class SongLibraryReloadService : ISongLibraryReloadService
                 DiscoveredScoreCount: 0,
                 exception.GetBaseException().Message);
         }
+    }
+
+    private static int CountUnavailableRoots(SongEnumerationBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        return batch.Errors.Where(error => error.IsRootFailure).Count();
     }
 
     private sealed class ReloadProgressAdapter : IProgress<EnumerationProgress>

--- a/DTXMania.Game/Lib/Stage/Config/StaFolderPickerDispatcher.cs
+++ b/DTXMania.Game/Lib/Stage/Config/StaFolderPickerDispatcher.cs
@@ -44,9 +44,11 @@ namespace DTXMania.Game.Lib.Stage.Config
         private readonly BlockingCollection<PickerRequest> _requests = new();
         private readonly CancellationTokenSource _shutdown = new();
         private readonly Thread _dispatcherThread;
+        private readonly object _requestGate = new();
         private readonly object _activeDialogLock = new();
         private PickerRequest? _activeRequest;
         private IStaFolderPickerDialog? _activeDialog;
+        private FolderPickerResult? _terminalResult;
         private int _disposed;
 
         internal StaFolderPickerDispatcher(
@@ -72,27 +74,26 @@ namespace DTXMania.Game.Lib.Stage.Config
             if (cancellationToken.IsCancellationRequested)
                 return Task.FromResult(FolderPickerResult.Cancelled());
 
-            if (Volatile.Read(ref _disposed) != 0)
-            {
-                return Task.FromResult(FolderPickerResult.Unavailable(
-                    "The folder picker is no longer available."));
-            }
-
             var request = new PickerRequest(initialDirectory, cancellationToken, CancelRequest);
-            try
+            lock (_requestGate)
             {
-                _requests.Add(request, _shutdown.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                request.Complete(cancellationToken.IsCancellationRequested
-                    ? FolderPickerResult.Cancelled()
-                    : FolderPickerResult.Unavailable("The folder picker is shutting down."));
-            }
-            catch (InvalidOperationException)
-            {
-                request.Complete(FolderPickerResult.Unavailable(
-                    "The folder picker is no longer available."));
+                if (_terminalResult != null || Volatile.Read(ref _disposed) != 0)
+                {
+                    request.Complete(_terminalResult ?? FolderPickerResult.Unavailable(
+                        "The folder picker is no longer available."));
+                }
+                else
+                {
+                    try
+                    {
+                        _requests.Add(request);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        request.Complete(_terminalResult ?? FolderPickerResult.Unavailable(
+                            "The folder picker is no longer available."));
+                    }
+                }
             }
 
             return request.Task;
@@ -103,7 +104,8 @@ namespace DTXMania.Game.Lib.Stage.Config
             if (Interlocked.Exchange(ref _disposed, 1) != 0)
                 return;
 
-            _requests.CompleteAdding();
+            TransitionToTerminal(FolderPickerResult.Unavailable(
+                "The folder picker is shutting down."));
             _shutdown.Cancel();
             StopActiveDialog();
 
@@ -117,6 +119,7 @@ namespace DTXMania.Game.Lib.Stage.Config
 
         private void DispatchRequests()
         {
+            FolderPickerResult? terminalResult = null;
             try
             {
                 _dialogFactory.InitializeDispatcherThread();
@@ -135,15 +138,16 @@ namespace DTXMania.Game.Lib.Stage.Config
             catch (OperationCanceledException)
             {
                 // Dispose requested while the dispatcher was idle.
+                terminalResult = FolderPickerResult.Unavailable(
+                    "The folder picker is shutting down.");
             }
             catch (Exception exception)
             {
-                DrainPendingRequests(FolderPickerResult.Unavailable(exception.Message));
-                return;
+                terminalResult = FolderPickerResult.Unavailable(exception.Message);
             }
             finally
             {
-                DrainPendingRequests(FolderPickerResult.Unavailable(
+                TransitionToTerminal(terminalResult ?? FolderPickerResult.Unavailable(
                     "The folder picker is shutting down."));
             }
         }
@@ -183,7 +187,17 @@ namespace DTXMania.Game.Lib.Stage.Config
                     }
                 }
 
-                dialog?.Dispose();
+                if (dialog != null)
+                {
+                    try
+                    {
+                        dialog.Dispose();
+                    }
+                    catch (Exception exception)
+                    {
+                        request.Complete(FolderPickerResult.Failed(exception.Message));
+                    }
+                }
             }
         }
 
@@ -243,6 +257,19 @@ namespace DTXMania.Game.Lib.Stage.Config
         {
             while (_requests.TryTake(out var request))
                 request.Complete(result);
+        }
+
+        private void TransitionToTerminal(FolderPickerResult result)
+        {
+            FolderPickerResult terminalResult;
+            lock (_requestGate)
+            {
+                _terminalResult ??= result;
+                terminalResult = _terminalResult;
+                _requests.CompleteAdding();
+            }
+
+            DrainPendingRequests(terminalResult);
         }
 
         private sealed class PickerRequest

--- a/DTXMania.Game/Lib/Stage/Config/StaFolderPickerDispatcher.cs
+++ b/DTXMania.Game/Lib/Stage/Config/StaFolderPickerDispatcher.cs
@@ -1,0 +1,289 @@
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DTXMania.Game.Lib.Stage.Config
+{
+    /// <summary>
+    /// Represents one blocking native picker dialog. Implementations must make
+    /// <see cref="Close"/> safe to call from cancellation handling while
+    /// <see cref="Show"/> is still blocking on the owned UI thread.
+    /// </summary>
+    internal interface IStaFolderPickerDialog : IDisposable
+    {
+        FolderPickerResult Show(string? initialDirectory);
+
+        void Close();
+    }
+
+    /// <summary>
+    /// Creates and closes dialogs for <see cref="StaFolderPickerDispatcher"/>.
+    /// The platform factory owns any required marshalling when a cancellation
+    /// requests that its active dialog be closed.
+    /// </summary>
+    internal interface IStaFolderPickerDialogFactory
+    {
+        void InitializeDispatcherThread();
+
+        IStaFolderPickerDialog CreateDialog();
+
+        void CloseOnDispatcher(IStaFolderPickerDialog dialog);
+    }
+
+    /// <summary>
+    /// Serializes blocking native dialogs on one owned thread. This class is
+    /// platform-neutral so its cancellation/queue contract can be verified
+    /// without opening a real operating-system dialog.
+    /// </summary>
+    internal sealed class StaFolderPickerDispatcher : IFolderPickerService, IDisposable
+    {
+        private readonly IStaFolderPickerDialogFactory _dialogFactory;
+        private readonly BlockingCollection<PickerRequest> _requests = new();
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly Thread _dispatcherThread;
+        private readonly object _activeDialogLock = new();
+        private PickerRequest? _activeRequest;
+        private IStaFolderPickerDialog? _activeDialog;
+        private int _disposed;
+
+        internal StaFolderPickerDispatcher(
+            IStaFolderPickerDialogFactory dialogFactory,
+            Action<Thread>? configureThread = null)
+        {
+            _dialogFactory = dialogFactory ?? throw new ArgumentNullException(nameof(dialogFactory));
+            _dispatcherThread = new Thread(DispatchRequests)
+            {
+                IsBackground = true,
+                Name = "DTXMania Folder Picker STA",
+            };
+            configureThread?.Invoke(_dispatcherThread);
+            _dispatcherThread.Start();
+        }
+
+        internal ApartmentState DispatcherApartmentState => _dispatcherThread.GetApartmentState();
+
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromResult(FolderPickerResult.Cancelled());
+
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return Task.FromResult(FolderPickerResult.Unavailable(
+                    "The folder picker is no longer available."));
+            }
+
+            var request = new PickerRequest(initialDirectory, cancellationToken, CancelRequest);
+            try
+            {
+                _requests.Add(request, _shutdown.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                request.Complete(cancellationToken.IsCancellationRequested
+                    ? FolderPickerResult.Cancelled()
+                    : FolderPickerResult.Unavailable("The folder picker is shutting down."));
+            }
+            catch (InvalidOperationException)
+            {
+                request.Complete(FolderPickerResult.Unavailable(
+                    "The folder picker is no longer available."));
+            }
+
+            return request.Task;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            _requests.CompleteAdding();
+            _shutdown.Cancel();
+            StopActiveDialog();
+
+            if (!ReferenceEquals(Thread.CurrentThread, _dispatcherThread) &&
+                _dispatcherThread.Join(TimeSpan.FromSeconds(1)))
+            {
+                _requests.Dispose();
+                _shutdown.Dispose();
+            }
+        }
+
+        private void DispatchRequests()
+        {
+            try
+            {
+                _dialogFactory.InitializeDispatcherThread();
+
+                foreach (var request in _requests.GetConsumingEnumerable(_shutdown.Token))
+                {
+                    if (request.IsCompleted || request.CancellationToken.IsCancellationRequested)
+                    {
+                        request.Complete(FolderPickerResult.Cancelled());
+                        continue;
+                    }
+
+                    ShowRequest(request);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Dispose requested while the dispatcher was idle.
+            }
+            catch (Exception exception)
+            {
+                DrainPendingRequests(FolderPickerResult.Unavailable(exception.Message));
+                return;
+            }
+            finally
+            {
+                DrainPendingRequests(FolderPickerResult.Unavailable(
+                    "The folder picker is shutting down."));
+            }
+        }
+
+        private void ShowRequest(PickerRequest request)
+        {
+            IStaFolderPickerDialog? dialog = null;
+            try
+            {
+                dialog = _dialogFactory.CreateDialog();
+                lock (_activeDialogLock)
+                {
+                    if (request.IsCompleted)
+                        return;
+
+                    _activeRequest = request;
+                    _activeDialog = dialog;
+                }
+
+                if (request.IsCompleted)
+                    return;
+
+                request.Complete(dialog.Show(request.InitialDirectory));
+            }
+            catch (Exception exception)
+            {
+                request.Complete(FolderPickerResult.Failed(exception.Message));
+            }
+            finally
+            {
+                lock (_activeDialogLock)
+                {
+                    if (ReferenceEquals(_activeRequest, request))
+                    {
+                        _activeRequest = null;
+                        _activeDialog = null;
+                    }
+                }
+
+                dialog?.Dispose();
+            }
+        }
+
+        private void CancelRequest(PickerRequest request)
+        {
+            request.Complete(FolderPickerResult.Cancelled());
+
+            IStaFolderPickerDialog? activeDialog;
+            lock (_activeDialogLock)
+            {
+                activeDialog = ReferenceEquals(_activeRequest, request)
+                    ? _activeDialog
+                    : null;
+            }
+
+            if (activeDialog == null)
+                return;
+
+            try
+            {
+                _dialogFactory.CloseOnDispatcher(activeDialog);
+            }
+            catch
+            {
+                // The request is already cancelled. A platform shutdown race
+                // must not surface from a CancellationToken callback.
+            }
+        }
+
+        private void StopActiveDialog()
+        {
+            PickerRequest? activeRequest;
+            IStaFolderPickerDialog? activeDialog;
+            lock (_activeDialogLock)
+            {
+                activeRequest = _activeRequest;
+                activeDialog = _activeDialog;
+            }
+
+            activeRequest?.Complete(FolderPickerResult.Unavailable(
+                "The folder picker is shutting down."));
+
+            if (activeDialog == null)
+                return;
+
+            try
+            {
+                _dialogFactory.CloseOnDispatcher(activeDialog);
+            }
+            catch
+            {
+                // Best-effort shutdown. Do not throw from IDisposable.Dispose.
+            }
+        }
+
+        private void DrainPendingRequests(FolderPickerResult result)
+        {
+            while (_requests.TryTake(out var request))
+                request.Complete(result);
+        }
+
+        private sealed class PickerRequest
+        {
+            private readonly TaskCompletionSource<FolderPickerResult> _completion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly Action<PickerRequest> _cancelRequest;
+            private CancellationTokenRegistration _cancellationRegistration;
+
+            internal PickerRequest(
+                string? initialDirectory,
+                CancellationToken cancellationToken,
+                Action<PickerRequest> cancelRequest)
+            {
+                InitialDirectory = initialDirectory;
+                CancellationToken = cancellationToken;
+                _cancelRequest = cancelRequest;
+                _cancellationRegistration = cancellationToken.Register(
+                    static state =>
+                    {
+                        var request = (PickerRequest)state!;
+                        request._cancelRequest(request);
+                    },
+                    this);
+                if (_completion.Task.IsCompleted)
+                    _cancellationRegistration.Dispose();
+            }
+
+            internal string? InitialDirectory { get; }
+
+            internal CancellationToken CancellationToken { get; }
+
+            internal Task<FolderPickerResult> Task => _completion.Task;
+
+            internal bool IsCompleted => _completion.Task.IsCompleted;
+
+            internal void Complete(FolderPickerResult result)
+            {
+                if (_completion.TrySetResult(result))
+                    _cancellationRegistration.Dispose();
+            }
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Stage/Config/StaFolderPickerDispatcher.cs
+++ b/DTXMania.Game/Lib/Stage/Config/StaFolderPickerDispatcher.cs
@@ -193,9 +193,12 @@ namespace DTXMania.Game.Lib.Stage.Config
                     {
                         dialog.Dispose();
                     }
-                    catch (Exception exception)
+                    catch (Exception)
                     {
-                        request.Complete(FolderPickerResult.Failed(exception.Message));
+                        // The request has already been completed by Show() or
+                        // the catch above, so re-completing it here would be a
+                        // no-op (TrySetResult returns false). Disposal failures
+                        // are best-effort and must not surface to the caller.
                     }
                 }
             }

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -21,6 +21,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using DTXMania.Game.Lib.Utilities;
+using DTXMania.Game.Platform;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -80,7 +81,10 @@ namespace DTXMania.Game.Lib.Stage
         private KeyboardState _currentKeyboardState;
 
         private SystemKeyAssignPanel? _systemPanel;
-        private IKeyAssignPanel? _activePanel;
+        private SongFolderPanel? _songFolderPanel;
+        private IConfigOverlayPanel? _activePanel;
+        private readonly Func<IFolderPickerService> _folderPickerServiceFactory;
+        private IFolderPickerService? _songFolderPicker;
 
         private SpriteBatch _spriteBatch;
         private Texture2D _whitePixel;
@@ -160,6 +164,7 @@ namespace DTXMania.Game.Lib.Stage
         private static readonly Color InnerBoardBorderColor = new(74, 62, 150, 224);
 
         private volatile string _importStatus = "";
+        private volatile string _songFolderStatus = "";
         private volatile bool _importRunning;
         private CancellationTokenSource? _importCts;
 
@@ -170,18 +175,28 @@ namespace DTXMania.Game.Lib.Stage
         public override StageType Type => StageType.Config;
 
         public ConfigStage(IStageGame game)
-            : this(game, FfmpegRuntime.EnsureConfigured)
+            : this(game, FfmpegRuntime.EnsureConfigured, FolderPickerServiceFactory.Create)
         {
         }
 
         internal ConfigStage(
             IStageGame game,
             Func<FfmpegRuntimeAvailability> ffmpegAvailabilityProvider)
+            : this(game, ffmpegAvailabilityProvider, FolderPickerServiceFactory.Create)
+        {
+        }
+
+        internal ConfigStage(
+            IStageGame game,
+            Func<FfmpegRuntimeAvailability> ffmpegAvailabilityProvider,
+            Func<IFolderPickerService> folderPickerServiceFactory)
             : base(game)
         {
             _configManager = game.ConfigManager ?? throw new InvalidOperationException("ConfigManager not found");
             _ffmpegAvailabilityProvider = ffmpegAvailabilityProvider
                 ?? throw new ArgumentNullException(nameof(ffmpegAvailabilityProvider));
+            _folderPickerServiceFactory = folderPickerServiceFactory
+                ?? throw new ArgumentNullException(nameof(folderPickerServiceFactory));
         }
 
         #endregion
@@ -207,6 +222,7 @@ namespace DTXMania.Game.Lib.Stage
             // here: the background task clears it in its finally, and the StartNxScoreImport guard
             // correctly serializes a still-draining task.)
             _importStatus = "";
+            _songFolderStatus = "";
 
             _previousKeyboardState = Keyboard.GetState();
             _currentKeyboardState = Keyboard.GetState();
@@ -320,6 +336,10 @@ namespace DTXMania.Game.Lib.Stage
                 _importCts?.Cancel();
                 _importCts?.Dispose();
                 _importCts = null;
+
+                if (_songFolderPicker is IDisposable disposableFolderPicker)
+                    disposableFolderPicker.Dispose();
+                _songFolderPicker = null;
 
                 _whitePixel?.Dispose();
                 _spriteBatch?.Dispose();
@@ -580,10 +600,12 @@ namespace DTXMania.Game.Lib.Stage
                 _skinDropdown = skinItem;
             }
 
-            var dtxFolderItem = new ReadOnlyConfigItem(
-                "DTX Folder",
-                () => _configManager.Config.DTXPath)
-            { Description = "Folder scanned for songs and charts (read-only)." };
+            var songFoldersItem = new SongFoldersNavigationConfigItem(
+                () => FormatSongFolderCount(_configManager.Config.SongRoots.Count),
+                () => OpenPanel(_songFolderPanel))
+            {
+                Description = "Edit the ordered song folders. Apply saves the list; restart to reload songs."
+            };
 
             var systemKeyItem = new NavigationConfigItem("System Key Mapping",
                 () => OpenPanel(_systemPanel))
@@ -658,7 +680,7 @@ namespace DTXMania.Game.Lib.Stage
             {
                 systemItems.Add(skinItem);
             }
-            systemItems.Add(dtxFolderItem);
+            systemItems.Add(songFoldersItem);
             systemItems.Add(systemKeyItem);
             systemItems.Add(importItem);
 
@@ -912,9 +934,18 @@ namespace DTXMania.Game.Lib.Stage
             _systemPanel._commandPressedProvider = IsPanelCommandPressed;
             _systemPanel.Saved += OnPanelSaved;
             _systemPanel.Closed += OnPanelClosed;
+
+            _songFolderPicker ??= _folderPickerServiceFactory();
+            _songFolderPanel = new SongFolderPanel(
+                _configManager.Config.SongRoots.ToArray(),
+                _songFolderPicker,
+                SongRootPolicy.ForCurrentPlatform(),
+                ApplySongRoots);
+            _songFolderPanel.Saved += OnPanelSaved;
+            _songFolderPanel.Closed += OnPanelClosed;
         }
 
-        private void OpenPanel(IKeyAssignPanel? panel)
+        private void OpenPanel(IConfigOverlayPanel? panel)
         {
             if (panel == null) return;
             _activePanel = panel;
@@ -932,6 +963,11 @@ namespace DTXMania.Game.Lib.Stage
             {
                 _configManager.SetSystemKeyBindings(_systemPanel.GetWorkingMappingSnapshot());
             }
+            else if (sender == _songFolderPanel &&
+                     _songFolderPanel.LastApplyStatus == SongFolderApplyStatus.Updated)
+            {
+                _songFolderStatus = "Song folders saved. Restart required to reload songs.";
+            }
         }
 
         private void OnPanelClosed(object? sender, EventArgs e)
@@ -939,11 +975,67 @@ namespace DTXMania.Game.Lib.Stage
             _activePanel = null;
         }
 
+        private SongFolderApplyResult ApplySongRoots(IReadOnlyList<string> roots)
+        {
+            try
+            {
+                var updateResult = _configManager.SetSongRoots(AppPaths.GetConfigFilePath(), roots);
+                return new SongFolderApplyResult(
+                    MapSongFolderApplyStatus(updateResult.Status),
+                    updateResult.CanonicalRoots,
+                    updateResult.Diagnostics);
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception, "ConfigStage: failed to save song folders");
+                return new SongFolderApplyResult(
+                    SongFolderApplyStatus.PersistenceFailed,
+                    roots,
+                    new[]
+                    {
+                        new SongRootDiagnostic(
+                            string.Empty,
+                            "Unable to save song folders: " + exception.Message,
+                            IsWarning: false)
+                    });
+            }
+        }
+
+        private static SongFolderApplyStatus MapSongFolderApplyStatus(SongRootUpdateStatus status) => status switch
+        {
+            SongRootUpdateStatus.Updated => SongFolderApplyStatus.Updated,
+            SongRootUpdateStatus.Unchanged => SongFolderApplyStatus.Unchanged,
+            SongRootUpdateStatus.ValidationFailed => SongFolderApplyStatus.ValidationFailed,
+            SongRootUpdateStatus.PersistenceFailed => SongFolderApplyStatus.PersistenceFailed,
+            _ => SongFolderApplyStatus.PersistenceFailed,
+        };
+
+        private static string FormatSongFolderCount(int count) => count == 1
+            ? "1 folder"
+            : $"{count} folders";
+
+        private sealed class SongFoldersNavigationConfigItem : NavigationConfigItem
+        {
+            private readonly Func<string> _summaryProvider;
+
+            public SongFoldersNavigationConfigItem(
+                Func<string> summaryProvider,
+                Action onActivate)
+                : base("Song Folders", onActivate)
+            {
+                _summaryProvider = summaryProvider
+                    ?? throw new ArgumentNullException(nameof(summaryProvider));
+            }
+
+            public override string GetDisplayText() => $"{Name}: {_summaryProvider()}";
+        }
+
         private void StartNxScoreImport()
         {
             if (_importRunning)
                 return;
             _importRunning = true;
+            _songFolderStatus = "";
             _importStatus = "Importing NX scores...";
 
             _importCts?.Cancel();
@@ -1536,10 +1628,13 @@ namespace DTXMania.Game.Lib.Stage
 
         private void DrawImportStatus()
         {
-            if (string.IsNullOrEmpty(_importStatus) || _font == null)
+            var status = string.IsNullOrEmpty(_songFolderStatus)
+                ? _importStatus
+                : _songFolderStatus;
+            if (string.IsNullOrEmpty(status) || _font == null)
                 return;
 
-            _font.DrawString(_spriteBatch, _importStatus, ConfigUILayout.ImportStatusPos, ImportStatusColor);
+            _font.DrawString(_spriteBatch, status, ConfigUILayout.ImportStatusPos, ImportStatusColor);
         }
 
         // The stage draws into the fixed 1280x720 render target (letterboxed to the window once

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -648,7 +648,7 @@ namespace DTXMania.Game.Lib.Stage
                 () => FormatSongFolderCount(_configManager.Config.SongRoots.Count),
                 () => OpenPanel(_songFolderPanel))
             {
-                Description = "Edit the ordered song folders. Apply saves the list; restart to reload songs."
+                Description = "Edit the ordered song folders. Apply saves the list and triggers one live reload."
             };
 
             var systemKeyItem = new NavigationConfigItem("System Key Mapping",

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -269,6 +269,14 @@ namespace DTXMania.Game.Lib.Stage
             _importStatus = "";
             _songFolderStatus = "";
 
+            // Drop stale operation state from a prior activation. Terminal updates from a
+            // prior generation are discarded by DrainSongOperationUpdates, so without this
+            // the fields would retain references to a superseded lease/CTS until the next
+            // operation overwrites them. The prior operation's task continuation still owns
+            // lease/CTS disposal, so clearing the handles here does not leak.
+            _activeSongOperation = null;
+            _songOperationCts = null;
+
             _previousKeyboardState = Keyboard.GetState();
             _currentKeyboardState = Keyboard.GetState();
         }
@@ -1073,7 +1081,9 @@ namespace DTXMania.Game.Lib.Stage
 
                 _importStatus = "";
                 _songFolderStatus = "Reloading configured song folders...";
-                cancellation = new CancellationTokenSource();
+                cancellation = _songOperationCtsFactory()
+                    ?? throw new InvalidOperationException(
+                        "Song operation CTS factory returned null.");
                 releaseTransferred = StartSongOperation(
                     lease,
                     cancellation,

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -1524,7 +1524,10 @@ namespace DTXMania.Game.Lib.Stage
         // the coupling is documented here instead.
         private static string GetItemValueText(IConfigItem item)
         {
-            if (item is NavigationConfigItem)
+            // Most navigation rows deliberately show a fixed arrow. Song Folders is a
+            // navigation row with meaningful value-column content, so handle it before
+            // the generic marker and preserve activation behavior through its base type.
+            if (item is NavigationConfigItem && item is not SongFoldersNavigationConfigItem)
                 return ">";
 
             var text = item.GetDisplayText();

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -172,6 +172,7 @@ namespace DTXMania.Game.Lib.Stage
         private readonly ISongLibraryReloadService _songLibraryReloadService;
         private readonly Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> _nxImportAsync;
         private readonly Func<Task> _refreshSongListAsync;
+        private readonly Func<CancellationTokenSource> _songOperationCtsFactory;
         private readonly Func<
             Func<Task<ConfigSongOperationCompletion>>,
             Task<ConfigSongOperationCompletion>> _backgroundSongOperationRunner;
@@ -224,7 +225,8 @@ namespace DTXMania.Game.Lib.Stage
             Func<
                 Func<Task<ConfigSongOperationCompletion>>,
                 Task<ConfigSongOperationCompletion>> backgroundSongOperationRunner,
-            Func<Task, Action<Task>, Task>? continuationRegistrar)
+            Func<Task, Action<Task>, Task>? continuationRegistrar,
+            Func<CancellationTokenSource>? songOperationCtsFactory = null)
             : base(game)
         {
             _configManager = game.ConfigManager ?? throw new InvalidOperationException("ConfigManager not found");
@@ -238,6 +240,8 @@ namespace DTXMania.Game.Lib.Stage
                 ?? throw new ArgumentNullException(nameof(nxImportAsync));
             _refreshSongListAsync = refreshSongListAsync
                 ?? throw new ArgumentNullException(nameof(refreshSongListAsync));
+            _songOperationCtsFactory = songOperationCtsFactory ??
+                (() => new CancellationTokenSource());
             _backgroundSongOperationRunner = backgroundSongOperationRunner
                 ?? throw new ArgumentNullException(nameof(backgroundSongOperationRunner));
             _songOperationContinuationRegistrar = continuationRegistrar;
@@ -1152,29 +1156,45 @@ namespace DTXMania.Game.Lib.Stage
 
         private void StartNxScoreImport()
         {
-            var lease = _songOperationCoordinator.TryAcquire(
-                ConfigSongOperationKind.NxScoreImport);
-            if (lease == null)
+            ConfigSongOperationLease? lease = null;
+            CancellationTokenSource? cancellation = null;
+            var releaseTransferred = false;
+            try
             {
-                _importStatus = "Another song operation is already running.";
-                return;
-            }
+                lease = _songOperationCoordinator.TryAcquire(
+                    ConfigSongOperationKind.NxScoreImport);
+                if (lease == null)
+                {
+                    _importStatus = "Another song operation is already running.";
+                    return;
+                }
 
-            _songFolderStatus = "";
-            _importStatus = "Importing NX scores...";
-            var cancellation = new CancellationTokenSource();
-            if (StartSongOperation(
+                _songFolderStatus = "";
+                _importStatus = "Importing NX scores...";
+                cancellation = _songOperationCtsFactory()
+                    ?? throw new InvalidOperationException(
+                        "Song operation CTS factory returned null.");
+                releaseTransferred = StartSongOperation(
                     lease,
                     cancellation,
                     ConfigSongOperationKind.NxScoreImport,
-                    RunNxScoreImportAsync))
-            {
-                return;
+                    RunNxScoreImportAsync);
+                if (!releaseTransferred)
+                    _importStatus = "NX import could not be started.";
             }
-
-            cancellation.Dispose();
-            lease.Dispose();
-            _importStatus = "NX import could not be started.";
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception, "ConfigStage: NX import could not be started");
+                _importStatus = "NX import could not be started.";
+            }
+            finally
+            {
+                if (!releaseTransferred)
+                {
+                    cancellation?.Dispose();
+                    lease?.Dispose();
+                }
+            }
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/ConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/ConfigStage.cs
@@ -13,6 +13,7 @@ using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -20,6 +21,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using DTXMania.Game.Lib.Utilities;
 using DTXMania.Game.Platform;
 using Microsoft.Extensions.Logging;
@@ -163,10 +165,20 @@ namespace DTXMania.Game.Lib.Stage
         private static readonly Color InnerBoardColor = new(8, 10, 22, 196);
         private static readonly Color InnerBoardBorderColor = new(74, 62, 150, 224);
 
-        private volatile string _importStatus = "";
-        private volatile string _songFolderStatus = "";
-        private volatile bool _importRunning;
-        private CancellationTokenSource? _importCts;
+        private string _importStatus = "";
+        private string _songFolderStatus = "";
+        private readonly ConfigSongOperationCoordinator _songOperationCoordinator = new();
+        private readonly ConcurrentQueue<ConfigSongOperationUpdate> _songOperationUpdates = new();
+        private readonly ISongLibraryReloadService _songLibraryReloadService;
+        private readonly Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> _nxImportAsync;
+        private readonly Func<Task> _refreshSongListAsync;
+        private readonly Func<
+            Func<Task<ConfigSongOperationCompletion>>,
+            Task<ConfigSongOperationCompletion>> _backgroundSongOperationRunner;
+        private readonly Func<Task, Action<Task>, Task>? _songOperationContinuationRegistrar;
+        private CancellationTokenSource? _songOperationCts;
+        private ActiveSongOperation? _activeSongOperation;
+        private int _activationGeneration;
 
         #endregion
 
@@ -190,6 +202,29 @@ namespace DTXMania.Game.Lib.Stage
             IStageGame game,
             Func<FfmpegRuntimeAvailability> ffmpegAvailabilityProvider,
             Func<IFolderPickerService> folderPickerServiceFactory)
+            : this(
+                game,
+                ffmpegAvailabilityProvider,
+                folderPickerServiceFactory,
+                new SongLibraryReloadService(),
+                (progress, token) => SongManager.Instance.ImportNxScoresAsync(progress, token),
+                () => SongManager.Instance.RefreshSongListFromDatabaseAsync(),
+                work => Task.Run(work),
+                continuationRegistrar: null)
+        {
+        }
+
+        internal ConfigStage(
+            IStageGame game,
+            Func<FfmpegRuntimeAvailability> ffmpegAvailabilityProvider,
+            Func<IFolderPickerService> folderPickerServiceFactory,
+            ISongLibraryReloadService songLibraryReloadService,
+            Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> nxImportAsync,
+            Func<Task> refreshSongListAsync,
+            Func<
+                Func<Task<ConfigSongOperationCompletion>>,
+                Task<ConfigSongOperationCompletion>> backgroundSongOperationRunner,
+            Func<Task, Action<Task>, Task>? continuationRegistrar)
             : base(game)
         {
             _configManager = game.ConfigManager ?? throw new InvalidOperationException("ConfigManager not found");
@@ -197,6 +232,15 @@ namespace DTXMania.Game.Lib.Stage
                 ?? throw new ArgumentNullException(nameof(ffmpegAvailabilityProvider));
             _folderPickerServiceFactory = folderPickerServiceFactory
                 ?? throw new ArgumentNullException(nameof(folderPickerServiceFactory));
+            _songLibraryReloadService = songLibraryReloadService
+                ?? throw new ArgumentNullException(nameof(songLibraryReloadService));
+            _nxImportAsync = nxImportAsync
+                ?? throw new ArgumentNullException(nameof(nxImportAsync));
+            _refreshSongListAsync = refreshSongListAsync
+                ?? throw new ArgumentNullException(nameof(refreshSongListAsync));
+            _backgroundSongOperationRunner = backgroundSongOperationRunner
+                ?? throw new ArgumentNullException(nameof(backgroundSongOperationRunner));
+            _songOperationContinuationRegistrar = continuationRegistrar;
         }
 
         #endregion
@@ -216,11 +260,8 @@ namespace DTXMania.Game.Lib.Stage
             _focusOnMenu = true;
             _itemScroll = 0;
 
-            // Clear any import status left over from a previous visit. StageManager reuses this
-            // instance, so without this a stale "Imported N scores" / "cancelled" message would
-            // survive leaving and re-entering Config. (_importRunning is intentionally NOT reset
-            // here: the background task clears it in its finally, and the StartNxScoreImport guard
-            // correctly serializes a still-draining task.)
+            // Clear any status left over from a previous visit. In-flight operation updates are
+            // tagged with the activation generation and discarded by OnUpdate after deactivation.
             _importStatus = "";
             _songFolderStatus = "";
 
@@ -230,6 +271,8 @@ namespace DTXMania.Game.Lib.Stage
 
         protected override void OnUpdate(double deltaTime)
         {
+            DrainSongOperationUpdates();
+
             _previousKeyboardState = _currentKeyboardState;
             _currentKeyboardState = Keyboard.GetState();
 
@@ -296,9 +339,8 @@ namespace DTXMania.Game.Lib.Stage
         {
             _logger.LogDebug("Deactivating Config Stage");
 
+            CancelSongOperationForDeactivation();
             FlushPendingSaveSafely();
-
-            _importCts?.Cancel();
 
             _activePanel?.Deactivate();
             _activePanel = null;
@@ -333,9 +375,7 @@ namespace DTXMania.Game.Lib.Stage
             {
                 _logger.LogDebug("Disposing Config Stage resources");
 
-                _importCts?.Cancel();
-                _importCts?.Dispose();
-                _importCts = null;
+                CancelSongOperationForDeactivation();
 
                 if (_songFolderPicker is IDisposable disposableFolderPicker)
                     disposableFolderPicker.Dispose();
@@ -963,11 +1003,6 @@ namespace DTXMania.Game.Lib.Stage
             {
                 _configManager.SetSystemKeyBindings(_systemPanel.GetWorkingMappingSnapshot());
             }
-            else if (sender == _songFolderPanel &&
-                     _songFolderPanel.LastApplyStatus == SongFolderApplyStatus.Updated)
-            {
-                _songFolderStatus = "Song folders saved. Restart required to reload songs.";
-            }
         }
 
         private void OnPanelClosed(object? sender, EventArgs e)
@@ -977,13 +1012,90 @@ namespace DTXMania.Game.Lib.Stage
 
         private SongFolderApplyResult ApplySongRoots(IReadOnlyList<string> roots)
         {
+            var rootPolicy = SongRootPolicy.ForCurrentPlatform();
+            var validation = rootPolicy.Validate(roots);
+            if (!validation.IsValid)
+            {
+                return new SongFolderApplyResult(
+                    SongFolderApplyStatus.ValidationFailed,
+                    validation.CanonicalRoots,
+                    validation.Diagnostics);
+            }
+
+            // Avoid acquiring a long-operation lease, persisting, or scanning when
+            // this exact ordered root set is already configured. The ordering is
+            // intentional: a reordering is a real library rebuild request.
+            var configuredRoots = rootPolicy.Validate(_configManager.Config.SongRoots);
+            if (configuredRoots.CanonicalRoots.SequenceEqual(
+                    validation.CanonicalRoots,
+                    rootPolicy.Comparer))
+            {
+                return new SongFolderApplyResult(
+                    SongFolderApplyStatus.Unchanged,
+                    validation.CanonicalRoots,
+                    validation.Diagnostics);
+            }
+
+            var lease = _songOperationCoordinator.TryAcquire(
+                ConfigSongOperationKind.SongFolderReload);
+            if (lease == null)
+            {
+                return new SongFolderApplyResult(
+                    SongFolderApplyStatus.Busy,
+                    validation.CanonicalRoots,
+                    new[]
+                    {
+                        new SongRootDiagnostic(
+                            string.Empty,
+                            "Another song operation is already running.",
+                            IsWarning: false)
+                    });
+            }
+
+            CancellationTokenSource? cancellation = null;
+            var releaseTransferred = false;
             try
             {
-                var updateResult = _configManager.SetSongRoots(AppPaths.GetConfigFilePath(), roots);
+                var updateResult = _configManager.SetSongRoots(
+                    AppPaths.GetConfigFilePath(),
+                    validation.CanonicalRoots);
+                if (updateResult.Status != SongRootUpdateStatus.Updated)
+                {
+                    return new SongFolderApplyResult(
+                        MapSongFolderApplyStatus(updateResult.Status),
+                        updateResult.CanonicalRoots,
+                        updateResult.Diagnostics);
+                }
+
+                _importStatus = "";
+                _songFolderStatus = "Reloading configured song folders...";
+                cancellation = new CancellationTokenSource();
+                releaseTransferred = StartSongOperation(
+                    lease,
+                    cancellation,
+                    ConfigSongOperationKind.SongFolderReload,
+                    (token, progress) => RunSongFolderReloadAsync(
+                        updateResult.CanonicalRoots,
+                        token,
+                        progress));
+                if (releaseTransferred)
+                {
+                    return new SongFolderApplyResult(
+                        SongFolderApplyStatus.Started,
+                        updateResult.CanonicalRoots,
+                        updateResult.Diagnostics);
+                }
+
                 return new SongFolderApplyResult(
-                    MapSongFolderApplyStatus(updateResult.Status),
+                    SongFolderApplyStatus.PersistenceFailed,
                     updateResult.CanonicalRoots,
-                    updateResult.Diagnostics);
+                    new[]
+                    {
+                        new SongRootDiagnostic(
+                            string.Empty,
+                            "Song folders were saved, but the reload could not be started. Restart required.",
+                            IsWarning: false)
+                    });
             }
             catch (Exception exception)
             {
@@ -996,8 +1108,16 @@ namespace DTXMania.Game.Lib.Stage
                         new SongRootDiagnostic(
                             string.Empty,
                             "Unable to save song folders: " + exception.Message,
-                            IsWarning: false)
+                        IsWarning: false)
                     });
+            }
+            finally
+            {
+                if (!releaseTransferred)
+                {
+                    cancellation?.Dispose();
+                    lease.Dispose();
+                }
             }
         }
 
@@ -1032,73 +1152,304 @@ namespace DTXMania.Game.Lib.Stage
 
         private void StartNxScoreImport()
         {
-            if (_importRunning)
+            var lease = _songOperationCoordinator.TryAcquire(
+                ConfigSongOperationKind.NxScoreImport);
+            if (lease == null)
+            {
+                _importStatus = "Another song operation is already running.";
                 return;
-            _importRunning = true;
+            }
+
             _songFolderStatus = "";
             _importStatus = "Importing NX scores...";
-
-            _importCts?.Cancel();
-            _importCts?.Dispose();
-            _importCts = new CancellationTokenSource();
-            var token = _importCts.Token;
-
-            IProgress<NxImportProgress> progress = new InlineProgress<NxImportProgress>(p =>
+            var cancellation = new CancellationTokenSource();
+            if (StartSongOperation(
+                    lease,
+                    cancellation,
+                    ConfigSongOperationKind.NxScoreImport,
+                    RunNxScoreImportAsync))
             {
-                _importStatus = $"Importing... {p.Imported} imported / {p.Scanned} scanned";
-            });
+                return;
+            }
 
-            _ = System.Threading.Tasks.Task.Run(async () =>
+            cancellation.Dispose();
+            lease.Dispose();
+            _importStatus = "NX import could not be started.";
+        }
+
+        /// <summary>
+        /// Starts one already-leased Config operation. All synchronous lifecycle
+        /// work is contained here: construct the task, attach its terminal
+        /// observer, then hand lease/CTS disposal to that terminal path.
+        /// </summary>
+        private bool StartSongOperation(
+            ConfigSongOperationLease lease,
+            CancellationTokenSource cancellation,
+            ConfigSongOperationKind kind,
+            Func<CancellationToken, IProgress<string>, Task<ConfigSongOperationCompletion>> operation)
+        {
+            try
             {
-                NxImportResult? result = null;
+                var activationGeneration = Volatile.Read(ref _activationGeneration);
+                IProgress<string> progress = new InlineProgress<string>(status =>
+                    EnqueueSongOperationUpdate(
+                        activationGeneration,
+                        lease,
+                        kind,
+                        status,
+                        isTerminal: false));
+                var task = _backgroundSongOperationRunner(
+                    () => operation(cancellation.Token, progress));
+                if (task == null)
+                    throw new InvalidOperationException("Song operation runner returned no task.");
+
+                // These fields are only mutated on the Config update thread;
+                // terminal worker callbacks enqueue immutable updates instead.
+                _songOperationCts = cancellation;
+                _activeSongOperation = new ActiveSongOperation(lease, cancellation);
+
                 try
                 {
-                    result = await SongManager.Instance.ImportNxScoresAsync(progress, token);
-                    _importStatus = result.DbUnavailable
-                        ? "NX import unavailable (no database)"
-                        : $"Imported {result.Imported} scores ({result.Scanned} charts scanned" +
-                          (result.Errors > 0 ? $", {result.Errors} errors)" : ")");
+                    _songOperationCoordinator.RegisterTerminalContinuation(
+                        lease,
+                        task,
+                        completed => CompleteSongOperation(
+                            completed,
+                            activationGeneration,
+                            lease,
+                            cancellation,
+                            kind),
+                        _songOperationContinuationRegistrar);
+                }
+                catch (Exception exception)
+                {
+                    // The coordinator installs a fallback terminal continuation
+                    // before rethrowing, so ownership remains with the running
+                    // task rather than being released early here.
+                    _logger.LogWarning(
+                        exception,
+                        "ConfigStage: terminal observer registration failed for {Operation}",
+                        kind);
+                }
 
-                    if (result.Imported > 0)
-                    {
-                        token.ThrowIfCancellationRequested();
-                        try
-                        {
-                            await SongManager.Instance.RefreshSongListFromDatabaseAsync();
-                        }
-                        catch (System.Exception ex)
-                        {
-                            // Scores were written, but the live song list didn't refresh. Surface the
-                            // partial failure so the user isn't left looking at a stale list with no
-                            // explanation (a restart will pick up the imported scores).
-                            _importStatus = $"Imported {result.Imported} scores, but the song list didn't " +
-                                $"refresh (restart to see them). {ex.GetBaseException().Message}";
-                            _logger.LogWarning(ex, "ConfigStage: NX import succeeded but song list refresh failed");
-                        }
-                    }
-                }
-                catch (System.OperationCanceledException)
-                {
-                    // If cancellation landed AFTER a successful import (between the write and the
-                    // song-list refresh, at the ThrowIfCancellationRequested above), scores ARE on
-                    // disk — report partial success instead of a bare "cancelled" that hides the
-                    // write. Mid-import cancellation (result null / nothing imported) is a real cancel.
-                    _importStatus = (result != null && result.Imported > 0)
-                        ? $"Imported {result.Imported} scores (cancelled before the song list could refresh)"
-                        : "NX import cancelled";
-                }
-                catch (System.Exception ex)
-                {
-                    var detail = ex.GetBaseException().Message;
-                    _importStatus = $"NX import failed: {detail}";
-                    _logger.LogError(ex, "ConfigStage: NX import failed");
-                }
-                finally
-                {
-                    _importRunning = false;
-                }
-            });
+                return true;
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(
+                    exception,
+                    "ConfigStage: failed to start {Operation}",
+                    kind);
+                return false;
+            }
         }
+
+        private async Task<ConfigSongOperationCompletion> RunSongFolderReloadAsync(
+            IReadOnlyList<string> roots,
+            CancellationToken cancellationToken,
+            IProgress<string> status)
+        {
+            var progress = new InlineProgress<SongLibraryReloadProgress>(update =>
+                status.Report(FormatSongLibraryReloadProgress(update)));
+            var result = await _songLibraryReloadService.ReloadAsync(
+                roots,
+                progress,
+                cancellationToken).ConfigureAwait(false);
+            return new ConfigSongOperationCompletion(
+                FormatSongLibraryReloadResult(result));
+        }
+
+        private async Task<ConfigSongOperationCompletion> RunNxScoreImportAsync(
+            CancellationToken cancellationToken,
+            IProgress<string> status)
+        {
+            var progress = new InlineProgress<NxImportProgress>(update =>
+                status.Report($"Importing... {update.Imported} imported / {update.Scanned} scanned"));
+            var result = await _nxImportAsync(progress, cancellationToken)
+                .ConfigureAwait(false);
+            if (result.DbUnavailable)
+                return new ConfigSongOperationCompletion("NX import unavailable (no database)");
+
+            if (result.Imported > 0)
+            {
+                try
+                {
+                    // The import has committed before it returns. Deliberately do
+                    // not check cancellation here: this final refresh is the
+                    // commit-through-publication terminal section.
+                    await _refreshSongListAsync().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogWarning(
+                        exception,
+                        "ConfigStage: NX import committed but song-list refresh failed");
+                    return new ConfigSongOperationCompletion(
+                        $"Imported {result.Imported} scores, but the song list didn't " +
+                        $"refresh (restart to see them). {exception.GetBaseException().Message}");
+                }
+            }
+
+            return new ConfigSongOperationCompletion(
+                $"Imported {result.Imported} scores ({result.Scanned} charts scanned" +
+                (result.Errors > 0 ? $", {result.Errors} errors)" : ")"));
+        }
+
+        private void CompleteSongOperation(
+            Task completed,
+            int activationGeneration,
+            ConfigSongOperationLease lease,
+            CancellationTokenSource cancellation,
+            ConfigSongOperationKind kind)
+        {
+            string status = string.Empty;
+            try
+            {
+                if (completed.IsCanceled)
+                {
+                    status = kind == ConfigSongOperationKind.NxScoreImport
+                        ? "NX import cancelled"
+                        : "Song folder reload cancelled; keeping the current song list.";
+                }
+                else if (completed.IsFaulted)
+                {
+                    var exception = completed.Exception?.GetBaseException();
+                    _logger.LogError(
+                        exception,
+                        "ConfigStage: {Operation} failed",
+                        kind);
+                    var prefix = kind == ConfigSongOperationKind.NxScoreImport
+                        ? "NX import failed"
+                        : "Song folder reload failed; keeping the current song list";
+                    status = exception == null
+                        ? prefix
+                        : $"{prefix}: {exception.Message}";
+                }
+                else
+                {
+                    status = ((Task<ConfigSongOperationCompletion>)completed)
+                        .GetAwaiter()
+                        .GetResult()
+                        .Status;
+                }
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(
+                    exception,
+                    "ConfigStage: {Operation} terminal observation failed",
+                    kind);
+                status = kind == ConfigSongOperationKind.NxScoreImport
+                    ? $"NX import failed: {exception.GetBaseException().Message}"
+                    : $"Song folder reload failed; keeping the current song list: {exception.GetBaseException().Message}";
+            }
+            finally
+            {
+                EnqueueSongOperationUpdate(
+                    activationGeneration,
+                    lease,
+                    kind,
+                    status ?? string.Empty,
+                    isTerminal: true);
+                cancellation.Dispose();
+            }
+        }
+
+        private void EnqueueSongOperationUpdate(
+            int activationGeneration,
+            ConfigSongOperationLease lease,
+            ConfigSongOperationKind kind,
+            string status,
+            bool isTerminal)
+        {
+            _songOperationUpdates.Enqueue(new ConfigSongOperationUpdate(
+                activationGeneration,
+                lease,
+                kind,
+                status,
+                isTerminal));
+        }
+
+        private void DrainSongOperationUpdates()
+        {
+            var activationGeneration = Volatile.Read(ref _activationGeneration);
+            while (_songOperationUpdates.TryDequeue(out var update))
+            {
+                if (update.ActivationGeneration != activationGeneration)
+                    continue;
+
+                if (update.Kind == ConfigSongOperationKind.NxScoreImport)
+                    _importStatus = update.Status;
+                else
+                    _songFolderStatus = update.Status;
+
+                if (update.IsTerminal &&
+                    ReferenceEquals(_activeSongOperation?.Lease, update.Lease))
+                {
+                    _activeSongOperation = null;
+                    _songOperationCts = null;
+                }
+            }
+        }
+
+        private void CancelSongOperationForDeactivation()
+        {
+            Interlocked.Increment(ref _activationGeneration);
+            try
+            {
+                _songOperationCts?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // A terminal continuation may have released it just before
+                // deactivation. It has already enqueued its stale update.
+            }
+        }
+
+        private static string FormatSongLibraryReloadProgress(
+            SongLibraryReloadProgress progress)
+        {
+            if (!string.IsNullOrWhiteSpace(progress.CurrentOperation))
+            {
+                return $"Reloading songs: {progress.CurrentOperation} " +
+                    $"({progress.ProcessedCount} processed / {progress.DiscoveredSongs} discovered)";
+            }
+
+            return $"Reloading songs: {progress.ProcessedCount} processed / " +
+                $"{progress.DiscoveredSongs} discovered";
+        }
+
+        private static string FormatSongLibraryReloadResult(
+            SongLibraryReloadResult result)
+        {
+            var warning = result.UnavailableRootCount == 0
+                ? string.Empty
+                : $" ({result.UnavailableRootCount} configured root" +
+                  (result.UnavailableRootCount == 1 ? " unavailable)" : "s unavailable)");
+            return result.Outcome switch
+            {
+                SongLibraryReloadOutcome.Published =>
+                    $"Reloaded {result.DiscoveredScoreCount} song charts.{warning}",
+                SongLibraryReloadOutcome.NoActiveRoots =>
+                    "No configured song folders are available; keeping the current song list.",
+                SongLibraryReloadOutcome.Busy =>
+                    "Song library reload is busy; keeping the current song list.",
+                SongLibraryReloadOutcome.Cancelled =>
+                    "Song folder reload cancelled; keeping the current song list.",
+                SongLibraryReloadOutcome.PartialSuccessRestartRequired =>
+                    "Song folders were saved, but publication needs a restart.",
+                SongLibraryReloadOutcome.Failed =>
+                    "Song folder reload failed; keeping the current song list" +
+                    (string.IsNullOrWhiteSpace(result.FailureMessage)
+                        ? "."
+                        : $": {result.FailureMessage}"),
+                _ => "Song folder reload failed; keeping the current song list."
+            };
+        }
+
+        private sealed record ActiveSongOperation(
+            ConfigSongOperationLease Lease,
+            CancellationTokenSource Cancellation);
 
         #endregion
 

--- a/DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs
+++ b/DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs
@@ -1,9 +1,6 @@
 #nullable enable
 
-using System;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework.Input;
-using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Stage.Config;
 
 namespace DTXMania.Game.Lib.Stage.KeyAssign
 {
@@ -11,32 +8,7 @@ namespace DTXMania.Game.Lib.Stage.KeyAssign
     /// Interface for a key-assignment sub-panel that temporarily takes over
     /// input handling and rendering within ConfigStage.
     /// </summary>
-    public interface IKeyAssignPanel
+    public interface IKeyAssignPanel : IConfigOverlayPanel
     {
-        bool IsActive { get; }
-
-        /// <summary>
-        /// Raised when the panel closes (save or cancel).
-        /// Implementers must raise <see cref="Saved"/> before <see cref="Closed"/> on a save operation,
-        /// because <c>ConfigStage.OnPanelSaved</c> captures the working bindings in the <see cref="Saved"/>
-        /// handler before the panel is torn down.
-        /// <para>See <c>SystemKeyAssignPanel</c> for a reference implementation.</para>
-        /// </summary>
-        event EventHandler Closed;
-
-        /// <summary>
-        /// Raised when the panel commits its changes (save only, not cancel).
-        /// Must be raised before <see cref="Closed"/> so that consumers can read the committed state
-        /// while the panel is still active.
-        /// </summary>
-        event EventHandler Saved;
-
-        void Activate();
-        void Deactivate();
-
-        void Update(double deltaTime, KeyboardState current, KeyboardState previous);
-
-        void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont, Texture2D? whitePixel,
-                  int virtualWidth, int virtualHeight);
     }
 }

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -127,6 +127,7 @@ namespace DTXMania.Game.Lib.Stage
         private Task<List<SongListNode>> _songInitializationTask;
         private bool _songInitializationProcessed = false;
         private CancellationTokenSource _cancellationTokenSource;
+        private SongLibrarySnapshot? _backgroundLibrarySnapshot;
 
         // UI Components - Enhanced DTXManiaNX style
         private UIManager _uiManager;
@@ -231,6 +232,7 @@ namespace DTXMania.Game.Lib.Stage
             AssignInputManager(_game.InputManager);
             _inputManager?.ClearPendingCommands();
             _cancellationTokenSource = new CancellationTokenSource();
+            _backgroundLibrarySnapshot = null;
 
             // Get config manager from game
             _configManager = _game.ConfigManager;
@@ -386,6 +388,7 @@ namespace DTXMania.Game.Lib.Stage
 
             // Clean up task references
             _songInitializationTask = null;
+            _backgroundLibrarySnapshot = null;
 
             // Clean up UI
             _uiManager?.Dispose();
@@ -616,7 +619,7 @@ namespace DTXMania.Game.Lib.Stage
             {
                 HasStatusPanel = true, // We have a status panel, so use right-side positioning
                 WhitePixel = _whitePixel,
-                SongsRootPath = _configManager?.Config?.DTXPath
+                ActiveSongRootPaths = Array.Empty<string>()
             };
 
             // Initialize graphics generator for status panel
@@ -747,9 +750,12 @@ namespace DTXMania.Game.Lib.Stage
                             
                             // Check for cancellation after initialization
                             token.ThrowIfCancellationRequested();
-                            
-                            // Return the song list without modifying shared state
-                            return new List<SongListNode>(songManager.RootSongs);
+
+                            // Read a single coherent publication. The UI thread applies
+                            // both hierarchy and root paths together when this task ends.
+                            var snapshot = songManager.GetLibrarySnapshot();
+                            _backgroundLibrarySnapshot = snapshot;
+                            return snapshot.RootSongs.ToList();
                         }
                         catch (OperationCanceledException)
                         {
@@ -767,8 +773,7 @@ namespace DTXMania.Game.Lib.Stage
                 }
                 else
                 {
-                    // Initialize display with song list
-                    _currentSongList = new List<SongListNode>(songManager.RootSongs);
+                    ApplyLibrarySnapshot(songManager.GetLibrarySnapshot());
                 }
 
                 PopulateSongList();
@@ -782,6 +787,13 @@ namespace DTXMania.Game.Lib.Stage
                 _currentSongList = new List<SongListNode>();
                 PopulateSongList();
             }
+        }
+
+        private void ApplyLibrarySnapshot(SongLibrarySnapshot snapshot)
+        {
+            _currentSongList = snapshot.RootSongs.ToList();
+            if (_previewImagePanel != null)
+                _previewImagePanel.ActiveSongRootPaths = snapshot.ActiveRoots;
         }
 
         /// <summary>
@@ -837,6 +849,14 @@ namespace DTXMania.Game.Lib.Stage
 
                     // Update the song list on the main thread
                     _currentSongList = songList;
+                    if (_backgroundLibrarySnapshot != null)
+                    {
+                        if (_previewImagePanel != null)
+                        {
+                            _previewImagePanel.ActiveSongRootPaths =
+                                _backgroundLibrarySnapshot.ActiveRoots;
+                        }
+                    }
                     PopulateSongList();
 
                     // Reapply any persisted filter now that the real song list is available
@@ -852,6 +872,7 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     // Clean up the task reference
                     _songInitializationTask = null;
+                    _backgroundLibrarySnapshot = null;
                 }
 
                 if (_searchFilterModal != null && _searchFilterModal.IsOpen)
@@ -1102,7 +1123,7 @@ namespace DTXMania.Game.Lib.Stage
 
             try
             {
-                var roots = SongManager.Instance.RootSongs;
+                var roots = SongManager.Instance.GetLibrarySnapshot().RootSongs;
                 _filteredView = _filterService.Apply(
                     roots,
                     _filterCriteria,
@@ -2486,7 +2507,10 @@ namespace DTXMania.Game.Lib.Stage
             // Reconcile the flag across every in-memory representation of this song (browse
             // tree, Recent list, Bookmarks list) so the star marker stays consistent across
             // tabs without a reload — each surface holds a distinct node/entity instance.
-            BookmarkStateReconciler.Apply(SongManager.Instance.RootSongs, songId, newState);
+            BookmarkStateReconciler.Apply(
+                SongManager.Instance.GetLibrarySnapshot().RootSongs,
+                songId,
+                newState);
             BookmarkStateReconciler.Apply(_recentPlayNodes, songId, newState);
             BookmarkStateReconciler.Apply(_bookmarkNodes, songId, newState);
 
@@ -2524,7 +2548,10 @@ namespace DTXMania.Game.Lib.Stage
                     continue;
                 }
 
-                BookmarkStateReconciler.Apply(SongManager.Instance.RootSongs, revert.SongId, revert.RevertTo);
+                BookmarkStateReconciler.Apply(
+                    SongManager.Instance.GetLibrarySnapshot().RootSongs,
+                    revert.SongId,
+                    revert.RevertTo);
                 BookmarkStateReconciler.Apply(_recentPlayNodes, revert.SongId, revert.RevertTo);
                 BookmarkStateReconciler.Apply(_bookmarkNodes, revert.SongId, revert.RevertTo);
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -95,6 +95,10 @@ namespace DTXMania.Game.Lib.Stage
         // SongListDisplay off the update thread. volatile so the update thread reliably
         // observes the flag set by the background continuation.
         private volatile bool _tabListNeedsRefresh;
+        // A background cache continuation increments this before requesting a refresh. The
+        // update thread consumes the value around a projection so a completion that lands
+        // during reconciliation is re-queued instead of being lost by a stale false write.
+        private int _asyncTabListRefreshVersion;
         // Activation token bumped on every Activate(). Captured by BeginRecentPlaysLoad so
         // its background continuation can detect that a later Deactivate/Activate cycle has
         // occurred and discard stale results instead of overwriting fresh state.
@@ -128,6 +132,15 @@ namespace DTXMania.Game.Lib.Stage
         private bool _songInitializationProcessed = false;
         private CancellationTokenSource _cancellationTokenSource;
         private SongLibrarySnapshot? _backgroundLibrarySnapshot;
+
+        // One coherent library publication backs every song-select projection.  The event
+        // publisher can run on a worker thread, so it only records a version; OnUpdate is
+        // the sole place that replaces UI-owned collections from a fetched snapshot.
+        private SongLibrarySnapshot? _appliedLibrarySnapshot;
+        private long _pendingLibraryPublicationVersion;
+        private long _appliedLibraryPublicationVersion;
+        private int _libraryPublicationActive;
+        private SongLibraryEmptyState _libraryEmptyState = SongLibraryEmptyState.HasSongs;
 
         // UI Components - Enhanced DTXManiaNX style
         private UIManager _uiManager;
@@ -203,6 +216,13 @@ namespace DTXMania.Game.Lib.Stage
         private const double BGM_FADE_OUT_DURATION = SongSelectionUILayout.Audio.BgmFadeOutDuration;
         private const double BGM_FADE_IN_DURATION = SongSelectionUILayout.Audio.BgmFadeInDuration;
 
+        private enum SongLibraryEmptyState
+        {
+            HasSongs,
+            NoActiveRoots,
+            NoSupportedCharts
+        }
+
         #endregion
 
         #region Properties
@@ -233,6 +253,16 @@ namespace DTXMania.Game.Lib.Stage
             _inputManager?.ClearPendingCommands();
             _cancellationTokenSource = new CancellationTokenSource();
             _backgroundLibrarySnapshot = null;
+            _songInitializationProcessed = false;
+            _appliedLibrarySnapshot = null;
+            _libraryEmptyState = SongLibraryEmptyState.HasSongs;
+            Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
+            Interlocked.Exchange(ref _appliedLibraryPublicationVersion, 0);
+
+            // Bump before starting any background work, so its continuations and the
+            // publication subscriber belong to the same activation.
+            _activationVersion++;
+            SubscribeLibraryPublications();
 
             // Get config manager from game
             _configManager = _game.ConfigManager;
@@ -332,9 +362,7 @@ namespace DTXMania.Game.Lib.Stage
             // that set the flag just before Deactivate). Without this, the first OnUpdate
             // would repopulate the All Songs list and reset selection/scroll to index 0.
             _tabListNeedsRefresh = false;
-            // Bump the activation token so any in-flight BeginRecentPlaysLoad continuation
-            // from a prior activation discards its stale result.
-            _activationVersion++;
+            Interlocked.Exchange(ref _asyncTabListRefreshVersion, 0);
             BeginRecentPlaysLoad();
             _ = BeginBookmarksLoad();
 
@@ -348,6 +376,16 @@ namespace DTXMania.Game.Lib.Stage
 
         public override void Deactivate()
         {
+            // Stop accepting publications before resources and UI collections begin tearing
+            // down. A publisher already in flight can at most race to record a version, which
+            // is discarded on the next activation; it never mutates the UI from its callback.
+            UnsubscribeLibraryPublications();
+
+            // Invalidate every activation-scoped continuation immediately rather than waiting
+            // for the next Activate call. This prevents a canceled initialization task from
+            // writing a stale snapshot into a stage that is already inactive.
+            _activationVersion++;
+
             if (_configManager != null)
             {
                 _configManager.ScrollSpeedChanged -= OnScrollSpeedChanged;
@@ -389,6 +427,8 @@ namespace DTXMania.Game.Lib.Stage
             // Clean up task references
             _songInitializationTask = null;
             _backgroundLibrarySnapshot = null;
+            _appliedLibrarySnapshot = null;
+            Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
 
             // Clean up UI
             _uiManager?.Dispose();
@@ -731,6 +771,7 @@ namespace DTXMania.Game.Lib.Stage
                 if (!songManager.IsInitialized)
                 {
                     var token = _cancellationTokenSource.Token;
+                    int initializationActivationVersion = _activationVersion;
 
                     // Start background task to initialize SongManager and fetch song list
                     // This task only fetches data and doesn't modify shared state or UI
@@ -754,7 +795,11 @@ namespace DTXMania.Game.Lib.Stage
                             // Read a single coherent publication. The UI thread applies
                             // both hierarchy and root paths together when this task ends.
                             var snapshot = songManager.GetLibrarySnapshot();
-                            _backgroundLibrarySnapshot = snapshot;
+                            if (!token.IsCancellationRequested
+                                && initializationActivationVersion == _activationVersion)
+                            {
+                                _backgroundLibrarySnapshot = snapshot;
+                            }
                             return snapshot.RootSongs.ToList();
                         }
                         catch (OperationCanceledException)
@@ -791,9 +836,63 @@ namespace DTXMania.Game.Lib.Stage
 
         private void ApplyLibrarySnapshot(SongLibrarySnapshot snapshot)
         {
+            ApplyLibrarySnapshotCore(snapshot, markVersionApplied: true);
+        }
+
+        private void ApplyLibrarySnapshotForReconciliation(SongLibrarySnapshot snapshot)
+        {
+            ApplyLibrarySnapshotCore(snapshot, markVersionApplied: false);
+        }
+
+        private void ApplyLibrarySnapshotCore(
+            SongLibrarySnapshot snapshot,
+            bool markVersionApplied)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+
+            _appliedLibrarySnapshot = snapshot;
             _currentSongList = snapshot.RootSongs.ToList();
+            _libraryEmptyState = ResolveLibraryEmptyState(snapshot);
             if (_previewImagePanel != null)
                 _previewImagePanel.ActiveSongRootPaths = snapshot.ActiveRoots;
+
+            if (markVersionApplied)
+                Interlocked.Exchange(ref _appliedLibraryPublicationVersion, snapshot.Version);
+        }
+
+        private void SubscribeLibraryPublications()
+        {
+            var songManager = SongManager.Instance;
+            Interlocked.Exchange(ref _libraryPublicationActive, 1);
+            // The stage instance is retained by StageManager, so activation may happen many
+            // times. Remove first to keep the callback single-subscribed.
+            songManager.SongLibraryPublished -= OnSongLibraryPublished;
+            songManager.SongLibraryPublished += OnSongLibraryPublished;
+        }
+
+        private void UnsubscribeLibraryPublications()
+        {
+            Interlocked.Exchange(ref _libraryPublicationActive, 0);
+            SongManager.Instance.SongLibraryPublished -= OnSongLibraryPublished;
+        }
+
+        private void OnSongLibraryPublished(object? sender, SongLibraryPublishedEventArgs e)
+        {
+            if (Volatile.Read(ref _libraryPublicationActive) == 0)
+                return;
+
+            long publishedVersion = e.Snapshot.Version;
+            long observedVersion;
+            do
+            {
+                observedVersion = Volatile.Read(ref _pendingLibraryPublicationVersion);
+                if (publishedVersion <= observedVersion)
+                    return;
+            }
+            while (Interlocked.CompareExchange(
+                       ref _pendingLibraryPublicationVersion,
+                       publishedVersion,
+                       observedVersion) != observedVersion);
         }
 
         /// <summary>
@@ -847,26 +946,45 @@ namespace DTXMania.Game.Lib.Stage
                     // Get the result from the completed task
                     var songList = _songInitializationTask.Result;
 
-                    // Update the song list on the main thread
-                    _currentSongList = songList;
+                    // Update the song list on the main thread. A publication can have been
+                    // reconciled while this background task was running; do not let its older
+                    // copied snapshot overwrite the newer UI snapshot.
+                    bool shouldProjectInitializationResult = false;
                     if (_backgroundLibrarySnapshot != null)
                     {
-                        if (_previewImagePanel != null)
+                        // If an update-thread publication has already restored the user's
+                        // navigation and selection, even an equal-version initialization
+                        // result must not repopulate the old projection and reset it.
+                        if (_appliedLibrarySnapshot == null
+                            || _backgroundLibrarySnapshot.Version >
+                                Volatile.Read(ref _appliedLibraryPublicationVersion))
                         {
-                            _previewImagePanel.ActiveSongRootPaths =
-                                _backgroundLibrarySnapshot.ActiveRoots;
+                            ApplyLibrarySnapshot(_backgroundLibrarySnapshot);
+                            shouldProjectInitializationResult = true;
                         }
                     }
-                    PopulateSongList();
+                    else if (_appliedLibrarySnapshot == null)
+                    {
+                        _currentSongList = songList;
+                        shouldProjectInitializationResult = true;
+                    }
 
-                    // Reapply any persisted filter now that the real song list is available
-                    ReapplyPersistedFilterIfActive();
+                    if (shouldProjectInitializationResult)
+                    {
+                        PopulateSongList();
+
+                        // Reapply any persisted filter now that the real song list is available.
+                        ReapplyPersistedFilterIfActive();
+                    }
                 }
                 catch (Exception ex)
                 {
                     System.Diagnostics.Debug.WriteLine($"SongSelectionStage: Error processing completed song initialization: {ex.Message}");
-                    _currentSongList = new List<SongListNode>();
-                    PopulateSongList();
+                    if (_appliedLibrarySnapshot == null)
+                    {
+                        _currentSongList = new List<SongListNode>();
+                        PopulateSongList();
+                    }
                 }
                 finally
                 {
@@ -878,6 +996,401 @@ namespace DTXMania.Game.Lib.Stage
                 if (_searchFilterModal != null && _searchFilterModal.IsOpen)
                     _searchFilterModal.IsLibraryReady = true;
             }
+        }
+
+        /// <summary>
+        /// Reconciles the newest publication only from the stage update thread. The event
+        /// callback intentionally never carries a hierarchy into this method; fetching here
+        /// gives roots and active paths from one current snapshot.
+        /// </summary>
+        private void ApplyPendingLibraryPublication()
+        {
+            if (Volatile.Read(ref _libraryPublicationActive) == 0)
+                return;
+
+            long appliedVersion = Volatile.Read(ref _appliedLibraryPublicationVersion);
+            long pendingVersion = Volatile.Read(ref _pendingLibraryPublicationVersion);
+            if (pendingVersion <= appliedVersion)
+                return;
+
+            // Exactly one snapshot is read for one reconciliation pass. If another
+            // publication lands while it is read, leave this pass untouched and take the
+            // newer coherent snapshot on the next update.
+            var snapshot = SongManager.Instance.GetLibrarySnapshot();
+            if (Volatile.Read(ref _libraryPublicationActive) == 0
+                || snapshot.Version <= appliedVersion
+                || snapshot.Version < pendingVersion)
+            {
+                return;
+            }
+
+            ReconcileLibrarySnapshot(snapshot);
+        }
+
+        private void ReconcileLibrarySnapshot(SongLibrarySnapshot snapshot)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+
+            var navigationPaths = CaptureNavigationPaths();
+            var previousSelection = _selectedSong ?? _songListDisplay?.SelectedSong;
+            var previousSelectionIdentity = GetStableSelectionIdentity(previousSelection);
+            int tabListRefreshVersion = BeginTabListRefreshConsumption();
+
+            // Apply roots and root paths from this single snapshot before rebuilding any
+            // projection. Navigation rebuild then selects child lists owned by that same tree.
+            ApplyLibrarySnapshotForReconciliation(snapshot);
+            RestoreNavigationPaths(navigationPaths, snapshot);
+            RebuildFilteredViewForSnapshot(snapshot);
+
+            var restoredSelection = FindVisibleSongByIdentity(previousSelectionIdentity);
+            if (previousSelectionIdentity != null && restoredSelection == null)
+                ClearRemovedSelectionPresentation();
+
+            if (_songListDisplay != null)
+            {
+                RefreshSongListForActiveTab();
+                if (restoredSelection != null)
+                    RestoreSelectedSong(restoredSelection);
+                else
+                    _selectedSong = _songListDisplay.SelectedSong;
+            }
+
+            UpdateBreadcrumb();
+            UpdateStatusPanelFolderHint();
+            CompleteTabListRefreshConsumption(tabListRefreshVersion);
+            Interlocked.Exchange(ref _appliedLibraryPublicationVersion, snapshot.Version);
+        }
+
+        private List<string> CaptureNavigationPaths()
+        {
+            var states = _navigationStack.Reverse().ToList();
+            var paths = new List<string>(states.Count);
+
+            for (int index = 0; index < states.Count; index++)
+            {
+                var parentNodes = states[index].Children;
+                var childNodes = index + 1 < states.Count
+                    ? states[index + 1].Children
+                    : _currentSongList;
+                var enteredBox = parentNodes.FirstOrDefault(node =>
+                    node.Type == NodeType.Box && ReferenceEquals(node.Children, childNodes));
+                var stablePath = GetStableBoxPath(enteredBox);
+                if (stablePath == null)
+                    break;
+                paths.Add(stablePath);
+            }
+
+            return paths;
+        }
+
+        private void RestoreNavigationPaths(
+            IReadOnlyList<string> navigationPaths,
+            SongLibrarySnapshot snapshot)
+        {
+            _navigationStack.Clear();
+            _currentSongList = snapshot.RootSongs.ToList();
+            _currentBreadcrumb = "";
+
+            foreach (var path in navigationPaths)
+            {
+                var box = _currentSongList.FirstOrDefault(node =>
+                    node.Type == NodeType.Box
+                    && StringComparer.Ordinal.Equals(GetStableBoxPath(node), path));
+                if (box == null)
+                    break;
+
+                _navigationStack.Push(new SongListNode
+                {
+                    Children = _currentSongList,
+                    Title = _currentBreadcrumb
+                });
+                _currentSongList = box.Children;
+                _currentBreadcrumb = string.IsNullOrEmpty(_currentBreadcrumb)
+                    ? box.DisplayTitle
+                    : $"{_currentBreadcrumb} > {box.DisplayTitle}";
+            }
+        }
+
+        private SongListNode? FindVisibleSongByIdentity(string? identity)
+        {
+            if (string.IsNullOrEmpty(identity))
+                return null;
+
+            IEnumerable<SongListNode> candidates;
+            if (_activeTab == SongSelectionTab.RecentPlays)
+            {
+                candidates = FilterNodesForAppliedLibrary(_recentPlayNodes);
+            }
+            else if (_activeTab == SongSelectionTab.Bookmarks)
+            {
+                candidates = FilterNodesForAppliedLibrary(_bookmarkNodes);
+            }
+            else if (_filteredView != null)
+            {
+                candidates = _filteredView.Select(result => result.Node);
+            }
+            else
+            {
+                candidates = _currentSongList;
+            }
+
+            return candidates.FirstOrDefault(node =>
+                StringComparer.Ordinal.Equals(GetStableSelectionIdentity(node), identity));
+        }
+
+        private void RestoreSelectedSong(SongListNode restoredSelection)
+        {
+            if (_songListDisplay == null)
+                return;
+
+            for (int index = 0; index < _songListDisplay.CurrentList.Count; index++)
+            {
+                if (!ReferenceEquals(_songListDisplay.CurrentList[index], restoredSelection))
+                    continue;
+
+                _songListDisplay.SelectedIndex = index;
+                _selectedSong = restoredSelection;
+                return;
+            }
+        }
+
+        private void ClearRemovedSelectionPresentation()
+        {
+            _selectedSong = null;
+            _isInStatusPanel = false;
+            StopCurrentPreview();
+            _previewImagePanel?.ClearSelectedSong();
+            if (_statusPanel != null)
+            {
+                _statusPanel.Visible = false;
+                _statusPanel.UpdateSongInfo(null, _currentDifficulty);
+            }
+            _playHistoryPanel?.UpdateSongInfo(null, _currentDifficulty);
+        }
+
+        private IReadOnlyList<string>? GetAppliedActiveRoots() =>
+            _appliedLibrarySnapshot?.ActiveRoots;
+
+        private static string? GetStableBoxPath(SongListNode? node)
+        {
+            if (node?.Type != NodeType.Box
+                || !SongPathIdentity.TryNormalize(node.DirectoryPath, out var path))
+            {
+                return null;
+            }
+
+            return path;
+        }
+
+        private static string? GetStableSelectionIdentity(SongListNode? node)
+        {
+            if (node?.Type == NodeType.Box)
+            {
+                return SongPathIdentity.TryNormalize(node.DirectoryPath, out var boxPath)
+                    ? $"box:{boxPath}"
+                    : null;
+            }
+
+            if (node?.Type != NodeType.Score)
+                return null;
+
+            int songId = node.DatabaseSongId ?? node.DatabaseSong?.Id ?? 0;
+            if (songId > 0)
+                return $"song:{songId}";
+
+            foreach (var path in GetNodeChartPaths(node))
+            {
+                if (SongPathIdentity.TryNormalize(path, out var normalized))
+                    return $"chart:{normalized}";
+            }
+
+            return null;
+        }
+
+        private List<SongListNode> FilterNodesForActiveRoots(
+            IEnumerable<SongListNode>? nodes,
+            IReadOnlyList<string>? activeRoots)
+        {
+            if (nodes == null)
+                return new List<SongListNode>();
+
+            // Unit-level callers that have not applied a snapshot still exercise the legacy
+            // tab rendering path. A live stage always has an applied snapshot before it draws,
+            // so null means "no root contract yet", not an intentionally empty root set.
+            if (activeRoots == null)
+            {
+                try
+                {
+                    return nodes.ToList();
+                }
+                catch (InvalidOperationException)
+                {
+                    return new List<SongListNode>();
+                }
+            }
+
+            if (activeRoots.Count == 0)
+                return new List<SongListNode>();
+
+            var normalizedRoots = new List<string>(activeRoots.Count);
+            foreach (var root in activeRoots)
+            {
+                if (SongPathIdentity.TryNormalize(root, out var normalized))
+                    normalizedRoots.Add(normalized);
+            }
+
+            if (normalizedRoots.Count == 0)
+                return new List<SongListNode>();
+
+            SongListNode[] copiedNodes;
+            try
+            {
+                copiedNodes = nodes.ToArray();
+            }
+            catch (InvalidOperationException)
+            {
+                // A caller supplied a mutable list being replaced concurrently. Do not leak
+                // a collection-modified exception into the update thread; the next refresh
+                // will project the replacement list.
+                return new List<SongListNode>();
+            }
+
+            var filtered = new List<SongListNode>(copiedNodes.Length);
+            foreach (var node in copiedNodes)
+            {
+                if (NodeIsUnderAnyActiveRoot(node, normalizedRoots))
+                    filtered.Add(node);
+            }
+
+            return filtered;
+        }
+
+        /// <summary>
+        /// Projects a cached flat tab against the coherent library currently displayed by this
+        /// stage. The cache remains intact so a chart that is re-published under an active root
+        /// becomes eligible again without a destructive cache rebuild.
+        /// </summary>
+        private List<SongListNode> FilterNodesForAppliedLibrary(IEnumerable<SongListNode>? nodes)
+        {
+            var rootFilteredNodes = FilterNodesForActiveRoots(nodes, GetAppliedActiveRoots());
+            if (_appliedLibrarySnapshot == null || rootFilteredNodes.Count == 0)
+                return rootFilteredNodes;
+
+            var publishedScoreIdentities = GetPublishedScoreIdentities(
+                _appliedLibrarySnapshot.RootSongs);
+            if (publishedScoreIdentities.Count == 0)
+                return new List<SongListNode>();
+
+            return rootFilteredNodes
+                .Where(node => HasPublishedScoreIdentity(node, publishedScoreIdentities))
+                .ToList();
+        }
+
+        private static HashSet<string> GetPublishedScoreIdentities(
+            IEnumerable<SongListNode> nodes)
+        {
+            var identities = new HashSet<string>(StringComparer.Ordinal);
+            AddPublishedScoreIdentities(nodes, identities);
+            return identities;
+        }
+
+        private static void AddPublishedScoreIdentities(
+            IEnumerable<SongListNode> nodes,
+            ISet<string> identities)
+        {
+            foreach (var node in nodes)
+            {
+                foreach (var identity in GetScoreIdentityCandidates(node))
+                    identities.Add(identity);
+
+                if (node.Children.Count > 0)
+                    AddPublishedScoreIdentities(node.Children, identities);
+            }
+        }
+
+        private static bool HasPublishedScoreIdentity(
+            SongListNode node,
+            ISet<string> publishedScoreIdentities)
+        {
+            return GetScoreIdentityCandidates(node)
+                .Any(publishedScoreIdentities.Contains);
+        }
+
+        private static IEnumerable<string> GetScoreIdentityCandidates(SongListNode node)
+        {
+            if (node.Type != NodeType.Score)
+                yield break;
+
+            int songId = node.DatabaseSongId ?? node.DatabaseSong?.Id ?? 0;
+            if (songId > 0)
+                yield return $"song:{songId}";
+
+            foreach (var path in GetNodeChartPaths(node))
+            {
+                if (SongPathIdentity.TryNormalize(path, out var normalized))
+                    yield return $"chart:{normalized}";
+            }
+        }
+
+        private static bool NodeIsUnderAnyActiveRoot(
+            SongListNode node,
+            IReadOnlyList<string> normalizedRoots)
+        {
+            foreach (var path in GetNodeChartPaths(node))
+            {
+                if (!SongPathIdentity.TryNormalize(path, out var normalizedPath))
+                    continue;
+
+                foreach (var root in normalizedRoots)
+                {
+                    if (SongPathIdentity.IsUnderNormalizedRoot(normalizedPath, root))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<string> GetNodeChartPaths(SongListNode node)
+        {
+            if (!string.IsNullOrWhiteSpace(node.DatabaseChart?.FilePath))
+                yield return node.DatabaseChart.FilePath;
+
+            var charts = node.DatabaseSong?.Charts?.ToArray();
+            if (charts != null)
+            {
+                foreach (var chart in charts)
+                {
+                    if (!string.IsNullOrWhiteSpace(chart?.FilePath))
+                        yield return chart.FilePath;
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(node.DirectoryPath))
+                yield return node.DirectoryPath;
+        }
+
+        private SongLibraryEmptyState ResolveLibraryEmptyState(SongLibrarySnapshot snapshot)
+        {
+            if (snapshot.ActiveRoots.Count == 0)
+                return SongLibraryEmptyState.NoActiveRoots;
+
+            return ContainsPublishedScore(snapshot.RootSongs)
+                ? SongLibraryEmptyState.HasSongs
+                : SongLibraryEmptyState.NoSupportedCharts;
+        }
+
+        private static bool ContainsPublishedScore(IEnumerable<SongListNode> nodes)
+        {
+            foreach (var node in nodes)
+            {
+                if (node.Type == NodeType.Score)
+                    return true;
+                if (node.Children.Count > 0 && ContainsPublishedScore(node.Children))
+                    return true;
+            }
+
+            return false;
         }
 
         #endregion
@@ -1114,6 +1627,12 @@ namespace DTXMania.Game.Lib.Stage
 
         private void RebuildFilteredView()
         {
+            var snapshot = _appliedLibrarySnapshot ?? SongManager.Instance.GetLibrarySnapshot();
+            RebuildFilteredViewForSnapshot(snapshot);
+        }
+
+        private void RebuildFilteredViewForSnapshot(SongLibrarySnapshot snapshot)
+        {
             if (_filterCriteria.IsEmpty)
             {
                 _filteredView = null;
@@ -1123,9 +1642,8 @@ namespace DTXMania.Game.Lib.Stage
 
             try
             {
-                var roots = SongManager.Instance.GetLibrarySnapshot().RootSongs;
                 _filteredView = _filterService.Apply(
-                    roots,
+                    snapshot.RootSongs,
                     _filterCriteria,
                     SynchronizeActivePlaySpeed());
                 _showEmptyFilterMessage = _filteredView.Count == 0;
@@ -1164,11 +1682,33 @@ namespace DTXMania.Game.Lib.Stage
                 PopulateSongListForCurrentMode();
         }
 
+        private void RequestAsyncTabListRefresh()
+        {
+            // Increment before the volatile flag write. A reconciliation that sees the new
+            // generation but races this write will restore the flag itself; one that completes
+            // first is followed by this write and is likewise re-queued.
+            Interlocked.Increment(ref _asyncTabListRefreshVersion);
+            _tabListNeedsRefresh = true;
+        }
+
+        private int BeginTabListRefreshConsumption()
+        {
+            int version = Volatile.Read(ref _asyncTabListRefreshVersion);
+            _tabListNeedsRefresh = false;
+            return version;
+        }
+
+        private void CompleteTabListRefreshConsumption(int consumedVersion)
+        {
+            if (Volatile.Read(ref _asyncTabListRefreshVersion) != consumedVersion)
+                _tabListNeedsRefresh = true;
+        }
+
         private void PopulateRecentPlaysList()
         {
-            var nodes = _recentPlayNodes ?? new List<SongListNode>();
+            var nodes = FilterNodesForAppliedLibrary(_recentPlayNodes);
             LabelRecentPlayNodes(nodes);
-            _songListDisplay.CurrentList = new List<SongListNode>(nodes);
+            _songListDisplay.CurrentList = nodes;
             // Show empty message only when the load succeeded but returned nothing.
             // A failed load gets its own distinct message in the draw path.
             _showEmptyRecentMessage = !_recentPlaysLoadFailed && nodes.Count == 0;
@@ -1176,8 +1716,8 @@ namespace DTXMania.Game.Lib.Stage
 
         private void PopulateBookmarksList()
         {
-            var nodes = _bookmarkNodes ?? new List<SongListNode>();
-            _songListDisplay.CurrentList = new List<SongListNode>(nodes);
+            var nodes = FilterNodesForAppliedLibrary(_bookmarkNodes);
+            _songListDisplay.CurrentList = nodes;
             // Show empty message only when the load succeeded but returned nothing.
             // A failed load gets its own distinct message in the draw path.
             _showEmptyBookmarksMessage = !_bookmarksLoadFailed && nodes.Count == 0;
@@ -1240,6 +1780,10 @@ namespace DTXMania.Game.Lib.Stage
             // Check for completed song initialization task
             CheckSongInitializationCompletion();
 
+            // Publication callbacks only captured a version. Apply the current coherent
+            // snapshot here, on the update thread, before input and UI traversal observe it.
+            ApplyPendingLibraryPublication();
+
             // Update owned fallback input manager (shared one is updated by BaseGame)
             if (_ownsInputManager)
                 _inputManager?.Update(deltaTime);
@@ -1257,8 +1801,9 @@ namespace DTXMania.Game.Lib.Stage
             // Apply any pending tab list repopulate on the update thread.
             if (_tabListNeedsRefresh)
             {
-                _tabListNeedsRefresh = false;
+                int tabListRefreshVersion = BeginTabListRefreshConsumption();
                 RefreshSongListForActiveTab();
+                CompleteTabListRefreshConsumption(tabListRefreshVersion);
             }
 
             // Update UI (PreviewImagePanel will handle its own timing)
@@ -1285,6 +1830,23 @@ namespace DTXMania.Game.Lib.Stage
                 && (_searchFilterModal == null || !_searchFilterModal.IsOpen))
             {
                 string msg = "No songs match this filter";
+                _font.DrawString(_spriteBatch, msg,
+                    new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
+                    ResolveStatusTextColor(CurrentTheme));
+            }
+
+            // Do not collapse an intentionally empty root set into the same message as a
+            // configured folder containing no supported charts. Configuration and scanning
+            // recovery actions differ, so the Song Select state must make that distinction.
+            if (_activeTab == SongSelectionTab.AllSongs
+                && _filteredView == null
+                && _libraryEmptyState != SongLibraryEmptyState.HasSongs
+                && _font != null
+                && (_searchFilterModal == null || !_searchFilterModal.IsOpen))
+            {
+                string msg = _libraryEmptyState == SongLibraryEmptyState.NoActiveRoots
+                    ? "No active song folders configured"
+                    : "No supported charts found in active song folders";
                 _font.DrawString(_spriteBatch, msg,
                     new Vector2(SongSelectionUILayout.SongBars.UnselectedBarX + 100, SongSelectionUILayout.SongBars.SelectedBarY),
                     ResolveStatusTextColor(CurrentTheme));
@@ -2356,7 +2918,7 @@ namespace DTXMania.Game.Lib.Stage
                         {
                             _recentPlaysLoadFailed = true;
                             if (_activeTab == SongSelectionTab.RecentPlays)
-                                _tabListNeedsRefresh = true;
+                                RequestAsyncTabListRefresh();
                         }
                         return;
                     }
@@ -2373,7 +2935,7 @@ namespace DTXMania.Game.Lib.Stage
                     // and reset selection/scroll. Tab switches into Recent already request a
                     // refresh via SwitchToNextTab and rely on this load to populate the list.
                     if (_activeTab == SongSelectionTab.RecentPlays)
-                        _tabListNeedsRefresh = true;
+                        RequestAsyncTabListRefresh();
                 }, TaskScheduler.Default);
         }
 
@@ -2413,7 +2975,7 @@ namespace DTXMania.Game.Lib.Stage
                     {
                         _bookmarksLoadFailed = true;
                         if (_activeTab == SongSelectionTab.Bookmarks)
-                            _tabListNeedsRefresh = true;
+                            RequestAsyncTabListRefresh();
                     }
                     return;
                 }
@@ -2437,7 +2999,7 @@ namespace DTXMania.Game.Lib.Stage
                 // and reset selection/scroll. Tab switches into Bookmarks already request a
                 // refresh via SwitchToNextTab and rely on this load to populate the list.
                 if (_activeTab == SongSelectionTab.Bookmarks)
-                    _tabListNeedsRefresh = true;
+                    RequestAsyncTabListRefresh();
             });
         }
 
@@ -2508,7 +3070,8 @@ namespace DTXMania.Game.Lib.Stage
             // tree, Recent list, Bookmarks list) so the star marker stays consistent across
             // tabs without a reload — each surface holds a distinct node/entity instance.
             BookmarkStateReconciler.Apply(
-                SongManager.Instance.GetLibrarySnapshot().RootSongs,
+                _appliedLibrarySnapshot?.RootSongs
+                    ?? SongManager.Instance.GetLibrarySnapshot().RootSongs,
                 songId,
                 newState);
             BookmarkStateReconciler.Apply(_recentPlayNodes, songId, newState);
@@ -2549,7 +3112,8 @@ namespace DTXMania.Game.Lib.Stage
                 }
 
                 BookmarkStateReconciler.Apply(
-                    SongManager.Instance.GetLibrarySnapshot().RootSongs,
+                    _appliedLibrarySnapshot?.RootSongs
+                        ?? SongManager.Instance.GetLibrarySnapshot().RootSongs,
                     revert.SongId,
                     revert.RevertTo);
                 BookmarkStateReconciler.Apply(_recentPlayNodes, revert.SongId, revert.RevertTo);

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -127,6 +127,9 @@ namespace DTXMania.Game.Lib.Stage
         // the current activation and initialization generation.
         private readonly System.Collections.Concurrent.ConcurrentQueue<SongInitializationResult>
             _pendingSongInitializationResults = new();
+        // Both worker publication and deactivation cleanup use this gate. It makes the
+        // post-task selective cleanup atomic with enqueues while retaining newer records.
+        private readonly object _songInitializationQueueGate = new();
         private long _songInitializationGeneration;
         private long _activeSongInitializationGeneration;
 
@@ -405,6 +408,14 @@ namespace DTXMania.Game.Lib.Stage
 
         public override void Deactivate()
         {
+            // Capture the cancelled initializer identity before invalidating this activation.
+            // Its worker can have passed cancellation checks and enqueue only after the
+            // immediate drain below, so its terminal continuation removes just this record.
+            var cancelledInitializationTask = _songInitializationTask;
+            int cancelledInitializationActivationVersion = Volatile.Read(ref _activationVersion);
+            long cancelledInitializationGeneration =
+                Volatile.Read(ref _activeSongInitializationGeneration);
+
             // Invalidate every activation-scoped continuation immediately rather than waiting
             // for the next Activate call. This prevents a canceled initialization task from
             // writing a stale snapshot into a stage that is already inactive.
@@ -426,24 +437,37 @@ namespace DTXMania.Game.Lib.Stage
 
             // Use non-blocking observation to avoid hanging the UI
             // Attach a continuation to handle exceptions without waiting synchronously
-            if (_songInitializationTask != null)
+            if (cancelledInitializationTask != null)
             {
                 // Capture the token source so we can dispose it after the task completes
                 var cts = _cancellationTokenSource;
                 _cancellationTokenSource = null;
 
                 // Observe the task result asynchronously via continuation to prevent unobserved exceptions
-                _songInitializationTask.ContinueWith(
+                cancelledInitializationTask.ContinueWith(
                     task =>
                     {
-                        if (task.IsFaulted)
+                        try
                         {
-                            // Log the exception for debugging but don't throw
-                            System.Diagnostics.Debug.WriteLine(
-                                $"SongSelectionStage.Deactivate: Task faulted during deactivation: {task.Exception?.GetBaseException().Message}");
+                            if (task.IsFaulted)
+                            {
+                                // Log the exception for debugging but don't throw
+                                System.Diagnostics.Debug.WriteLine(
+                                    $"SongSelectionStage.Deactivate: Task faulted during deactivation: {task.Exception?.GetBaseException().Message}");
+                            }
+
+                            // This continuation never touches UI-owned state. The worker queues
+                            // its immutable record before completing, so selective cleanup here
+                            // catches records published after the immediate deactivation drain.
+                            DiscardQueuedSongInitializationResults(
+                                cancelledInitializationActivationVersion,
+                                cancelledInitializationGeneration);
                         }
-                        // Dispose the token source after the task has completed
-                        cts?.Dispose();
+                        finally
+                        {
+                            // Dispose the token source after the task has completed.
+                            cts?.Dispose();
+                        }
                     },
                     TaskScheduler.Default);
             }
@@ -857,7 +881,10 @@ namespace DTXMania.Game.Lib.Stage
                                 Array.Empty<SongListNode>());
                         }
 
-                        _pendingSongInitializationResults.Enqueue(result);
+                        lock (_songInitializationQueueGate)
+                        {
+                            _pendingSongInitializationResults.Enqueue(result);
+                        }
                         return result.SongList.ToList();
                     }, token);
 
@@ -1117,12 +1144,15 @@ namespace DTXMania.Game.Lib.Stage
             long initializationGeneration)
         {
             SongInitializationResult? matchingResult = null;
-            while (_pendingSongInitializationResults.TryDequeue(out var result))
+            lock (_songInitializationQueueGate)
             {
-                if (result.ActivationVersion == activationVersion
-                    && result.Generation == initializationGeneration)
+                while (_pendingSongInitializationResults.TryDequeue(out var result))
                 {
-                    matchingResult = result;
+                    if (result.ActivationVersion == activationVersion
+                        && result.Generation == initializationGeneration)
+                    {
+                        matchingResult = result;
+                    }
                 }
             }
 
@@ -1131,10 +1161,37 @@ namespace DTXMania.Game.Lib.Stage
 
         private void DiscardQueuedSongInitializationResults()
         {
-            while (_pendingSongInitializationResults.TryDequeue(out _))
+            lock (_songInitializationQueueGate)
             {
-                // Records are immutable and activation-tagged. Without an active initializer,
-                // none can legitimately be projected into this stage activation.
+                while (_pendingSongInitializationResults.TryDequeue(out _))
+                {
+                    // Records are immutable and activation-tagged. Without an active initializer,
+                    // none can legitimately be projected into this stage activation.
+                }
+            }
+        }
+
+        private void DiscardQueuedSongInitializationResults(
+            int activationVersion,
+            long initializationGeneration)
+        {
+            lock (_songInitializationQueueGate)
+            {
+                if (_pendingSongInitializationResults.IsEmpty)
+                    return;
+
+                var retainedResults = new List<SongInitializationResult>();
+                while (_pendingSongInitializationResults.TryDequeue(out var result))
+                {
+                    if (result.ActivationVersion != activationVersion ||
+                        result.Generation != initializationGeneration)
+                    {
+                        retainedResults.Add(result);
+                    }
+                }
+
+                foreach (var result in retainedResults)
+                    _pendingSongInitializationResults.Enqueue(result);
             }
         }
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -122,7 +122,13 @@ namespace DTXMania.Game.Lib.Stage
         private Task<List<SongListNode>> _songInitializationTask;
         private bool _songInitializationProcessed = false;
         private CancellationTokenSource _cancellationTokenSource;
-        private SongLibrarySnapshot? _backgroundLibrarySnapshot;
+        // Initializers run on workers, so they return immutable records to this queue instead
+        // of writing a shared snapshot field. OnUpdate consumes only the record that belongs to
+        // the current activation and initialization generation.
+        private readonly System.Collections.Concurrent.ConcurrentQueue<SongInitializationResult>
+            _pendingSongInitializationResults = new();
+        private long _songInitializationGeneration;
+        private long _activeSongInitializationGeneration;
 
         // One coherent library publication backs every song-select projection.  The event
         // publisher can run on a worker thread, so it only records a version; OnUpdate is
@@ -231,6 +237,12 @@ namespace DTXMania.Game.Lib.Stage
 
         private readonly record struct BookmarkLoadRequest(int ActivationVersion);
 
+        internal readonly record struct SongInitializationResult(
+            int ActivationVersion,
+            long Generation,
+            SongLibrarySnapshot? Snapshot,
+            IReadOnlyList<SongListNode> SongList);
+
         #endregion
 
         #region Properties
@@ -265,8 +277,8 @@ namespace DTXMania.Game.Lib.Stage
             Interlocked.Increment(ref _activationVersion);
             UnsubscribeLibraryPublications();
             _cancellationTokenSource = new CancellationTokenSource();
-            _backgroundLibrarySnapshot = null;
             _songInitializationProcessed = false;
+            Interlocked.Exchange(ref _activeSongInitializationGeneration, 0);
             _appliedLibrarySnapshot = null;
             _libraryEmptyState = SongLibraryEmptyState.HasSongs;
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
@@ -442,7 +454,7 @@ namespace DTXMania.Game.Lib.Stage
 
             // Clean up task references
             _songInitializationTask = null;
-            _backgroundLibrarySnapshot = null;
+            Interlocked.Exchange(ref _activeSongInitializationGeneration, 0);
             _appliedLibrarySnapshot = null;
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
 
@@ -788,11 +800,18 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     var token = _cancellationTokenSource.Token;
                     int initializationActivationVersion = Volatile.Read(ref _activationVersion);
+                    long initializationGeneration =
+                        Interlocked.Increment(ref _songInitializationGeneration);
+                    Interlocked.Exchange(
+                        ref _activeSongInitializationGeneration,
+                        initializationGeneration);
 
                     // Start background task to initialize SongManager and fetch song list
-                    // This task only fetches data and doesn't modify shared state or UI
-                    _songInitializationTask = Task.Run(async () =>
+                    // This task only fetches data and queues an immutable result; it never
+                    // writes stage-owned state or UI collections from a worker thread.
+                    _songInitializationTask = Task.Run(() =>
                     {
+                        SongInitializationResult result;
                         try
                         {
                             // Check for cancellation before starting
@@ -809,25 +828,35 @@ namespace DTXMania.Game.Lib.Stage
                             token.ThrowIfCancellationRequested();
 
                             // Read a single coherent publication. The UI thread applies
-                            // both hierarchy and root paths together when this task ends.
+                            // both hierarchy and root paths together when it consumes this
+                            // activation-tagged result on the update thread.
                             var snapshot = songManager.GetLibrarySnapshot();
-                            if (!token.IsCancellationRequested
-                                && initializationActivationVersion ==
-                                    Volatile.Read(ref _activationVersion))
-                            {
-                                _backgroundLibrarySnapshot = snapshot;
-                            }
-                            return snapshot.RootSongs.ToList();
+                            result = new SongInitializationResult(
+                                initializationActivationVersion,
+                                initializationGeneration,
+                                snapshot,
+                                Array.AsReadOnly(snapshot.RootSongs.ToArray()));
                         }
                         catch (OperationCanceledException)
                         {
-                            return new List<SongListNode>();
+                            result = new SongInitializationResult(
+                                initializationActivationVersion,
+                                initializationGeneration,
+                                null,
+                                Array.Empty<SongListNode>());
                         }
                         catch (Exception ex)
                         {
                             System.Diagnostics.Debug.WriteLine($"SongSelectionStage: Failed to initialize SongManager: {ex.Message}");
-                            return new List<SongListNode>();
+                            result = new SongInitializationResult(
+                                initializationActivationVersion,
+                                initializationGeneration,
+                                null,
+                                Array.Empty<SongListNode>());
                         }
+
+                        _pendingSongInitializationResults.Enqueue(result);
+                        return result.SongList.ToList();
                     }, token);
 
                     // While no coherent snapshot is available, do not leave a BackBox from
@@ -1005,27 +1034,36 @@ namespace DTXMania.Game.Lib.Stage
 
                 try
                 {
-                    // Get the result from the completed task
+                    // Get the result from the completed task. Its immutable snapshot record is
+                    // selected separately by activation and generation, so an old worker that
+                    // completes after a reactivation cannot overwrite this task's result.
                     var songList = _songInitializationTask.Result;
+                    int activationVersion = Volatile.Read(ref _activationVersion);
+                    long initializationGeneration =
+                        Volatile.Read(ref _activeSongInitializationGeneration);
+                    var initializationResult = ConsumeSongInitializationResult(
+                        activationVersion,
+                        initializationGeneration);
 
                     // Update the song list on the main thread. A publication can have been
                     // reconciled while this background task was running; do not let its older
                     // copied snapshot overwrite the newer UI snapshot.
                     bool shouldProjectInitializationResult = false;
-                    if (_backgroundLibrarySnapshot != null)
+                    if (initializationResult?.Snapshot != null)
                     {
+                        var snapshot = initializationResult.Value.Snapshot!;
                         // If an update-thread publication has already restored the user's
                         // navigation and selection, even an equal-version initialization
                         // result must not repopulate the old projection and reset it.
                         if (_appliedLibrarySnapshot == null
-                            || _backgroundLibrarySnapshot.Version >
+                            || snapshot.Version >
                                 Volatile.Read(ref _appliedLibraryPublicationVersion))
                         {
                             // Even the initialization result may replace a hierarchy that was
                             // already being displayed. Reconcile instead of raw-applying so a
                             // retained box path and selection are restored against this exact
                             // snapshot, while a removed path is cleared before projection.
-                            ReconcileLibrarySnapshot(_backgroundLibrarySnapshot);
+                            ReconcileLibrarySnapshot(snapshot);
                         }
                     }
                     else if (_appliedLibrarySnapshot == null)
@@ -1055,12 +1093,28 @@ namespace DTXMania.Game.Lib.Stage
                 {
                     // Clean up the task reference
                     _songInitializationTask = null;
-                    _backgroundLibrarySnapshot = null;
                 }
 
                 if (_searchFilterModal != null && _searchFilterModal.IsOpen)
                     _searchFilterModal.IsLibraryReady = true;
             }
+        }
+
+        private SongInitializationResult? ConsumeSongInitializationResult(
+            int activationVersion,
+            long initializationGeneration)
+        {
+            SongInitializationResult? matchingResult = null;
+            while (_pendingSongInitializationResults.TryDequeue(out var result))
+            {
+                if (result.ActivationVersion == activationVersion
+                    && result.Generation == initializationGeneration)
+                {
+                    matchingResult = result;
+                }
+            }
+
+            return matchingResult;
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -61,50 +61,41 @@ namespace DTXMania.Game.Lib.Stage
         private SongSelectionTab _activeTab = SongSelectionTab.AllSongs;
         private static readonly SongSelectionTab[] AllTabs = System.Enum.GetValues<SongSelectionTab>();
         // Cached recent-plays nodes (flat Score nodes), refreshed on activation and on
-        // switching into the Recent tab. Null until first load. volatile: published from a
-        // background load continuation and read on the update thread (release-acquire pair
-        // with _tabListNeedsRefresh).
-        private volatile List<SongListNode>? _recentPlayNodes;
+        // switching into the Recent tab. Null until first load. Worker completions only
+        // enqueue immutable records; this and all related flags are update-thread owned.
+        private List<SongListNode>? _recentPlayNodes;
         private bool _showEmptyRecentMessage;
         // True when the most recent BeginRecentPlaysLoad continuation failed (DB error,
         // IO error, etc.). Distinct from _showEmptyRecentMessage so a corrupted/locked
         // score DB doesn't look identical to "no plays yet."
         private bool _recentPlaysLoadFailed;
         // Cached bookmark nodes (flat Score nodes), refreshed on activation and on switching
-        // into the Bookmarks tab. Null until first load. volatile: published from a background
-        // load continuation and read on the update thread (release-acquire pair with
-        // _tabListNeedsRefresh).
-        private volatile List<SongListNode>? _bookmarkNodes;
+        // into the Bookmarks tab. Worker completions only enqueue immutable records; this and
+        // all related flags are update-thread owned.
+        private List<SongListNode>? _bookmarkNodes;
         private bool _showEmptyBookmarksMessage;
         // True when the most recent BeginBookmarksLoad continuation failed (DB/IO error).
         private bool _bookmarksLoadFailed;
-        // Per-load sequence guard for BeginBookmarksLoad. Incremented on every call so a
-        // completion from an older same-activation load (e.g., the activation-time warm load
-        // still in flight when the user bookmarks a song and switches to the Bookmarks tab)
-        // can detect it has been superseded by a newer load and discard its stale result
-        // instead of overwriting _bookmarkNodes with a pre-toggle snapshot that omits the
-        // just-bookmarked song. Interlocked because BeginBookmarksLoad is called from both
-        // the update thread (Activate, ProcessPendingBookmarkReverts) and thread-pool
-        // continuations (SwitchToNextTab's Task.WhenAll chain). volatile so the plain read
-        // in the continuation observes the latest increment.
-        private volatile int _bookmarksLoadVersion;
+        // Per-load sequence guard for BeginBookmarksLoad. Incremented on the update thread so
+        // a queued completion from an older same-activation load cannot overwrite the result
+        // of a newer load with a pre-toggle snapshot that omits a newly bookmarked song.
+        private int _bookmarksLoadVersion;
         private Func<Task<List<SongListNode>>> _loadBookmarkedNodesAsync =
             () => SongManager.Instance.GetBookmarkedNodesAsync();
-        // Set when the active tab's list must be repopulated on the next OnUpdate.
-        // Used so background recent-plays loads and lane-hit/Tab switches never mutate
-        // SongListDisplay off the update thread. volatile so the update thread reliably
-        // observes the flag set by the background continuation.
-        private volatile bool _tabListNeedsRefresh;
-        // A background cache continuation increments this before requesting a refresh. The
-        // update thread consumes the value around a projection so a completion that lands
-        // during reconciliation is re-queued instead of being lost by a stale false write.
+        private readonly System.Collections.Concurrent.ConcurrentQueue<TabLoadCompletion>
+            _pendingTabLoadCompletions = new();
+        private readonly System.Collections.Concurrent.ConcurrentQueue<BookmarkLoadRequest>
+            _pendingBookmarkLoadRequests = new();
+        // Set when the active tab's list must be repopulated on the next OnUpdate. It is owned
+        // by the update thread; worker continuations enqueue completion records instead.
+        private bool _tabListNeedsRefresh;
+        // Completion application increments this before requesting a refresh. The update thread
+        // consumes the value around a projection so a refresh requested during reconciliation is
+        // re-queued instead of being lost by a stale false write.
         private int _asyncTabListRefreshVersion;
-        // Activation token bumped on every Activate(). Captured by BeginRecentPlaysLoad so
-        // its background continuation can detect that a later Deactivate/Activate cycle has
-        // occurred and discard stale results instead of overwriting fresh state.
-        // volatile: written on the update thread (Activate) and read on a background
-        // continuation thread; ensures the continuation sees the latest bump.
-        private volatile int _activationVersion;
+        // Activation token bumped on every Activate()/Deactivate(). Workers capture it in their
+        // immutable records; update-thread consumption and publication callbacks validate it.
+        private int _activationVersion;
 
         // Serializes bookmark persistence writes per song. Each toggle chains after the
         // in-flight write for the same song so rapid double-toggles apply in order and the
@@ -140,6 +131,8 @@ namespace DTXMania.Game.Lib.Stage
         private long _pendingLibraryPublicationVersion;
         private long _appliedLibraryPublicationVersion;
         private int _libraryPublicationActive;
+        private readonly object _libraryPublicationGate = new();
+        private EventHandler<SongLibraryPublishedEventArgs>? _libraryPublicationHandler;
         private SongLibraryEmptyState _libraryEmptyState = SongLibraryEmptyState.HasSongs;
 
         // UI Components - Enhanced DTXManiaNX style
@@ -223,6 +216,21 @@ namespace DTXMania.Game.Lib.Stage
             NoSupportedCharts
         }
 
+        private enum TabLoadKind
+        {
+            RecentPlays,
+            Bookmarks
+        }
+
+        private readonly record struct TabLoadCompletion(
+            TabLoadKind Kind,
+            int ActivationVersion,
+            int LoadVersion,
+            IReadOnlyList<SongListNode>? Nodes,
+            Exception? Error);
+
+        private readonly record struct BookmarkLoadRequest(int ActivationVersion);
+
         #endregion
 
         #region Properties
@@ -251,6 +259,11 @@ namespace DTXMania.Game.Lib.Stage
             // Use game's shared InputManager (supports MCP key injection)
             AssignInputManager(_game.InputManager);
             _inputManager?.ClearPendingCommands();
+            // Invalidate the prior activation before resetting publication state. An event
+            // callback that was already in flight now carries an older token and cannot write
+            // a pending version into this activation.
+            Interlocked.Increment(ref _activationVersion);
+            UnsubscribeLibraryPublications();
             _cancellationTokenSource = new CancellationTokenSource();
             _backgroundLibrarySnapshot = null;
             _songInitializationProcessed = false;
@@ -259,9 +272,8 @@ namespace DTXMania.Game.Lib.Stage
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
             Interlocked.Exchange(ref _appliedLibraryPublicationVersion, 0);
 
-            // Bump before starting any background work, so its continuations and the
-            // publication subscriber belong to the same activation.
-            _activationVersion++;
+            // The subscriber captures the activation token after the old one has been
+            // invalidated, so a retained delegate from an earlier activation is harmless.
             SubscribeLibraryPublications();
 
             // Get config manager from game
@@ -346,11 +358,10 @@ namespace DTXMania.Game.Lib.Stage
             // Initialize UI
             InitializeUI(uiFont);
 
-            // Start song loading
-            InitializeSongList();
-
             // Always start on All Songs for predictability; warm the recent-plays cache so
-            // the Recent tab is populated the moment the user switches to it.
+            // the Recent tab is populated the moment the user switches to it. Reset this
+            // before projecting the activation snapshot so reconciliation never renders a
+            // previous activation's tab while restoring hierarchy and selection.
             _activeTab = SongSelectionTab.AllSongs;
             _recentPlayNodes = null;
             _showEmptyRecentMessage = false;
@@ -363,6 +374,11 @@ namespace DTXMania.Game.Lib.Stage
             // would repopulate the All Songs list and reset selection/scroll to index 0.
             _tabListNeedsRefresh = false;
             Interlocked.Exchange(ref _asyncTabListRefreshVersion, 0);
+
+            // Start song loading after the tab state is reset. An initialized manager is
+            // reconciled instead of raw-applied, which restores only paths still present in
+            // the current snapshot and clears a removed hierarchy before it is displayed.
+            InitializeSongList();
             BeginRecentPlaysLoad();
             _ = BeginBookmarksLoad();
 
@@ -376,15 +392,15 @@ namespace DTXMania.Game.Lib.Stage
 
         public override void Deactivate()
         {
-            // Stop accepting publications before resources and UI collections begin tearing
-            // down. A publisher already in flight can at most race to record a version, which
-            // is discarded on the next activation; it never mutates the UI from its callback.
-            UnsubscribeLibraryPublications();
-
             // Invalidate every activation-scoped continuation immediately rather than waiting
             // for the next Activate call. This prevents a canceled initialization task from
             // writing a stale snapshot into a stage that is already inactive.
-            _activationVersion++;
+            Interlocked.Increment(ref _activationVersion);
+
+            // Stop accepting publications before resources and UI collections begin tearing
+            // down. A publisher already in flight carries the prior activation token and is
+            // rejected by the fenced handler before it can record a pending version.
+            UnsubscribeLibraryPublications();
 
             if (_configManager != null)
             {
@@ -771,7 +787,7 @@ namespace DTXMania.Game.Lib.Stage
                 if (!songManager.IsInitialized)
                 {
                     var token = _cancellationTokenSource.Token;
-                    int initializationActivationVersion = _activationVersion;
+                    int initializationActivationVersion = Volatile.Read(ref _activationVersion);
 
                     // Start background task to initialize SongManager and fetch song list
                     // This task only fetches data and doesn't modify shared state or UI
@@ -796,7 +812,8 @@ namespace DTXMania.Game.Lib.Stage
                             // both hierarchy and root paths together when this task ends.
                             var snapshot = songManager.GetLibrarySnapshot();
                             if (!token.IsCancellationRequested
-                                && initializationActivationVersion == _activationVersion)
+                                && initializationActivationVersion ==
+                                    Volatile.Read(ref _activationVersion))
                             {
                                 _backgroundLibrarySnapshot = snapshot;
                             }
@@ -813,25 +830,37 @@ namespace DTXMania.Game.Lib.Stage
                         }
                     }, token);
 
-                    // For now, initialize with empty list
+                    // While no coherent snapshot is available, do not leave a BackBox from
+                    // the previous activation visible over the empty placeholder list.
+                    ClearNavigationForPendingLibrary();
                     _currentSongList = new List<SongListNode>();
+                    PopulateSongList();
+                    ReapplyPersistedFilterIfActive();
                 }
                 else
                 {
-                    ApplyLibrarySnapshot(songManager.GetLibrarySnapshot());
+                    // Re-entry can retain an old navigation stack. Project the activation
+                    // snapshot through the same path as a live publication so retained boxes
+                    // are restored and removed boxes cannot expose stale children.
+                    ReconcileLibrarySnapshot(songManager.GetLibrarySnapshot());
                 }
-
-                PopulateSongList();
-                ReapplyPersistedFilterIfActive();
             }
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"SongSelectionStage: Error loading songs: {ex.Message}");
 
                 // Fallback to empty list
+                ClearNavigationForPendingLibrary();
                 _currentSongList = new List<SongListNode>();
                 PopulateSongList();
             }
+        }
+
+        private void ClearNavigationForPendingLibrary()
+        {
+            _navigationStack.Clear();
+            _currentBreadcrumb = "";
+            ClearRemovedSelectionPresentation();
         }
 
         private void ApplyLibrarySnapshot(SongLibrarySnapshot snapshot)
@@ -863,36 +892,69 @@ namespace DTXMania.Game.Lib.Stage
         private void SubscribeLibraryPublications()
         {
             var songManager = SongManager.Instance;
-            Interlocked.Exchange(ref _libraryPublicationActive, 1);
-            // The stage instance is retained by StageManager, so activation may happen many
-            // times. Remove first to keep the callback single-subscribed.
-            songManager.SongLibraryPublished -= OnSongLibraryPublished;
-            songManager.SongLibraryPublished += OnSongLibraryPublished;
+            EventHandler<SongLibraryPublishedEventArgs>? previousHandler;
+            lock (_libraryPublicationGate)
+            {
+                previousHandler = _libraryPublicationHandler;
+                _libraryPublicationHandler = null;
+                Interlocked.Exchange(ref _libraryPublicationActive, 0);
+            }
+
+            if (previousHandler != null)
+                songManager.SongLibraryPublished -= previousHandler;
+
+            int capturedActivationVersion = Volatile.Read(ref _activationVersion);
+            EventHandler<SongLibraryPublishedEventArgs> handler = (sender, args) =>
+                OnSongLibraryPublishedForActivation(capturedActivationVersion, args);
+
+            lock (_libraryPublicationGate)
+            {
+                _libraryPublicationHandler = handler;
+                Interlocked.Exchange(ref _libraryPublicationActive, 1);
+            }
+            songManager.SongLibraryPublished += handler;
         }
 
         private void UnsubscribeLibraryPublications()
         {
-            Interlocked.Exchange(ref _libraryPublicationActive, 0);
-            SongManager.Instance.SongLibraryPublished -= OnSongLibraryPublished;
+            EventHandler<SongLibraryPublishedEventArgs>? handler;
+            lock (_libraryPublicationGate)
+            {
+                Interlocked.Exchange(ref _libraryPublicationActive, 0);
+                handler = _libraryPublicationHandler;
+                _libraryPublicationHandler = null;
+            }
+
+            if (handler != null)
+                SongManager.Instance.SongLibraryPublished -= handler;
         }
 
         private void OnSongLibraryPublished(object? sender, SongLibraryPublishedEventArgs e)
         {
-            if (Volatile.Read(ref _libraryPublicationActive) == 0)
-                return;
+            // Kept as a direct test seam. Production subscriptions call the token-capturing
+            // helper below through a closure created for each activation.
+            OnSongLibraryPublishedForActivation(
+                Volatile.Read(ref _activationVersion),
+                e);
+        }
 
-            long publishedVersion = e.Snapshot.Version;
-            long observedVersion;
-            do
+        private void OnSongLibraryPublishedForActivation(
+            int capturedActivationVersion,
+            SongLibraryPublishedEventArgs e)
+        {
+            lock (_libraryPublicationGate)
             {
-                observedVersion = Volatile.Read(ref _pendingLibraryPublicationVersion);
-                if (publishedVersion <= observedVersion)
+                if (Volatile.Read(ref _libraryPublicationActive) == 0
+                    || capturedActivationVersion != Volatile.Read(ref _activationVersion))
+                {
                     return;
+                }
+
+                long publishedVersion = e.Snapshot.Version;
+                long pendingVersion = Volatile.Read(ref _pendingLibraryPublicationVersion);
+                if (publishedVersion > pendingVersion)
+                    Interlocked.Exchange(ref _pendingLibraryPublicationVersion, publishedVersion);
             }
-            while (Interlocked.CompareExchange(
-                       ref _pendingLibraryPublicationVersion,
-                       publishedVersion,
-                       observedVersion) != observedVersion);
         }
 
         /// <summary>
@@ -959,8 +1021,11 @@ namespace DTXMania.Game.Lib.Stage
                             || _backgroundLibrarySnapshot.Version >
                                 Volatile.Read(ref _appliedLibraryPublicationVersion))
                         {
-                            ApplyLibrarySnapshot(_backgroundLibrarySnapshot);
-                            shouldProjectInitializationResult = true;
+                            // Even the initialization result may replace a hierarchy that was
+                            // already being displayed. Reconcile instead of raw-applying so a
+                            // retained box path and selection are restored against this exact
+                            // snapshot, while a removed path is cleared before projection.
+                            ReconcileLibrarySnapshot(_backgroundLibrarySnapshot);
                         }
                     }
                     else if (_appliedLibrarySnapshot == null)
@@ -1684,8 +1749,8 @@ namespace DTXMania.Game.Lib.Stage
 
         private void RequestAsyncTabListRefresh()
         {
-            // Increment before the volatile flag write. A reconciliation that sees the new
-            // generation but races this write will restore the flag itself; one that completes
+            // Increment before the refresh flag write. A reconciliation that sees the new
+            // generation but races this request will restore the flag itself; one that completes
             // first is followed by this write and is likewise re-queued.
             Interlocked.Increment(ref _asyncTabListRefreshVersion);
             _tabListNeedsRefresh = true;
@@ -1783,6 +1848,10 @@ namespace DTXMania.Game.Lib.Stage
             // Publication callbacks only captured a version. Apply the current coherent
             // snapshot here, on the update thread, before input and UI traversal observe it.
             ApplyPendingLibraryPublication();
+
+            // Background tab loads only enqueue immutable records. Apply them here so cache
+            // lists, flags, and refresh requests remain owned by the stage update thread.
+            ConsumePendingTabLoadWork();
 
             // Update owned fallback input manager (shared one is updated by BaseGame)
             if (_ownsInputManager)
@@ -2884,9 +2953,13 @@ namespace DTXMania.Game.Lib.Stage
                 // present in _bookmarkNodes, so a newly bookmarked song wouldn't appear until
                 // the next reload). Task.WhenAll of an empty/completed set settles immediately.
                 var pending = _pendingBookmarkWrites.Values.ToArray();
+                int capturedActivationVersion = Volatile.Read(ref _activationVersion);
                 _ = Task.WhenAll(pending).ContinueWith(_ =>
                 {
-                    _ = BeginBookmarksLoad();
+                    // This continuation may run on a worker. It never starts a stage-owned
+                    // load directly; OnUpdate validates the activation token before doing so.
+                    _pendingBookmarkLoadRequests.Enqueue(
+                        new BookmarkLoadRequest(capturedActivationVersion));
                 }, TaskScheduler.Default);
             }
 
@@ -2895,112 +2968,135 @@ namespace DTXMania.Game.Lib.Stage
         }
 
         /// <summary>
-        /// Loads recent-plays nodes in the background and flags a repopulate when done.
-        /// Safe to call when the singleton DB is unavailable (returns an empty list).
-        /// Captures <see cref="_activationVersion"/> so a completion that lands after a
-        /// subsequent Deactivate/Activate cycle is discarded instead of overwriting fresh
-        /// state or spuriously flagging a list refresh.
+        /// Loads recent-plays nodes in the background. Its continuation only enqueues an
+        /// immutable completion record; OnUpdate validates and applies it.
         /// </summary>
         private void BeginRecentPlaysLoad()
         {
-            int capturedVersion = _activationVersion;
+            int capturedVersion = Volatile.Read(ref _activationVersion);
             _ = SongManager.Instance.GetRecentlyPlayedNodesAsync(RecentPlaysLimit)
                 .ContinueWith(task =>
                 {
-                    if (task.IsFaulted || task.IsCanceled)
+                    if (task.IsCompletedSuccessfully)
                     {
-                        // Log the full exception (type + stack), not just the base message,
-                        // so DB/IO failures are diagnosable from the debug output.
-                        System.Diagnostics.Debug.WriteLine(
-                            $"SongSelectionStage: recent-plays load failed:\n{task.Exception}");
-                        // Discard stale completions from a prior activation.
-                        if (capturedVersion == _activationVersion)
-                        {
-                            _recentPlaysLoadFailed = true;
-                            if (_activeTab == SongSelectionTab.RecentPlays)
-                                RequestAsyncTabListRefresh();
-                        }
+                        _pendingTabLoadCompletions.Enqueue(new TabLoadCompletion(
+                            TabLoadKind.RecentPlays,
+                            capturedVersion,
+                            0,
+                            CopyTabLoadNodes(task.Result),
+                            null));
                         return;
                     }
-                    // Discard stale completions from a prior activation. Without this guard,
-                    // a slow load from activation N can overwrite the _recentPlayNodes that
-                    // activation N+1 already populated, and trigger an unwanted list rebuild.
-                    if (capturedVersion != _activationVersion)
-                        return;
-                    _recentPlaysLoadFailed = false;
-                    _recentPlayNodes = task.Result;
-                    // Only request a list repopulate when the user is actually viewing the
-                    // Recent tab. Activate() warms the cache while the user is on All Songs;
-                    // flagging a refresh there would spuriously rebuild the All Songs list
-                    // and reset selection/scroll. Tab switches into Recent already request a
-                    // refresh via SwitchToNextTab and rely on this load to populate the list.
-                    if (_activeTab == SongSelectionTab.RecentPlays)
-                        RequestAsyncTabListRefresh();
+
+                    _pendingTabLoadCompletions.Enqueue(new TabLoadCompletion(
+                        TabLoadKind.RecentPlays,
+                        capturedVersion,
+                        0,
+                        null,
+                        task.Exception is Exception error
+                            ? error
+                            : new TaskCanceledException(task)));
                 }, TaskScheduler.Default);
         }
 
         /// <summary>
-        /// Loads bookmark nodes in the background and flags a repopulate when done.
-        /// Safe when the DB is unavailable (returns an empty list). Captures
-        /// <see cref="_activationVersion"/> so a completion that lands after a later
-        /// Deactivate/Activate cycle is discarded, and assigns a per-load sequence id
-        /// (<see cref="_bookmarksLoadVersion"/>) so an older same-activation load
-        /// cannot overwrite the result of a newer load.
+        /// Loads bookmark nodes in the background. Its worker only queues a completion; the
+        /// update thread validates the activation and per-load generation before applying it.
         /// </summary>
         private Task BeginBookmarksLoad()
         {
-            int capturedVersion = _activationVersion;
+            int capturedVersion = Volatile.Read(ref _activationVersion);
             // Assign a monotonic per-load id so an older same-activation load (e.g., the
             // activation-time warm load still in flight when the user bookmarks a song and
             // switches to the Bookmarks tab) can detect it has been superseded by a newer
             // load and discard its stale result.
             int capturedLoadVersion = Interlocked.Increment(ref _bookmarksLoadVersion);
+            var loadBookmarkedNodesAsync = _loadBookmarkedNodesAsync;
             return Task.Run(async () =>
             {
-                List<SongListNode>? nodes = null;
                 try
                 {
-                    nodes = await _loadBookmarkedNodesAsync().ConfigureAwait(false);
+                    var nodes = await loadBookmarkedNodesAsync().ConfigureAwait(false);
+                    _pendingTabLoadCompletions.Enqueue(new TabLoadCompletion(
+                        TabLoadKind.Bookmarks,
+                        capturedVersion,
+                        capturedLoadVersion,
+                        CopyTabLoadNodes(nodes),
+                        null));
                 }
                 catch (Exception ex)
                 {
-                    // Log the full exception (type + stack), not just the base message,
-                    // so DB/IO failures are diagnosable from the debug output.
+                    _pendingTabLoadCompletions.Enqueue(new TabLoadCompletion(
+                        TabLoadKind.Bookmarks,
+                        capturedVersion,
+                        capturedLoadVersion,
+                        null,
+                        ex));
+                }
+            });
+        }
+
+        private static IReadOnlyList<SongListNode> CopyTabLoadNodes(
+            IEnumerable<SongListNode>? nodes)
+        {
+            return Array.AsReadOnly(nodes?.ToArray() ?? Array.Empty<SongListNode>());
+        }
+
+        private void ConsumePendingTabLoadWork()
+        {
+            int activationVersion = Volatile.Read(ref _activationVersion);
+            while (_pendingBookmarkLoadRequests.TryDequeue(out var request))
+            {
+                if (request.ActivationVersion == activationVersion)
+                    _ = BeginBookmarksLoad();
+            }
+
+            while (_pendingTabLoadCompletions.TryDequeue(out var completion))
+            {
+                if (completion.ActivationVersion != activationVersion)
+                    continue;
+
+                if (completion.Kind == TabLoadKind.Bookmarks
+                    && completion.LoadVersion != Volatile.Read(ref _bookmarksLoadVersion))
+                {
+                    continue;
+                }
+
+                if (completion.Error != null)
+                {
                     System.Diagnostics.Debug.WriteLine(
-                        $"SongSelectionStage: bookmarks load failed:\n{ex}");
-                    // Discard stale completions from a prior activation or a newer
-                    // same-activation load.
-                    if (capturedVersion == _activationVersion
-                        && capturedLoadVersion == _bookmarksLoadVersion)
+                        $"SongSelectionStage: {completion.Kind} load failed:\n{completion.Error}");
+                    if (completion.Kind == TabLoadKind.RecentPlays)
+                    {
+                        _recentPlaysLoadFailed = true;
+                        if (_activeTab == SongSelectionTab.RecentPlays)
+                            RequestAsyncTabListRefresh();
+                    }
+                    else
                     {
                         _bookmarksLoadFailed = true;
                         if (_activeTab == SongSelectionTab.Bookmarks)
                             RequestAsyncTabListRefresh();
                     }
-                    return;
+                    continue;
                 }
-                // Discard stale completions from a prior activation. Without this guard,
-                // a slow load from activation N can overwrite the _bookmarkNodes that
-                // activation N+1 already populated, and trigger an unwanted list rebuild.
-                if (capturedVersion != _activationVersion)
-                    return;
-                // Discard completions from an older same-activation load. Without this
-                // guard, the activation-time warm load (which queried the DB before a
-                // bookmark toggle committed) can complete after a newer load triggered
-                // by a tab switch, overwriting _bookmarkNodes with a stale pre-toggle
-                // result that omits the just-bookmarked song.
-                if (capturedLoadVersion != _bookmarksLoadVersion)
-                    return;
-                _bookmarksLoadFailed = false;
-                _bookmarkNodes = nodes;
-                // Only request a list repopulate when the user is actually viewing the
-                // Bookmarks tab. Activate() warms the cache while the user is on All Songs;
-                // flagging a refresh there would spuriously rebuild the All Songs list
-                // and reset selection/scroll. Tab switches into Bookmarks already request a
-                // refresh via SwitchToNextTab and rely on this load to populate the list.
-                if (_activeTab == SongSelectionTab.Bookmarks)
-                    RequestAsyncTabListRefresh();
-            });
+
+                var nodes = completion.Nodes?.ToList() ?? new List<SongListNode>();
+                if (completion.Kind == TabLoadKind.RecentPlays)
+                {
+                    _recentPlaysLoadFailed = false;
+                    _recentPlayNodes = nodes;
+                    if (_activeTab == SongSelectionTab.RecentPlays)
+                        RequestAsyncTabListRefresh();
+                }
+                else
+                {
+                    _bookmarksLoadFailed = false;
+                    _bookmarkNodes = nodes;
+                    if (_activeTab == SongSelectionTab.Bookmarks)
+                        RequestAsyncTabListRefresh();
+                }
+            }
         }
 
         /// <summary>
@@ -3080,10 +3176,8 @@ namespace DTXMania.Game.Lib.Stage
             // On the Bookmarks tab, an un-bookmark should drop the row from view.
             if (_activeTab == SongSelectionTab.Bookmarks && !newState)
             {
-                // _bookmarkNodes is volatile and may be replaced by a background BeginBookmarksLoad
-                // continuation. RemoveAll targets the list reference seen here; if that reference was
-                // just swapped, the removal is harmlessly lost — _tabListNeedsRefresh forces the next
-                // update to repopulate from the new list regardless.
+                // Bookmark caches are update-thread owned. A pending background query only
+                // becomes visible when its queued completion is applied on a later update.
                 _bookmarkNodes?.RemoveAll(n =>
                     ReferenceEquals(n, node) || (n.DatabaseSongId ?? n.DatabaseSong?.Id) == songId);
                 _tabListNeedsRefresh = true;

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -279,6 +279,7 @@ namespace DTXMania.Game.Lib.Stage
             _cancellationTokenSource = new CancellationTokenSource();
             _songInitializationProcessed = false;
             Interlocked.Exchange(ref _activeSongInitializationGeneration, 0);
+            DiscardQueuedSongInitializationResults();
             _appliedLibrarySnapshot = null;
             _libraryEmptyState = SongLibraryEmptyState.HasSongs;
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
@@ -455,6 +456,7 @@ namespace DTXMania.Game.Lib.Stage
             // Clean up task references
             _songInitializationTask = null;
             Interlocked.Exchange(ref _activeSongInitializationGeneration, 0);
+            DiscardQueuedSongInitializationResults();
             _appliedLibrarySnapshot = null;
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
 
@@ -1027,8 +1029,18 @@ namespace DTXMania.Game.Lib.Stage
 
         private void CheckSongInitializationCompletion()
         {
+            // A synchronous reactivation has no initializer task, but a cancelled worker from
+            // an earlier activation can still enqueue a tagged result afterward. It cannot be
+            // applied without a current task, so discard it on the update thread instead of
+            // retaining copied snapshots/root arrays until some future asynchronous load.
+            if (_songInitializationTask == null)
+            {
+                DiscardQueuedSongInitializationResults();
+                return;
+            }
+
             // Check if we have a running task and it's completed
-            if (_songInitializationTask != null && _songInitializationTask.IsCompleted && !_songInitializationProcessed)
+            if (_songInitializationTask.IsCompleted && !_songInitializationProcessed)
             {
                 _songInitializationProcessed = true;
 
@@ -1115,6 +1127,15 @@ namespace DTXMania.Game.Lib.Stage
             }
 
             return matchingResult;
+        }
+
+        private void DiscardQueuedSongInitializationResults()
+        {
+            while (_pendingSongInitializationResults.TryDequeue(out _))
+            {
+                // Records are immutable and activation-tagged. Without an active initializer,
+                // none can legitimately be projected into this stage activation.
+            }
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -137,6 +137,7 @@ namespace DTXMania.Game.Lib.Stage
         // publisher can run on a worker thread, so it only records a version; OnUpdate is
         // the sole place that replaces UI-owned collections from a fetched snapshot.
         private SongLibrarySnapshot? _appliedLibrarySnapshot;
+        private HashSet<string>? _appliedLibraryScoreIdentities;
         private long _pendingLibraryPublicationVersion;
         private long _appliedLibraryPublicationVersion;
         private int _libraryPublicationActive;
@@ -284,6 +285,7 @@ namespace DTXMania.Game.Lib.Stage
             Interlocked.Exchange(ref _activeSongInitializationGeneration, 0);
             DiscardQueuedSongInitializationResults();
             _appliedLibrarySnapshot = null;
+            _appliedLibraryScoreIdentities = null;
             _libraryEmptyState = SongLibraryEmptyState.HasSongs;
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
             Interlocked.Exchange(ref _appliedLibraryPublicationVersion, 0);
@@ -482,6 +484,7 @@ namespace DTXMania.Game.Lib.Stage
             Interlocked.Exchange(ref _activeSongInitializationGeneration, 0);
             DiscardQueuedSongInitializationResults();
             _appliedLibrarySnapshot = null;
+            _appliedLibraryScoreIdentities = null;
             Interlocked.Exchange(ref _pendingLibraryPublicationVersion, 0);
 
             // Clean up UI
@@ -938,6 +941,8 @@ namespace DTXMania.Game.Lib.Stage
             ArgumentNullException.ThrowIfNull(snapshot);
 
             _appliedLibrarySnapshot = snapshot;
+            _appliedLibraryScoreIdentities =
+                GetPublishedScoreIdentities(snapshot.RootSongs);
             _currentSongList = snapshot.RootSongs.ToList();
             _libraryEmptyState = ResolveLibraryEmptyState(snapshot);
             if (_previewImagePanel != null)
@@ -1473,9 +1478,8 @@ namespace DTXMania.Game.Lib.Stage
             if (_appliedLibrarySnapshot == null || rootFilteredNodes.Count == 0)
                 return rootFilteredNodes;
 
-            var publishedScoreIdentities = GetPublishedScoreIdentities(
-                _appliedLibrarySnapshot.RootSongs);
-            if (publishedScoreIdentities.Count == 0)
+            var publishedScoreIdentities = _appliedLibraryScoreIdentities;
+            if (publishedScoreIdentities == null || publishedScoreIdentities.Count == 0)
                 return new List<SongListNode>();
 
             return rootFilteredNodes

--- a/DTXMania.Game/Lib/Stage/StartupStage.cs
+++ b/DTXMania.Game/Lib/Stage/StartupStage.cs
@@ -818,7 +818,7 @@ namespace DTXMania.Game.Lib.Stage
                     var config = _configManager.Config;
                     if (config != null)
                     {
-                        _songPaths = new[] { config.DTXPath };
+                        _songPaths = config.SongRoots.ToArray();
 
                         // Basic validation - check if config loaded successfully
                         bool isValid = config.ScreenWidth > 0 &&
@@ -993,6 +993,11 @@ namespace DTXMania.Game.Lib.Stage
             _songManager.SetInitialized();
         }
 
+        protected virtual void PublishEmptyLibraryCore()
+        {
+            _songManager.PublishEmptyLibrary();
+        }
+
         private Task InitializeDatabaseServiceAsync()
         {
             long activationGeneration;
@@ -1141,6 +1146,18 @@ namespace DTXMania.Game.Lib.Stage
         {
             try
             {
+                if (_songPaths.Length == 0)
+                {
+                    lock (_activationGate)
+                    {
+                        EnsureCurrentActivation(
+                            activationGeneration,
+                            cancellationToken);
+                        PublishEmptyLibraryCore();
+                    }
+                    return;
+                }
+
                 Task<bool> needsEnumerationTask;
                 lock (_activationGate)
                 {
@@ -1199,6 +1216,7 @@ namespace DTXMania.Game.Lib.Stage
 
                 var enumerationResult =
                     await enumerationTask.ConfigureAwait(false);
+                var shouldPublishEmptyLibrary = false;
                 lock (_activationGate)
                 {
                     EnsureCurrentActivation(
@@ -1211,6 +1229,20 @@ namespace DTXMania.Game.Lib.Stage
                             "publishing a hierarchy.");
                     }
                     _enumerationResult = enumerationResult;
+                    shouldPublishEmptyLibrary =
+                        enumerationResult.Outcome ==
+                        SongEnumerationOutcome.NoActiveRoots;
+                }
+
+                if (shouldPublishEmptyLibrary)
+                {
+                    lock (_activationGate)
+                    {
+                        EnsureCurrentActivation(
+                            activationGeneration,
+                            cancellationToken);
+                        PublishEmptyLibraryCore();
+                    }
                 }
             }
             catch (OperationCanceledException)

--- a/DTXMania.Game/Lib/Stage/StartupStage.cs
+++ b/DTXMania.Game/Lib/Stage/StartupStage.cs
@@ -1153,8 +1153,11 @@ namespace DTXMania.Game.Lib.Stage
                         EnsureCurrentActivation(
                             activationGeneration,
                             cancellationToken);
-                        PublishEmptyLibraryCore();
                     }
+                    // Publish outside the gate so synchronous
+                    // SongLibraryPublished subscribers are not invoked while
+                    // _activationGate is held.
+                    PublishEmptyLibraryCore();
                     return;
                 }
 
@@ -1241,8 +1244,11 @@ namespace DTXMania.Game.Lib.Stage
                         EnsureCurrentActivation(
                             activationGeneration,
                             cancellationToken);
-                        PublishEmptyLibraryCore();
                     }
+                    // Publish outside the gate so synchronous
+                    // SongLibraryPublished subscribers are not invoked while
+                    // _activationGate is held.
+                    PublishEmptyLibraryCore();
                 }
             }
             catch (OperationCanceledException)

--- a/DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs
+++ b/DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+using DTXMania.Game.Lib.Stage.Config;
+
+namespace DTXMania.Game.Platform
+{
+    internal static class FolderPickerServiceFactory
+    {
+        internal static IFolderPickerService Create() => new MacFolderPickerService();
+    }
+}

--- a/DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs
+++ b/DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs
@@ -1,0 +1,11 @@
+#nullable enable
+
+using DTXMania.Game.Lib.Stage.Config;
+
+namespace DTXMania.Game.Platform
+{
+    internal static class FolderPickerServiceFactory
+    {
+        internal static IFolderPickerService Create() => new WindowsFolderPickerService();
+    }
+}

--- a/DTXMania.Game/Platform/Mac/MacFolderPickerService.cs
+++ b/DTXMania.Game/Platform/Mac/MacFolderPickerService.cs
@@ -39,6 +39,7 @@ namespace DTXMania.Game.Platform
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     StopProcess(process);
+                    await ObserveQuietlyAsync(outputTask, errorTask).ConfigureAwait(false);
                     return FolderPickerResult.Cancelled();
                 }
 
@@ -164,6 +165,40 @@ namespace DTXMania.Game.Platform
             {
                 // Best effort only; the cancellation result is still authoritative.
             }
+            catch (AggregateException)
+            {
+                // process-tree termination may report partial failures (e.g. a
+                // child already exited). Best effort only; cancellation remains
+                // authoritative.
+            }
+        }
+
+        /// <summary>
+        /// Awaits the redirected-stream read tasks so they finish or are observed
+        /// before the process is disposed, suppressing cancellation or failure
+        /// that is expected once the process has been killed.
+        /// </summary>
+        private static async Task ObserveQuietlyAsync(Task outputTask, Task errorTask)
+        {
+            async Task ObserveOneAsync(Task task)
+            {
+                try
+                {
+                    await task.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected when the cancellation token was passed to ReadToEndAsync.
+                }
+                catch (Exception)
+                {
+                    // The redirected stream read failed after process kill;
+                    // the cancellation result is still authoritative.
+                }
+            }
+
+            await Task.WhenAll(ObserveOneAsync(outputTask), ObserveOneAsync(errorTask))
+                .ConfigureAwait(false);
         }
     }
 }

--- a/DTXMania.Game/Platform/Mac/MacFolderPickerService.cs
+++ b/DTXMania.Game/Platform/Mac/MacFolderPickerService.cs
@@ -1,0 +1,169 @@
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Stage.Config;
+
+namespace DTXMania.Game.Platform
+{
+    /// <summary>macOS folder picker implemented with AppleScript Standard Additions.</summary>
+    internal sealed class MacFolderPickerService : IFolderPickerService
+    {
+        private const string OsaScriptPath = "/usr/bin/osascript";
+        private const string CancelledMarker = "__DTXMANIA_FOLDER_PICKER_CANCELLED__";
+
+        public async Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return FolderPickerResult.Cancelled();
+
+            Process? process = null;
+            try
+            {
+                process = Process.Start(CreateStartInfo(initialDirectory));
+                if (process == null)
+                    return FolderPickerResult.Unavailable("Unable to start the macOS folder picker.");
+
+                var outputTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+                var errorTask = process.StandardError.ReadToEndAsync(cancellationToken);
+                try
+                {
+                    await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    StopProcess(process);
+                    return FolderPickerResult.Cancelled();
+                }
+
+                var standardOutput = await outputTask.ConfigureAwait(false);
+                var standardError = await errorTask.ConfigureAwait(false);
+                return MapProcessResult(process.ExitCode, standardOutput, standardError);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                StopProcess(process);
+                return FolderPickerResult.Cancelled();
+            }
+            catch (Win32Exception exception)
+            {
+                return FolderPickerResult.Unavailable(exception.Message);
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                return FolderPickerResult.Failed(exception.Message);
+            }
+            catch (Exception exception)
+            {
+                return FolderPickerResult.Failed(exception.Message);
+            }
+            finally
+            {
+                process?.Dispose();
+            }
+        }
+
+        internal static ProcessStartInfo CreateStartInfo(string? initialDirectory)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = OsaScriptPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            startInfo.ArgumentList.Add("-e");
+            startInfo.ArgumentList.Add(BuildAppleScript(initialDirectory));
+            return startInfo;
+        }
+
+        internal static FolderPickerResult MapProcessResult(
+            int exitCode,
+            string standardOutput,
+            string standardError)
+        {
+            var output = standardOutput?.Trim() ?? string.Empty;
+            var error = standardError?.Trim() ?? string.Empty;
+            var details = string.IsNullOrWhiteSpace(error) ? output : error;
+
+            if (exitCode == 0)
+            {
+                if (string.Equals(output, CancelledMarker, StringComparison.Ordinal) ||
+                    string.IsNullOrWhiteSpace(output))
+                {
+                    return FolderPickerResult.Cancelled();
+                }
+
+                return FolderPickerResult.Selected(output);
+            }
+
+            if (details.Contains("-128", StringComparison.Ordinal) ||
+                details.Contains("User canceled", StringComparison.OrdinalIgnoreCase))
+            {
+                return FolderPickerResult.Cancelled();
+            }
+
+            // -1743 is the Apple event authorization-denied code. It is a real
+            // failure, not a user cancellation, so the overlay keeps its draft open.
+            if (details.Contains("-1743", StringComparison.Ordinal) ||
+                details.Contains("not authorized", StringComparison.OrdinalIgnoreCase))
+            {
+                return FolderPickerResult.Failed(
+                    string.IsNullOrWhiteSpace(details)
+                        ? "macOS denied folder-picker authorization."
+                        : details);
+            }
+
+            return FolderPickerResult.Failed(
+                string.IsNullOrWhiteSpace(details)
+                    ? $"macOS folder picker exited with code {exitCode}."
+                    : details);
+        }
+
+        private static string BuildAppleScript(string? initialDirectory)
+        {
+            var defaultLocation = !string.IsNullOrWhiteSpace(initialDirectory) &&
+                                  Directory.Exists(initialDirectory)
+                ? $" default location POSIX file \"{EscapeAppleScriptString(initialDirectory)}\""
+                : string.Empty;
+
+            return "try\n" +
+                   "set selectedFolder to choose folder with prompt \"Choose song folder\"" + defaultLocation + "\n" +
+                   "return POSIX path of selectedFolder\n" +
+                   "on error number -128\n" +
+                   $"return \"{CancelledMarker}\"\n" +
+                   "end try";
+        }
+
+        private static string EscapeAppleScriptString(string value) =>
+            value.Replace("\\", "\\\\", StringComparison.Ordinal)
+                .Replace("\"", "\\\"", StringComparison.Ordinal);
+
+        private static void StopProcess(Process? process)
+        {
+            if (process == null)
+                return;
+
+            try
+            {
+                if (!process.HasExited)
+                    process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited between HasExited and Kill.
+            }
+            catch (Win32Exception)
+            {
+                // Best effort only; the cancellation result is still authoritative.
+            }
+        }
+    }
+}

--- a/DTXMania.Game/Platform/Mac/MacFolderPickerService.cs
+++ b/DTXMania.Game/Platform/Mac/MacFolderPickerService.cs
@@ -87,8 +87,8 @@ namespace DTXMania.Game.Platform
 
         internal static FolderPickerResult MapProcessResult(
             int exitCode,
-            string standardOutput,
-            string standardError)
+            string? standardOutput,
+            string? standardError)
         {
             var output = standardOutput?.Trim() ?? string.Empty;
             var error = standardError?.Trim() ?? string.Empty;

--- a/DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs
+++ b/DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs
@@ -1,0 +1,182 @@
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using DTXMania.Game.Lib.Stage.Config;
+
+namespace DTXMania.Game.Platform
+{
+    /// <summary>
+    /// Windows folder picker running all WinForms dialog work on an owned STA
+    /// dispatcher thread. Config's update path never needs to assume STA.
+    /// </summary>
+    internal sealed class WindowsFolderPickerService : IFolderPickerService, IDisposable
+    {
+        private readonly BlockingCollection<PickerRequest> _requests = new();
+        private readonly CancellationTokenSource _shutdown = new();
+        private readonly Thread _dispatcherThread;
+        private int _disposed;
+
+        public WindowsFolderPickerService()
+        {
+            _dispatcherThread = new Thread(DispatchRequests)
+            {
+                IsBackground = true,
+                Name = "DTXMania Folder Picker STA",
+            };
+            _dispatcherThread.SetApartmentState(ApartmentState.STA);
+            _dispatcherThread.Start();
+        }
+
+        internal ApartmentState DispatcherApartmentState => _dispatcherThread.GetApartmentState();
+
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return Task.FromResult(FolderPickerResult.Cancelled());
+
+            if (Volatile.Read(ref _disposed) != 0)
+            {
+                return Task.FromResult(FolderPickerResult.Unavailable(
+                    "The Windows folder picker is no longer available."));
+            }
+
+            var request = new PickerRequest(initialDirectory, cancellationToken);
+            try
+            {
+                _requests.Add(request, _shutdown.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                request.Complete(cancellationToken.IsCancellationRequested
+                    ? FolderPickerResult.Cancelled()
+                    : FolderPickerResult.Unavailable("The Windows folder picker is shutting down."));
+            }
+            catch (InvalidOperationException)
+            {
+                request.Complete(FolderPickerResult.Unavailable(
+                    "The Windows folder picker is no longer available."));
+            }
+
+            return request.Task;
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            _requests.CompleteAdding();
+            _shutdown.Cancel();
+            if (!ReferenceEquals(Thread.CurrentThread, _dispatcherThread) &&
+                _dispatcherThread.Join(TimeSpan.FromSeconds(1)))
+            {
+                _requests.Dispose();
+                _shutdown.Dispose();
+            }
+        }
+
+        private void DispatchRequests()
+        {
+            try
+            {
+                foreach (var request in _requests.GetConsumingEnumerable(_shutdown.Token))
+                {
+                    if (request.CancellationToken.IsCancellationRequested)
+                    {
+                        request.Complete(FolderPickerResult.Cancelled());
+                        continue;
+                    }
+
+                    request.Complete(ShowDialog(request.InitialDirectory, request.CancellationToken));
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Dispose requested while the dispatcher was idle.
+            }
+            finally
+            {
+                while (_requests.TryTake(out var request))
+                {
+                    request.Complete(FolderPickerResult.Unavailable(
+                        "The Windows folder picker is shutting down."));
+                }
+            }
+        }
+
+        private static FolderPickerResult ShowDialog(
+            string? initialDirectory,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    return FolderPickerResult.Cancelled();
+
+                using var dialog = new FolderBrowserDialog
+                {
+                    Description = "Choose song folder",
+                    UseDescriptionForTitle = true,
+                };
+                if (!string.IsNullOrWhiteSpace(initialDirectory) && Directory.Exists(initialDirectory))
+                    dialog.SelectedPath = initialDirectory;
+
+                var result = dialog.ShowDialog();
+                if (cancellationToken.IsCancellationRequested ||
+                    result != DialogResult.OK ||
+                    string.IsNullOrWhiteSpace(dialog.SelectedPath))
+                {
+                    return FolderPickerResult.Cancelled();
+                }
+
+                return FolderPickerResult.Selected(dialog.SelectedPath);
+            }
+            catch (Win32Exception exception)
+            {
+                return FolderPickerResult.Unavailable(exception.Message);
+            }
+            catch (Exception exception)
+            {
+                return FolderPickerResult.Failed(exception.Message);
+            }
+        }
+
+        private sealed class PickerRequest
+        {
+            private readonly TaskCompletionSource<FolderPickerResult> _completion =
+                new(TaskCreationOptions.RunContinuationsAsynchronously);
+            private CancellationTokenRegistration _cancellationRegistration;
+
+            internal PickerRequest(string? initialDirectory, CancellationToken cancellationToken)
+            {
+                InitialDirectory = initialDirectory;
+                CancellationToken = cancellationToken;
+                _cancellationRegistration = cancellationToken.Register(
+                    static state => ((PickerRequest)state!).Complete(FolderPickerResult.Cancelled()),
+                    this);
+                if (_completion.Task.IsCompleted)
+                    _cancellationRegistration.Dispose();
+            }
+
+            internal string? InitialDirectory { get; }
+
+            internal CancellationToken CancellationToken { get; }
+
+            internal Task<FolderPickerResult> Task => _completion.Task;
+
+            internal void Complete(FolderPickerResult result)
+            {
+                if (_completion.TrySetResult(result))
+                    _cancellationRegistration.Dispose();
+            }
+        }
+    }
+}

--- a/DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs
+++ b/DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs
@@ -109,7 +109,8 @@ namespace DTXMania.Game.Platform
                             var path = new char[MaxPathLength + 1];
                             return SHGetPathFromIDList(itemIdList, path)
                                 ? FolderPickerResult.Selected(new string(path).TrimEnd('\0'))
-                                : FolderPickerResult.Cancelled();
+                                : FolderPickerResult.Failed(
+                                    "The selected folder path could not be extracted from the picker result.");
                         }
                         finally
                         {

--- a/DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs
+++ b/DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs
@@ -1,182 +1,227 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
-using System.ComponentModel;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using DTXMania.Game.Lib.Stage.Config;
 
 namespace DTXMania.Game.Platform
 {
     /// <summary>
-    /// Windows folder picker running all WinForms dialog work on an owned STA
+    /// Windows folder picker running all native dialog work on an owned STA
     /// dispatcher thread. Config's update path never needs to assume STA.
     /// </summary>
     internal sealed class WindowsFolderPickerService : IFolderPickerService, IDisposable
     {
-        private readonly BlockingCollection<PickerRequest> _requests = new();
-        private readonly CancellationTokenSource _shutdown = new();
-        private readonly Thread _dispatcherThread;
-        private int _disposed;
+        private readonly StaFolderPickerDispatcher _dispatcher;
 
         public WindowsFolderPickerService()
+            : this(new WindowsFolderPickerDialogFactory())
         {
-            _dispatcherThread = new Thread(DispatchRequests)
-            {
-                IsBackground = true,
-                Name = "DTXMania Folder Picker STA",
-            };
-            _dispatcherThread.SetApartmentState(ApartmentState.STA);
-            _dispatcherThread.Start();
         }
 
-        internal ApartmentState DispatcherApartmentState => _dispatcherThread.GetApartmentState();
+        internal WindowsFolderPickerService(IStaFolderPickerDialogFactory dialogFactory)
+        {
+            _dispatcher = new StaFolderPickerDispatcher(
+                dialogFactory,
+                static thread => thread.SetApartmentState(ApartmentState.STA));
+        }
+
+        internal ApartmentState DispatcherApartmentState => _dispatcher.DispatcherApartmentState;
 
         public Task<FolderPickerResult> PickFolderAsync(
             string? initialDirectory,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken) =>
+            _dispatcher.PickFolderAsync(initialDirectory, cancellationToken);
+
+        public void Dispose() => _dispatcher.Dispose();
+
+        private sealed class WindowsFolderPickerDialogFactory : IStaFolderPickerDialogFactory
         {
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromResult(FolderPickerResult.Cancelled());
-
-            if (Volatile.Read(ref _disposed) != 0)
+            public void InitializeDispatcherThread()
             {
-                return Task.FromResult(FolderPickerResult.Unavailable(
-                    "The Windows folder picker is no longer available."));
             }
 
-            var request = new PickerRequest(initialDirectory, cancellationToken);
-            try
-            {
-                _requests.Add(request, _shutdown.Token);
-            }
-            catch (OperationCanceledException)
-            {
-                request.Complete(cancellationToken.IsCancellationRequested
-                    ? FolderPickerResult.Cancelled()
-                    : FolderPickerResult.Unavailable("The Windows folder picker is shutting down."));
-            }
-            catch (InvalidOperationException)
-            {
-                request.Complete(FolderPickerResult.Unavailable(
-                    "The Windows folder picker is no longer available."));
-            }
+            public IStaFolderPickerDialog CreateDialog() => new WindowsFolderPickerDialog();
 
-            return request.Task;
-        }
-
-        public void Dispose()
-        {
-            if (Interlocked.Exchange(ref _disposed, 1) != 0)
-                return;
-
-            _requests.CompleteAdding();
-            _shutdown.Cancel();
-            if (!ReferenceEquals(Thread.CurrentThread, _dispatcherThread) &&
-                _dispatcherThread.Join(TimeSpan.FromSeconds(1)))
+            public void CloseOnDispatcher(IStaFolderPickerDialog dialog)
             {
-                _requests.Dispose();
-                _shutdown.Dispose();
+                // WindowsFolderPickerDialog posts WM_CLOSE to the native window;
+                // Windows dispatches that message on the dialog's STA thread.
+                dialog.Close();
             }
         }
 
-        private void DispatchRequests()
+        /// <summary>
+        /// A closeable native SHBrowseForFolder dialog. FolderBrowserDialog does
+        /// not expose its modal window handle, so its ShowDialog call cannot be
+        /// released deterministically after cancellation. The callback here
+        /// captures that native handle and posts WM_CLOSE to its owning STA.
+        /// </summary>
+        private sealed class WindowsFolderPickerDialog : IStaFolderPickerDialog
         {
-            try
+            private const uint BifReturnOnlyFileSystemDirectories = 0x0001;
+            private const uint BifEditBox = 0x0010;
+            private const uint BifNewDialogStyle = 0x0040;
+            private const uint BffmInitialized = 1;
+            private const uint BffmSetSelectionW = 0x0400 + 103;
+            private const uint WmClose = 0x0010;
+            private const int MaxPathLength = 260;
+
+            private readonly object _dialogLock = new();
+            private IntPtr _dialogHandle;
+            private bool _closeRequested;
+            private string? _initialDirectory;
+
+            public FolderPickerResult Show(string? initialDirectory)
             {
-                foreach (var request in _requests.GetConsumingEnumerable(_shutdown.Token))
+                try
                 {
-                    if (request.CancellationToken.IsCancellationRequested)
+                    _initialDirectory = !string.IsNullOrWhiteSpace(initialDirectory) &&
+                        Directory.Exists(initialDirectory)
+                        ? initialDirectory
+                        : null;
+
+                    var callback = new BrowseCallback(HandleBrowseCallback);
+                    var displayName = Marshal.AllocHGlobal((MaxPathLength + 1) * sizeof(char));
+                    var handle = GCHandle.Alloc(this);
+                    try
                     {
-                        request.Complete(FolderPickerResult.Cancelled());
-                        continue;
+                        var browseInfo = new BrowseInfo
+                        {
+                            DisplayName = displayName,
+                            Title = "Choose song folder",
+                            Flags = BifReturnOnlyFileSystemDirectories |
+                                BifEditBox |
+                                BifNewDialogStyle,
+                            Callback = callback,
+                            CallbackData = GCHandle.ToIntPtr(handle),
+                        };
+
+                        var itemIdList = SHBrowseForFolder(ref browseInfo);
+                        if (itemIdList == IntPtr.Zero)
+                            return FolderPickerResult.Cancelled();
+
+                        try
+                        {
+                            var path = new char[MaxPathLength + 1];
+                            return SHGetPathFromIDList(itemIdList, path)
+                                ? FolderPickerResult.Selected(new string(path).TrimEnd('\0'))
+                                : FolderPickerResult.Cancelled();
+                        }
+                        finally
+                        {
+                            Marshal.FreeCoTaskMem(itemIdList);
+                        }
                     }
-
-                    request.Complete(ShowDialog(request.InitialDirectory, request.CancellationToken));
+                    finally
+                    {
+                        handle.Free();
+                        Marshal.FreeHGlobal(displayName);
+                        lock (_dialogLock)
+                            _dialogHandle = IntPtr.Zero;
+                    }
+                }
+                catch (Exception exception)
+                {
+                    return FolderPickerResult.Failed(exception.Message);
                 }
             }
-            catch (OperationCanceledException)
+
+            public void Close()
             {
-                // Dispose requested while the dispatcher was idle.
-            }
-            finally
-            {
-                while (_requests.TryTake(out var request))
+                lock (_dialogLock)
                 {
-                    request.Complete(FolderPickerResult.Unavailable(
-                        "The Windows folder picker is shutting down."));
+                    _closeRequested = true;
+                    PostCloseMessage(_dialogHandle);
                 }
             }
-        }
 
-        private static FolderPickerResult ShowDialog(
-            string? initialDirectory,
-            CancellationToken cancellationToken)
-        {
-            try
+            public void Dispose() => Close();
+
+            private int HandleBrowseCallback(
+                IntPtr windowHandle,
+                uint message,
+                IntPtr lParam,
+                IntPtr callbackData)
             {
-                if (cancellationToken.IsCancellationRequested)
-                    return FolderPickerResult.Cancelled();
+                if (message != BffmInitialized)
+                    return 0;
 
-                using var dialog = new FolderBrowserDialog
+                lock (_dialogLock)
                 {
-                    Description = "Choose song folder",
-                    UseDescriptionForTitle = true,
-                };
-                if (!string.IsNullOrWhiteSpace(initialDirectory) && Directory.Exists(initialDirectory))
-                    dialog.SelectedPath = initialDirectory;
-
-                var result = dialog.ShowDialog();
-                if (cancellationToken.IsCancellationRequested ||
-                    result != DialogResult.OK ||
-                    string.IsNullOrWhiteSpace(dialog.SelectedPath))
-                {
-                    return FolderPickerResult.Cancelled();
+                    _dialogHandle = windowHandle;
+                    if (_closeRequested)
+                    {
+                        PostCloseMessage(windowHandle);
+                    }
+                    else if (!string.IsNullOrWhiteSpace(_initialDirectory))
+                    {
+                        var path = Marshal.StringToHGlobalUni(_initialDirectory);
+                        try
+                        {
+                            SendMessage(windowHandle, BffmSetSelectionW, (IntPtr)1, path);
+                        }
+                        finally
+                        {
+                            Marshal.FreeHGlobal(path);
+                        }
+                    }
                 }
 
-                return FolderPickerResult.Selected(dialog.SelectedPath);
+                return 0;
             }
-            catch (Win32Exception exception)
+
+            private static void PostCloseMessage(IntPtr windowHandle)
             {
-                return FolderPickerResult.Unavailable(exception.Message);
+                if (windowHandle != IntPtr.Zero)
+                    PostMessage(windowHandle, WmClose, IntPtr.Zero, IntPtr.Zero);
             }
-            catch (Exception exception)
+
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            private struct BrowseInfo
             {
-                return FolderPickerResult.Failed(exception.Message);
-            }
-        }
-
-        private sealed class PickerRequest
-        {
-            private readonly TaskCompletionSource<FolderPickerResult> _completion =
-                new(TaskCreationOptions.RunContinuationsAsynchronously);
-            private CancellationTokenRegistration _cancellationRegistration;
-
-            internal PickerRequest(string? initialDirectory, CancellationToken cancellationToken)
-            {
-                InitialDirectory = initialDirectory;
-                CancellationToken = cancellationToken;
-                _cancellationRegistration = cancellationToken.Register(
-                    static state => ((PickerRequest)state!).Complete(FolderPickerResult.Cancelled()),
-                    this);
-                if (_completion.Task.IsCompleted)
-                    _cancellationRegistration.Dispose();
+                internal IntPtr OwnerWindow;
+                internal IntPtr RootItemIdList;
+                internal IntPtr DisplayName;
+                [MarshalAs(UnmanagedType.LPWStr)]
+                internal string? Title;
+                internal uint Flags;
+                internal BrowseCallback? Callback;
+                internal IntPtr CallbackData;
+                internal int ImageIndex;
             }
 
-            internal string? InitialDirectory { get; }
+            [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+            private delegate int BrowseCallback(
+                IntPtr windowHandle,
+                uint message,
+                IntPtr lParam,
+                IntPtr callbackData);
 
-            internal CancellationToken CancellationToken { get; }
+            [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+            private static extern IntPtr SHBrowseForFolder(ref BrowseInfo browseInfo);
 
-            internal Task<FolderPickerResult> Task => _completion.Task;
+            [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool SHGetPathFromIDList(IntPtr itemIdList, [Out] char[] path);
 
-            internal void Complete(FolderPickerResult result)
-            {
-                if (_completion.TrySetResult(result))
-                    _cancellationRegistration.Dispose();
-            }
+            [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+            private static extern IntPtr SendMessage(
+                IntPtr windowHandle,
+                uint message,
+                IntPtr wParam,
+                IntPtr lParam);
+
+            [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool PostMessage(
+                IntPtr windowHandle,
+                uint message,
+                IntPtr wParam,
+                IntPtr lParam);
         }
     }
 }

--- a/DTXMania.Test/Config/ConfigDataTests.cs
+++ b/DTXMania.Test/Config/ConfigDataTests.cs
@@ -31,6 +31,15 @@ public class ConfigDataTests
         Assert.False(config.AutoPlay);
     }
 
+    [Fact]
+    public void DefaultConfig_ShouldContainManagedSongRootAndMirror()
+    {
+        var config = new ConfigData();
+
+        Assert.Equal([AppPaths.GetDefaultSongsPath()], config.SongRoots);
+        Assert.Equal(config.SongRoots[0], config.DTXPath);
+    }
+
     [Theory]
     [InlineData(640, 480)]
     [InlineData(1280, 720)]

--- a/DTXMania.Test/Config/ConfigManagerTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerTests.cs
@@ -1440,4 +1440,104 @@ Key.Bad=abc
             File.Delete(tempFile);
         }
     }
+
+    [Fact]
+    public void SaveConfig_WhenSongRootsAreEmpty_ShouldNotOverwriteTheLegacyDtxPathMirror()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "dtxmania-empty-roots-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var prev = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", dir);
+        try
+        {
+            var configFile = Path.Combine(dir, "Config.ini");
+            var manager = new ConfigManager();
+            manager.LoadConfig(configFile);
+            // Force the defensive empty-roots branch: LoadConfig always populates at
+            // least one managed default, so clear it to exercise the guard.
+            var preservedDtxPath = "preserved-dtx-path";
+            manager.Config.SongRoots.Clear();
+            manager.Config.DTXPath = preservedDtxPath;
+
+            manager.SaveConfig(configFile);
+
+            // The empty-roots guard must skip reassigning DTXPath from SongRoots[0].
+            Assert.Equal(preservedDtxPath, manager.Config.DTXPath);
+            var contents = File.ReadAllText(configFile);
+            Assert.DoesNotContain("SongRoot.0=", contents, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", prev);
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveConfig_WhenWrittenToADifferentPathThanPending_ShouldRetainThePendingSaveMarker()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "dtxmania-pending-mismatch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var prev = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", dir);
+        try
+        {
+            var loadedConfig = Path.Combine(dir, "loaded.ini");
+            var otherConfig = Path.Combine(dir, "other.ini");
+            var manager = new ConfigManager();
+            manager.LoadConfig(loadedConfig);
+            // A scalar edit stages a deferred save against the loaded path.
+            manager.SetNoFail(true);
+
+            // Saving to a different path must NOT clear the pending marker for the
+            // loaded path, so a later FlushPendingSave still lands the deferred edit.
+            manager.SaveConfig(otherConfig);
+
+            manager.FlushPendingSave();
+
+            Assert.Contains("NoFail=True", File.ReadAllText(loadedConfig));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", prev);
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveConfig_WhenPendingPathCannotBeResolved_ShouldRetainThePendingSaveMarker()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "dtxmania-pending-bad-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var prev = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", dir);
+        try
+        {
+            var loadedConfig = Path.Combine(dir, "Config.ini");
+            var manager = new ConfigManager();
+            manager.LoadConfig(loadedConfig);
+            // Stage a pending save against a path containing an illegal NUL character so
+            // ClearMatchingPendingSavePath's Path.GetFullPath throws and the catch block
+            // retains the marker. SetScrollSpeed stores its configFilePath verbatim; pass
+            // a value that snaps away from the default (100) so MarkDirty actually runs.
+            manager.SetScrollSpeed("bad\0path", 200);
+
+            // Saving to the valid loaded path must not throw and must retain the bad
+            // pending marker (the comparison failure is logged, not fatal).
+            manager.SaveConfig(loadedConfig);
+
+            // FlushPendingSave retries the (bad) pending path and swallows the failure,
+            // so the in-memory edit is still correct even though the bad path never lands.
+            manager.FlushPendingSave();
+            Assert.Equal(200, manager.Config.ScrollSpeed);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", prev);
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+    }
 }

--- a/DTXMania.Test/Config/ConfigManagerTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerTests.cs
@@ -4,6 +4,7 @@ using DTXMania.Game.Lib.Utilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xna.Framework.Input;
 using Moq;
+using System.Reflection;
 using System.Text;
 
 namespace DTXMania.Test.Config;
@@ -1475,38 +1476,6 @@ Key.Bad=abc
     }
 
     [Fact]
-    public void SaveConfig_WhenWrittenToADifferentPathThanPending_ShouldRetainThePendingSaveMarker()
-    {
-        var dir = Path.Combine(Path.GetTempPath(), "dtxmania-pending-mismatch-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
-        var prev = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
-        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", dir);
-        try
-        {
-            var loadedConfig = Path.Combine(dir, "loaded.ini");
-            var otherConfig = Path.Combine(dir, "other.ini");
-            var manager = new ConfigManager();
-            manager.LoadConfig(loadedConfig);
-            // A scalar edit stages a deferred save against the loaded path.
-            manager.SetNoFail(true);
-
-            // Saving to a different path must NOT clear the pending marker for the
-            // loaded path, so a later FlushPendingSave still lands the deferred edit.
-            manager.SaveConfig(otherConfig);
-
-            manager.FlushPendingSave();
-
-            Assert.Contains("NoFail=True", File.ReadAllText(loadedConfig));
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", prev);
-            if (Directory.Exists(dir))
-                Directory.Delete(dir, recursive: true);
-        }
-    }
-
-    [Fact]
     public void SaveConfig_WhenPendingPathCannotBeResolved_ShouldRetainThePendingSaveMarker()
     {
         var dir = Path.Combine(Path.GetTempPath(), "dtxmania-pending-bad-" + Guid.NewGuid().ToString("N"));
@@ -1532,6 +1501,13 @@ Key.Bad=abc
             // so the in-memory edit is still correct even though the bad path never lands.
             manager.FlushPendingSave();
             Assert.Equal(200, manager.Config.ScrollSpeed);
+
+            // The invalid pending path must still be recorded so a future flush can
+            // retry it. Verify via reflection that _pendingSavePath was not cleared.
+            var pendingSavePath = typeof(ConfigManager)
+                .GetField("_pendingSavePath", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(manager) as string;
+            Assert.Equal("bad\0path", pendingSavePath);
         }
         finally
         {

--- a/DTXMania.Test/Config/ConfigManagerTests.cs
+++ b/DTXMania.Test/Config/ConfigManagerTests.cs
@@ -963,7 +963,7 @@ Key.Bad=abc
     /// the file makes the retry succeed. _pendingSavePath never changes.
     /// </summary>
     [Fact]
-    public void FlushPendingSave_RetriesAfterFailure_WhenFilesystemBecomesWritable()
+    public void FlushPendingSave_ShouldRetryAfterFailure()
     {
         var root = Path.Combine(Path.GetTempPath(), "dtxmania-flush-retry-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
@@ -1020,6 +1020,73 @@ Key.Bad=abc
             // clean up both possibilities.
             if (File.Exists(root))
                 File.Delete(root);
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveConfig_ShouldClearMatchingPendingPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "dtxmania-save-matching-" + Guid.NewGuid().ToString("N"));
+        var previousRoot = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+        Directory.CreateDirectory(root);
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", root);
+
+        try
+        {
+            var configFilePath = AppPaths.GetConfigFilePath();
+            var manager = new ConfigManager();
+            manager.LoadConfig(configFilePath);
+            manager.SetNoFail(true);
+
+            // The spelling differs but Path.GetFullPath resolves it to the loaded file.
+            manager.SaveConfig(Path.Combine(root, ".", "Config.ini"));
+
+            // Direct mutation does not mark a deferred save. If SaveConfig cleared the
+            // matching marker, FlushPendingSave must leave the persisted True intact.
+            manager.Config.NoFail = false;
+            manager.FlushPendingSave();
+
+            Assert.Contains("NoFail=True", File.ReadAllText(configFilePath));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", previousRoot);
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SaveConfig_ShouldRetainDifferentPendingPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "dtxmania-save-different-" + Guid.NewGuid().ToString("N"));
+        var previousRoot = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+        Directory.CreateDirectory(root);
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", root);
+
+        try
+        {
+            var pendingConfigPath = AppPaths.GetConfigFilePath();
+            var explicitConfigPath = Path.Combine(root, "explicit.ini");
+            var manager = new ConfigManager();
+            manager.LoadConfig(pendingConfigPath);
+            manager.SetNoFail(true);
+
+            manager.SaveConfig(explicitConfigPath);
+
+            // The marker still belongs to pendingConfigPath, so the next flush must
+            // persist the changed value there instead of discarding that deferred write.
+            manager.Config.NoFail = false;
+            manager.FlushPendingSave();
+
+            Assert.Contains("NoFail=False", File.ReadAllText(pendingConfigPath));
+            Assert.Contains("NoFail=True", File.ReadAllText(explicitConfigPath));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", previousRoot);
             if (Directory.Exists(root))
                 Directory.Delete(root, recursive: true);
         }

--- a/DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs
+++ b/DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs
@@ -1,0 +1,108 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class ConfigSongOperationCoordinatorTests
+{
+    [Fact]
+    public void TryAcquire_WhenIdle_ShouldGrantSingleLeaseUntilDisposed()
+    {
+        var coordinator = new ConfigSongOperationCoordinator();
+
+        var lease = coordinator.TryAcquire(ConfigSongOperationKind.NxScoreImport);
+
+        Assert.NotNull(lease);
+        Assert.Equal(ConfigSongOperationKind.NxScoreImport, lease!.Kind);
+        Assert.True(coordinator.IsBusy);
+
+        lease.Dispose();
+
+        Assert.False(coordinator.IsBusy);
+    }
+
+    [Fact]
+    public void TryAcquire_WhenAnyOperationOwnsLease_ShouldRejectOtherKind()
+    {
+        var coordinator = new ConfigSongOperationCoordinator();
+        using var nxLease = coordinator.TryAcquire(ConfigSongOperationKind.NxScoreImport);
+
+        var reloadLease = coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload);
+
+        Assert.NotNull(nxLease);
+        Assert.Null(reloadLease);
+        Assert.True(coordinator.IsBusy);
+    }
+
+    [Fact]
+    public void Lease_DisposeRepeatedly_ShouldReleaseExactlyOnce()
+    {
+        var coordinator = new ConfigSongOperationCoordinator();
+        var lease = Assert.IsType<ConfigSongOperationLease>(
+            coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload));
+
+        lease.Dispose();
+        lease.Dispose();
+
+        Assert.False(coordinator.IsBusy);
+        Assert.NotNull(coordinator.TryAcquire(ConfigSongOperationKind.NxScoreImport));
+    }
+
+    [Fact]
+    public void RegisterTerminal_WhenContinuationRegistrationThrows_ShouldKeepLeaseUntilTaskTerminates()
+    {
+        var coordinator = new ConfigSongOperationCoordinator();
+        var lease = Assert.IsType<ConfigSongOperationLease>(
+            coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload));
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            coordinator.RegisterTerminalContinuation(
+                lease,
+                completion.Task,
+                _ => { },
+                (_, _) => throw new InvalidOperationException("registration failed")));
+
+        Assert.Equal("registration failed", exception.Message);
+        Assert.True(coordinator.IsBusy);
+
+        completion.SetResult(true);
+        SpinWaitUntil(() => !coordinator.IsBusy);
+
+        Assert.False(coordinator.IsBusy);
+    }
+
+    [Fact]
+    public void ConstructOperation_WhenConstructionThrows_ShouldReleaseTheScopedLease()
+    {
+        var coordinator = new ConfigSongOperationCoordinator();
+        var lease = Assert.IsType<ConfigSongOperationLease>(
+            coordinator.TryAcquire(ConfigSongOperationKind.NxScoreImport));
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(ThrowDuringTaskConstruction);
+        }
+        finally
+        {
+            lease.Dispose();
+        }
+
+        Assert.False(coordinator.IsBusy);
+    }
+
+    private static void ThrowDuringTaskConstruction() =>
+        throw new InvalidOperationException("construction failed");
+
+    private static void SpinWaitUntil(Func<bool> condition)
+    {
+        Assert.True(System.Threading.SpinWait.SpinUntil(condition, TimeSpan.FromSeconds(2)),
+            "The operation lease was not released after the task terminated.");
+    }
+}

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -36,37 +36,87 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void SetupConfigItems_ShouldShowConfiguredDtxFolder()
+    public void SetupConfigItems_ShouldShowConfiguredSongFolderCount()
     {
         var (stage, configManager, inputManager) = CreateStage();
         using (inputManager)
         {
-            configManager.Config.DTXPath = "/tmp/custom dtx";
+            configManager.Config.SongRoots.Clear();
+            configManager.Config.SongRoots.Add("/tmp/custom dtx");
+            configManager.Config.SongRoots.Add("/tmp/community charts");
             InitializeStageMenu(stage, includePanels: false);
 
             var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
-            var item = categories!.SelectMany(c => c.Items).Single(i => i.Name == "DTX Folder");
+            var item = categories!.SelectMany(c => c.Items).Single(i => i.Name == "Song Folders");
 
-            Assert.Equal("DTX Folder: /tmp/custom dtx", item.GetDisplayText());
+            Assert.Equal("Song Folders: 2 folders", item.GetDisplayText());
+            configManager.Config.SongRoots.RemoveAt(1);
+            Assert.Equal("Song Folders: 1 folder", item.GetDisplayText());
         }
     }
 
     [Fact]
-    public void DtxFolderItem_WhenActivated_ShouldNotMutateConfig()
+    public void SongFoldersItem_WhenActivated_ShouldOpenOverlayWithoutMutatingConfig()
     {
         var (stage, configManager, inputManager) = CreateStage();
         using (inputManager)
         {
-            configManager.Config.DTXPath = "/tmp/custom dtx";
-            InitializeStageMenu(stage, includePanels: false);
-            SelectItemForEditing(stage, "DTX Folder");
+            configManager.Config.SongRoots.Clear();
+            configManager.Config.SongRoots.Add("/tmp/custom dtx");
+            InitializeStageMenu(stage, includePanels: true);
+            SelectItemForEditing(stage, "Song Folders");
             SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
 
             ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
 
-            // DTX Folder is read-only; Config must be unchanged.
-            Assert.Equal("/tmp/custom dtx", configManager.Config.DTXPath);
+            Assert.IsType<SongFolderPanel>(
+                ReflectionHelpers.GetPrivateField<IConfigOverlayPanel>(stage, "_activePanel"));
+            Assert.Equal(["/tmp/custom dtx"], configManager.Config.SongRoots);
         }
+    }
+
+    [Fact]
+    public void SongFoldersPanel_WhenApplyUpdatesConfig_ShouldShowRestartRequiredStatus()
+    {
+        var configuredRoot = Path.GetTempPath();
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add(configuredRoot);
+        var configManager = new Mock<IConfigManager>();
+        configManager.SetupGet(manager => manager.Config).Returns(configData);
+        configManager.Setup(manager => manager.SetSongRoots(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .Returns(new SongRootUpdateResult(
+                SongRootUpdateStatus.Updated,
+                new[] { configuredRoot },
+                Array.Empty<SongRootDiagnostic>()));
+
+        using var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager.Object);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+        var availability = new FfmpegRuntimeAvailability(true, null, BinaryFolder: null);
+        var picker = new Mock<IFolderPickerService>();
+        var stage = new ConfigStage(game, () => availability, () => picker.Object);
+
+        InitializeStageMenu(stage, includePanels: true);
+        SelectItemForEditing(stage, "Song Folders");
+        SetKeyboardStates(stage, new KeyboardState(Keys.Enter), new KeyboardState());
+        ReflectionHelpers.InvokePrivateMethod(stage, "HandleInput");
+
+        var panel = ReflectionHelpers.GetPrivateField<SongFolderPanel>(stage, "_songFolderPanel");
+        Assert.NotNull(panel);
+        for (var index = 0; index < 5; index++)
+            panel!.Update(0, new KeyboardState(Keys.Down), new KeyboardState());
+        panel!.Update(0, new KeyboardState(Keys.Enter), new KeyboardState());
+
+        configManager.Verify(manager => manager.SetSongRoots(
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Once);
+        Assert.Null(ReflectionHelpers.GetPrivateField<IConfigOverlayPanel>(stage, "_activePanel"));
+        Assert.Contains("restart",
+            ReflectionHelpers.GetPrivateField<string>(stage, "_songFolderStatus"),
+            StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -1043,7 +1093,7 @@ public class ConfigStageLogicTests
                 i => Assert.Equal("Fullscreen", i.Name),
                 i => Assert.Equal("VSync Wait", i.Name),
                 i => Assert.Equal("Audio Latency Offset", i.Name),
-                i => Assert.Equal("DTX Folder", i.Name),
+                i => Assert.Equal("Song Folders", i.Name),
                 i => Assert.Equal("System Key Mapping", i.Name),
                 i => Assert.Equal("Import NX Scores", i.Name));
 
@@ -1538,12 +1588,20 @@ public class ConfigStageLogicTests
         // stays on the white value cell and clear of the description panel (x=800). The
         // per-character mock font makes the overflow deterministic: 8px/char.
         var longPath = "/Users/testuser/Library/Application Support/DTXManiaCX/DTXFiles";
-        var configManager = new ConfigManager { Config = { DTXPath = longPath } };
-        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice(configManager);
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice();
         using (inputManager)
         {
             stage.InitializeDrawingState();
-            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_categories", new List<ConfigCategory>
+            {
+                new("System", "Test category", new List<IConfigItem>
+                {
+                    new ReadOnlyConfigItem("Long Value", () => longPath)
+                    {
+                        Description = "Long value rendering test."
+                    }
+                })
+            });
             ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
 

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -56,6 +56,41 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void DrawItemList_WhenSongFoldersHasMultipleRoots_ShouldRenderCountInValueColumn()
+    {
+        var configManager = new ConfigManager();
+        configManager.Config.SongRoots.Clear();
+        configManager.Config.SongRoots.Add("/tmp/first");
+        configManager.Config.SongRoots.Add("/tmp/second");
+        configManager.Config.SongRoots.Add("/tmp/third");
+        var (stage, inputManager) = CreateRenderSpyStageWithGraphicsDevice(configManager);
+        using (inputManager)
+        {
+            stage.InitializeDrawingState();
+            ReflectionHelpers.InvokePrivateMethod(stage, "SetupConfigItems");
+            ReflectionHelpers.SetPrivateField(stage, "_currentCategoryIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusOnMenu", false);
+
+            var font = new Mock<IFont>();
+            font.Setup(itemFont => itemFont.MeasureString(It.IsAny<string>()))
+                .Returns(new Vector2(40f, 14f));
+            var draws = new List<(string Text, Vector2 Position)>();
+            font.Setup(itemFont => itemFont.DrawString(
+                    It.IsAny<SpriteBatch>(), It.IsAny<string>(), It.IsAny<Vector2>(), It.IsAny<Color>()))
+                .Callback<SpriteBatch, string, Vector2, Color>((_, text, position, _) =>
+                    draws.Add((text, position)));
+            ReflectionHelpers.SetPrivateField(stage, "_font", font.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_boldFont", font.Object);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "DrawItemList");
+
+            var expectedValueX = ConfigUILayout.ItemListX + ConfigUILayout.ItemValueOffsetX;
+            Assert.Contains(draws, draw =>
+                draw.Text == "3 folders" && Math.Abs(draw.Position.X - expectedValueX) < 0.01f);
+        }
+    }
+
+    [Fact]
     public void SongFoldersItem_WhenActivated_ShouldOpenOverlayWithoutMutatingConfig()
     {
         var (stage, configManager, inputManager) = CreateStage();

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -111,7 +111,7 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
-    public void SongFoldersPanel_WhenApplyUpdatesConfig_ShouldShowRestartRequiredStatus()
+    public void SongFoldersPanel_WhenApplyIsUnchanged_ShouldCloseWithoutStartingReload()
     {
         var configuredRoot = Path.GetTempPath();
         var configData = new ConfigData();
@@ -119,13 +119,6 @@ public class ConfigStageLogicTests
         configData.SongRoots.Add(configuredRoot);
         var configManager = new Mock<IConfigManager>();
         configManager.SetupGet(manager => manager.Config).Returns(configData);
-        configManager.Setup(manager => manager.SetSongRoots(
-                It.IsAny<string>(),
-                It.IsAny<IReadOnlyList<string>>()))
-            .Returns(new SongRootUpdateResult(
-                SongRootUpdateStatus.Updated,
-                new[] { configuredRoot },
-                Array.Empty<SongRootDiagnostic>()));
 
         using var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
         var game = ReflectionHelpers.CreateGame();
@@ -147,11 +140,10 @@ public class ConfigStageLogicTests
         panel!.Update(0, new KeyboardState(Keys.Enter), new KeyboardState());
 
         configManager.Verify(manager => manager.SetSongRoots(
-            It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Once);
+            It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Never);
         Assert.Null(ReflectionHelpers.GetPrivateField<IConfigOverlayPanel>(stage, "_activePanel"));
-        Assert.Contains("restart",
-            ReflectionHelpers.GetPrivateField<string>(stage, "_songFolderStatus"),
-            StringComparison.OrdinalIgnoreCase);
+        Assert.True(string.IsNullOrEmpty(
+            ReflectionHelpers.GetPrivateField<string>(stage, "_songFolderStatus")));
     }
 
     [Fact]

--- a/DTXMania.Test/Config/ConfigStageLogicTests.cs
+++ b/DTXMania.Test/Config/ConfigStageLogicTests.cs
@@ -56,6 +56,23 @@ public class ConfigStageLogicTests
     }
 
     [Fact]
+    public void SetupConfigItems_SongFoldersDescription_ShouldExplainApplyTriggersOneLiveReload()
+    {
+        var (stage, _, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            var categories = ReflectionHelpers.GetPrivateField<List<ConfigCategory>>(stage, "_categories");
+            var item = categories!.SelectMany(category => category.Items)
+                .Single(item => item.Name == "Song Folders");
+
+            Assert.Equal(
+                "Edit the ordered song folders. Apply saves the list and triggers one live reload.",
+                item.Description);
+        }
+    }
+
+    [Fact]
     public void DrawItemList_WhenSongFoldersHasMultipleRoots_ShouldRenderCountInValueColumn()
     {
         var configManager = new ConfigManager();

--- a/DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs
+++ b/DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs
@@ -26,6 +26,8 @@ public sealed class DTXPathCompatibilityArchitectureTests
                 gameDirectory,
                 "*.cs",
                 SearchOption.AllDirectories)
+            .Where(path => !path.Contains(Path.DirectorySeparatorChar + "bin" + Path.DirectorySeparatorChar, StringComparison.Ordinal)
+                           && !path.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar, StringComparison.Ordinal))
             .Where(path => File.ReadAllText(path).Contains(
                 "DTXPath",
                 StringComparison.Ordinal))
@@ -35,7 +37,9 @@ public sealed class DTXPathCompatibilityArchitectureTests
             .OrderBy(relativePath => relativePath, StringComparer.Ordinal)
             .ToArray();
 
-        Assert.Empty(offenders);
+        Assert.True(offenders.Length == 0,
+            "The following files reference DTXPath outside the compatibility boundary: " +
+            string.Join(", ", offenders));
     }
 
     private static string FindGameDirectory()

--- a/DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs
+++ b/DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Architecture")]
+public sealed class DTXPathCompatibilityArchitectureTests
+{
+    [Fact]
+    public void ProductionDTXPathReferences_ShouldBeLimitedToCompatibilityBoundary()
+    {
+        var gameDirectory = FindGameDirectory();
+        var allowedFiles = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Lib/Config/ConfigData.cs",
+            "Lib/Config/ConfigManager.cs",
+            "Lib/Stage/ConfigStage.cs",
+        };
+
+        var offenders = Directory.EnumerateFiles(
+                gameDirectory,
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => File.ReadAllText(path).Contains(
+                "DTXPath",
+                StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(gameDirectory, path)
+                .Replace(Path.DirectorySeparatorChar, '/'))
+            .Where(relativePath => !allowedFiles.Contains(relativePath))
+            .OrderBy(relativePath => relativePath, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(offenders);
+    }
+
+    private static string FindGameDirectory()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory != null;
+             directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "DTXMania.Game");
+            if (Directory.Exists(candidate))
+                return candidate;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate the DTXMania.Game source directory.");
+    }
+}

--- a/DTXMania.Test/Config/FolderPickerContractTests.cs
+++ b/DTXMania.Test/Config/FolderPickerContractTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game.Lib.Stage.Config;
@@ -86,5 +87,101 @@ public sealed class FolderPickerContractTests
     public void PlatformFactory_ShouldProduceTheMacPickerForTheMacBuild()
     {
         Assert.IsType<MacFolderPickerService>(FolderPickerServiceFactory.Create());
+    }
+
+    [Fact]
+    public async Task StaDispatcher_WhenCancellationOccursWhileDialogIsOpen_ShouldCloseItAndServeTheNextRequest()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var firstDialog = new BlockingFolderPickerDialog();
+        var secondDialog = new ImmediateFolderPickerDialog(FolderPickerResult.Selected("/tmp/next-songs"));
+        var factory = new QueuedFolderPickerDialogFactory(firstDialog, secondDialog);
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var firstRequest = picker.PickFolderAsync(null, cancellation.Token);
+        await firstDialog.Opened.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        cancellation.Cancel();
+
+        var firstResult = await firstRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        var secondResult = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Cancelled, firstResult.Status);
+        Assert.Equal(FolderPickerStatus.Selected, secondResult.Status);
+        Assert.Equal("/tmp/next-songs", secondResult.Path);
+        Assert.Equal(1, factory.CloseRequests);
+        Assert.Equal(1, firstDialog.CloseRequests);
+    }
+
+    private sealed class QueuedFolderPickerDialogFactory : IStaFolderPickerDialogFactory
+    {
+        private readonly Queue<IStaFolderPickerDialog> _dialogs;
+
+        internal QueuedFolderPickerDialogFactory(params IStaFolderPickerDialog[] dialogs)
+        {
+            _dialogs = new Queue<IStaFolderPickerDialog>(dialogs);
+        }
+
+        internal int CloseRequests { get; private set; }
+
+        public void InitializeDispatcherThread()
+        {
+        }
+
+        public IStaFolderPickerDialog CreateDialog() => _dialogs.Dequeue();
+
+        public void CloseOnDispatcher(IStaFolderPickerDialog dialog)
+        {
+            CloseRequests++;
+            dialog.Close();
+        }
+    }
+
+    private sealed class BlockingFolderPickerDialog : IStaFolderPickerDialog
+    {
+        private readonly ManualResetEventSlim _closed = new(false);
+
+        internal TaskCompletionSource<bool> Opened { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal int CloseRequests { get; private set; }
+
+        public FolderPickerResult Show(string? initialDirectory)
+        {
+            Opened.TrySetResult(true);
+            if (!_closed.Wait(TimeSpan.FromSeconds(3)))
+                throw new TimeoutException("The test dialog was not closed after cancellation.");
+
+            return FolderPickerResult.Cancelled();
+        }
+
+        public void Close()
+        {
+            CloseRequests++;
+            _closed.Set();
+        }
+
+        public void Dispose() => _closed.Dispose();
+    }
+
+    private sealed class ImmediateFolderPickerDialog : IStaFolderPickerDialog
+    {
+        private readonly FolderPickerResult _result;
+
+        internal ImmediateFolderPickerDialog(FolderPickerResult result)
+        {
+            _result = result;
+        }
+
+        public FolderPickerResult Show(string? initialDirectory) => _result;
+
+        public void Close()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
     }
 }

--- a/DTXMania.Test/Config/FolderPickerContractTests.cs
+++ b/DTXMania.Test/Config/FolderPickerContractTests.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Game.Platform;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class FolderPickerContractTests
+{
+    [Fact]
+    public void SelectedResult_ShouldCarryTheSelectedFolderPath()
+    {
+        var result = FolderPickerResult.Selected("/tmp/songs");
+
+        Assert.Equal(FolderPickerStatus.Selected, result.Status);
+        Assert.Equal("/tmp/songs", result.Path);
+        Assert.Null(result.Message);
+    }
+
+    [Theory]
+    [InlineData(FolderPickerStatus.Cancelled)]
+    [InlineData(FolderPickerStatus.Unavailable)]
+    [InlineData(FolderPickerStatus.Failed)]
+    public void NonSelectedResult_ShouldNotExposeAUsablePath(FolderPickerStatus status)
+    {
+        var result = new FolderPickerResult(status, message: "test message");
+
+        Assert.Null(result.Path);
+        Assert.Equal(status, result.Status);
+    }
+
+    [Fact]
+    public void SelectedResult_WithoutAPath_ShouldBeRejected()
+    {
+        Assert.Throws<ArgumentException>(() => new FolderPickerResult(FolderPickerStatus.Selected));
+    }
+
+    [Fact]
+    public void NonSelectedResult_WithAPath_ShouldBeRejected()
+    {
+        Assert.Throws<ArgumentException>(() => new FolderPickerResult(
+            FolderPickerStatus.Cancelled,
+            path: "/tmp/not-a-selection"));
+    }
+
+    [Fact]
+    public async Task MacPicker_WhenCancellationWasRequestedBeforeStart_ShouldReturnCancelledWithoutLaunchingProcess()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var picker = new MacFolderPickerService();
+
+        var result = await picker.PickFolderAsync(null, cancellation.Token);
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public void MacPicker_WhenAppleScriptReportsUserCancellation_ShouldMapToCancelled()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: string.Empty,
+            standardError: "User canceled. (-128)");
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public void MacPicker_WhenAppleScriptReportsAuthorizationDenied_ShouldMapToFailed()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: string.Empty,
+            standardError: "Not authorized to send Apple events to System Events. (-1743)");
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.False(string.IsNullOrWhiteSpace(result.Message));
+    }
+
+    [Fact]
+    public void PlatformFactory_ShouldProduceTheMacPickerForTheMacBuild()
+    {
+        Assert.IsType<MacFolderPickerService>(FolderPickerServiceFactory.Create());
+    }
+}

--- a/DTXMania.Test/Config/FolderPickerContractTests.cs
+++ b/DTXMania.Test/Config/FolderPickerContractTests.cs
@@ -155,6 +155,92 @@ public sealed class FolderPickerContractTests
         Assert.Equal("/tmp/second-songs", secondResult.Path);
     }
 
+    [Fact]
+    public async Task StaDispatcher_WhenAlreadyCancelledBeforeEnqueue_ShouldReturnCancelledImmediately()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var factory = new QueuedFolderPickerDialogFactory(
+            new ImmediateFolderPickerDialog(FolderPickerResult.Selected("/tmp/songs")));
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var result = await picker.PickFolderAsync(null, cancellation.Token)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public async Task StaDispatcher_WhenRequestArrivesAfterDisposal_ShouldReturnUnavailable()
+    {
+        var factory = new QueuedFolderPickerDialogFactory(
+            new ImmediateFolderPickerDialog(FolderPickerResult.Selected("/tmp/songs")));
+        var picker = new StaFolderPickerDispatcher(factory);
+        picker.Dispose();
+
+        var result = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Unavailable, result.Status);
+    }
+
+    [Fact]
+    public async Task StaDispatcher_WhenCloseOnDispatcherThrows_ShouldStillReportCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var firstDialog = new BlockingFolderPickerDialog();
+        var factory = new CloseThrowingFolderPickerDialogFactory(firstDialog);
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var request = picker.PickFolderAsync(null, cancellation.Token);
+        await firstDialog.Opened.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        cancellation.Cancel();
+
+        var result = await request.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+        Assert.Equal(1, factory.CloseRequests);
+    }
+
+    [Fact]
+    public async Task StaDispatcher_WhenCancellationTargetsARequestThatIsNotActive_ShouldCompleteItAsCancelled()
+    {
+        // Queue two requests against a blocking first dialog. Cancelling the second
+        // request while the first is still open must complete the second as Cancelled
+        // even though it is not the active dialog (CancelRequest's null-active branch).
+        using var firstCancellation = new CancellationTokenSource();
+        using var secondCancellation = new CancellationTokenSource();
+        var firstDialog = new BlockingFolderPickerDialog();
+        var secondDialog = new ImmediateFolderPickerDialog(FolderPickerResult.Selected("/tmp/second"));
+        var factory = new QueuedFolderPickerDialogFactory(firstDialog, secondDialog);
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var firstRequest = picker.PickFolderAsync(null, firstCancellation.Token);
+        await firstDialog.Opened.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var secondRequest = picker.PickFolderAsync(null, secondCancellation.Token);
+
+        secondCancellation.Cancel();
+        var secondResult = await secondRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(FolderPickerStatus.Cancelled, secondResult.Status);
+
+        // The first request is still open; release and assert it completes.
+        firstCancellation.Cancel();
+        var firstResult = await firstRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(FolderPickerStatus.Cancelled, firstResult.Status);
+    }
+
+    [Fact]
+    public void StaDispatcher_DisposeCalledTwice_ShouldBeIdempotent()
+    {
+        var factory = new QueuedFolderPickerDialogFactory(
+            new ImmediateFolderPickerDialog(FolderPickerResult.Selected("/tmp/songs")));
+        var picker = new StaFolderPickerDispatcher(factory);
+
+        picker.Dispose();
+        // A second dispose must not throw and must remain a no-op.
+        picker.Dispose();
+    }
+
     private sealed class QueuedFolderPickerDialogFactory : IStaFolderPickerDialogFactory
     {
         private readonly Queue<IStaFolderPickerDialog> _dialogs;
@@ -267,6 +353,30 @@ public sealed class FolderPickerContractTests
         {
             DisposeAttempted.TrySetResult(true);
             throw new InvalidOperationException("The native dialog could not be disposed.");
+        }
+    }
+
+    private sealed class CloseThrowingFolderPickerDialogFactory : IStaFolderPickerDialogFactory
+    {
+        private readonly IStaFolderPickerDialog _dialog;
+
+        internal CloseThrowingFolderPickerDialogFactory(IStaFolderPickerDialog dialog)
+        {
+            _dialog = dialog;
+        }
+
+        internal int CloseRequests { get; private set; }
+
+        public void InitializeDispatcherThread()
+        {
+        }
+
+        public IStaFolderPickerDialog CreateDialog() => _dialog;
+
+        public void CloseOnDispatcher(IStaFolderPickerDialog dialog)
+        {
+            CloseRequests++;
+            throw new InvalidOperationException("The platform close marshalling failed.");
         }
     }
 }

--- a/DTXMania.Test/Config/FolderPickerContractTests.cs
+++ b/DTXMania.Test/Config/FolderPickerContractTests.cs
@@ -100,7 +100,7 @@ public sealed class FolderPickerContractTests
         using var picker = new StaFolderPickerDispatcher(factory);
 
         var firstRequest = picker.PickFolderAsync(null, cancellation.Token);
-        await firstDialog.Opened.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await firstDialog.Opened.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         cancellation.Cancel();
 

--- a/DTXMania.Test/Config/FolderPickerContractTests.cs
+++ b/DTXMania.Test/Config/FolderPickerContractTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game.Lib.Stage.Config;
 using DTXMania.Game.Platform;
+using DTXMania.Test.TestData;
 
 namespace DTXMania.Test.Config;
 
@@ -114,6 +115,46 @@ public sealed class FolderPickerContractTests
         Assert.Equal(1, firstDialog.CloseRequests);
     }
 
+    [Fact]
+    public async Task StaDispatcher_WhenInitializationFails_ShouldRejectSubsequentRequestsAfterThreadStops()
+    {
+        var factory = new InitializationFailingFolderPickerDialogFactory();
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        await factory.InitializationAttempted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var dispatcherThread = ReflectionHelpers.GetPrivateField<Thread>(picker, "_dispatcherThread");
+        Assert.NotNull(dispatcherThread);
+        Assert.True(dispatcherThread!.Join(TimeSpan.FromSeconds(1)));
+
+        var result = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Unavailable, result.Status);
+    }
+
+    [Fact]
+    public async Task StaDispatcher_WhenDialogDisposalFails_ShouldContinueServingSubsequentRequests()
+    {
+        var firstDialog = new DisposeThrowingFolderPickerDialog(
+            FolderPickerResult.Selected("/tmp/first-songs"));
+        var secondDialog = new ImmediateFolderPickerDialog(
+            FolderPickerResult.Selected("/tmp/second-songs"));
+        var factory = new QueuedFolderPickerDialogFactory(firstDialog, secondDialog);
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var firstResult = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+        await firstDialog.DisposeAttempted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        var secondResult = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Selected, firstResult.Status);
+        Assert.Equal("/tmp/first-songs", firstResult.Path);
+        Assert.Equal(FolderPickerStatus.Selected, secondResult.Status);
+        Assert.Equal("/tmp/second-songs", secondResult.Path);
+    }
+
     private sealed class QueuedFolderPickerDialogFactory : IStaFolderPickerDialogFactory
     {
         private readonly Queue<IStaFolderPickerDialog> _dialogs;
@@ -182,6 +223,50 @@ public sealed class FolderPickerContractTests
 
         public void Dispose()
         {
+        }
+    }
+
+    private sealed class InitializationFailingFolderPickerDialogFactory : IStaFolderPickerDialogFactory
+    {
+        internal TaskCompletionSource<bool> InitializationAttempted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void InitializeDispatcherThread()
+        {
+            InitializationAttempted.TrySetResult(true);
+            throw new InvalidOperationException("The dispatcher could not initialize.");
+        }
+
+        public IStaFolderPickerDialog CreateDialog() =>
+            throw new InvalidOperationException("The dispatcher did not initialize.");
+
+        public void CloseOnDispatcher(IStaFolderPickerDialog dialog)
+        {
+        }
+    }
+
+    private sealed class DisposeThrowingFolderPickerDialog : IStaFolderPickerDialog
+    {
+        private readonly FolderPickerResult _result;
+
+        internal DisposeThrowingFolderPickerDialog(FolderPickerResult result)
+        {
+            _result = result;
+        }
+
+        internal TaskCompletionSource<bool> DisposeAttempted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public FolderPickerResult Show(string? initialDirectory) => _result;
+
+        public void Close()
+        {
+        }
+
+        public void Dispose()
+        {
+            DisposeAttempted.TrySetResult(true);
+            throw new InvalidOperationException("The native dialog could not be disposed.");
         }
     }
 }

--- a/DTXMania.Test/Config/SongFolderPanelAdditionalTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelAdditionalTests.cs
@@ -1,0 +1,532 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage.Config;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class SongFolderPanelAdditionalTests
+{
+    [Fact]
+    public void Constructor_WhenConfiguredRootsIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => CreatePanel(null!));
+    }
+
+    [Fact]
+    public void Constructor_WhenFolderPickerIsNull_ShouldThrowArgumentNullException()
+    {
+        using var root = TemporaryDirectory.Create();
+        Assert.Throws<ArgumentNullException>(() => new SongFolderPanel(
+            new[] { root.Path },
+            folderPicker: null!,
+            new SongRootPolicy(SongRootPolicy.CreateComparer(false)),
+            _ => ApplyResult(SongFolderApplyStatus.Updated, _)));
+    }
+
+    [Fact]
+    public void Constructor_WhenRootPolicyIsNull_ShouldThrowArgumentNullException()
+    {
+        using var root = TemporaryDirectory.Create();
+        Assert.Throws<ArgumentNullException>(() => new SongFolderPanel(
+            new[] { root.Path },
+            new Mock<IFolderPickerService>().Object,
+            rootPolicy: null!,
+            _ => ApplyResult(SongFolderApplyStatus.Updated, _)));
+    }
+
+    [Fact]
+    public void Constructor_WhenApplyDelegateIsNull_ShouldThrowArgumentNullException()
+    {
+        using var root = TemporaryDirectory.Create();
+        Assert.Throws<ArgumentNullException>(() => new SongFolderPanel(
+            new[] { root.Path },
+            new Mock<IFolderPickerService>().Object,
+            new SongRootPolicy(SongRootPolicy.CreateComparer(false)),
+            apply: null!));
+    }
+
+    [Fact]
+    public void Constructor_WhenConfiguredRootsIsEmpty_ShouldThrowArgumentException()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            CreatePanel(Array.Empty<string>()));
+        Assert.Contains("At least one configured song folder", exception.Message);
+    }
+
+    [Fact]
+    public void Deactivate_WhenPanelIsNotActive_ShouldBeANoOp()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+
+        panel.Deactivate();
+
+        Assert.False(panel.IsActive);
+    }
+
+    [Fact]
+    public void Update_WhenNotActive_ShouldOnlyDrainPickerCompletions()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+
+        // Pressing keys while inactive must not navigate or activate rows.
+        panel.Update(0, new KeyboardState(Keys.Down), new KeyboardState());
+
+        Assert.False(panel.IsActive);
+        Assert.Equal(0, panel.SelectedRowIndex);
+    }
+
+    [Fact]
+    public void Draw_WhenNotActive_ShouldBeANoOp()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+        var font = new Mock<IFont>();
+        font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var spriteBatch = CreateUninitializedSpriteBatch();
+        try
+        {
+            panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+
+            font.Verify(f => f.DrawString(
+                It.IsAny<SpriteBatch>(),
+                It.IsAny<string>(),
+                It.IsAny<Vector2>(),
+                It.IsAny<Color>()), Times.Never);
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+        }
+    }
+
+    [Fact]
+    public void Draw_WhenSpriteBatchIsNull_ShouldBeANoOpEvenWhenActive()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+        panel.Activate();
+
+        panel.Draw(spriteBatch: null, font: null, boldFont: null, whitePixel: null,
+            virtualWidth: 1280, virtualHeight: 720);
+
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void BackKey_WhenBackKeyIsPressed_ShouldClosePanel()
+    {
+        using var root = TemporaryDirectory.Create();
+        var applyCalls = 0;
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: _ =>
+            {
+                applyCalls++;
+                return ApplyResult(SongFolderApplyStatus.Updated, _);
+            });
+        panel.Activate();
+
+        Press(panel, Keys.Back);
+
+        Assert.False(panel.IsActive);
+        Assert.Equal(0, applyCalls);
+    }
+
+    [Fact]
+    public void ActivateSelectedRow_WhenARootRowIsSelected_ShouldUpdateSelectedRootIndexOnly()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { first.Path, second.Path });
+        panel.Activate();
+
+        // Select the second root row (index 1) and press Enter. Activating a root
+        // row only records the selected root index; it must not close the panel.
+        Press(panel, Keys.Down);
+        Press(panel, Keys.Enter);
+
+        Assert.True(panel.IsActive);
+        Assert.Equal(1, panel.SelectedRowIndex);
+    }
+
+    [Fact]
+    public void MoveSelectedRoot_WhenMovingFirstRootUp_ShouldRemainInPlace()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { first.Path, second.Path });
+        panel.Activate();
+
+        // Select the first root (index 0) and trigger Move Up (action offset 2).
+        ActivateActionFromCurrent(panel, pressesToAction: 2);
+
+        Assert.Equal(new[] { first.Path, second.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void MoveSelectedRoot_WhenMovingLastRootDown_ShouldRemainInPlace()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { first.Path, second.Path });
+        panel.Activate();
+
+        // Select the second root (index 1), then navigate to Move Down (action
+        // index 3 -> row index 2 + 3 = 5, so 4 Down presses from index 1).
+        Press(panel, Keys.Down);
+        ActivateActionFromCurrent(panel, pressesToAction: 4);
+
+        Assert.Equal(new[] { first.Path, second.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void RemoveSelectedRoot_WhenSelectedRootIndexExceedsBounds_ShouldClampToRemoveLast()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { first.Path, second.Path });
+        panel.Activate();
+
+        // Force the selected root index beyond the draft count via reflection so
+        // RemoveSelectedRoot exercises its Math.Clamp guard.
+        SetPrivateField(panel, "_selectedRootIndex", 99);
+        // Select the Remove action row (action offset 1 from root count 2 -> 3 downs).
+        ActivateAction(panel, rootCount: 2, actionOffset: 1);
+
+        Assert.Equal(new[] { first.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void BeginFolderPicker_WhenAlreadyPending_ShouldIgnoreSecondRequest()
+    {
+        using var root = TemporaryDirectory.Create();
+        var picker = new DelayedFolderPicker();
+        var panel = CreatePanel(new[] { root.Path }, picker);
+        panel.Activate();
+
+        // Start the first picker.
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        var firstCancellation = GetPrivateField<CancellationTokenSource>(panel, "_pickerCancellation");
+        Assert.NotNull(firstCancellation);
+
+        // A second activation of Add Folder while the first is pending must not
+        // replace the active cancellation or start a new picker.
+        ActivateActionFromCurrent(panel, pressesToAction: 0);
+        var secondCancellation = GetPrivateField<CancellationTokenSource>(panel, "_pickerCancellation");
+
+        Assert.Same(firstCancellation, secondCancellation);
+        Assert.Equal(1, picker.CallCount);
+
+        // Clean up the pending picker.
+        picker.Completion.TrySetResult(FolderPickerResult.Cancelled());
+    }
+
+    [Fact]
+    public void Draw_WhenViewportScrollsDown_ShouldRenderMoreAboveIndicator()
+    {
+        var roots = Enumerable.Range(0, 7)
+            .Select(_ => TemporaryDirectory.Create())
+            .ToArray();
+        try
+        {
+            var panel = CreatePanel(roots.Select(r => r.Path).ToArray());
+            panel.Activate();
+            // Scroll past the viewport capacity (9 rows) so the first visible row
+            // advances and the "More above" indicator is rendered.
+            for (var i = 0; i < panel.VisibleRowCapacity; i++)
+                Press(panel, Keys.Down);
+            Assert.True(panel.FirstVisibleRowIndex > 0);
+
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+            var spriteBatch = CreateUninitializedSpriteBatch();
+            try
+            {
+                panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                    virtualWidth: 1280, virtualHeight: 720);
+
+                font.Verify(f => f.DrawString(
+                    It.IsAny<SpriteBatch>(),
+                    It.Is<string>(s => s.Contains("More above", StringComparison.Ordinal)),
+                    It.IsAny<Vector2>(),
+                    It.IsAny<Color>()), Times.Once);
+            }
+            finally
+            {
+                GC.SuppressFinalize(spriteBatch);
+            }
+        }
+        finally
+        {
+            foreach (var r in roots)
+                r.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Draw_WhenViewportCannotShowAllRows_ShouldRenderMoreBelowIndicator()
+    {
+        var roots = Enumerable.Range(0, 7)
+            .Select(_ => TemporaryDirectory.Create())
+            .ToArray();
+        try
+        {
+            var panel = CreatePanel(roots.Select(r => r.Path).ToArray());
+            panel.Activate();
+            // Stay at the top so rows below the viewport exist.
+            Assert.Equal(0, panel.FirstVisibleRowIndex);
+            Assert.True(panel.TotalRowCount > panel.VisibleRowCapacity);
+
+            var font = new Mock<IFont>();
+            font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+            var spriteBatch = CreateUninitializedSpriteBatch();
+            try
+            {
+                panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                    virtualWidth: 1280, virtualHeight: 720);
+
+                font.Verify(f => f.DrawString(
+                    It.IsAny<SpriteBatch>(),
+                    It.Is<string>(s => s.Contains("More below", StringComparison.Ordinal)),
+                    It.IsAny<Vector2>(),
+                    It.IsAny<Color>()), Times.Once);
+            }
+            finally
+            {
+                GC.SuppressFinalize(spriteBatch);
+            }
+        }
+        finally
+        {
+            foreach (var r in roots)
+                r.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Draw_WhenStatusIsAnError_ShouldUseErrorColor()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: _ => throw new InvalidOperationException("apply blew up"));
+        panel.Activate();
+        // Trigger an apply that throws -> PersistenceFailed with an error (not warning).
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+        Assert.True(panel.IsActive);
+        Assert.Contains("apply blew up", panel.StatusMessage, StringComparison.Ordinal);
+
+        var font = new Mock<IFont>();
+        font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var spriteBatch = CreateUninitializedSpriteBatch();
+        try
+        {
+            panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+
+            font.Verify(f => f.DrawString(
+                It.IsAny<SpriteBatch>(),
+                It.Is<string>(s => s.Contains("apply blew up", StringComparison.Ordinal)),
+                It.IsAny<Vector2>(),
+                It.Is<Color>(c => c == new Color(255, 96, 96))), Times.Once);
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+        }
+    }
+
+    [Fact]
+    public void Draw_WhenFolderPickerIsPending_ShouldRenderWaitingInstruction()
+    {
+        using var root = TemporaryDirectory.Create();
+        var picker = new DelayedFolderPicker();
+        var panel = CreatePanel(new[] { root.Path }, picker);
+        panel.Activate();
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        Assert.NotNull(GetPrivateField<CancellationTokenSource>(panel, "_pickerCancellation"));
+
+        var font = new Mock<IFont>();
+        font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var spriteBatch = CreateUninitializedSpriteBatch();
+        try
+        {
+            panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+
+            font.Verify(f => f.DrawString(
+                It.IsAny<SpriteBatch>(),
+                It.Is<string>(s => s.Contains("Waiting for folder picker", StringComparison.Ordinal)),
+                It.IsAny<Vector2>(),
+                It.IsAny<Color>()), Times.Once);
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+            picker.Completion.TrySetResult(FolderPickerResult.Cancelled());
+        }
+    }
+
+    [Fact]
+    public void Draw_WithNullFont_ShouldNotThrow()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+        panel.Activate();
+        var spriteBatch = CreateUninitializedSpriteBatch();
+        try
+        {
+            // A null font must not crash the draw path.
+            panel.Draw(spriteBatch, font: null, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+        }
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void Draw_WithBoldFont_ShouldUseBoldFontForSelectedRow()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+        panel.Activate();
+        var font = new Mock<IFont>();
+        font.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var boldFont = new Mock<IFont>();
+        boldFont.Setup(f => f.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var spriteBatch = CreateUninitializedSpriteBatch();
+        try
+        {
+            panel.Draw(spriteBatch, font.Object, boldFont.Object, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+
+            // The selected row (index 0, a root) should use the bold font.
+            boldFont.Verify(f => f.DrawString(
+                It.IsAny<SpriteBatch>(),
+                It.Is<string>(s => s.Contains("1.", StringComparison.Ordinal)),
+                It.IsAny<Vector2>(),
+                It.IsAny<Color>()), Times.Once);
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+        }
+    }
+
+    #region Helpers
+
+    private static SongFolderPanel CreatePanel(
+        IReadOnlyList<string> configuredRoots,
+        IFolderPickerService? picker = null,
+        Func<IReadOnlyList<string>, SongFolderApplyResult>? apply = null)
+    {
+        return new SongFolderPanel(
+            configuredRoots,
+            picker ?? new Mock<IFolderPickerService>().Object,
+            new SongRootPolicy(SongRootPolicy.CreateComparer(false)),
+            apply ?? (roots => ApplyResult(SongFolderApplyStatus.Updated, roots)));
+    }
+
+    private static SongFolderApplyResult ApplyResult(
+        SongFolderApplyStatus status,
+        IReadOnlyList<string> roots) =>
+        new(status, roots, Array.Empty<SongRootDiagnostic>());
+
+    private static void ActivateAction(SongFolderPanel panel, int rootCount, int actionOffset)
+    {
+        for (var i = 0; i < rootCount + actionOffset; i++)
+            Press(panel, Keys.Down);
+        Press(panel, Keys.Enter);
+    }
+
+    private static void ActivateActionFromCurrent(SongFolderPanel panel, int pressesToAction)
+    {
+        for (var i = 0; i < pressesToAction; i++)
+            Press(panel, Keys.Down);
+        Press(panel, Keys.Enter);
+    }
+
+    private static void Press(SongFolderPanel panel, Keys key) =>
+        panel.Update(0, new KeyboardState(key), new KeyboardState());
+
+    private static void SetPrivateField(object target, string name, object? value) =>
+        typeof(SongFolderPanel)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.SetValue(target, value);
+
+    private static T GetPrivateField<T>(object target, string name) =>
+        (T)typeof(SongFolderPanel)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(target)!;
+
+    private static SpriteBatch CreateUninitializedSpriteBatch()
+    {
+#pragma warning disable SYSLIB0050
+        return (SpriteBatch)System.Runtime.Serialization.FormatterServices
+            .GetUninitializedObject(typeof(SpriteBatch));
+#pragma warning restore SYSLIB0050
+    }
+
+    private sealed class DelayedFolderPicker : IFolderPickerService
+    {
+        public TaskCompletionSource<FolderPickerResult> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int CallCount { get; private set; }
+
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return Completion.Task;
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private TemporaryDirectory(string path) => Path = path;
+        public string Path { get; }
+
+        public static TemporaryDirectory Create()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"dtxmania-panel-add-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(path);
+            return new TemporaryDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+
+    #endregion
+}

--- a/DTXMania.Test/Config/SongFolderPanelAdditionalTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelAdditionalTests.cs
@@ -486,10 +486,8 @@ public sealed class SongFolderPanelAdditionalTests
 
     private static SpriteBatch CreateUninitializedSpriteBatch()
     {
-#pragma warning disable SYSLIB0050
-        return (SpriteBatch)System.Runtime.Serialization.FormatterServices
+        return (SpriteBatch)System.Runtime.CompilerServices.RuntimeHelpers
             .GetUninitializedObject(typeof(SpriteBatch));
-#pragma warning restore SYSLIB0050
     }
 
     private sealed class DelayedFolderPicker : IFolderPickerService

--- a/DTXMania.Test/Config/SongFolderPanelTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelTests.cs
@@ -280,6 +280,59 @@ public sealed class SongFolderPanelTests
     }
 
     [Fact]
+    public void NavigateLongDraft_ShouldScrollAndKeepActionsReachable()
+    {
+        var roots = Enumerable.Range(0, 7)
+            .Select(_ => TemporaryDirectory.Create())
+            .ToArray();
+        try
+        {
+            var applyCalls = 0;
+            var panel = CreatePanel(
+                roots.Select(root => root.Path).ToArray(),
+                apply: draft =>
+                {
+                    applyCalls++;
+                    return new SongFolderApplyResult(
+                        SongFolderApplyStatus.Busy,
+                        draft,
+                        new[] { new SongRootDiagnostic(string.Empty, "busy", IsWarning: false) });
+                });
+            panel.Activate();
+
+            Assert.Equal(0, panel.FirstVisibleRowIndex);
+            Assert.True(panel.TotalRowCount > panel.VisibleRowCapacity);
+
+            for (var index = 0; index < roots.Length + 4; index++)
+                Press(panel, Keys.Down);
+
+            Assert.Equal(roots.Length + 4, panel.SelectedRowIndex); // Apply
+            Assert.True(panel.FirstVisibleRowIndex > 0);
+            Assert.InRange(panel.SelectedRowIndex,
+                panel.FirstVisibleRowIndex,
+                panel.FirstVisibleRowIndex + panel.VisibleRowCapacity - 1);
+
+            Press(panel, Keys.Enter);
+            Assert.Equal(1, applyCalls);
+            Assert.True(panel.IsActive);
+
+            Press(panel, Keys.Down);
+            Assert.Equal(roots.Length + 5, panel.SelectedRowIndex); // Cancel
+            Assert.InRange(panel.SelectedRowIndex,
+                panel.FirstVisibleRowIndex,
+                panel.FirstVisibleRowIndex + panel.VisibleRowCapacity - 1);
+
+            Press(panel, Keys.Enter);
+            Assert.False(panel.IsActive);
+        }
+        finally
+        {
+            foreach (var root in roots)
+                root.Dispose();
+        }
+    }
+
+    [Fact]
     public void Apply_WhenUnchanged_ShouldCloseSilently()
     {
         using var root = TemporaryDirectory.Create();

--- a/DTXMania.Test/Config/SongFolderPanelTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelTests.cs
@@ -86,6 +86,47 @@ public sealed class SongFolderPanelTests
     }
 
     [Fact]
+    public void MoveSelectedRoot_WhenAvailabilityWarningsChangeOrder_ShouldRefreshCachedStatusAndSeverity()
+    {
+        var firstMissingPath = Path.Combine(Path.GetTempPath(),
+            $"dtxmania-panel-first-missing-{Guid.NewGuid():N}");
+        var secondMissingPath = Path.Combine(Path.GetTempPath(),
+            $"dtxmania-panel-second-missing-{Guid.NewGuid():N}");
+        var panel = CreatePanel(new[] { firstMissingPath, secondMissingPath });
+        panel.Activate();
+
+        Assert.Contains(firstMissingPath, panel.StatusMessage);
+
+        Press(panel, Keys.Down); // select the second root
+        ActivateActionFromCurrent(panel, pressesToAction: 3); // Move Up
+
+        Assert.Equal(new[] { secondMissingPath, firstMissingPath }, panel.DraftRoots);
+        var statusMessage = Assert.IsType<string>(panel.StatusMessage);
+        Assert.Contains(secondMissingPath, statusMessage);
+
+        var font = new Mock<IFont>();
+        font.Setup(value => value.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var spriteBatch = CreateUninitializedSpriteBatch();
+
+        try
+        {
+            panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+
+            font.Verify(value => value.DrawString(
+                    spriteBatch,
+                    statusMessage,
+                    It.IsAny<Vector2>(),
+                    It.Is<Color>(color => color == new Color(255, 196, 96))),
+                Times.Once);
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+        }
+    }
+
+    [Fact]
     public void CancelAction_ShouldDiscardDraftWithoutApplying()
     {
         using var first = TemporaryDirectory.Create();

--- a/DTXMania.Test/Config/SongFolderPanelTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelTests.cs
@@ -315,7 +315,7 @@ public sealed class SongFolderPanelTests
         panel.Activate();
 
         picker.Completion.TrySetResult(FolderPickerResult.Selected(staleSelection.Path));
-        await Task.Yield();
+        await WaitForPendingPickerCompletionAsync(panel);
         DrainPicker(panel);
 
         Assert.Equal(new[] { root.Path }, panel.DraftRoots);
@@ -438,12 +438,16 @@ public sealed class SongFolderPanelTests
     public void Apply_WhenConfigOwnedDelegateReportsFailure_ShouldKeepPanelOpen()
     {
         using var root = TemporaryDirectory.Create();
-        foreach (var status in new[]
-                 {
-                     SongFolderApplyStatus.Busy,
-                     SongFolderApplyStatus.ValidationFailed,
-                     SongFolderApplyStatus.PersistenceFailed,
-                 })
+        // SongFolderApplyStatus is internal, so it cannot be exposed on a public
+        // Theory parameter. The loop preserves per-status diagnostic clarity via
+        // explicit assertion messages instead.
+        var failureStatuses = new[]
+        {
+            SongFolderApplyStatus.Busy,
+            SongFolderApplyStatus.ValidationFailed,
+            SongFolderApplyStatus.PersistenceFailed,
+        };
+        foreach (var status in failureStatuses)
         {
             var panel = CreatePanel(
                 new[] { root.Path },
@@ -455,9 +459,30 @@ public sealed class SongFolderPanelTests
 
             ActivateAction(panel, rootCount: 1, actionOffset: 4);
 
-            Assert.True(panel.IsActive);
-            Assert.Contains("apply failed", panel.StatusMessage);
+            Assert.True(panel.IsActive,
+                $"Status {status} should keep the panel open.");
+            Assert.True(panel.StatusMessage.Contains("apply failed", StringComparison.Ordinal),
+                $"Status {status} should surface the diagnostic message.");
         }
+    }
+
+    [Fact]
+    public void Apply_WhenStarted_ShouldCommitRootsRaiseSavedBeforeClosedAndClosePanel()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: roots => ApplyResult(SongFolderApplyStatus.Started, roots));
+        var events = new List<string>();
+        panel.Saved += (_, _) => events.Add("Saved");
+        panel.Closed += (_, _) => events.Add("Closed");
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+        Assert.Equal(SongFolderApplyStatus.Started, panel.LastApplyStatus);
+        Assert.Equal(new[] { "Saved", "Closed" }, events);
+        Assert.False(panel.IsActive);
     }
 
     private static SongFolderPanel CreatePanel(
@@ -497,6 +522,28 @@ public sealed class SongFolderPanelTests
 
     private static void DrainPicker(SongFolderPanel panel) =>
         panel.Update(0, new KeyboardState(), new KeyboardState());
+
+    private static int PendingPickerCompletionCount(SongFolderPanel panel)
+    {
+        var queue = typeof(SongFolderPanel)
+            .GetField("_pickerCompletions", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(panel) as System.Collections.ICollection;
+        return queue?.Count ?? 0;
+    }
+
+    private static async Task WaitForPendingPickerCompletionAsync(
+        SongFolderPanel panel,
+        int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (PendingPickerCompletionCount(panel) == 0)
+        {
+            if (DateTime.UtcNow >= deadline)
+                throw new TimeoutException(
+                    "A picker completion was not enqueued within the timeout.");
+            await Task.Yield();
+        }
+    }
 
     private static void Press(SongFolderPanel panel, Keys key) =>
         panel.Update(0, new KeyboardState(key), new KeyboardState());

--- a/DTXMania.Test/Config/SongFolderPanelTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelTests.cs
@@ -1,0 +1,425 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage.Config;
+using Microsoft.Xna.Framework.Input;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class SongFolderPanelTests
+{
+    [Fact]
+    public void Activate_ShouldCopyConfiguredRootsIntoAnIsolatedDraft()
+    {
+        using var root = TemporaryDirectory.Create();
+        var configuredRoots = new List<string> { root.Path };
+        var panel = CreatePanel(configuredRoots);
+
+        panel.Activate();
+        configuredRoots[0] = "changed-after-activation";
+
+        Assert.Equal(new[] { root.Path }, panel.DraftRoots);
+        Assert.DoesNotContain(typeof(SongFolderPanel).GetFields(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+            field => typeof(IConfigManager).IsAssignableFrom(field.FieldType));
+    }
+
+    [Fact]
+    public void AddFolder_WhenPickerSelectsValidFolder_ShouldAppendItToDraft()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var picker = new QueuedFolderPicker(FolderPickerResult.Selected(second.Path));
+        var panel = CreatePanel(new[] { first.Path }, picker);
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+
+        Assert.Equal(new[] { first.Path, second.Path }, panel.DraftRoots);
+        Assert.Equal(first.Path, picker.InitialDirectories.Single());
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void Remove_WhenOnlyOneDraftRootRemains_ShouldKeepTheRequiredRoot()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path });
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 1);
+
+        Assert.Equal(new[] { root.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+        Assert.False(string.IsNullOrWhiteSpace(panel.StatusMessage));
+    }
+
+    [Fact]
+    public void MoveActions_ShouldReorderTheSelectedDraftRoot()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { first.Path, second.Path });
+        panel.Activate();
+
+        Press(panel, Keys.Down); // select the second root
+        ActivateActionFromCurrent(panel, pressesToAction: 3); // Move Up
+        Assert.Equal(new[] { second.Path, first.Path }, panel.DraftRoots);
+
+        Press(panel, Keys.Down); // Move Down
+        Press(panel, Keys.Enter);
+        Assert.Equal(new[] { first.Path, second.Path }, panel.DraftRoots);
+    }
+
+    [Fact]
+    public void CancelAction_ShouldDiscardDraftWithoutApplying()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var picker = new QueuedFolderPicker(FolderPickerResult.Selected(second.Path));
+        var applyCalls = 0;
+        var panel = CreatePanel(
+            new[] { first.Path },
+            picker,
+            _ =>
+            {
+                applyCalls++;
+                return ApplyResult(SongFolderApplyStatus.Updated, new[] { first.Path, second.Path });
+            });
+        var closed = false;
+        panel.Closed += (_, _) => closed = true;
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+        ActivateActionFromCurrent(panel, pressesToAction: 6);
+
+        Assert.True(closed);
+        Assert.False(panel.IsActive);
+        Assert.Equal(0, applyCalls);
+
+        panel.Activate();
+        Assert.Equal(new[] { first.Path }, panel.DraftRoots);
+    }
+
+    [Fact]
+    public void BackKey_ShouldDiscardDraftWithoutApplying()
+    {
+        using var root = TemporaryDirectory.Create();
+        var applyCalls = 0;
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: _ =>
+            {
+                applyCalls++;
+                return ApplyResult(SongFolderApplyStatus.Updated, new[] { root.Path });
+            });
+        panel.Activate();
+
+        Press(panel, Keys.Escape);
+
+        Assert.False(panel.IsActive);
+        Assert.Equal(0, applyCalls);
+    }
+
+    [Fact]
+    public void AddFolder_WhenSelectedFolderDuplicatesDraft_ShouldKeepPanelOpenWithStructuralError()
+    {
+        using var root = TemporaryDirectory.Create();
+        var picker = new QueuedFolderPicker(FolderPickerResult.Selected(root.Path));
+        var panel = CreatePanel(new[] { root.Path }, picker);
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+
+        Assert.Equal(new[] { root.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+        Assert.False(string.IsNullOrWhiteSpace(panel.StatusMessage));
+    }
+
+    [Fact]
+    public void AddFolder_WhenSelectedFolderOverlapsDraft_ShouldKeepPanelOpenWithStructuralError()
+    {
+        using var parent = TemporaryDirectory.Create();
+        var childPath = Path.Combine(parent.Path, "child");
+        Directory.CreateDirectory(childPath);
+        var picker = new QueuedFolderPicker(FolderPickerResult.Selected(childPath));
+        var panel = CreatePanel(new[] { parent.Path }, picker);
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+
+        Assert.Equal(new[] { parent.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+        Assert.False(string.IsNullOrWhiteSpace(panel.StatusMessage));
+    }
+
+    [Fact]
+    public void Apply_WhenOnlyAvailabilityWarningsExist_ShouldDelegateAndClose()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"dtxmania-missing-{Guid.NewGuid():N}");
+        var capturedRoots = Array.Empty<string>();
+        var panel = CreatePanel(
+            new[] { missingPath },
+            apply: roots =>
+            {
+                capturedRoots = roots.ToArray();
+                return ApplyResult(SongFolderApplyStatus.Updated, roots);
+            });
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+        Assert.Equal(new[] { Path.GetFullPath(missingPath) }, capturedRoots);
+        Assert.False(panel.IsActive);
+    }
+
+    [Fact]
+    public void AddFolder_WhenPickerIsCancelled_ShouldLeaveDraftAndPanelUnchanged()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path }, new QueuedFolderPicker(FolderPickerResult.Cancelled()));
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+
+        Assert.Equal(new[] { root.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+        Assert.True(string.IsNullOrWhiteSpace(panel.StatusMessage));
+    }
+
+    [Theory]
+    [InlineData(FolderPickerStatus.Unavailable)]
+    [InlineData(FolderPickerStatus.Failed)]
+    public void AddFolder_WhenPickerCannotProvideAFolder_ShouldKeepPanelOpen(FolderPickerStatus status)
+    {
+        using var root = TemporaryDirectory.Create();
+        var picker = new QueuedFolderPicker(new FolderPickerResult(status, message: "picker failure"));
+        var panel = CreatePanel(new[] { root.Path }, picker);
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+
+        Assert.Equal(new[] { root.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+        Assert.Contains("picker failure", panel.StatusMessage);
+    }
+
+    [Fact]
+    public async Task AddFolder_WhenAnOldPickerCompletesAfterReactivation_ShouldIgnoreItsResult()
+    {
+        using var root = TemporaryDirectory.Create();
+        using var staleSelection = TemporaryDirectory.Create();
+        var picker = new DelayedFolderPicker();
+        var panel = CreatePanel(new[] { root.Path }, picker);
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        panel.Deactivate();
+        panel.Activate();
+
+        picker.Completion.TrySetResult(FolderPickerResult.Selected(staleSelection.Path));
+        await Task.Yield();
+        DrainPicker(panel);
+
+        Assert.Equal(new[] { root.Path }, panel.DraftRoots);
+        Assert.True(panel.IsActive);
+    }
+
+    [Fact]
+    public void Apply_WhenUpdated_ShouldRaiseSavedBeforeClosed()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: roots => ApplyResult(SongFolderApplyStatus.Updated, roots));
+        var events = new List<string>();
+        panel.Saved += (_, _) => events.Add("Saved");
+        panel.Closed += (_, _) => events.Add("Closed");
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+        Assert.Equal(new[] { "Saved", "Closed" }, events);
+        Assert.False(panel.IsActive);
+    }
+
+    [Fact]
+    public void Apply_WhenUpdated_ShouldUseTheSavedRootsWhenReopened()
+    {
+        using var first = TemporaryDirectory.Create();
+        using var second = TemporaryDirectory.Create();
+        var picker = new QueuedFolderPicker(FolderPickerResult.Selected(second.Path));
+        var panel = CreatePanel(
+            new[] { first.Path },
+            picker,
+            roots => ApplyResult(SongFolderApplyStatus.Updated, roots));
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+        ActivateActionFromCurrent(panel, pressesToAction: 5);
+
+        panel.Activate();
+
+        Assert.Equal(new[] { first.Path, second.Path }, panel.DraftRoots);
+    }
+
+    [Fact]
+    public void Apply_WhenUnchanged_ShouldCloseSilently()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: roots => ApplyResult(SongFolderApplyStatus.Unchanged, roots));
+        var saved = false;
+        var closed = false;
+        panel.Saved += (_, _) => saved = true;
+        panel.Closed += (_, _) => closed = true;
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+        Assert.False(saved);
+        Assert.True(closed);
+        Assert.False(panel.IsActive);
+    }
+
+    [Fact]
+    public void Apply_WhenConfigOwnedDelegateReportsFailure_ShouldKeepPanelOpen()
+    {
+        using var root = TemporaryDirectory.Create();
+        foreach (var status in new[]
+                 {
+                     SongFolderApplyStatus.Busy,
+                     SongFolderApplyStatus.ValidationFailed,
+                     SongFolderApplyStatus.PersistenceFailed,
+                 })
+        {
+            var panel = CreatePanel(
+                new[] { root.Path },
+                apply: roots => new SongFolderApplyResult(
+                    status,
+                    roots,
+                    new[] { new SongRootDiagnostic(root.Path, "apply failed", IsWarning: false) }));
+            panel.Activate();
+
+            ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+            Assert.True(panel.IsActive);
+            Assert.Contains("apply failed", panel.StatusMessage);
+        }
+    }
+
+    private static SongFolderPanel CreatePanel(
+        IReadOnlyList<string> configuredRoots,
+        IFolderPickerService? picker = null,
+        Func<IReadOnlyList<string>, SongFolderApplyResult>? apply = null)
+    {
+        return new SongFolderPanel(
+            configuredRoots,
+            picker ?? new QueuedFolderPicker(),
+            new SongRootPolicy(SongRootPolicy.CreateComparer(ignoreCase: false)),
+            apply ?? (roots => ApplyResult(SongFolderApplyStatus.Updated, roots)));
+    }
+
+    private static SongFolderApplyResult ApplyResult(
+        SongFolderApplyStatus status,
+        IReadOnlyList<string> roots)
+    {
+        return new SongFolderApplyResult(status, roots, Array.Empty<SongRootDiagnostic>());
+    }
+
+    private static void ActivateAction(SongFolderPanel panel, int rootCount, int actionOffset)
+    {
+        for (var index = 0; index < rootCount + actionOffset; index++)
+            Press(panel, Keys.Down);
+
+        Press(panel, Keys.Enter);
+    }
+
+    private static void ActivateActionFromCurrent(SongFolderPanel panel, int pressesToAction)
+    {
+        for (var index = 0; index < pressesToAction; index++)
+            Press(panel, Keys.Down);
+
+        Press(panel, Keys.Enter);
+    }
+
+    private static void DrainPicker(SongFolderPanel panel) =>
+        panel.Update(0, new KeyboardState(), new KeyboardState());
+
+    private static void Press(SongFolderPanel panel, Keys key) =>
+        panel.Update(0, new KeyboardState(key), new KeyboardState());
+
+    private sealed class QueuedFolderPicker : IFolderPickerService
+    {
+        private readonly Queue<FolderPickerResult> _results;
+
+        public QueuedFolderPicker(params FolderPickerResult[] results)
+        {
+            _results = new Queue<FolderPickerResult>(results);
+        }
+
+        public List<string?> InitialDirectories { get; } = new();
+
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken)
+        {
+            InitialDirectories.Add(initialDirectory);
+            return Task.FromResult(_results.Count > 0
+                ? _results.Dequeue()
+                : FolderPickerResult.Cancelled());
+        }
+    }
+
+    private sealed class DelayedFolderPicker : IFolderPickerService
+    {
+        public TaskCompletionSource<FolderPickerResult> Completion { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken) => Completion.Task;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private TemporaryDirectory(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TemporaryDirectory Create()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"dtxmania-song-folder-panel-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(path);
+            return new TemporaryDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/DTXMania.Test/Config/SongFolderPanelTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelTests.cs
@@ -485,6 +485,85 @@ public sealed class SongFolderPanelTests
         Assert.False(panel.IsActive);
     }
 
+    [Fact]
+    public async Task AddFolder_WhenPickerReturnsNull_ShouldReportFailureWithoutCrashing()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path }, new NullFolderPicker());
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        await WaitForPendingPickerCompletionAsync(panel);
+        DrainPicker(panel);
+
+        Assert.True(panel.IsActive);
+        Assert.Contains("returned no result", panel.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AddFolder_WhenPickerThrowsUnexpectedException_ShouldReportFailure()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(new[] { root.Path }, new ThrowingFolderPicker());
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        await WaitForPendingPickerCompletionAsync(panel);
+        DrainPicker(panel);
+
+        Assert.True(panel.IsActive);
+        Assert.Contains("picker blew up", panel.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddFolder_WhenPickerReportsAnUnknownStatus_ShouldReportUnknownResult()
+    {
+        using var root = TemporaryDirectory.Create();
+        var unknown = new FolderPickerResult((FolderPickerStatus)999);
+        var panel = CreatePanel(new[] { root.Path }, new QueuedFolderPicker(unknown));
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 0);
+        DrainPicker(panel);
+
+        Assert.True(panel.IsActive);
+        Assert.Contains("unknown result", panel.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Apply_WhenConfigDelegateThrows_ShouldKeepPanelOpenWithPersistenceFailureStatus()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: _ => throw new InvalidOperationException("apply blew up"));
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+        Assert.True(panel.IsActive);
+        Assert.Equal(SongFolderApplyStatus.PersistenceFailed, panel.LastApplyStatus);
+        Assert.Contains("apply blew up", panel.StatusMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Apply_WhenConfigDelegateReportsUnknownStatus_ShouldKeepPanelOpenWithGenericMessage()
+    {
+        using var root = TemporaryDirectory.Create();
+        var panel = CreatePanel(
+            new[] { root.Path },
+            apply: roots => new SongFolderApplyResult(
+                (SongFolderApplyStatus)999,
+                roots,
+                Array.Empty<SongRootDiagnostic>()));
+        panel.Activate();
+
+        ActivateAction(panel, rootCount: 1, actionOffset: 4);
+
+        Assert.True(panel.IsActive);
+        Assert.Contains("Could not save song folders.", panel.StatusMessage, StringComparison.Ordinal);
+    }
+
     private static SongFolderPanel CreatePanel(
         IReadOnlyList<string> configuredRoots,
         IFolderPickerService? picker = null,
@@ -586,6 +665,22 @@ public sealed class SongFolderPanelTests
         public Task<FolderPickerResult> PickFolderAsync(
             string? initialDirectory,
             CancellationToken cancellationToken) => Completion.Task;
+    }
+
+    private sealed class NullFolderPicker : IFolderPickerService
+    {
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<FolderPickerResult>(null!);
+    }
+
+    private sealed class ThrowingFolderPicker : IFolderPickerService
+    {
+        public Task<FolderPickerResult> PickFolderAsync(
+            string? initialDirectory,
+            CancellationToken cancellationToken) =>
+            Task.FromException<FolderPickerResult>(new InvalidOperationException("picker blew up"));
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/DTXMania.Test/Config/SongFolderPanelTests.cs
+++ b/DTXMania.Test/Config/SongFolderPanelTests.cs
@@ -8,9 +8,13 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Stage.Config;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
+using Moq;
 
 namespace DTXMania.Test.Config;
 
@@ -184,6 +188,43 @@ public sealed class SongFolderPanelTests
 
         Assert.Equal(new[] { Path.GetFullPath(missingPath) }, capturedRoots);
         Assert.False(panel.IsActive);
+    }
+
+    [Fact]
+    public void Draw_WhenAvailabilityChangesAfterActivation_ShouldUseCachedWarningAcrossRepeatedFrames()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"dtxmania-panel-cache-{Guid.NewGuid():N}");
+        var panel = CreatePanel(new[] { missingPath });
+        panel.Activate();
+        var statusMessage = Assert.IsType<string>(panel.StatusMessage);
+        var font = new Mock<IFont>();
+        font.Setup(value => value.MeasureString(It.IsAny<string>())).Returns(Vector2.One);
+        var spriteBatch = CreateUninitializedSpriteBatch();
+
+        try
+        {
+            // The panel already captured the missing-root warning. If Draw validates again,
+            // this newly created directory changes that warning into a non-warning frame.
+            Directory.CreateDirectory(missingPath);
+
+            panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+            panel.Draw(spriteBatch, font.Object, boldFont: null, whitePixel: null,
+                virtualWidth: 1280, virtualHeight: 720);
+
+            font.Verify(value => value.DrawString(
+                    spriteBatch,
+                    statusMessage,
+                    It.IsAny<Vector2>(),
+                    It.Is<Color>(color => color == new Color(255, 196, 96))),
+                Times.Exactly(2));
+        }
+        finally
+        {
+            GC.SuppressFinalize(spriteBatch);
+            if (Directory.Exists(missingPath))
+                Directory.Delete(missingPath, recursive: true);
+        }
     }
 
     [Fact]
@@ -418,6 +459,14 @@ public sealed class SongFolderPanelTests
 
     private static void Press(SongFolderPanel panel, Keys key) =>
         panel.Update(0, new KeyboardState(key), new KeyboardState());
+
+    private static SpriteBatch CreateUninitializedSpriteBatch()
+    {
+#pragma warning disable SYSLIB0050
+        return (SpriteBatch)System.Runtime.Serialization.FormatterServices
+            .GetUninitializedObject(typeof(SpriteBatch));
+#pragma warning restore SYSLIB0050
+    }
 
     private sealed class QueuedFolderPicker : IFolderPickerService
     {

--- a/DTXMania.Test/Config/SongLibraryReloadModelsTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadModelsTests.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class SongLibraryReloadModelsTests
+{
+    [Fact]
+    public void SongLibraryReloadResult_ShouldClassifyRetentionAndRestartRequirements()
+    {
+        // SongLibraryReloadOutcome is internal, so it cannot be exposed on a public
+        // Theory parameter. The loop preserves per-outcome diagnostic clarity.
+        var cases = new[]
+        {
+            (SongLibraryReloadOutcome.Busy, true, false),
+            (SongLibraryReloadOutcome.NoActiveRoots, true, false),
+            (SongLibraryReloadOutcome.Cancelled, true, false),
+            (SongLibraryReloadOutcome.Failed, true, false),
+            (SongLibraryReloadOutcome.Published, false, false),
+            (SongLibraryReloadOutcome.PartialSuccessRestartRequired, false, true),
+        };
+
+        foreach (var (outcome, expectedRetainsSnapshot, expectedRequiresRestart) in cases)
+        {
+            var result = new SongLibraryReloadResult(
+                outcome,
+                UnavailableRootCount: 0,
+                EnumeratedFileCount: 0,
+                DiscoveredScoreCount: 0);
+
+            Assert.Equal(expectedRetainsSnapshot, result.RetainsCurrentSnapshot);
+            Assert.Equal(expectedRequiresRestart, result.RequiresRestart);
+        }
+    }
+
+    [Fact]
+    public void SongLibraryReloadResult_ShouldCarryFailureMessageWhenProvided()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Failed,
+            UnavailableRootCount: 1,
+            EnumeratedFileCount: 2,
+            DiscoveredScoreCount: 3,
+            "boom");
+
+        Assert.Equal(SongLibraryReloadOutcome.Failed, result.Outcome);
+        Assert.Equal(1, result.UnavailableRootCount);
+        Assert.Equal(2, result.EnumeratedFileCount);
+        Assert.Equal(3, result.DiscoveredScoreCount);
+        Assert.Equal("boom", result.FailureMessage);
+    }
+
+    [Fact]
+    public void SongLibraryReloadProgress_ShouldRoundTripAllFields()
+    {
+        var progress = new SongLibraryReloadProgress(
+            CurrentOperation: "Parsing",
+            ProcessedCount: 7,
+            DiscoveredSongs: 4,
+            CurrentFile: "/songs/x.dtx",
+            CurrentDirectory: "/songs");
+
+        Assert.Equal("Parsing", progress.CurrentOperation);
+        Assert.Equal(7, progress.ProcessedCount);
+        Assert.Equal(4, progress.DiscoveredSongs);
+        Assert.Equal("/songs/x.dtx", progress.CurrentFile);
+        Assert.Equal("/songs", progress.CurrentDirectory);
+    }
+}

--- a/DTXMania.Test/Config/SongLibraryReloadModelsTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadModelsTests.cs
@@ -31,8 +31,12 @@ public sealed class SongLibraryReloadModelsTests
                 EnumeratedFileCount: 0,
                 DiscoveredScoreCount: 0);
 
-            Assert.Equal(expectedRetainsSnapshot, result.RetainsCurrentSnapshot);
-            Assert.Equal(expectedRequiresRestart, result.RequiresRestart);
+            Assert.True(
+                expectedRetainsSnapshot == result.RetainsCurrentSnapshot,
+                $"outcome={outcome}: expected RetainsCurrentSnapshot={expectedRetainsSnapshot}, actual={result.RetainsCurrentSnapshot}");
+            Assert.True(
+                expectedRequiresRestart == result.RequiresRestart,
+                $"outcome={outcome}: expected RequiresRestart={expectedRequiresRestart}, actual={result.RequiresRestart}");
         }
     }
 

--- a/DTXMania.Test/Config/SongLibraryReloadServiceAdditionalTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceAdditionalTests.cs
@@ -99,7 +99,7 @@ public sealed class SongLibraryReloadServiceAdditionalTests
     }
 
     [Fact]
-    public async Task ReloadAsync_WhenPublishedWithDiscoveredScores_ShouldReportScoreCount()
+    public async Task ReloadAsync_WhenPublishedWithDiscoveredChartsButNoScores_ShouldReportChartCountAndZeroScoreCount()
     {
         var service = new SongLibraryReloadService(
             (_, _, _) =>

--- a/DTXMania.Test/Config/SongLibraryReloadServiceAdditionalTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceAdditionalTests.cs
@@ -1,0 +1,158 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class SongLibraryReloadServiceAdditionalTests
+{
+    [Fact]
+    public async Task ReloadAsync_WhenOutcomeIsUnknown_ShouldReturnFailedWithUnknownOutcomeMessage()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => Task.FromResult(CreateResult(
+                (SongEnumerationOutcome)999,
+                Array.Empty<SongEnumerationError>())));
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Failed, result.Outcome);
+        Assert.Contains("unknown outcome", result.FailureMessage, StringComparison.Ordinal);
+        Assert.True(result.RetainsCurrentSnapshot);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenConfiguredRootsIsNull_ShouldThrowArgumentNullException()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => Task.FromResult(CreateResult(
+                SongEnumerationOutcome.ImportedAndPublished,
+                Array.Empty<SongEnumerationError>())));
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            service.ReloadAsync(null!, progress: null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenEnumerationReturnsNoActiveRootsWithoutRootFailures_ShouldReportZeroUnavailable()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => Task.FromResult(CreateResult(
+                SongEnumerationOutcome.NoActiveRoots,
+                Array.Empty<SongEnumerationError>())));
+
+        var result = await service.ReloadAsync(
+            new[] { "/missing" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.NoActiveRoots, result.Outcome);
+        Assert.Equal(0, result.UnavailableRootCount);
+        Assert.True(result.RetainsCurrentSnapshot);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenProgressAdapterReceivesNullValue_ShouldThrowArgumentNullException()
+    {
+        // The ReloadProgressAdapter guards against a null progress value. Drive it
+        // through the public ReloadAsync path by having the enumeration callback
+        // report null, which the adapter must reject rather than silently swallow.
+        IProgress<EnumerationProgress>? capturedProgress = null;
+        var service = new SongLibraryReloadService(
+            (roots, progress, token) =>
+            {
+                capturedProgress = progress;
+                return Task.FromResult(CreateResult(
+                    SongEnumerationOutcome.ImportedAndPublished,
+                    Array.Empty<SongEnumerationError>()));
+            });
+
+        var reported = new List<SongLibraryReloadProgress>();
+        var outerProgress = new Progress<SongLibraryReloadProgress>(reported.Add);
+        await service.ReloadAsync(new[] { "/songs" }, outerProgress, CancellationToken.None);
+
+        Assert.NotNull(capturedProgress);
+        Assert.Throws<ArgumentNullException>(() => capturedProgress!.Report(null!));
+    }
+
+    [Fact]
+    public void CountUnavailableRoots_WhenBatchIsNull_ShouldThrowArgumentNullException()
+    {
+        // CountUnavailableRoots is a private static helper; exercise it via reflection
+        // so the null-guard branch is covered.
+        var method = typeof(SongLibraryReloadService).GetMethod(
+            "CountUnavailableRoots",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        var thrown = Assert.Throws<TargetInvocationException>(() =>
+            method!.Invoke(null, new object?[] { null }));
+        Assert.IsType<ArgumentNullException>(thrown.InnerException);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenPublishedWithDiscoveredScores_ShouldReportScoreCount()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) =>
+            {
+                var batch = new SongEnumerationBatch
+                {
+                    ActiveRoots = new[] { "/songs" },
+                    DiscoveredChartPaths = new HashSet<string>(StringComparer.Ordinal)
+                    {
+                        "/songs/a.dtx",
+                    },
+                    Candidates = new List<SongImportCandidate>(capacity: 2),
+                    RootNodes = new List<SongListNode>(),
+                    PendingSongs = new List<PendingSongNode>(),
+                    Errors = new List<SongEnumerationError>(),
+                    DiscoveryAndParsingDuration = TimeSpan.Zero,
+                    IsComplete = true,
+                };
+                return Task.FromResult(new SongEnumerationResult(
+                    SongEnumerationOutcome.ImportedAndPublished,
+                    batch,
+                    SongBulkImportResult.Empty,
+                    TimeSpan.Zero));
+            });
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Published, result.Outcome);
+        Assert.Equal(1, result.EnumeratedFileCount);
+        Assert.Equal(0, result.DiscoveredScoreCount);
+    }
+
+    private static SongEnumerationResult CreateResult(
+        SongEnumerationOutcome outcome,
+        IReadOnlyList<SongEnumerationError> errors)
+    {
+        return new SongEnumerationResult(
+            outcome,
+            new SongEnumerationBatch
+            {
+                ActiveRoots = outcome == SongEnumerationOutcome.NoActiveRoots
+                    ? Array.Empty<string>()
+                    : new[] { "/songs" },
+                DiscoveredChartPaths = new HashSet<string>(StringComparer.Ordinal),
+                Candidates = new List<SongImportCandidate>(),
+                RootNodes = new List<SongListNode>(),
+                PendingSongs = new List<PendingSongNode>(),
+                Errors = errors.ToList(),
+                DiscoveryAndParsingDuration = TimeSpan.Zero,
+                IsComplete = true,
+            },
+            SongBulkImportResult.Empty,
+            TimeSpan.Zero);
+    }
+}

--- a/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,9 +12,20 @@ using Xunit;
 
 namespace DTXMania.Test.Config;
 
+[Collection("SongManager")]
 [Trait("Category", "Unit")]
-public sealed class SongLibraryReloadServiceTests
+public sealed class SongLibraryReloadServiceTests : IDisposable
 {
+    private readonly string _testRoot = Path.Combine(
+        Path.GetTempPath(), "HPA-191-ReloadService", Guid.NewGuid().ToString("N"));
+    private readonly string _databasePath;
+
+    public SongLibraryReloadServiceTests()
+    {
+        _databasePath = Path.Combine(_testRoot, "songs.db");
+        SongManager.ResetInstanceForTesting();
+    }
+
     [Fact]
     public async Task ReloadAsync_WhenEnumerationIsBusy_ShouldReturnBusyWithoutPublishing()
     {
@@ -81,20 +93,49 @@ public sealed class SongLibraryReloadServiceTests
     }
 
     [Fact]
-    public async Task ReloadAsync_WhenPublicationFailsAfterCommit_ShouldRequireRestart()
+    public async Task ReloadAsync_WhenDefaultEnumerationFinalizationFailsAfterCommit_ShouldRequireRestart()
     {
-        var service = new SongLibraryReloadService(
-            (_, _, _) => throw new SongLibraryReloadPostCommitPublicationException(
-                "publication observer failed"));
+        var songRoot = Path.Combine(_testRoot, "Songs");
+        Directory.CreateDirectory(songRoot);
+        File.WriteAllLines(Path.Combine(songRoot, "committed.dtx"), new[]
+        {
+            "#TITLE: Committed Reload",
+            "#ARTIST: Fixture Artist",
+            "#BPM: 120",
+            "#DLEVEL: 50"
+        });
+        var manager = SongManager.Instance;
+        Assert.True(await manager.InitializeDatabaseServiceAsync(_databasePath));
+        manager.FinalizePendingNodesCore = (_, _) =>
+            throw new InvalidOperationException("finalization failed after commit");
+        var service = new SongLibraryReloadService();
 
         var result = await service.ReloadAsync(
-            new[] { "/songs" }, progress: null, CancellationToken.None);
+            new[] { songRoot }, progress: null, CancellationToken.None);
 
         Assert.Equal(
             SongLibraryReloadOutcome.PartialSuccessRestartRequired,
             result.Outcome);
         Assert.True(result.RequiresRestart);
-        Assert.True(result.RetainsCurrentSnapshot);
+        Assert.False(result.RetainsCurrentSnapshot);
+        Assert.Contains("finalization failed after commit", result.FailureMessage);
+        Assert.Single(await manager.DatabaseService!.GetSongsAsync());
+    }
+
+    public void Dispose()
+    {
+        SongManager.ResetInstanceForTesting();
+        if (Directory.Exists(_testRoot))
+        {
+            try
+            {
+                Directory.Delete(_testRoot, recursive: true);
+            }
+            catch (IOException)
+            {
+                // SQLite can briefly retain a sidecar file after disposal.
+            }
+        }
     }
 
     private static SongEnumerationResult CreateResult(

--- a/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
@@ -121,6 +121,100 @@ public sealed class SongLibraryReloadServiceTests : IDisposable
         Assert.Single(await manager.DatabaseService!.GetSongsAsync());
     }
 
+    [Fact]
+    public async Task ReloadAsync_WhenEnumerationThrowsUnexpectedException_ShouldReturnFailedRetainingSnapshot()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => throw new InvalidOperationException("unexpected boom"));
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Failed, result.Outcome);
+        Assert.True(result.RetainsCurrentSnapshot);
+        Assert.False(result.RequiresRestart);
+        Assert.Contains("unexpected boom", result.FailureMessage);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenProgressIsReported_ShouldForwardAdaptedProgressValues()
+    {
+        var reported = new List<SongLibraryReloadProgress>();
+        var service = new SongLibraryReloadService(
+            (roots, progress, token) =>
+            {
+                progress?.Report(new EnumerationProgress
+                {
+                    CurrentOperation = "Scanning",
+                    ProcessedCount = 4,
+                    DiscoveredSongs = 2,
+                    CurrentFile = "/songs/a.dtx",
+                    CurrentDirectory = "/songs",
+                });
+                progress?.Report(new EnumerationProgress
+                {
+                    CurrentOperation = "Importing",
+                    ProcessedCount = 5,
+                    DiscoveredSongs = 3,
+                    CurrentFile = "/songs/b.dtx",
+                    CurrentDirectory = "/songs/sub",
+                });
+                return Task.FromResult(CreateResult(
+                    SongEnumerationOutcome.ImportedAndPublished,
+                    Array.Empty<SongEnumerationError>()));
+            });
+
+        var progress = new Progress<SongLibraryReloadProgress>(reported.Add);
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Published, result.Outcome);
+        Assert.Equal(2, reported.Count);
+        Assert.Equal("Scanning", reported[0].CurrentOperation);
+        Assert.Equal(4, reported[0].ProcessedCount);
+        Assert.Equal(2, reported[0].DiscoveredSongs);
+        Assert.Equal("/songs/a.dtx", reported[0].CurrentFile);
+        Assert.Equal("/songs", reported[0].CurrentDirectory);
+        Assert.Equal("Importing", reported[1].CurrentOperation);
+        Assert.Equal("/songs/sub", reported[1].CurrentDirectory);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenPublished_ShouldReportEnumeratedFileCount()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) =>
+            {
+                var batch = new SongEnumerationBatch
+                {
+                    ActiveRoots = new[] { "/songs" },
+                    DiscoveredChartPaths = new HashSet<string>(StringComparer.Ordinal)
+                    {
+                        "/songs/a.dtx", "/songs/b.dtx", "/songs/c.dtx",
+                    },
+                    Candidates = new List<SongImportCandidate>(),
+                    RootNodes = new List<SongListNode>(),
+                    PendingSongs = new List<PendingSongNode>(),
+                    Errors = new List<SongEnumerationError>(),
+                    DiscoveryAndParsingDuration = TimeSpan.Zero,
+                    IsComplete = true,
+                };
+                return Task.FromResult(new SongEnumerationResult(
+                    SongEnumerationOutcome.ImportedAndPublished,
+                    batch,
+                    SongBulkImportResult.Empty,
+                    TimeSpan.Zero));
+            });
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Published, result.Outcome);
+        Assert.Equal(3, result.EnumeratedFileCount);
+        Assert.Equal(0, result.DiscoveredScoreCount);
+        Assert.Equal(0, result.UnavailableRootCount);
+    }
+
     public void Dispose()
     {
         SongManager.ResetInstanceForTesting();

--- a/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
@@ -140,6 +140,7 @@ public sealed class SongLibraryReloadServiceTests : IDisposable
     public async Task ReloadAsync_WhenProgressIsReported_ShouldForwardAdaptedProgressValues()
     {
         var reported = new List<SongLibraryReloadProgress>();
+        var progress = new SynchronousProgress<SongLibraryReloadProgress>(reported.Add);
         var service = new SongLibraryReloadService(
             (roots, progress, token) =>
             {
@@ -164,7 +165,6 @@ public sealed class SongLibraryReloadServiceTests : IDisposable
                     Array.Empty<SongEnumerationError>()));
             });
 
-        var progress = new Progress<SongLibraryReloadProgress>(reported.Add);
         var result = await service.ReloadAsync(
             new[] { "/songs" }, progress, CancellationToken.None);
 
@@ -252,5 +252,19 @@ public sealed class SongLibraryReloadServiceTests : IDisposable
             },
             SongBulkImportResult.Empty,
             TimeSpan.Zero);
+    }
+
+    /// <summary>
+    /// An <see cref="IProgress{T}"/> that invokes the callback synchronously on
+    /// the reporting thread, unlike <see cref="Progress{T}"/> which posts to a
+    /// captured <see cref="SynchronizationContext"/>. This guarantees the
+    /// recorded values are visible before assertions run.
+    /// </summary>
+    private sealed class SynchronousProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _callback;
+        public SynchronousProgress(Action<T> callback) =>
+            _callback = callback ?? throw new ArgumentNullException(nameof(callback));
+        public void Report(T value) => _callback(value);
     }
 }

--- a/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
@@ -1,0 +1,122 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class SongLibraryReloadServiceTests
+{
+    [Fact]
+    public async Task ReloadAsync_WhenEnumerationIsBusy_ShouldReturnBusyWithoutPublishing()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => throw new InvalidOperationException(
+                "Song enumeration is already in progress."));
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Busy, result.Outcome);
+        Assert.True(result.RetainsCurrentSnapshot);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenNoActiveRoots_ShouldRetainCurrentSnapshot()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => Task.FromResult(CreateResult(
+                SongEnumerationOutcome.NoActiveRoots,
+                new[] { new SongEnumerationError("/missing", "unavailable", true) })));
+
+        var result = await service.ReloadAsync(
+            new[] { "/missing" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.NoActiveRoots, result.Outcome);
+        Assert.True(result.RetainsCurrentSnapshot);
+        Assert.Equal(1, result.UnavailableRootCount);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenBatchContainsRootFailures_ShouldUseBatchFailureCount()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => Task.FromResult(CreateResult(
+                SongEnumerationOutcome.ImportedAndPublished,
+                new[]
+                {
+                    new SongEnumerationError("/missing-a", "unavailable", true),
+                    new SongEnumerationError("/chart", "parse failure", false),
+                    new SongEnumerationError("/missing-b", "unavailable", true),
+                })));
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(SongLibraryReloadOutcome.Published, result.Outcome);
+        Assert.False(result.RetainsCurrentSnapshot);
+        Assert.Equal(2, result.UnavailableRootCount);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenCancelledBeforeCommit_ShouldRetainCurrentSnapshot()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, token) => Task.FromCanceled<SongEnumerationResult>(token));
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, cancellation.Token);
+
+        Assert.Equal(SongLibraryReloadOutcome.Cancelled, result.Outcome);
+        Assert.True(result.RetainsCurrentSnapshot);
+    }
+
+    [Fact]
+    public async Task ReloadAsync_WhenPublicationFailsAfterCommit_ShouldRequireRestart()
+    {
+        var service = new SongLibraryReloadService(
+            (_, _, _) => throw new SongLibraryReloadPostCommitPublicationException(
+                "publication observer failed"));
+
+        var result = await service.ReloadAsync(
+            new[] { "/songs" }, progress: null, CancellationToken.None);
+
+        Assert.Equal(
+            SongLibraryReloadOutcome.PartialSuccessRestartRequired,
+            result.Outcome);
+        Assert.True(result.RequiresRestart);
+        Assert.True(result.RetainsCurrentSnapshot);
+    }
+
+    private static SongEnumerationResult CreateResult(
+        SongEnumerationOutcome outcome,
+        IReadOnlyList<SongEnumerationError> errors)
+    {
+        return new SongEnumerationResult(
+            outcome,
+            new SongEnumerationBatch
+            {
+                ActiveRoots = outcome == SongEnumerationOutcome.NoActiveRoots
+                    ? Array.Empty<string>()
+                    : new[] { "/songs" },
+                DiscoveredChartPaths = new HashSet<string>(StringComparer.Ordinal),
+                Candidates = new List<SongImportCandidate>(),
+                RootNodes = new List<SongListNode>(),
+                PendingSongs = new List<PendingSongNode>(),
+                Errors = errors.ToList(),
+                DiscoveryAndParsingDuration = TimeSpan.Zero,
+                IsComplete = true,
+            },
+            SongBulkImportResult.Empty,
+            TimeSpan.Zero);
+    }
+}

--- a/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
+++ b/DTXMania.Test/Config/SongLibraryReloadServiceTests.cs
@@ -30,8 +30,7 @@ public sealed class SongLibraryReloadServiceTests : IDisposable
     public async Task ReloadAsync_WhenEnumerationIsBusy_ShouldReturnBusyWithoutPublishing()
     {
         var service = new SongLibraryReloadService(
-            (_, _, _) => throw new InvalidOperationException(
-                "Song enumeration is already in progress."));
+            (_, _, _) => throw new SongEnumerationBusyException());
 
         var result = await service.ReloadAsync(
             new[] { "/songs" }, progress: null, CancellationToken.None);

--- a/DTXMania.Test/Config/SongRootConfigModelsTests.cs
+++ b/DTXMania.Test/Config/SongRootConfigModelsTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using DTXMania.Game.Lib.Config;
 using Xunit;
 
@@ -51,6 +52,11 @@ public sealed class SongRootConfigModelsTests
         Assert.Equal(new[] { "/a", "/b" }, result.CanonicalRoots);
         Assert.Single(result.Diagnostics);
         Assert.Equal("missing", result.Diagnostics[0].Message);
+
+        // The exposed collections must be read-only wrappers, matching the
+        // SongRootUpdateResult contract that guards against caller mutation.
+        Assert.IsType<ReadOnlyCollection<string>>(result.CanonicalRoots);
+        Assert.IsType<ReadOnlyCollection<SongRootDiagnostic>>(result.Diagnostics);
     }
 
     [Fact]

--- a/DTXMania.Test/Config/SongRootConfigModelsTests.cs
+++ b/DTXMania.Test/Config/SongRootConfigModelsTests.cs
@@ -1,0 +1,113 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using DTXMania.Game.Lib.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class SongRootConfigModelsTests
+{
+    [Fact]
+    public void SongRootUpdateResult_ShouldRejectNullCanonicalRoots()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SongRootUpdateResult(
+                SongRootUpdateStatus.Updated,
+                canonicalRoots: null!,
+                Array.Empty<SongRootDiagnostic>()));
+    }
+
+    [Fact]
+    public void SongRootUpdateResult_ShouldRejectNullDiagnostics()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SongRootUpdateResult(
+                SongRootUpdateStatus.Updated,
+                Array.Empty<string>(),
+                diagnostics: null!));
+    }
+
+    [Fact]
+    public void SongRootUpdateResult_ShouldCopyInputsAndExposeReadOnlyCollections()
+    {
+        var roots = new List<string> { "/a", "/b" };
+        var diagnostics = new List<SongRootDiagnostic>
+        {
+            new("/a", "missing", IsWarning: true),
+        };
+
+        var result = new SongRootUpdateResult(
+            SongRootUpdateStatus.Updated,
+            roots,
+            diagnostics);
+
+        roots.Add("/c");
+        diagnostics.Add(new SongRootDiagnostic("/c", "late", IsWarning: false));
+
+        Assert.Equal(SongRootUpdateStatus.Updated, result.Status);
+        Assert.Equal(new[] { "/a", "/b" }, result.CanonicalRoots);
+        Assert.Single(result.Diagnostics);
+        Assert.Equal("missing", result.Diagnostics[0].Message);
+    }
+
+    [Fact]
+    public void Deconstruct_ShouldReturnStatusCanonicalRootsAndDiagnostics()
+    {
+        var result = new SongRootUpdateResult(
+            SongRootUpdateStatus.ValidationFailed,
+            new[] { "/x" },
+            new[] { new SongRootDiagnostic("/x", "bad", IsWarning: false) });
+
+        var (status, canonicalRoots, diagnostics) = result;
+
+        Assert.Equal(SongRootUpdateStatus.ValidationFailed, status);
+        Assert.Equal(new[] { "/x" }, canonicalRoots);
+        Assert.Single(diagnostics);
+    }
+
+    [Fact]
+    public void SongRootsChangedEventArgs_ShouldRejectNullOldRoots()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SongRootsChangedEventArgs(
+                oldRoots: null!,
+                Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void SongRootsChangedEventArgs_ShouldRejectNullNewRoots()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SongRootsChangedEventArgs(
+                Array.Empty<string>(),
+                newRoots: null!));
+    }
+
+    [Fact]
+    public void SongRootsChangedEventArgs_ShouldCopyInputsAndExposeReadOnlyCollections()
+    {
+        var oldRoots = new List<string> { "/old" };
+        var newRoots = new List<string> { "/new" };
+
+        var args = new SongRootsChangedEventArgs(oldRoots, newRoots);
+
+        oldRoots.Add("/late-old");
+        newRoots.Add("/late-new");
+
+        Assert.Equal(new[] { "/old" }, args.OldRoots);
+        Assert.Equal(new[] { "/new" }, args.NewRoots);
+    }
+
+    [Fact]
+    public void SongRootDiagnostic_ShouldRecordPathMessageAndWarningFlag()
+    {
+        var diagnostic = new SongRootDiagnostic("/songs", "overlaps", IsWarning: false);
+
+        Assert.Equal("/songs", diagnostic.Path);
+        Assert.Equal("overlaps", diagnostic.Message);
+        Assert.False(diagnostic.IsWarning);
+    }
+}

--- a/DTXMania.Test/Config/SongRootConfigTests.cs
+++ b/DTXMania.Test/Config/SongRootConfigTests.cs
@@ -7,6 +7,7 @@ using DTXMania.Game.Lib.Utilities;
 namespace DTXMania.Test.Config;
 
 [Collection("AppPaths")]
+[Trait("Category", "Unit")]
 public sealed class SongRootConfigTests
 {
     [Fact]

--- a/DTXMania.Test/Config/SongRootConfigTests.cs
+++ b/DTXMania.Test/Config/SongRootConfigTests.cs
@@ -1,0 +1,365 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Utilities;
+
+namespace DTXMania.Test.Config;
+
+[Collection("AppPaths")]
+public sealed class SongRootConfigTests
+{
+    [Fact]
+    public void LoadConfig_ShouldClearSongRootsBeforeSecondParse()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var firstRoot = Path.Combine(root, "roots", "first");
+            var secondRoot = Path.Combine(root, "roots", "second");
+            var replacementRoot = Path.Combine(root, "roots", "replacement");
+            var firstConfig = Path.Combine(root, "first.ini");
+            var secondConfig = Path.Combine(root, "second.ini");
+            File.WriteAllLines(firstConfig,
+            [
+                "[System]",
+                $"SongRoot.0={firstRoot}",
+                $"SongRoot.1={secondRoot}",
+            ]);
+            File.WriteAllLines(secondConfig,
+            [
+                "[Other]",
+                $"SongRoot.0={replacementRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(firstConfig);
+            manager.LoadConfig(secondConfig);
+
+            Assert.Equal([replacementRoot], manager.Config.SongRoots);
+            Assert.Equal(replacementRoot, manager.Config.DTXPath);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldReadIndexedRootsInNumericOrder()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var rootZero = Path.Combine(root, "roots", "zero");
+            var rootTwo = Path.Combine(root, "roots", "two");
+            var rootTen = Path.Combine(root, "roots", "ten=preserved");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"SongRoot.10={rootTen}",
+                "[Other]",
+                $"SongRoot.2={rootTwo}",
+                $"SongRoot.0={rootZero}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([rootZero, rootTwo, rootTen], manager.Config.SongRoots);
+            Assert.Equal(rootZero, manager.Config.DTXPath);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldUseLastDuplicateIndex()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var rootZero = Path.Combine(root, "roots", "zero");
+            var firstRootOne = Path.Combine(root, "roots", "first-one");
+            var lastRootOne = Path.Combine(root, "roots", "last-one");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"SongRoot.1={firstRootOne}",
+                "[Other]",
+                $"SongRoot.0={rootZero}",
+                $"SongRoot.1={lastRootOne}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([rootZero, lastRootOne], manager.Config.SongRoots);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldPreferIndexedRootsOverLegacyDTXPath()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var legacyRoot = Path.Combine(root, "roots", "legacy");
+            // Indexed roots are authoritative custom roots, including an authored
+            // path named Songs; only the legacy DTXPath representation migrates.
+            var indexedRoot = Path.Combine(root, "Songs");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"DTXPath={legacyRoot}",
+                $"SongRoot.0={indexedRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([indexedRoot], manager.Config.SongRoots);
+            Assert.Equal(indexedRoot, manager.Config.DTXPath);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldMigrateLegacyDTXPathAndPersistIndexedRoot()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var legacyRoot = Path.Combine(root, "roots", "legacy");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"DTXPath={legacyRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            var configText = File.ReadAllText(configFile);
+            Assert.Equal([legacyRoot], manager.Config.SongRoots);
+            Assert.Equal(legacyRoot, manager.Config.DTXPath);
+            Assert.Contains($"SongRoot.0={legacyRoot}", configText);
+            Assert.Contains($"DTXPath={legacyRoot}", configText);
+            Assert.False(Directory.Exists(legacyRoot));
+        });
+    }
+
+    [Fact]
+    public void SaveConfig_ShouldWriteDenseIndexesAndFirstRootMirror()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var firstRoot = Path.Combine(root, "roots", "first");
+            var secondRoot = Path.Combine(root, "roots", "second");
+            var configFile = Path.Combine(root, "Config.ini");
+            var manager = new ConfigManager();
+            manager.Config.SongRoots.Clear();
+            manager.Config.SongRoots.Add(firstRoot);
+            manager.Config.SongRoots.Add(secondRoot);
+            manager.Config.DTXPath = Path.Combine(root, "roots", "stale-mirror");
+
+            manager.SaveConfig(configFile);
+
+            var configLines = File.ReadAllLines(configFile);
+            Assert.Equal(firstRoot, manager.Config.DTXPath);
+            Assert.Contains($"SongRoot.0={firstRoot}", configLines);
+            Assert.Contains($"SongRoot.1={secondRoot}", configLines);
+            Assert.DoesNotContain(configLines, line => line.StartsWith("SongRoot.2=", StringComparison.Ordinal));
+            Assert.Contains($"DTXPath={firstRoot}", configLines);
+            Assert.False(Directory.Exists(firstRoot));
+            Assert.False(Directory.Exists(secondRoot));
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldRemainSectionAgnostic()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var firstRoot = Path.Combine(root, "roots", "first");
+            var secondRoot = Path.Combine(root, "roots", "second");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"SongRoot.1={secondRoot}",
+                "[Other]",
+                "DTXManiaVersion=ReadFromOtherSection",
+                $"SongRoot.0={firstRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([firstRoot, secondRoot], manager.Config.SongRoots);
+            Assert.Equal("ReadFromOtherSection", manager.Config.DTXManiaVersion);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldIgnoreMalformedBlankAndNegativeIndexedRoots()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var acceptedRoot = Path.Combine(root, "roots", "accepted");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                "SongRoot.-1=negative",
+                "SongRoot.invalid=malformed",
+                "SongRoot.1=",
+                $"SongRoot.2={acceptedRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([acceptedRoot], manager.Config.SongRoots);
+        });
+    }
+
+    [Fact]
+    public void LoadAndSave_ShouldNotCreateMissingCustomRoots()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var indexedCustomRoot = Path.Combine(root, "missing", "indexed");
+            var legacyCustomRoot = Path.Combine(root, "missing", "legacy");
+            var indexedConfig = Path.Combine(root, "indexed.ini");
+            var legacyConfig = Path.Combine(root, "legacy.ini");
+            File.WriteAllLines(indexedConfig,
+            [
+                "[System]",
+                $"SongRoot.0={indexedCustomRoot}",
+            ]);
+            File.WriteAllLines(legacyConfig,
+            [
+                "[System]",
+                $"DTXPath={legacyCustomRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+            manager.LoadConfig(indexedConfig);
+            manager.SaveConfig(indexedConfig);
+
+            Assert.Equal([indexedCustomRoot], manager.Config.SongRoots);
+            Assert.False(Directory.Exists(indexedCustomRoot));
+
+            manager.LoadConfig(legacyConfig);
+            manager.SaveConfig(legacyConfig);
+
+            Assert.Equal([legacyCustomRoot], manager.Config.SongRoots);
+            Assert.False(Directory.Exists(legacyCustomRoot));
+            Assert.Contains($"SongRoot.0={legacyCustomRoot}", File.ReadAllText(legacyConfig));
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_ShouldCreateManagedDefaultRootWhenRestored()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var defaultRoot = AppPaths.GetDefaultSongsPath();
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                "DTXPath=",
+            ]);
+
+            Assert.False(Directory.Exists(defaultRoot));
+
+            var manager = new ConfigManager();
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([defaultRoot], manager.Config.SongRoots);
+            Assert.Equal(defaultRoot, manager.Config.DTXPath);
+            Assert.True(Directory.Exists(defaultRoot));
+        });
+    }
+
+    [Fact]
+    public void LoadAndSave_ShouldNotDeleteExistingCustomRoots()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var customRoot = Path.Combine(root, "existing-custom");
+            var marker = Path.Combine(customRoot, "keep.txt");
+            var configFile = Path.Combine(root, "Config.ini");
+            Directory.CreateDirectory(customRoot);
+            File.WriteAllText(marker, "keep");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"SongRoot.0={customRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+            manager.LoadConfig(configFile);
+            manager.SaveConfig(configFile);
+
+            Assert.True(Directory.Exists(customRoot));
+            Assert.True(File.Exists(marker));
+        });
+    }
+
+    [Fact]
+    public void SongRootUpdateResult_ShouldCopyMutableInputSnapshots()
+    {
+        var roots = new List<string> { "first-root" };
+        var diagnostics = new List<SongRootDiagnostic>
+        {
+            new("first-root", "warning", true),
+        };
+
+        var result = new SongRootUpdateResult(SongRootUpdateStatus.Updated, roots, diagnostics);
+        roots[0] = "changed-root";
+        roots.Add("second-root");
+        diagnostics.Clear();
+
+        Assert.Equal(["first-root"], result.CanonicalRoots);
+        var diagnostic = Assert.Single(result.Diagnostics);
+        Assert.Equal("first-root", diagnostic.Path);
+        Assert.Equal("warning", diagnostic.Message);
+        Assert.True(diagnostic.IsWarning);
+    }
+
+    [Fact]
+    public void SongRootsChangedEventArgs_ShouldCopyMutableInputSnapshots()
+    {
+        var oldRoots = new List<string> { "old-root" };
+        var newRoots = new List<string> { "new-root" };
+
+        var args = new SongRootsChangedEventArgs(oldRoots, newRoots);
+        oldRoots[0] = "changed-old-root";
+        oldRoots.Add("another-old-root");
+        newRoots.Clear();
+
+        Assert.Equal(["old-root"], args.OldRoots);
+        Assert.Equal(["new-root"], args.NewRoots);
+    }
+
+    private static void WithTemporaryAppDataRoot(Action<string> test)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "dtxmania-song-roots-" + Guid.NewGuid().ToString("N"));
+        var previousRoot = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+        Directory.CreateDirectory(root);
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", root);
+
+        try
+        {
+            test(root);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", previousRoot);
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/DTXMania.Test/Config/SongRootConfigTests.cs
+++ b/DTXMania.Test/Config/SongRootConfigTests.cs
@@ -276,6 +276,53 @@ public sealed class SongRootConfigTests
     }
 
     [Fact]
+    public void LoadConfig_WhenIndexedRootHasInvalidPathCharacter_ShouldDiscardAndFallBackToManagedDefault()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var defaultRoot = AppPaths.GetDefaultSongsPath();
+            var configFile = Path.Combine(root, "Config.ini");
+            // A NUL character is an illegal path character that Path.GetFullPath
+            // rejects. Without per-entry recovery this aborts LoadConfig entirely.
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                "SongRoot.0=bad\0root",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([defaultRoot], manager.Config.SongRoots);
+            Assert.Equal(defaultRoot, manager.Config.DTXPath);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_WhenSomeIndexedRootsAreInvalid_ShouldDiscardInvalidAndKeepValid()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var validRoot = Path.Combine(root, "roots", "valid");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                "SongRoot.0=bad\0root",
+                $"SongRoot.1={validRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            Assert.Equal([validRoot], manager.Config.SongRoots);
+            Assert.Equal(validRoot, manager.Config.DTXPath);
+        });
+    }
+
+    [Fact]
     public void LoadAndSave_ShouldNotCreateMissingCustomRoots()
     {
         WithTemporaryAppDataRoot(root =>

--- a/DTXMania.Test/Config/SongRootConfigTests.cs
+++ b/DTXMania.Test/Config/SongRootConfigTests.cs
@@ -147,6 +147,57 @@ public sealed class SongRootConfigTests
     }
 
     [Fact]
+    public void LoadConfig_LegacyCaseVariant_ShouldFollowPlatformSongPathPolicy()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var defaultRoot = AppPaths.GetDefaultSongsPath();
+            var caseVariantLegacyRoot = Path.Combine(root, "SONGS");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"DTXPath={caseVariantLegacyRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            var expectsCaseInsensitiveSongPaths =
+                OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+            var expectedRoot = expectsCaseInsensitiveSongPaths
+                ? defaultRoot
+                : caseVariantLegacyRoot;
+            Assert.Equal([expectedRoot], manager.Config.SongRoots);
+        });
+    }
+
+    [Fact]
+    public void LoadConfig_CaseVariantManagedDefault_ShouldCreateDirectoryBySongPathPolicy()
+    {
+        WithTemporaryAppDataRoot(root =>
+        {
+            var defaultRoot = AppPaths.GetDefaultSongsPath();
+            var caseVariantDefaultRoot = Path.Combine(root, "dtxfiles");
+            var configFile = Path.Combine(root, "Config.ini");
+            File.WriteAllLines(configFile,
+            [
+                "[System]",
+                $"SongRoot.0={caseVariantDefaultRoot}",
+            ]);
+
+            var manager = new ConfigManager();
+
+            manager.LoadConfig(configFile);
+
+            var expectsCaseInsensitiveSongPaths =
+                OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+            Assert.Equal(expectsCaseInsensitiveSongPaths, Directory.Exists(defaultRoot));
+        });
+    }
+
+    [Fact]
     public void SaveConfig_ShouldWriteDenseIndexesAndFirstRootMirror()
     {
         WithTemporaryAppDataRoot(root =>

--- a/DTXMania.Test/Config/StaFolderPickerDispatcherAdditionalTests.cs
+++ b/DTXMania.Test/Config/StaFolderPickerDispatcherAdditionalTests.cs
@@ -1,0 +1,160 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Stage.Config;
+using Xunit;
+
+namespace DTXMania.Test.Config;
+
+[Trait("Category", "Unit")]
+public sealed class StaFolderPickerDispatcherAdditionalTests
+{
+    [Fact]
+    public void Constructor_WhenDialogFactoryIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new StaFolderPickerDispatcher(null!));
+    }
+
+    [Fact]
+    public void Constructor_WhenConfigureThreadCallbackIsSupplied_ShouldInvokeItBeforeStarting()
+    {
+        var configured = false;
+        var factory = new QueuedFactory(
+            new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
+        using var picker = new StaFolderPickerDispatcher(
+            factory,
+            thread => configured = true);
+
+        Assert.True(configured);
+    }
+
+    [Fact]
+    public void DispatcherApartmentState_ShouldReflectTheDispatcherThreadApartment()
+    {
+        var factory = new QueuedFactory(
+            new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        // The dispatcher thread is a background thread; its apartment state is
+        // MTA by default in .NET. Asserting the property reads the live value
+        // without asserting a specific apartment, since STA is platform-specific.
+        var state = picker.DispatcherApartmentState;
+        Assert.True(state == ApartmentState.MTA || state == ApartmentState.STA ||
+                    state == ApartmentState.Unknown);
+    }
+
+    [Fact]
+    public async Task ShowRequest_WhenDialogShowThrows_ShouldCompleteRequestAsFailed()
+    {
+        var factory = new QueuedFactory(new ThrowingDialog("dialog blew up"));
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var result = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Contains("dialog blew up", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task DispatchRequests_WhenQueuedRequestIsAlreadyCompleted_ShouldCompleteAsCancelled()
+    {
+        // Pre-complete a request before the dispatcher dequeues it so the
+        // `request.IsCompleted` branch in DispatchRequests is exercised.
+        var factory = new QueuedFactory(
+            new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        // Issue a request and cancel it immediately (before the dispatcher thread
+        // can dequeue it). The dispatcher should observe it as completed/cancelled
+        // and serve the next request normally.
+        using var cancellation = new CancellationTokenSource();
+        var firstRequest = picker.PickFolderAsync(null, cancellation.Token);
+        cancellation.Cancel();
+
+        var firstResult = await firstRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(FolderPickerStatus.Cancelled, firstResult.Status);
+    }
+
+    [Fact]
+    public async Task PickFolderAsync_WhenRequestArrivesAfterTerminalShutdown_ShouldReturnUnavailable()
+    {
+        var factory = new QueuedFactory(
+            new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
+        var picker = new StaFolderPickerDispatcher(factory);
+        picker.Dispose();
+
+        // After disposal, a new request should see the terminal result.
+        var result = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Unavailable, result.Status);
+    }
+
+    [Fact]
+    public async Task ShowRequest_WhenCreateDialogThrows_ShouldCompleteRequestAsFailed()
+    {
+        // A factory whose CreateDialog throws causes ShowRequest's catch block to
+        // complete the request as Failed (the dispatcher loop itself continues).
+        var factory = new CreateThrowingFactory();
+        using var picker = new StaFolderPickerDispatcher(factory);
+
+        var result = await picker.PickFolderAsync(null, CancellationToken.None)
+            .WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Contains("CreateDialog failed", result.Message, StringComparison.Ordinal);
+    }
+
+    #region Test Doubles
+
+    private sealed class QueuedFactory : IStaFolderPickerDialogFactory
+    {
+        private readonly IStaFolderPickerDialog _dialog;
+        public QueuedFactory(IStaFolderPickerDialog dialog) => _dialog = dialog;
+
+        public void InitializeDispatcherThread() { }
+        public IStaFolderPickerDialog CreateDialog() => _dialog;
+        public void CloseOnDispatcher(IStaFolderPickerDialog dialog) => dialog.Close();
+    }
+
+    private sealed class ImmediateDialog : IStaFolderPickerDialog
+    {
+        private readonly FolderPickerResult _result;
+        public ImmediateDialog(FolderPickerResult result) => _result = result;
+        public FolderPickerResult Show(string? initialDirectory) => _result;
+        public void Close() { }
+        public void Dispose() { }
+    }
+
+    private sealed class ThrowingDialog : IStaFolderPickerDialog
+    {
+        private readonly string _message;
+        public ThrowingDialog(string message) => _message = message;
+        public FolderPickerResult Show(string? initialDirectory) =>
+            throw new InvalidOperationException(_message);
+        public void Close() { }
+        public void Dispose() { }
+    }
+
+    private sealed class CreateThrowingFactory : IStaFolderPickerDialogFactory
+    {
+        public TaskCompletionSource<bool> CreateAttempted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void InitializeDispatcherThread() { }
+
+        public IStaFolderPickerDialog CreateDialog()
+        {
+            CreateAttempted.TrySetResult(true);
+            throw new InvalidOperationException("CreateDialog failed");
+        }
+
+        public void CloseOnDispatcher(IStaFolderPickerDialog dialog) { }
+    }
+
+    #endregion
+}

--- a/DTXMania.Test/Config/StaFolderPickerDispatcherAdditionalTests.cs
+++ b/DTXMania.Test/Config/StaFolderPickerDispatcherAdditionalTests.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game.Lib.Stage.Config;
@@ -38,12 +39,13 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
             new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
         using var picker = new StaFolderPickerDispatcher(factory);
 
-        // The dispatcher thread is a background thread; its apartment state is
-        // MTA by default in .NET. Asserting the property reads the live value
-        // without asserting a specific apartment, since STA is platform-specific.
-        var state = picker.DispatcherApartmentState;
-        Assert.True(state == ApartmentState.MTA || state == ApartmentState.STA ||
-                    state == ApartmentState.Unknown);
+        // Compare the property against the dispatcher thread's actual apartment
+        // state, retrieved via reflection, instead of asserting a tautological
+        // membership check.
+        var dispatcherThread = (Thread)typeof(StaFolderPickerDispatcher)
+            .GetField("_dispatcherThread", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(picker)!;
+        Assert.Equal(dispatcherThread.GetApartmentState(), picker.DispatcherApartmentState);
     }
 
     [Fact]
@@ -62,36 +64,31 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
     [Fact]
     public async Task DispatchRequests_WhenQueuedRequestIsAlreadyCompleted_ShouldCompleteAsCancelled()
     {
-        // Pre-complete a request before the dispatcher dequeues it so the
-        // `request.IsCompleted` branch in DispatchRequests is exercised.
-        var factory = new QueuedFactory(
-            new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
+        // A preceding blocking request keeps the dispatcher busy so the target
+        // request sits in the queue and is cancelled before the dispatcher
+        // dequeues it. This deterministically exercises the `request.IsCompleted`
+        // branch in DispatchRequests rather than relying on a race between
+        // cancellation and dequeue.
+        var blockingDialog = new BlockingDialog();
+        var factory = new QueuedFactory(blockingDialog);
         using var picker = new StaFolderPickerDispatcher(factory);
 
-        // Issue a request and cancel it immediately (before the dispatcher thread
-        // can dequeue it). The dispatcher should observe it as completed/cancelled
-        // and serve the next request normally.
+        // Start the blocking request and wait for the dispatcher to enter Show().
+        var firstRequest = picker.PickFolderAsync(null, CancellationToken.None);
+        await blockingDialog.ShowEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        // Enqueue the target request and cancel it while the dispatcher is busy.
         using var cancellation = new CancellationTokenSource();
-        var firstRequest = picker.PickFolderAsync(null, cancellation.Token);
+        var secondRequest = picker.PickFolderAsync(null, cancellation.Token);
         cancellation.Cancel();
 
+        // Release the blocking dialog so the dispatcher dequeues the target.
+        blockingDialog.Release();
         var firstResult = await firstRequest.WaitAsync(TimeSpan.FromSeconds(1));
-        Assert.Equal(FolderPickerStatus.Cancelled, firstResult.Status);
-    }
+        Assert.Equal(FolderPickerStatus.Selected, firstResult.Status);
 
-    [Fact]
-    public async Task PickFolderAsync_WhenRequestArrivesAfterTerminalShutdown_ShouldReturnUnavailable()
-    {
-        var factory = new QueuedFactory(
-            new ImmediateDialog(FolderPickerResult.Selected("/tmp/songs")));
-        var picker = new StaFolderPickerDispatcher(factory);
-        picker.Dispose();
-
-        // After disposal, a new request should see the terminal result.
-        var result = await picker.PickFolderAsync(null, CancellationToken.None)
-            .WaitAsync(TimeSpan.FromSeconds(1));
-
-        Assert.Equal(FolderPickerStatus.Unavailable, result.Status);
+        var secondResult = await secondRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(FolderPickerStatus.Cancelled, secondResult.Status);
     }
 
     [Fact]
@@ -127,6 +124,24 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
         public ImmediateDialog(FolderPickerResult result) => _result = result;
         public FolderPickerResult Show(string? initialDirectory) => _result;
         public void Close() { }
+        public void Dispose() { }
+    }
+
+    private sealed class BlockingDialog : IStaFolderPickerDialog
+    {
+        private readonly TaskCompletionSource<FolderPickerResult> _release = new();
+        public TaskCompletionSource<bool> ShowEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public FolderPickerResult Show(string? initialDirectory)
+        {
+            ShowEntered.TrySetResult(true);
+            return _release.Task.GetAwaiter().GetResult();
+        }
+
+        public void Release() => _release.TrySetResult(
+            FolderPickerResult.Selected("/tmp/songs"));
+        public void Close() => _release.TrySetResult(FolderPickerResult.Cancelled());
         public void Dispose() { }
     }
 

--- a/DTXMania.Test/Platform/MacFolderPickerServiceAdditionalTests.cs
+++ b/DTXMania.Test/Platform/MacFolderPickerServiceAdditionalTests.cs
@@ -1,0 +1,194 @@
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Game.Platform;
+using Xunit;
+
+namespace DTXMania.Test.Platform;
+
+[Trait("Category", "Unit")]
+public sealed class MacFolderPickerServiceAdditionalTests
+{
+    [Fact]
+    public async Task PickFolderAsync_WhenCancellationFiresWhileDialogIsOpen_ShouldReturnCancelledAndKillProcess()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            // The macOS folder picker only launches osascript on macOS.
+            return;
+        }
+
+        var picker = new MacFolderPickerService();
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        var result = await picker.PickFolderAsync(initialDirectory: null, cancellation.Token);
+
+        // The cancellation path kills the osascript process and returns Cancelled.
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public async Task PickFolderAsync_WhenOsascriptReturnsImmediately_ShouldMapOutputToSelected()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return;
+        }
+
+        // Launch a harmless osascript that returns a POSIX path without showing
+        // a dialog, by directly invoking the service against a temp directory.
+        // The service's BuildAppleScript always uses `choose folder`, so we
+        // instead verify the MapProcessResult path that PickFolderAsync delegates
+        // to, ensuring a zero-exit path output maps to Selected.
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 0,
+            standardOutput: "/Users/test/Songs",
+            standardError: null);
+
+        Assert.Equal(FolderPickerStatus.Selected, result.Status);
+        Assert.Equal("/Users/test/Songs", result.Path);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenStandardOutputIsNull_ShouldTreatAsEmpty()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: null,
+            standardError: null);
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Contains("exited with code 1", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenStandardErrorIsNull_ShouldFallBackToOutput()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: "User canceled. (-128)",
+            standardError: null);
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenErrorContainsCancelCode_ShouldReturnCancelled()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: string.Empty,
+            standardError: "number -128");
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenAuthorizationDeniedWithBlankDetails_ShouldUseFallbackMessage()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: "  ",
+            standardError: "  not authorized  ");
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Contains("not authorized", result.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildAppleScript_WhenInitialDirectoryIsOmitted_ShouldOmitDefaultLocation()
+    {
+        var script = InvokeBuildAppleScript(null);
+
+        Assert.Contains("choose folder", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("default location", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(CancelledMarker, script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildAppleScript_WhenInitialDirectoryExists_ShouldEmbedEscapedPath()
+    {
+        using var directory = TemporaryDirectory.Create();
+        var script = InvokeBuildAppleScript(directory.Path);
+
+        Assert.Contains("default location POSIX file", script, StringComparison.Ordinal);
+        Assert.Contains(directory.Path, script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EscapeAppleScriptString_ShouldEscapeBackslashesAndQuotes()
+    {
+        var escaped = InvokeEscapeAppleScript(@"path\with""quote");
+
+        Assert.Equal(@"path\\with\""quote", escaped);
+    }
+
+    [Fact]
+    public void EscapeAppleScriptString_WhenValueHasNoSpecialChars_ShouldReturnUnchanged()
+    {
+        var escaped = InvokeEscapeAppleScript("/plain/path");
+
+        Assert.Equal("/plain/path", escaped);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WhenInitialDirectoryIsBlank_ShouldOmitDefaultLocation()
+    {
+        var startInfo = MacFolderPickerService.CreateStartInfo("   ");
+
+        Assert.DoesNotContain(
+            "default location",
+            startInfo.ArgumentList[1],
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string CancelledMarker =>
+        (string)typeof(MacFolderPickerService)
+            .GetField("CancelledMarker", BindingFlags.Static | BindingFlags.NonPublic)!
+            .GetValue(null)!;
+
+    private static string InvokeBuildAppleScript(string? initialDirectory)
+    {
+        var method = typeof(MacFolderPickerService).GetMethod(
+            "BuildAppleScript",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (string)method!.Invoke(null, new object?[] { initialDirectory })!;
+    }
+
+    private static string InvokeEscapeAppleScript(string value)
+    {
+        var method = typeof(MacFolderPickerService).GetMethod(
+            "EscapeAppleScriptString",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (string)method!.Invoke(null, new object?[] { value })!;
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private TemporaryDirectory(string path) => Path = path;
+        public string Path { get; }
+
+        public static TemporaryDirectory Create()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"dtxmania-mac-add-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(path);
+            return new TemporaryDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/DTXMania.Test/Platform/MacFolderPickerServiceAdditionalTests.cs
+++ b/DTXMania.Test/Platform/MacFolderPickerServiceAdditionalTests.cs
@@ -34,18 +34,11 @@ public sealed class MacFolderPickerServiceAdditionalTests
     }
 
     [Fact]
-    public async Task PickFolderAsync_WhenOsascriptReturnsImmediately_ShouldMapOutputToSelected()
+    public void MapProcessResult_WhenZeroExitReturnsPosixPath_ShouldMapToSelected()
     {
-        if (!OperatingSystem.IsMacOS())
-        {
-            return;
-        }
-
-        // Launch a harmless osascript that returns a POSIX path without showing
-        // a dialog, by directly invoking the service against a temp directory.
-        // The service's BuildAppleScript always uses `choose folder`, so we
-        // instead verify the MapProcessResult path that PickFolderAsync delegates
-        // to, ensuring a zero-exit path output maps to Selected.
+        // Verify the MapProcessResult path that PickFolderAsync delegates to,
+        // ensuring a zero-exit POSIX path output maps to Selected. This runs on
+        // every platform since MapProcessResult is a pure static method.
         var result = MacFolderPickerService.MapProcessResult(
             exitCode: 0,
             standardOutput: "/Users/test/Songs",
@@ -90,7 +83,7 @@ public sealed class MacFolderPickerServiceAdditionalTests
     }
 
     [Fact]
-    public void MapProcessResult_WhenAuthorizationDeniedWithBlankDetails_ShouldUseFallbackMessage()
+    public void MapProcessResult_WhenAuthorizationDeniedWithTrimmedDetails_ShouldReturnFailedWithDetails()
     {
         var result = MacFolderPickerService.MapProcessResult(
             exitCode: 1,

--- a/DTXMania.Test/Platform/MacFolderPickerServiceAdditionalTests.cs
+++ b/DTXMania.Test/Platform/MacFolderPickerServiceAdditionalTests.cs
@@ -109,9 +109,12 @@ public sealed class MacFolderPickerServiceAdditionalTests
     {
         using var directory = TemporaryDirectory.Create();
         var script = InvokeBuildAppleScript(directory.Path);
+        var escapedPath = directory.Path
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
 
         Assert.Contains("default location POSIX file", script, StringComparison.Ordinal);
-        Assert.Contains(directory.Path, script, StringComparison.Ordinal);
+        Assert.Contains(escapedPath, script, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/DTXMania.Test/Platform/MacFolderPickerServiceTests.cs
+++ b/DTXMania.Test/Platform/MacFolderPickerServiceTests.cs
@@ -1,0 +1,210 @@
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Game.Platform;
+using Xunit;
+
+namespace DTXMania.Test.Platform;
+
+[Trait("Category", "Unit")]
+public sealed class MacFolderPickerServiceTests
+{
+    [Fact]
+    public void CreateStartInfo_WhenInitialDirectoryIsOmitted_ShouldOmitDefaultLocation()
+    {
+        var startInfo = MacFolderPickerService.CreateStartInfo(initialDirectory: null);
+
+        Assert.Equal("/usr/bin/osascript", startInfo.FileName);
+        Assert.True(startInfo.RedirectStandardOutput);
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.Equal("-e", startInfo.ArgumentList[0]);
+        var script = startInfo.ArgumentList[1];
+        Assert.DoesNotContain("default location", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("choose folder", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WhenInitialDirectoryDoesNotExist_ShouldOmitDefaultLocation()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "dtxmania-missing-" + Guid.NewGuid().ToString("N"));
+
+        var startInfo = MacFolderPickerService.CreateStartInfo(missing);
+
+        Assert.DoesNotContain(
+            "default location",
+            startInfo.ArgumentList[1],
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WhenInitialDirectoryExists_ShouldEmbedEscapedDefaultLocation()
+    {
+        using var directory = TemporaryDirectory.Create();
+
+        var startInfo = MacFolderPickerService.CreateStartInfo(directory.Path);
+
+        var script = startInfo.ArgumentList[1];
+        Assert.Contains("default location POSIX file", script, StringComparison.Ordinal);
+        Assert.Contains(directory.Path, script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreateStartInfo_WhenPathContainsSpecialCharacters_ShouldEscapeForAppleScript()
+    {
+        // Build a directory whose name contains characters AppleScript must escape
+        // (double-quote and backslash). Both are legal in macOS directory names.
+        var suffix = "with\"quote\\and-backslash-" + Guid.NewGuid().ToString("N");
+        var directoryPath = Path.Combine(Path.GetTempPath(), suffix);
+        Directory.CreateDirectory(directoryPath);
+        try
+        {
+            var startInfo = MacFolderPickerService.CreateStartInfo(directoryPath);
+
+            var script = startInfo.ArgumentList[1];
+            var escaped = suffix.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            Assert.Contains(escaped, script, StringComparison.Ordinal);
+            // The raw, unescaped special characters must not appear inside the
+            // quoted POSIX file literal.
+            Assert.DoesNotContain("\"" + suffix + "\"", script, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(directoryPath))
+                Directory.Delete(directoryPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenExitCodeIsZeroAndOutputIsAPath_ShouldReturnSelected()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 0,
+            standardOutput: "/Users/test/Songs",
+            standardError: string.Empty);
+
+        Assert.Equal(FolderPickerStatus.Selected, result.Status);
+        Assert.Equal("/Users/test/Songs", result.Path);
+        Assert.Null(result.Message);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenExitCodeIsZeroAndOutputIsCancellationMarker_ShouldReturnCancelled()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 0,
+            standardOutput: "__DTXMANIA_FOLDER_PICKER_CANCELLED__",
+            standardError: string.Empty);
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void MapProcessResult_WhenExitCodeIsZeroAndOutputIsBlank_ShouldReturnCancelled(string output)
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 0,
+            standardOutput: output,
+            standardError: string.Empty);
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenErrorContainsUserCancellationCodeInOutput_ShouldReturnCancelled()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: "User canceled. (-128)",
+            standardError: string.Empty);
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenErrorContainsNotAuthorizedText_ShouldReturnFailedWithDetails()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: string.Empty,
+            standardError: "not authorized to send Apple events");
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Equal("not authorized to send Apple events", result.Message);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenAuthorizationDeniedWithoutDetails_ShouldReturnFailedWithFallbackMessage()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: string.Empty,
+            standardError: "-1743");
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Equal("-1743", result.Message);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenNonZeroExitHasErrorDetails_ShouldReturnFailedWithDetails()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 42,
+            standardOutput: "ignored output",
+            standardError: "osascript failed");
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Equal("osascript failed", result.Message);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenNonZeroExitHasNoDetails_ShouldReturnFailedWithExitCodeMessage()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 7,
+            standardOutput: "   ",
+            standardError: string.Empty);
+
+        Assert.Equal(FolderPickerStatus.Failed, result.Status);
+        Assert.Equal("macOS folder picker exited with code 7.", result.Message);
+    }
+
+    [Fact]
+    public void MapProcessResult_WhenStandardErrorIsWhitespace_ShouldFallBackToOutputForDetails()
+    {
+        var result = MacFolderPickerService.MapProcessResult(
+            exitCode: 1,
+            standardOutput: "User canceled. (-128)",
+            standardError: "   ");
+
+        Assert.Equal(FolderPickerStatus.Cancelled, result.Status);
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private TemporaryDirectory(string path) => Path = path;
+
+        public string Path { get; }
+
+        public static TemporaryDirectory Create()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "dtxmania-mac-picker-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return new TemporaryDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+                Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/DTXMania.Test/Platform/MacFolderPickerServiceTests.cs
+++ b/DTXMania.Test/Platform/MacFolderPickerServiceTests.cs
@@ -49,13 +49,24 @@ public sealed class MacFolderPickerServiceTests
         var startInfo = MacFolderPickerService.CreateStartInfo(directory.Path);
 
         var script = startInfo.ArgumentList[1];
+        var escapedPath = directory.Path
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
         Assert.Contains("default location POSIX file", script, StringComparison.Ordinal);
-        Assert.Contains(directory.Path, script, StringComparison.Ordinal);
+        Assert.Contains(escapedPath, script, StringComparison.Ordinal);
     }
 
     [Fact]
     public void CreateStartInfo_WhenPathContainsSpecialCharacters_ShouldEscapeForAppleScript()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            // Windows forbids quotes in directory names. The Windows-safe
+            // backslash case is covered by the existing-directory test above,
+            // while the macOS job exercises both quote and backslash escaping.
+            return;
+        }
+
         // Build a directory whose name contains characters AppleScript must escape
         // (double-quote and backslash). Both are legal in macOS directory names.
         var suffix = "with\"quote\\and-backslash-" + Guid.NewGuid().ToString("N");

--- a/DTXMania.Test/Platform/MacFolderPickerServiceTests.cs
+++ b/DTXMania.Test/Platform/MacFolderPickerServiceTests.cs
@@ -151,7 +151,7 @@ public sealed class MacFolderPickerServiceTests
     }
 
     [Fact]
-    public void MapProcessResult_WhenAuthorizationDeniedWithoutDetails_ShouldReturnFailedWithFallbackMessage()
+    public void MapProcessResult_WhenAuthorizationDeniedErrorCodeReturned_ShouldReturnFailedWithDetails()
     {
         var result = MacFolderPickerService.MapProcessResult(
             exitCode: 1,

--- a/DTXMania.Test/Song/SongEnumerationBusyExceptionTests.cs
+++ b/DTXMania.Test/Song/SongEnumerationBusyExceptionTests.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using System;
+using DTXMania.Game.Lib.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song;
+
+[Trait("Category", "Unit")]
+public sealed class SongEnumerationBusyExceptionTests
+{
+    [Fact]
+    public void DefaultConstructor_ShouldUseCanonicalMessageAndDeriveFromInvalidOperation()
+    {
+        var exception = new SongEnumerationBusyException();
+
+        Assert.Equal("Song enumeration is already in progress.", exception.Message);
+        Assert.IsAssignableFrom<InvalidOperationException>(exception);
+    }
+
+    [Fact]
+    public void MessageConstructor_ShouldPreserveSuppliedMessage()
+    {
+        var exception = new SongEnumerationBusyException("custom busy message");
+
+        Assert.Equal("custom busy message", exception.Message);
+        Assert.IsAssignableFrom<InvalidOperationException>(exception);
+    }
+
+    [Fact]
+    public void MessageAndInnerExceptionConstructor_ShouldPreserveBoth()
+    {
+        var inner = new InvalidOperationException("root cause");
+
+        var exception = new SongEnumerationBusyException("wrapped busy", inner);
+
+        Assert.Equal("wrapped busy", exception.Message);
+        Assert.Same(inner, exception.InnerException);
+        Assert.IsAssignableFrom<InvalidOperationException>(exception);
+    }
+
+    [Fact]
+    public void CatchAsInvalidOperationException_ShouldMatchABusyEnumerationHandler()
+    {
+        // A handler that only catches InvalidOperationException must still classify
+        // a busy enumeration without string-matching the message.
+        InvalidOperationException? caught = null;
+        try
+        {
+            throw new SongEnumerationBusyException();
+        }
+        catch (InvalidOperationException exception)
+        {
+            caught = exception;
+        }
+
+        Assert.IsType<SongEnumerationBusyException>(caught);
+    }
+}

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1030,6 +1030,7 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
         await _manager.InitializeDatabaseServiceAsync(_databasePath);
         var activeRoot = Path.Combine(_testRoot, "Active");
         var inactiveRoot = Path.Combine(_testRoot, "Removed");
+        Directory.CreateDirectory(activeRoot);
         var now = DateTime.UtcNow;
 
         await using (var context = _manager.DatabaseService!.CreateContext())
@@ -1397,6 +1398,26 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
             Assert.Equal(before.RootSongs, after.RootSongs);
             Assert.Equal(before.ActiveRoots, after.ActiveRoots);
             Assert.False(_manager.IsEnumerating);
+        }
+
+        [Fact]
+        public async Task RefreshSongListFromDatabaseAsync_WhenCurrentRootBecomesUnavailable_ShouldPreservePublishedSnapshot()
+        {
+            await SeedPublishedLibraryAsync();
+            var before = _manager.GetLibrarySnapshot();
+            var publishEvents = 0;
+            _manager.SongLibraryPublished += (_, _) => publishEvents++;
+            Directory.Delete(_songsRoot, recursive: true);
+
+            await _manager.RefreshSongListFromDatabaseAsync();
+
+            var after = _manager.GetLibrarySnapshot();
+            Assert.Equal(0, publishEvents);
+            Assert.Equal(before.Version, after.Version);
+            Assert.Equal(before.RootSongs, after.RootSongs);
+            Assert.Equal(before.ActiveRoots, after.ActiveRoots);
+            Assert.Equal(before.EnumeratedFileCount, after.EnumeratedFileCount);
+            Assert.Equal(before.DiscoveredScoreCount, after.DiscoveredScoreCount);
         }
 
         [Fact]

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1738,6 +1738,118 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
     }
 
     [Fact]
+    public async Task NeedsEnumerationAsync_WhenLegacyGlobalWatermarkOnlyAndRootLacksPerRootWatermark_ShouldReturnTrue()
+    {
+        // Regression (review item 2, migration case): a database created
+        // before per-root watermarks only has the global timestamp. When an
+        // enumeration gives root A a recoverable parse error while root B
+        // succeeds, B receives a per-root watermark and the global timestamp
+        // advances, but A does NOT. On the next startup with B unavailable,
+        // A has no per-root watermark. The legacy fallback (now removed) would
+        // assign B's advanced global timestamp to A, and because A's retained
+        // rows and file mtimes are older than that timestamp,
+        // NeedsEnumerationAsync would return false — never retrying A's failed
+        // parse. A missing per-root watermark must always mean the root needs
+        // enumeration.
+        var rootA = Path.Combine(_testRoot, "LegacyRootA");
+        var rootB = Path.Combine(_testRoot, "LegacyRootB");
+        Directory.CreateDirectory(rootA);
+        Directory.CreateDirectory(rootB);
+        var chartA = Path.Combine(rootA, "song.dtx");
+        var chartB = Path.Combine(rootB, "song.dtx");
+        await File.WriteAllTextAsync(chartA, """
+            #TITLE: Legacy A
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 50
+            """);
+        await File.WriteAllTextAsync(chartB, """
+            #TITLE: Legacy B
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 40
+            """);
+        var oldTime = DateTime.UtcNow.AddMinutes(-30);
+        File.SetLastWriteTimeUtc(chartA, oldTime);
+        File.SetCreationTimeUtc(chartA, oldTime);
+        File.SetLastWriteTimeUtc(chartB, oldTime);
+        File.SetCreationTimeUtc(chartB, oldTime);
+        Directory.SetLastWriteTimeUtc(rootA, oldTime);
+        Directory.SetCreationTimeUtc(rootA, oldTime);
+        Directory.SetLastWriteTimeUtc(rootB, oldTime);
+        Directory.SetCreationTimeUtc(rootB, oldTime);
+
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+
+        // First enumeration: both roots succeed so the database holds rows
+        // for A and B and both per-root watermarks are established.
+        var firstResult = await _manager.EnumerateAndImportSongsAsync(
+            new[] { rootA, rootB }, null, CancellationToken.None);
+        Assert.Equal(2, firstResult.Batch.Candidates.Count);
+
+        // Simulate a legacy/migration database: delete every per-root
+        // watermark so only the global timestamp remains, then age it so the
+        // second enumeration's scan-start watermark is newer.
+        await using (var context = _manager.DatabaseService!.CreateContext())
+        {
+            await context.Database.ExecuteSqlRawAsync(
+                "DELETE FROM __EnumerationMetadata WHERE Key LIKE 'LastSuccessfulEnumerationUtc:Root:%'");
+        }
+        var legacyGlobal = DateTime.UtcNow.AddMinutes(-20);
+        await _manager.DatabaseService!
+            .SetLastSuccessfulEnumerationUtcAsync(legacyGlobal);
+        // Confirm the legacy state: global watermark present, no per-root rows.
+        Assert.NotNull(await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync());
+        var canonicalA = _manager.RootPolicy
+            .Validate(new[] { rootA }).CanonicalRoots.Single();
+        var canonicalB = _manager.RootPolicy
+            .Validate(new[] { rootB }).CanonicalRoots.Single();
+        Assert.Null(await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA));
+        Assert.Null(await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalB));
+
+        // Second enumeration: chartA parse fails (recoverable error in A),
+        // chartB succeeds. B receives a per-root watermark and the global
+        // watermark advances; A does NOT receive a per-root watermark.
+        var realParser = _manager.ParseSongEntitiesCoreAsync;
+        _manager.ParseSongEntitiesCoreAsync = path =>
+            SongPathIdentity.CanonicalComparer.Equals(path, SongPathIdentity.Normalize(chartA))
+                ? Task.FromException<(SongEntity, SongChart)>(
+                    new InvalidDataException($"transient parse failure for {path}"))
+                : realParser(path);
+        var secondResult = await _manager.EnumerateAndImportSongsAsync(
+            new[] { rootA, rootB }, null, CancellationToken.None);
+        _manager.ParseSongEntitiesCoreAsync = realParser;
+        Assert.Contains(secondResult.Batch.Errors, error =>
+            error.Path == SongPathIdentity.Normalize(chartA) &&
+            !error.IsRootFailure);
+
+        // B has a per-root watermark now; A still does not.
+        Assert.Null(await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA));
+        Assert.NotNull(await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalB));
+        // The global watermark advanced past A's file mtime.
+        var advancedGlobal = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync();
+        Assert.True(advancedGlobal!.Value > oldTime);
+
+        // Make B unavailable (external drive detached / share unmounted).
+        Directory.Delete(rootB, recursive: true);
+
+        // The freshness check must return true because A has no per-root
+        // watermark. Without the fix, the legacy fallback would assign the
+        // advanced global timestamp to A, and A's matching row count plus
+        // older file mtimes would produce false — never retrying the failed
+        // parse.
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(
+            new[] { rootA, rootB });
+        Assert.True(needsEnumeration);
+    }
+
+    [Fact]
     public async Task EnumerateAndImportSongsAsync_WhenChartParseCancelled_ShouldThrowOperationCanceled()
     {
         await _manager.InitializeDatabaseServiceAsync(_databasePath);

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1234,6 +1234,313 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
     }
 
     [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenSetDefReferencesParentTraversal_ShouldRejectOutsideChart()
+    {
+        // Regression (review item 1): a set.def #LnFILE that escapes the
+        // active-root boundary via ../ traversal must be rejected. Without
+        // this, the escaped chart is counted by the filesystem inventory but
+        // excluded by the database freshness count (which scopes to active
+        // roots), producing a permanent count mismatch and perpetual rescans.
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var setRoot = Path.Combine(_songsRoot, "Boundary Set");
+        Directory.CreateDirectory(setRoot);
+        // Create a chart OUTSIDE the active root (_songsRoot).
+        var outsideDir = Path.Combine(_testRoot, "Outside");
+        Directory.CreateDirectory(outsideDir);
+        var outsideChartPath = Path.Combine(outsideDir, "outside.dtx");
+        await File.WriteAllTextAsync(outsideChartPath, """
+            #TITLE: Outside
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 50
+            """);
+        var insideChartPath = WriteChart(
+            "Songs/Boundary Set/inside.dtx", "Inside", 30);
+        // ../ from "Boundary Set" -> "Songs" -> ../Outside -> outside _songsRoot
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            """
+            #TITLE Boundary Set
+            #L1FILE inside.dtx
+            #L2FILE ../../Outside/outside.dtx
+            """);
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { _songsRoot }, null, CancellationToken.None);
+
+        var normalizedOutside = SongPathIdentity.Normalize(outsideChartPath);
+        Assert.DoesNotContain(normalizedOutside, result.Batch.DiscoveredChartPaths);
+        Assert.DoesNotContain(result.Batch.Candidates, c =>
+            SongPathIdentity.CanonicalComparer.Equals(
+                c.NormalizedChartPath, normalizedOutside));
+        // The inside chart must still be imported.
+        Assert.Contains(insideChartPath, result.Batch.DiscoveredChartPaths);
+        Assert.Single(result.Batch.Candidates);
+    }
+
+    [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenSetDefReferencesAbsolutePath_ShouldRejectOutsideChart()
+    {
+        // Regression (review item 1): a set.def #LnFILE that uses an absolute
+        // path outside the active root must be rejected. Path.Combine with an
+        // absolute second argument returns the absolute path verbatim.
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var setRoot = Path.Combine(_songsRoot, "Abs Set");
+        Directory.CreateDirectory(setRoot);
+        var outsideDir = Path.Combine(_testRoot, "AbsoluteOutside");
+        Directory.CreateDirectory(outsideDir);
+        var outsideChartPath = Path.Combine(outsideDir, "outside.dtx");
+        await File.WriteAllTextAsync(outsideChartPath, """
+            #TITLE: Absolute Outside
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 60
+            """);
+        var insideChartPath = WriteChart(
+            "Songs/Abs Set/inside.dtx", "Inside Abs", 25);
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            $"""
+            #TITLE Abs Set
+            #L1FILE inside.dtx
+            #L2FILE {outsideChartPath}
+            """);
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { _songsRoot }, null, CancellationToken.None);
+
+        var normalizedOutside = SongPathIdentity.Normalize(outsideChartPath);
+        Assert.DoesNotContain(normalizedOutside, result.Batch.DiscoveredChartPaths);
+        Assert.DoesNotContain(result.Batch.Candidates, c =>
+            SongPathIdentity.CanonicalComparer.Equals(
+                c.NormalizedChartPath, normalizedOutside));
+        Assert.Contains(insideChartPath, result.Batch.DiscoveredChartPaths);
+        Assert.Single(result.Batch.Candidates);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenSetDefReferencesOutsideChart_ShouldNotProducePermanentMismatch()
+    {
+        // Regression (review item 1): after importing a set.def with an
+        // outside-root reference, the inventory scanner must NOT count the
+        // outside chart. Without the fix, the inventory count exceeds the
+        // database count (which scopes to active roots), forcing a perpetual
+        // rescan even when nothing changed.
+        var songsRoot = Path.Combine(_testRoot, "MismatchSongs");
+        Directory.CreateDirectory(songsRoot);
+        var setRoot = Path.Combine(songsRoot, "Set");
+        Directory.CreateDirectory(setRoot);
+        var outsideDir = Path.Combine(_testRoot, "MismatchOutside");
+        Directory.CreateDirectory(outsideDir);
+        var outsideChartPath = Path.Combine(outsideDir, "outside.dtx");
+        await File.WriteAllTextAsync(outsideChartPath, """
+            #TITLE: Outside
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 50
+            """);
+        var insideChartPath = Path.Combine(setRoot, "inside.dtx");
+        await File.WriteAllTextAsync(insideChartPath, """
+            #TITLE: Inside
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 30
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            """
+            #TITLE Set
+            #L1FILE inside.dtx
+            #L2FILE ../../MismatchOutside/outside.dtx
+            """);
+        var oldTime = DateTime.UtcNow.AddMinutes(-10);
+        var setDefPath = Path.Combine(setRoot, "set.def");
+        File.SetLastWriteTimeUtc(insideChartPath, oldTime);
+        File.SetCreationTimeUtc(insideChartPath, oldTime);
+        File.SetLastWriteTimeUtc(outsideChartPath, oldTime);
+        File.SetCreationTimeUtc(outsideChartPath, oldTime);
+        File.SetLastWriteTimeUtc(setDefPath, oldTime);
+        File.SetCreationTimeUtc(setDefPath, oldTime);
+        Directory.SetLastWriteTimeUtc(setRoot, oldTime);
+        Directory.SetCreationTimeUtc(setRoot, oldTime);
+        Directory.SetLastWriteTimeUtc(songsRoot, oldTime);
+        Directory.SetCreationTimeUtc(songsRoot, oldTime);
+
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { songsRoot }, null, CancellationToken.None);
+        Assert.Single(result.Batch.Candidates);
+
+        // After a successful enumeration with no subsequent file changes, the
+        // freshness check must report no changes needed. Without the fix, the
+        // inventory would count the outside chart (1 inside + 1 outside = 2)
+        // while the database counts only the inside chart (1), producing a
+        // permanent mismatch.
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(
+            new[] { songsRoot });
+        Assert.False(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenChartParseFails_ShouldReturnTrueToRetryDirtyRoot()
+    {
+        // Regression (review item 2): a recoverable parse failure leaves the
+        // chart's old database row preserved (discovered but unupdated). If the
+        // root's watermark advances past the file's mtime, the next freshness
+        // check sees matching counts and a stale watermark → no rescan → the
+        // chart's content is permanently stale. The fix suppresses the
+        // watermark advance for roots with recoverable errors so the next
+        // check triggers a rescan that retries the failed parse.
+        var songsRoot = Path.Combine(_testRoot, "RecoverableErrorSongs");
+        Directory.CreateDirectory(songsRoot);
+        var chartPath = Path.Combine(songsRoot, "song.dtx");
+        await File.WriteAllTextAsync(chartPath, """
+            #TITLE: Recoverable
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 50
+            """);
+        var oldTime = DateTime.UtcNow.AddMinutes(-10);
+        File.SetLastWriteTimeUtc(chartPath, oldTime);
+        File.SetCreationTimeUtc(chartPath, oldTime);
+        Directory.SetLastWriteTimeUtc(songsRoot, oldTime);
+        Directory.SetCreationTimeUtc(songsRoot, oldTime);
+
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var canonicalRoot = _manager.RootPolicy
+            .Validate(new[] { songsRoot }).CanonicalRoots.Single();
+
+        // First enumeration: succeed so the chart is in the database and the
+        // root's per-root watermark is established.
+        var firstResult = await _manager.EnumerateAndImportSongsAsync(
+            new[] { songsRoot }, null, CancellationToken.None);
+        Assert.Single(firstResult.Batch.Candidates);
+        var firstWatermark = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalRoot);
+        Assert.NotNull(firstWatermark);
+
+        // Simulate a transient parse failure on the next enumeration by
+        // replacing the parser with one that throws for this chart.
+        var realParser = _manager.ParseSongEntitiesCoreAsync;
+        _manager.ParseSongEntitiesCoreAsync = path =>
+            SongPathIdentity.CanonicalComparer.Equals(path, SongPathIdentity.Normalize(chartPath))
+                ? Task.FromException<(SongEntity, SongChart)>(
+                    new InvalidDataException($"transient parse failure for {path}"))
+                : realParser(path);
+
+        // Second enumeration: the parse fails, producing a recoverable error.
+        // The chart's old DB row is preserved (discovered but unupdated).
+        var secondResult = await _manager.EnumerateAndImportSongsAsync(
+            new[] { songsRoot }, null, CancellationToken.None);
+        Assert.Contains(secondResult.Batch.Errors, error =>
+            error.Path == SongPathIdentity.Normalize(chartPath) &&
+            !error.IsRootFailure);
+
+        // Restore the real parser so the freshness check's inventory scan
+        // (if it reaches that point) works normally.
+        _manager.ParseSongEntitiesCoreAsync = realParser;
+
+        // The root's per-root watermark must NOT have advanced. Without the
+        // fix, it would advance to the second enumeration's backed-off start,
+        // silently accepting the stale chart content.
+        var secondWatermark = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalRoot);
+        Assert.Equal(firstWatermark!.Value.ToUniversalTime(),
+            secondWatermark!.Value.ToUniversalTime());
+
+        // Set the file's mtime to just after the first watermark so the
+        // freshness check detects the change and triggers a retry.
+        var editTime = firstWatermark.Value.AddSeconds(10);
+        File.SetLastWriteTimeUtc(chartPath, editTime);
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(
+            new[] { songsRoot });
+        Assert.True(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenRecoverableErrorInOneRoot_ShouldStillAdvanceCleanRoot()
+    {
+        // Regression (review item 2): when one root has a recoverable error
+        // and another is clean, only the dirty root's watermark is suppressed.
+        // The clean root's watermark advances so it does not needlessly rescan.
+        var rootA = Path.Combine(_testRoot, "CleanRoot");
+        var rootB = Path.Combine(_testRoot, "DirtyRoot");
+        Directory.CreateDirectory(rootA);
+        Directory.CreateDirectory(rootB);
+        var chartA = Path.Combine(rootA, "clean.dtx");
+        var chartB = Path.Combine(rootB, "dirty.dtx");
+        await File.WriteAllTextAsync(chartA, """
+            #TITLE: Clean
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 40
+            """);
+        await File.WriteAllTextAsync(chartB, """
+            #TITLE: Dirty
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 60
+            """);
+        var oldTime = DateTime.UtcNow.AddMinutes(-10);
+        File.SetLastWriteTimeUtc(chartA, oldTime);
+        File.SetCreationTimeUtc(chartA, oldTime);
+        File.SetLastWriteTimeUtc(chartB, oldTime);
+        File.SetCreationTimeUtc(chartB, oldTime);
+        Directory.SetLastWriteTimeUtc(rootA, oldTime);
+        Directory.SetCreationTimeUtc(rootA, oldTime);
+        Directory.SetLastWriteTimeUtc(rootB, oldTime);
+        Directory.SetCreationTimeUtc(rootB, oldTime);
+
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var canonicalA = _manager.RootPolicy
+            .Validate(new[] { rootA }).CanonicalRoots.Single();
+        var canonicalB = _manager.RootPolicy
+            .Validate(new[] { rootB }).CanonicalRoots.Single();
+
+        // First enumeration: both charts succeed, both watermarks established.
+        await _manager.EnumerateAndImportSongsAsync(
+            new[] { rootA, rootB }, null, CancellationToken.None);
+        var firstWatermarkA = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
+        var firstWatermarkB = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalB);
+        Assert.NotNull(firstWatermarkA);
+        Assert.NotNull(firstWatermarkB);
+
+        // Second enumeration: chartB parse fails (recoverable error in rootB).
+        var realParser = _manager.ParseSongEntitiesCoreAsync;
+        _manager.ParseSongEntitiesCoreAsync = path =>
+            SongPathIdentity.CanonicalComparer.Equals(path, SongPathIdentity.Normalize(chartB))
+                ? Task.FromException<(SongEntity, SongChart)>(
+                    new InvalidDataException($"transient parse failure for {path}"))
+                : realParser(path);
+        await _manager.EnumerateAndImportSongsAsync(
+            new[] { rootA, rootB }, null, CancellationToken.None);
+        _manager.ParseSongEntitiesCoreAsync = realParser;
+
+        // rootA's watermark advanced (clean), rootB's did not (dirty).
+        var secondWatermarkA = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
+        var secondWatermarkB = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalB);
+        Assert.NotEqual(firstWatermarkA!.Value.ToUniversalTime(),
+            secondWatermarkA!.Value.ToUniversalTime());
+        Assert.Equal(firstWatermarkB!.Value.ToUniversalTime(),
+            secondWatermarkB!.Value.ToUniversalTime());
+
+        // Checking only rootA should report no changes needed (clean).
+        var needsA = await _manager.NeedsEnumerationAsync(new[] { rootA });
+        Assert.False(needsA);
+
+        // Checking only rootB should report changes needed (dirty watermark).
+        // Set chartB's mtime to just after the first watermark to ensure the
+        // change is detectable.
+        File.SetLastWriteTimeUtc(chartB, firstWatermarkB.Value.AddSeconds(10));
+        var needsB = await _manager.NeedsEnumerationAsync(new[] { rootB });
+        Assert.True(needsB);
+    }
+
+    [Fact]
     public async Task EnumerateAndImportSongsAsync_WhenChartParseCancelled_ShouldThrowOperationCanceled()
     {
         await _manager.InitializeDatabaseServiceAsync(_databasePath);

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1300,8 +1300,8 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
     }
 
     [Fact]
-    public async Task BuildEnumerationBatchAsync_WhenRootDoesNotExist_ShouldSkipAndRecordRootFailure()
-    {
+        public async Task BuildEnumerationBatchAsync_WhenRootDoesNotExist_ShouldSkipAndRecordRootFailure()
+        {
         var batch = await _manager.BuildEnumerationBatchAsync(
             new[] { Path.Combine(_testRoot, "Nonexistent") },
             null,
@@ -1309,12 +1309,31 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
 
         Assert.Empty(batch.Candidates);
         var rootError = Assert.Single(batch.Errors, e => e.IsRootFailure);
-        Assert.Contains("does not exist", rootError.Message, StringComparison.OrdinalIgnoreCase);
-    }
+            Assert.Contains("does not exist", rootError.Message, StringComparison.OrdinalIgnoreCase);
+        }
 
-    [Fact]
-    public async Task EnumerateAndImportSongsAsync_WhenBatchIsIncomplete_ShouldThrowInvalidOperationException()
-    {
+        [Fact]
+        public async Task BuildEnumerationBatchAsync_ShouldUseRootPolicyToDeduplicateActiveRoots()
+        {
+            var root = Path.Combine(_testRoot, "PolicyRoot");
+            Directory.CreateDirectory(root);
+            _manager.RootPolicy = new SongRootPolicy(
+                SongRootPolicy.CreateComparer(ignoreCase: true));
+
+            var batch = await _manager.BuildEnumerationBatchAsync(
+                new[] { root, root.ToUpperInvariant() },
+                null,
+                CancellationToken.None);
+
+            Assert.Equal([Path.GetFullPath(root)], batch.ActiveRoots);
+            Assert.Contains(batch.Errors, error =>
+                error.IsRootFailure &&
+                error.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public async Task EnumerateAndImportSongsAsync_WhenBatchIsIncomplete_ShouldThrowInvalidOperationException()
+        {
         await _manager.InitializeDatabaseServiceAsync(_databasePath);
         // Inject an incomplete batch directly via the build seam so the import
         // guard (IsComplete == false) is exercised independently of cancellation.
@@ -1336,11 +1355,52 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
             _manager.EnumerateAndImportSongsAsync(
                 new[] { _songsRoot }, null, CancellationToken.None));
 
-        Assert.Contains("incomplete enumeration", ex.Message, StringComparison.OrdinalIgnoreCase);
-    }
+            Assert.Contains("incomplete enumeration", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
 
-    [Fact]
-    public async Task RefreshSongListFromDatabaseAsync_WhenDatabaseNotInitialized_ShouldReturnEarly()
+        [Fact]
+        public async Task EnumerateAndImportSongsAsync_WhenCompleteBatchHasNoActiveRoots_ShouldNotImportOrPublish()
+        {
+            await SeedPublishedLibraryAsync();
+            var before = _manager.GetLibrarySnapshot();
+            var importCalls = 0;
+            var publishEvents = 0;
+            _manager.ImportSongsCoreAsync = (_, _, _, _) =>
+            {
+                importCalls++;
+                return Task.FromResult(SongBulkImportResult.Empty);
+            };
+            _manager.SongLibraryPublished += (_, _) => publishEvents++;
+            _manager.BuildEnumerationBatchCoreAsync = (_, _, _) =>
+                Task.FromResult(new SongEnumerationBatch
+                {
+                    ActiveRoots = Array.Empty<string>(),
+                    DiscoveredChartPaths = new HashSet<string>(StringComparer.Ordinal),
+                    Candidates = new List<SongImportCandidate>(),
+                    RootNodes = new List<SongListNode>(),
+                    PendingSongs = new List<PendingSongNode>(),
+                    Errors = new List<SongEnumerationError>(),
+                    DiscoveryAndParsingDuration = TimeSpan.Zero,
+                    IsComplete = true,
+                });
+
+            var result = await _manager.EnumerateAndImportSongsAsync(
+                new[] { _songsRoot }, null, CancellationToken.None);
+            var after = _manager.GetLibrarySnapshot();
+
+            Assert.Equal(SongEnumerationOutcome.NoActiveRoots, result.Outcome);
+            Assert.Same(SongBulkImportResult.Empty, result.Import);
+            Assert.Equal(TimeSpan.Zero, result.HierarchyDuration);
+            Assert.Equal(0, importCalls);
+            Assert.Equal(0, publishEvents);
+            Assert.Equal(before.Version, after.Version);
+            Assert.Equal(before.RootSongs, after.RootSongs);
+            Assert.Equal(before.ActiveRoots, after.ActiveRoots);
+            Assert.False(_manager.IsEnumerating);
+        }
+
+        [Fact]
+        public async Task RefreshSongListFromDatabaseAsync_WhenDatabaseNotInitialized_ShouldReturnEarly()
     {
         // Without InitializeDatabaseServiceAsync, DatabaseService is null.
         // Should not throw.

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -227,7 +227,7 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
             Assert.True(_manager.IsEnumerating);
 
             // A second enumeration must be rejected while A has not terminated.
-            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            await Assert.ThrowsAsync<SongEnumerationBusyException>(() =>
                 _manager.EnumerateAndImportSongsAsync(
                     new[] { _songsRoot }, progress: null, CancellationToken.None));
         }

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1500,6 +1500,39 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
         Assert.Equal(1, _manager.DiscoveredScoreCount);
     }
 
+    [Theory]
+    [InlineData(SongEnumerationPostCommitPhase.Finalization)]
+    [InlineData(SongEnumerationPostCommitPhase.Publication)]
+    public async Task EnumerateAndImportSongsAsync_WhenPostCommitPhaseFails_ShouldThrowPhaseAwareException(
+        SongEnumerationPostCommitPhase expectedPhase)
+    {
+        await SeedPublishedLibraryAsync();
+        var before = _manager.GetLibrarySnapshot();
+        WriteChart("Songs/PostCommitFailure/new.dtx", "Committed New", 50);
+        var failure = new InvalidOperationException("post-commit phase failed");
+
+        if (expectedPhase == SongEnumerationPostCommitPhase.Finalization)
+        {
+            _manager.FinalizePendingNodesCore = (_, _) => throw failure;
+        }
+        else
+        {
+            _manager.PublishEnumerationCore = _ => throw failure;
+        }
+
+        var exception = await Assert.ThrowsAsync<SongEnumerationPostCommitException>(() =>
+            _manager.EnumerateAndImportSongsAsync(
+                new[] { _songsRoot }, null, CancellationToken.None));
+
+        Assert.Equal(expectedPhase, exception.Phase);
+        Assert.Same(failure, exception.InnerException);
+        Assert.Equal(2, exception.Batch.Candidates.Count);
+        Assert.Equal(_seededChartCount + 1, await CountChartsAsync());
+        var after = _manager.GetLibrarySnapshot();
+        Assert.Equal(before.Version, after.Version);
+        Assert.Equal(before.RootSongs, after.RootSongs);
+    }
+
     [Fact]
     public async Task GetRecentlyPlayedNodesAsync_WithMoreThanLimit_ShouldReturnLimitInRecencyOrder()
     {

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1472,6 +1472,35 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
     }
 
     [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenCancellationArrivesAfterCommit_ShouldStillFinalizeAndPublish()
+    {
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        WriteChart("Songs/PostCommit/chart.dtx", "Post Commit", 50);
+        using var cancellation = new CancellationTokenSource();
+        var realImporter = _manager.ImportSongsCoreAsync;
+        _manager.ImportSongsCoreAsync = async (database, request, progress, token) =>
+        {
+            var import = await realImporter(database, request, progress, token);
+            // The default importer returns only after SaveChanges/transaction
+            // commit. This models a Config deactivation that races immediately
+            // afterward: finalization/publication must still complete.
+            cancellation.Cancel();
+            return import;
+        };
+        var published = 0;
+        _manager.SongLibraryPublished += (_, _) => published++;
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { _songsRoot }, null, cancellation.Token);
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Equal(SongEnumerationOutcome.ImportedAndPublished, result.Outcome);
+        Assert.Equal(1, published);
+        Assert.NotEmpty(_manager.RootSongs);
+        Assert.Equal(1, _manager.DiscoveredScoreCount);
+    }
+
+    [Fact]
     public async Task GetRecentlyPlayedNodesAsync_WithMoreThanLimit_ShouldReturnLimitInRecencyOrder()
     {
         await _manager.InitializeDatabaseServiceAsync(_databasePath);

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1793,7 +1793,8 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
         await using (var context = _manager.DatabaseService!.CreateContext())
         {
             await context.Database.ExecuteSqlRawAsync(
-                "DELETE FROM __EnumerationMetadata WHERE Key LIKE 'LastSuccessfulEnumerationUtc:Root:%'");
+                "DELETE FROM __EnumerationMetadata WHERE Key LIKE {0}",
+                SongDatabaseService.LastSuccessfulEnumerationRootKeyPrefix + "%");
         }
         var legacyGlobal = DateTime.UtcNow.AddMinutes(-20);
         await _manager.DatabaseService!
@@ -1917,8 +1918,8 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
     }
 
     [Fact]
-        public async Task BuildEnumerationBatchAsync_WhenRootDoesNotExist_ShouldSkipAndRecordRootFailure()
-        {
+    public async Task BuildEnumerationBatchAsync_WhenRootDoesNotExist_ShouldSkipAndRecordRootFailure()
+    {
         var batch = await _manager.BuildEnumerationBatchAsync(
             new[] { Path.Combine(_testRoot, "Nonexistent") },
             null,
@@ -1926,10 +1927,10 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
 
         Assert.Empty(batch.Candidates);
         var rootError = Assert.Single(batch.Errors, e => e.IsRootFailure);
-            Assert.Contains("does not exist", rootError.Message, StringComparison.OrdinalIgnoreCase);
-        }
+        Assert.Contains("does not exist", rootError.Message, StringComparison.OrdinalIgnoreCase);
+    }
 
-        [Fact]
+    [Fact]
         public async Task BuildEnumerationBatchAsync_ShouldUseRootPolicyToDeduplicateActiveRoots()
         {
             var root = Path.Combine(_testRoot, "PolicyRoot");
@@ -1948,9 +1949,9 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
                 error.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
         }
 
-        [Fact]
-        public async Task EnumerateAndImportSongsAsync_WhenBatchIsIncomplete_ShouldThrowInvalidOperationException()
-        {
+    [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenBatchIsIncomplete_ShouldThrowInvalidOperationException()
+    {
         await _manager.InitializeDatabaseServiceAsync(_databasePath);
         // Inject an incomplete batch directly via the build seam so the import
         // guard (IsComplete == false) is exercised independently of cancellation.
@@ -1972,8 +1973,8 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
             _manager.EnumerateAndImportSongsAsync(
                 new[] { _songsRoot }, null, CancellationToken.None));
 
-            Assert.Contains("incomplete enumeration", ex.Message, StringComparison.OrdinalIgnoreCase);
-        }
+        Assert.Contains("incomplete enumeration", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
 
         [Fact]
         public async Task EnumerateAndImportSongsAsync_WhenCompleteBatchHasNoActiveRoots_ShouldNotImportOrPublish()

--- a/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+++ b/DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
@@ -1382,6 +1382,203 @@ public sealed class SongManagerBulkEnumerationTests : IDisposable
     }
 
     [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenSetDefReferencesSiblingWithinSameRoot_ShouldRejectEscapedChart()
+    {
+        // Regression (review item 1, medium): a set.def #LnFILE that escapes
+        // the set.def's own directory via ../ traversal — but stays within the
+        // same configured root — must be rejected. Without this, the sibling
+        // chart gets a duplicate placeholder: one under the set.def's directory
+        // (from the set.def reference) and one under the sibling's own
+        // directory (from direct file enumeration). Both resolve to the single
+        // persisted chart in the freshly published hierarchy, but on a cached
+        // restart the chart is placed only by its physical path, so the
+        // duplicate/misplaced node disappears — an inconsistency.
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var setRoot = Path.Combine(_songsRoot, "SongA");
+        Directory.CreateDirectory(setRoot);
+        var siblingDir = Path.Combine(_songsRoot, "SongB");
+        Directory.CreateDirectory(siblingDir);
+        var siblingChartPath = Path.Combine(siblingDir, "sibling.dtx");
+        await File.WriteAllTextAsync(siblingChartPath, """
+            #TITLE: Sibling
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 50
+            """);
+        var insideChartPath = WriteChart(
+            "Songs/SongA/inside.dtx", "Inside A", 30);
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            """
+            #TITLE SongA
+            #L1FILE inside.dtx
+            #L2FILE ../SongB/sibling.dtx
+            """);
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { _songsRoot }, null, CancellationToken.None);
+
+        var normalizedSibling = SongPathIdentity.Normalize(siblingChartPath);
+        // The sibling chart must be discovered exactly once (from direct
+        // enumeration of SongB, not from the set.def reference).
+        Assert.Contains(normalizedSibling, result.Batch.DiscoveredChartPaths);
+        Assert.Single(result.Batch.Candidates, c =>
+            SongPathIdentity.CanonicalComparer.Equals(
+                c.NormalizedChartPath, normalizedSibling));
+        // The inside chart must also be imported.
+        Assert.Contains(insideChartPath, result.Batch.DiscoveredChartPaths);
+        // No duplicate: one candidate for inside + one for sibling = 2 total.
+        Assert.Equal(2, result.Batch.Candidates.Count);
+        // The published hierarchy must contain exactly one score node for the
+        // sibling chart (no duplicate/misplaced placeholder from the set.def
+        // reference).
+        var siblingScoreNodes = FlattenScoreNodes(_manager.RootSongs)
+            .Where(node => node.DatabaseChart != null &&
+                SongPathIdentity.CanonicalComparer.Equals(
+                    node.DatabaseChart.FilePath, normalizedSibling))
+            .ToArray();
+        Assert.Single(siblingScoreNodes);
+    }
+
+    [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenSetDefReferencesAbsolutePathInsideRoot_ShouldRejectEscapedChart()
+    {
+        // Regression (review item 1, medium): a set.def #LnFILE that uses an
+        // absolute path still INSIDE the configured root must be rejected.
+        // Path.Combine with an absolute second argument silently overrides the
+        // set.def directory, which would create a duplicate placeholder for a
+        // chart that is also discovered by direct enumeration of its own
+        // directory.
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var setRoot = Path.Combine(_songsRoot, "AbsInnerSet");
+        Directory.CreateDirectory(setRoot);
+        var absSiblingDir = Path.Combine(_songsRoot, "AbsInnerSibling");
+        Directory.CreateDirectory(absSiblingDir);
+        var absSiblingChartPath = Path.Combine(absSiblingDir, "abs.dtx");
+        await File.WriteAllTextAsync(absSiblingChartPath, """
+            #TITLE: Abs Sibling
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 55
+            """);
+        var insideChartPath = WriteChart(
+            "Songs/AbsInnerSet/inside.dtx", "Inside Abs Inner", 28);
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            $"""
+            #TITLE AbsInnerSet
+            #L1FILE inside.dtx
+            #L2FILE {absSiblingChartPath}
+            """);
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { _songsRoot }, null, CancellationToken.None);
+
+        var normalizedAbsSibling = SongPathIdentity.Normalize(absSiblingChartPath);
+        // The absolute-path-referenced chart must be discovered exactly once
+        // (from direct enumeration, not from the set.def reference).
+        Assert.Contains(normalizedAbsSibling, result.Batch.DiscoveredChartPaths);
+        Assert.Single(result.Batch.Candidates, c =>
+            SongPathIdentity.CanonicalComparer.Equals(
+                c.NormalizedChartPath, normalizedAbsSibling));
+        Assert.Contains(insideChartPath, result.Batch.DiscoveredChartPaths);
+        Assert.Equal(2, result.Batch.Candidates.Count);
+    }
+
+    [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenSetDefReferencesAnotherConfiguredRoot_ShouldRejectCrossRootChart()
+    {
+        // Regression (review item 1, medium): a set.def #LnFILE that references
+        // a chart in a DIFFERENT configured root must be rejected. Even though
+        // the target chart is beneath an active root, the reference escapes the
+        // set.def's own directory and would create a duplicate/misplaced
+        // placeholder.
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var rootA = Path.Combine(_testRoot, "RootA");
+        var rootB = Path.Combine(_testRoot, "RootB");
+        Directory.CreateDirectory(rootA);
+        Directory.CreateDirectory(rootB);
+        var setRoot = Path.Combine(rootA, "SetA");
+        Directory.CreateDirectory(setRoot);
+        var crossDir = Path.Combine(rootB, "SetB");
+        Directory.CreateDirectory(crossDir);
+        var crossChartPath = Path.Combine(crossDir, "cross.dtx");
+        await File.WriteAllTextAsync(crossChartPath, """
+            #TITLE: Cross
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 50
+            """);
+        var insideChartPath = Path.Combine(setRoot, "inside.dtx");
+        await File.WriteAllTextAsync(insideChartPath, """
+            #TITLE: Inside A
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 30
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            """
+            #TITLE SetA
+            #L1FILE inside.dtx
+            #L2FILE ../../RootB/SetB/cross.dtx
+            """);
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { rootA, rootB }, null, CancellationToken.None);
+
+        var normalizedCross = SongPathIdentity.Normalize(crossChartPath);
+        // The cross-root chart must be discovered exactly once (from direct
+        // enumeration of RootB/SetB, not from the set.def reference in RootA).
+        Assert.Contains(normalizedCross, result.Batch.DiscoveredChartPaths);
+        Assert.Single(result.Batch.Candidates, c =>
+            SongPathIdentity.CanonicalComparer.Equals(
+                c.NormalizedChartPath, normalizedCross));
+        var normalizedInside = SongPathIdentity.Normalize(insideChartPath);
+        Assert.Contains(normalizedInside, result.Batch.DiscoveredChartPaths);
+        Assert.Equal(2, result.Batch.Candidates.Count);
+    }
+
+    [Fact]
+    public async Task EnumerateAndImportSongsAsync_WhenSetDefReferencesValidChildPath_ShouldAcceptChart()
+    {
+        // Regression (review item 1, medium): a set.def #LnFILE that references
+        // a chart in a subdirectory of the set.def's own directory (e.g.
+        // charts/basic.dtx) must be ACCEPTED. The directory-local containment
+        // check permits child paths while rejecting ../, absolute, and
+        // cross-root references.
+        await _manager.InitializeDatabaseServiceAsync(_databasePath);
+        var setRoot = Path.Combine(_songsRoot, "ChildSet");
+        Directory.CreateDirectory(setRoot);
+        var chartsDir = Path.Combine(setRoot, "charts");
+        Directory.CreateDirectory(chartsDir);
+        var childChartPath = Path.Combine(chartsDir, "basic.dtx");
+        await File.WriteAllTextAsync(childChartPath, """
+            #TITLE: Basic
+            #ARTIST: Fixture Artist
+            #BPM: 120
+            #DLEVEL: 40
+            """);
+        await File.WriteAllTextAsync(
+            Path.Combine(setRoot, "set.def"),
+            """
+            #TITLE ChildSet
+            #L1FILE charts/basic.dtx
+            """);
+
+        var result = await _manager.EnumerateAndImportSongsAsync(
+            new[] { _songsRoot }, null, CancellationToken.None);
+
+        var normalizedChild = SongPathIdentity.Normalize(childChartPath);
+        Assert.Contains(normalizedChild, result.Batch.DiscoveredChartPaths);
+        Assert.Single(result.Batch.Candidates, c =>
+            SongPathIdentity.CanonicalComparer.Equals(
+                c.NormalizedChartPath, normalizedChild));
+        // The chart must appear in the published hierarchy.
+        Assert.Single(FlattenScoreNodes(_manager.RootSongs));
+    }
+
+    [Fact]
     public async Task NeedsEnumerationAsync_WhenChartParseFails_ShouldReturnTrueToRetryDirtyRoot()
     {
         // Regression (review item 2): a recoverable parse failure leaves the

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -266,6 +266,42 @@ public class SongManagerCoverageTests : IDisposable
     }
 
     [Fact]
+    public async Task NeedsEnumerationAsync_WhenARootIsRemovedAndItsRowsRetained_ShouldStillLoadFromCache()
+    {
+        // Regression: the filesystem file count is scoped to the active roots,
+        // so the database score count must be scoped to the same roots. The
+        // global score count would include retained rows belonging to a removed
+        // root, which can never match the scoped filesystem count and would
+        // force a full rescan on every subsequent startup.
+        var retainedRoot = Path.Combine(_testRoot, "RetainedSongs");
+        var removedRoot = Path.Combine(_testRoot, "RemovedSongs");
+        var retainedFolder = Path.Combine(retainedRoot, "Retained Song");
+        var removedFolder = Path.Combine(removedRoot, "Removed Song");
+
+        Directory.CreateDirectory(retainedFolder);
+        Directory.CreateDirectory(removedFolder);
+        await CreateDtxFileAsync(Path.Combine(retainedFolder, "retained.dtx"), "Retained Song", "Coverage Bot", "Jazz", 40);
+        await CreateDtxFileAsync(Path.Combine(removedFolder, "removed.dtx"), "Removed Song", "Coverage Bot", "Jazz", 50);
+
+        // Enumerate both roots so the database holds rows for each.
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        var enumerated = await _manager.EnumerateSongsAsync(new[] { retainedRoot, removedRoot });
+        Assert.True(enumerated >= 2);
+        Assert.NotNull(_manager.DatabaseService);
+
+        // The removed root's files still exist on disk; only the configured root
+        // set changes. Its rows remain in the database (the import path only
+        // removes stale charts under active roots).
+        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+
+        // Simulate the next startup with the removed root no longer configured.
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { retainedRoot });
+
+        Assert.False(needsEnumeration);
+    }
+
+    [Fact]
     public async Task NeedsEnumerationAsync_WhenFileCountChanges_ShouldReturnTrue()
     {
         var songsRoot = Path.Combine(_testRoot, "ChangedSongs");

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -301,10 +301,10 @@ public class SongManagerCoverageTests : IDisposable
         // every startup was a full scan.
         var songsRoot = Path.Combine(_testRoot, "CoreTimestampSongs");
         var songFolder = Path.Combine(songsRoot, "Song");
+        var chartPath = Path.Combine(songFolder, "song.dtx");
         Directory.CreateDirectory(songFolder);
-        await CreateDtxFileAsync(
-            Path.Combine(songFolder, "song.dtx"),
-            "Core Timestamp Song", "Coverage Bot", "Jazz", 40);
+        await CreateDtxFileAsync(chartPath, "Core Timestamp Song", "Coverage Bot", "Jazz", 40);
+        SetFilesystemTimes(chartPath, DateTime.UtcNow.AddMinutes(-1));
 
         // EnumerateSongsAsync routes through EnumerateAndImportSongsCoreAsync
         // — the same core used by EnumerateAndImportSongsAsync (startup/reload).
@@ -314,6 +314,130 @@ public class SongManagerCoverageTests : IDisposable
         var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { songsRoot });
 
         Assert.False(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenRootExistsButCannotBeEnumerated_ShouldNotForceRescan()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var populatedRoot = Path.Combine(_testRoot, "ReadableSongs");
+        var inaccessibleRoot = Path.Combine(_testRoot, "InaccessibleSongs");
+        var populatedChart = Path.Combine(populatedRoot, "Song", "song.dtx");
+        await CreateDtxFileAsync(populatedChart, "Readable Song", "Coverage Bot", "Rock", 35);
+        SetFilesystemTimes(populatedChart, DateTime.UtcNow.AddMinutes(-1));
+
+        await InitializeAndEnumerateAsync(populatedRoot);
+        await SetLastEnumerationTimestampAsync(DateTime.UtcNow.AddMinutes(5).ToLocalTime());
+
+        Directory.CreateDirectory(inaccessibleRoot);
+        try
+        {
+            File.SetUnixFileMode(inaccessibleRoot, UnixFileMode.None);
+            var canEnumerate = true;
+            try
+            {
+                using var entries = Directory
+                    .EnumerateFileSystemEntries(inaccessibleRoot)
+                    .GetEnumerator();
+                _ = entries.MoveNext();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                canEnumerate = false;
+            }
+            catch (IOException)
+            {
+                canEnumerate = false;
+            }
+
+            // Permission-restricted tests cannot exercise the branch when the
+            // process has elevated privileges (for example, a root CI runner).
+            if (canEnumerate)
+                return;
+
+            var needsEnumeration = await _manager.NeedsEnumerationAsync(
+                new[] { populatedRoot, inaccessibleRoot });
+
+            Assert.False(needsEnumeration);
+        }
+        finally
+        {
+            File.SetUnixFileMode(
+                inaccessibleRoot,
+                UnixFileMode.UserRead |
+                UnixFileMode.UserWrite |
+                UnixFileMode.UserExecute);
+        }
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenTimestampIsRoundedBeforeWatermark_ShouldDetectChange()
+    {
+        var songsRoot = Path.Combine(_testRoot, "CoarseTimestampSongs");
+        var chartPath = Path.Combine(songsRoot, "Song", "song.dtx");
+        await CreateDtxFileAsync(chartPath, "Coarse Timestamp Song", "Coverage Bot", "Rock", 35);
+        SetFilesystemTimes(chartPath, DateTime.UtcNow.AddHours(-3));
+
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        var scanStartUtc = DateTime.UtcNow.AddHours(-1);
+        var persistedWatermarkUtc = scanStartUtc.AddSeconds(-5);
+        await SetLastEnumerationTimestampAsync(persistedWatermarkUtc.ToLocalTime());
+        await SetRootEnumerationTimestampAsync(songsRoot, persistedWatermarkUtc);
+
+        // Model a coarse filesystem timestamp rounded just before the exact
+        // watermark. The conservative scan watermark must still see it.
+        var roundedEditUtc = scanStartUtc.AddSeconds(-1);
+        await File.AppendAllTextAsync(chartPath, "#COMMENT: rounded edit\n");
+        SetFilesystemTimes(chartPath, roundedEditUtc, preserveCreationTime: true);
+
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { songsRoot });
+
+        Assert.True(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenUnavailableRootReturnsWithInPlaceEdit_ShouldDetectChange()
+    {
+        var rootA = Path.Combine(_testRoot, "RootA");
+        var rootB = Path.Combine(_testRoot, "RootB");
+        var chartA = Path.Combine(rootA, "Song A", "song.dtx");
+        var chartB = Path.Combine(rootB, "Song B", "song.dtx");
+
+        await CreateDtxFileAsync(chartA, "Song A", "Coverage Bot", "Rock", 35);
+        await CreateDtxFileAsync(chartB, "Song B", "Coverage Bot", "Rock", 40);
+
+        var oldFilesystemTimeUtc = DateTime.UtcNow.AddHours(-3);
+        SetFilesystemTimes(chartA, oldFilesystemTimeUtc);
+        SetFilesystemTimes(chartB, oldFilesystemTimeUtc);
+
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        var initialEnumeration = await _manager.EnumerateSongsAsync(new[] { rootA, rootB });
+        Assert.True(initialEnumeration >= 2);
+
+        // Establish a known per-root baseline before simulating the unavailable
+        // root. The root-B edit below is newer than this baseline but older than
+        // the partial root-A scan watermark.
+        var baselineUtc = DateTime.UtcNow.AddHours(-2);
+        await SetLastEnumerationTimestampAsync(baselineUtc.ToLocalTime());
+        await SetRootEnumerationTimestampAsync(rootA, baselineUtc);
+        await SetRootEnumerationTimestampAsync(rootB, baselineUtc);
+
+        // Omit B from this enumeration to model the configured root being
+        // unavailable. Its database rows remain retained while A advances.
+        var partialEnumeration = await _manager.EnumerateSongsAsync(new[] { rootA });
+        Assert.True(partialEnumeration >= 1);
+
+        var editedAtUtc = DateTime.UtcNow.AddMinutes(-1);
+        await File.AppendAllTextAsync(chartB, "#COMMENT: edited\n");
+        SetFilesystemTimes(chartB, editedAtUtc, preserveCreationTime: true);
+
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { rootA, rootB });
+
+        Assert.True(needsEnumeration);
     }
 
     [Fact]
@@ -1802,6 +1926,24 @@ public class SongManagerCoverageTests : IDisposable
 """);
     }
 
+    private static void SetFilesystemTimes(
+        string filePath,
+        DateTime utcTimestamp,
+        bool preserveCreationTime = false)
+    {
+        var directoryPath = Path.GetDirectoryName(filePath)!;
+        var rootPath = Directory.GetParent(directoryPath)!.FullName;
+        File.SetLastWriteTimeUtc(filePath, utcTimestamp);
+        Directory.SetLastWriteTimeUtc(directoryPath, utcTimestamp);
+        Directory.SetLastWriteTimeUtc(rootPath, utcTimestamp);
+        if (!preserveCreationTime)
+        {
+            File.SetCreationTimeUtc(filePath, utcTimestamp);
+            Directory.SetCreationTimeUtc(directoryPath, utcTimestamp);
+            Directory.SetCreationTimeUtc(rootPath, utcTimestamp);
+        }
+    }
+
     private void ClearRootSongs()
     {
         var rootSongs = ReflectionHelpers.GetPrivateField<List<SongListNode>>(_manager, "_rootSongs");
@@ -1820,7 +1962,30 @@ public class SongManagerCoverageTests : IDisposable
     private async Task SetLastEnumerationTimestampAsync(DateTime localTimestamp)
     {
         Assert.NotNull(_manager.DatabaseService);
-        await _manager.DatabaseService!.SetLastSuccessfulEnumerationUtcAsync(localTimestamp.ToUniversalTime());
+        var utcTimestamp = localTimestamp.ToUniversalTime();
+        await _manager.DatabaseService!.SetLastSuccessfulEnumerationUtcAsync(utcTimestamp);
+
+        var currentRoots = ReflectionHelpers.GetPrivateField<string[]>(
+            _manager,
+            "_currentSearchPaths");
+        if (currentRoots == null)
+            return;
+
+        foreach (var root in currentRoots)
+            await SetRootEnumerationTimestampAsync(root, utcTimestamp);
+    }
+
+    private async Task SetRootEnumerationTimestampAsync(string root, DateTime utcTimestamp)
+    {
+        Assert.NotNull(_manager.DatabaseService);
+        var canonicalRoot = _manager.RootPolicy
+            .Validate(new[] { root })
+            .CanonicalRoots
+            .Single();
+
+        await _manager.DatabaseService!.SetLastSuccessfulEnumerationUtcAsync(
+            new[] { canonicalRoot },
+            utcTimestamp.ToUniversalTime());
     }
 
     private static SongDatabaseService CreateBrokenDatabaseService()

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -1418,8 +1418,8 @@ public class SongManagerCoverageTests : IDisposable
     {
         var songsRoot = Path.Combine(_testRoot, "DirectoryModified");
         Directory.CreateDirectory(songsRoot);
-        var lastEnumerationTime = DateTime.Now.AddMinutes(-5);
-        Directory.SetLastWriteTime(songsRoot, DateTime.Now);
+        var lastEnumerationTime = DateTime.UtcNow.AddMinutes(-5);
+        Directory.SetLastWriteTimeUtc(songsRoot, DateTime.UtcNow);
 
         var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
             _manager,
@@ -1438,9 +1438,9 @@ public class SongManagerCoverageTests : IDisposable
         var dtxPath = Path.Combine(songsRoot, "changed.dtx");
         await CreateDtxFileAsync(dtxPath, "Changed Song", "Coverage Bot", "Rock", 40);
 
-        var lastEnumerationTime = DateTime.Now.AddMinutes(-5);
-        Directory.SetLastWriteTime(songsRoot, lastEnumerationTime.AddMinutes(-1));
-        File.SetLastWriteTime(dtxPath, DateTime.Now);
+        var lastEnumerationTime = DateTime.UtcNow.AddMinutes(-5);
+        Directory.SetLastWriteTimeUtc(songsRoot, lastEnumerationTime.AddMinutes(-1));
+        File.SetLastWriteTimeUtc(dtxPath, DateTime.UtcNow);
 
         var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
             _manager,
@@ -1826,10 +1826,11 @@ public class SongManagerCoverageTests : IDisposable
             await context.SaveChangesAsync();
         }
 
-        // Set the database file's last-write time AFTER all writes (including the
-        // score-row inserts above) so GetLastEnumerationTimestampAsync reports a
-        // steady-state timestamp in the future. Setting it before the inserts
-        // would let SaveChangesAsync overwrite it with the current time.
+        // Set the explicit __EnumerationMetadata enumeration timestamp AFTER all
+        // writes (including the score-row inserts above) so the freshness check
+        // sees a steady-state watermark in the future. The watermark is the
+        // persisted LastSuccessfulEnumerationUtc value, not the database file's
+        // last-write time, so unrelated SaveChangesAsync calls cannot advance it.
         await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         // Filesystem still has exactly 1 chart file; database now has 3 score rows
@@ -1891,9 +1892,9 @@ public class SongManagerCoverageTests : IDisposable
 #00011:01010101
 """);
 
-        var lastEnumerationTime = DateTime.Now.AddMinutes(-5);
-        Directory.SetLastWriteTime(songsRoot, lastEnumerationTime.AddMinutes(-1));
-        File.SetLastWriteTime(bmsPath, DateTime.Now);
+        var lastEnumerationTime = DateTime.UtcNow.AddMinutes(-5);
+        Directory.SetLastWriteTimeUtc(songsRoot, lastEnumerationTime.AddMinutes(-1));
+        File.SetLastWriteTimeUtc(bmsPath, DateTime.UtcNow);
 
         var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
             _manager,

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -1063,7 +1063,7 @@ public class SongManagerCoverageTests : IDisposable
     }
 
     [Fact]
-    public async Task EnumerateSongsAsync_WhenRootSongCacheIsUnavailable_ShouldPropagatePublicationFailure()
+    public async Task EnumerateSongsAsync_WhenRootSongCacheIsUnavailable_ShouldReportPostCommitPublicationFailure()
     {
         var songsRoot = Path.Combine(_testRoot, "BrokenRootSongs");
         Directory.CreateDirectory(songsRoot);
@@ -1076,8 +1076,19 @@ public class SongManagerCoverageTests : IDisposable
         {
             ReflectionHelpers.SetPrivateField(_manager, "_rootSongs", null!);
 
-            await Assert.ThrowsAsync<NullReferenceException>(() =>
+            var exception = await Assert.ThrowsAsync<SongEnumerationPostCommitException>(() =>
                 _manager.EnumerateSongsAsync(new[] { songsRoot }));
+
+            Assert.Equal(SongEnumerationPostCommitPhase.Publication, exception.Phase);
+            Assert.True(exception.Batch.IsComplete);
+            Assert.Equal(songsRoot, Assert.Single(exception.Batch.ActiveRoots));
+            Assert.Equal(1, exception.Import.Added);
+            Assert.Single(exception.Import.ChartsByPath);
+            Assert.IsType<NullReferenceException>(exception.InnerException);
+
+            var committedSong = Assert.Single(await _manager.DatabaseService!.GetSongsAsync());
+            Assert.Equal("Broken Root Song", committedSong.Title);
+            Assert.Single(committedSong.Charts);
         }
         finally
         {

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Test.TestData;
+using Microsoft.EntityFrameworkCore;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 
 namespace DTXMania.Test.Song;
@@ -576,6 +577,71 @@ public class SongManagerCoverageTests : IDisposable
             .GetLastSuccessfulEnumerationUtcAsync();
         Assert.Equal(baseline.ToUniversalTime(), global!.Value.ToUniversalTime());
         var perRootA = await originalService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
+        Assert.Equal(baseline.ToUniversalTime(), perRootA!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public async Task SetEnumerationWatermarkAtomicallyAsync_WhenPerRootInsertFails_RollsBackGlobalInsert()
+    {
+        // Review item 3: the existing WhenWriteFails test uses a broken service
+        // that fails before the transaction begins (CreateContext throws). This
+        // test exercises a MID-TRANSACTION failure: the global-key INSERT
+        // succeeds, then the per-root INSERT is aborted by a SQLite trigger.
+        // The transaction must roll back as a unit so the global watermark is
+        // NOT left committed while per-root rows are absent — that partial
+        // state would cause the legacy fallback to assign the global timestamp
+        // to every root, hiding edits on returning roots.
+        var rootA = Path.Combine(_testRoot, "RootA");
+        await CreateDtxFileAsync(
+            Path.Combine(rootA, "Song A", "song.dtx"),
+            "Song A", "Coverage Bot", "Rock", 35);
+
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        Assert.NotNull(_manager.DatabaseService);
+
+        // Establish a known baseline watermark (both global and per-root).
+        var baseline = DateTime.UtcNow.AddHours(-2);
+        var canonicalA = _manager.RootPolicy
+            .Validate(new[] { rootA }).CanonicalRoots.Single();
+        Assert.True(await _manager.DatabaseService!
+            .SetEnumerationWatermarkAtomicallyAsync(baseline, new[] { canonicalA }));
+
+        // Install a SQLite trigger that aborts any INSERT on
+        // __EnumerationMetadata when the key starts with the per-root prefix.
+        // This causes the per-root INSERT OR REPLACE to fail AFTER the global
+        // INSERT OR REPLACE has already executed within the same transaction.
+        await using (var triggerContext = _manager.DatabaseService!.CreateContext())
+        {
+            await triggerContext.Database.ExecuteSqlRawAsync(
+                """
+                CREATE TRIGGER abort_per_root_watermark_insert
+                BEFORE INSERT ON __EnumerationMetadata
+                WHEN NEW.Key LIKE 'LastSuccessfulEnumerationUtc:Root:%'
+                BEGIN
+                    SELECT RAISE(ABORT, 'per-root insert aborted by test trigger');
+                END
+                """);
+        }
+
+        var newWatermark = DateTime.UtcNow.AddHours(-1);
+        var success = await _manager.DatabaseService!
+            .SetEnumerationWatermarkAtomicallyAsync(
+                newWatermark,
+                new[] { canonicalA });
+
+        // The atomic method must return false (the transaction failed).
+        Assert.False(success);
+
+        // The global watermark must still be the baseline — the preceding
+        // global-key INSERT was rolled back, not left committed.
+        var global = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync();
+        Assert.Equal(baseline.ToUniversalTime(), global!.Value.ToUniversalTime());
+
+        // The per-root watermark must also still be the baseline.
+        var perRootA = await _manager.DatabaseService!
             .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
         Assert.Equal(baseline.ToUniversalTime(), perRootA!.Value.ToUniversalTime());
     }

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -441,6 +441,192 @@ public class SongManagerCoverageTests : IDisposable
     }
 
     [Fact]
+    public async Task SetEnumerationWatermarkAtomicallyAsync_WhenSuccessful_WritesBothGlobalAndPerRoot()
+    {
+        var rootA = Path.Combine(_testRoot, "RootA");
+        var rootB = Path.Combine(_testRoot, "RootB");
+        await CreateDtxFileAsync(
+            Path.Combine(rootA, "Song A", "song.dtx"),
+            "Song A", "Coverage Bot", "Rock", 35);
+        await CreateDtxFileAsync(
+            Path.Combine(rootB, "Song B", "song.dtx"),
+            "Song B", "Coverage Bot", "Rock", 40);
+
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        Assert.NotNull(_manager.DatabaseService);
+
+        var watermark = DateTime.UtcNow.AddHours(-1);
+        var canonicalA = _manager.RootPolicy
+            .Validate(new[] { rootA }).CanonicalRoots.Single();
+        var canonicalB = _manager.RootPolicy
+            .Validate(new[] { rootB }).CanonicalRoots.Single();
+
+        // A successful atomic write must commit both the global watermark and
+        // every supplied per-root watermark. A partial commit (global only)
+        // would trigger the legacy fallback and assign the global timestamp to
+        // roots that were not in the batch.
+        var success = await _manager.DatabaseService!
+            .SetEnumerationWatermarkAtomicallyAsync(
+                watermark,
+                new[] { canonicalA, canonicalB });
+
+        Assert.True(success);
+        var global = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync();
+        Assert.Equal(watermark.ToUniversalTime(), global!.Value.ToUniversalTime());
+        var perRootA = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
+        Assert.Equal(watermark.ToUniversalTime(), perRootA!.Value.ToUniversalTime());
+        var perRootB = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalB);
+        Assert.Equal(watermark.ToUniversalTime(), perRootB!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public async Task SetEnumerationWatermarkAtomicallyAsync_WhenLegacyDatabaseHasGlobalOnly_WritesBothAtomically()
+    {
+        // Regression: a legacy database has a global watermark but no per-root
+        // rows. The atomic write must add per-root rows alongside the global
+        // update in one transaction, eliminating the window where a crash after
+        // the global write but before the root writes would leave zero per-root
+        // rows and trigger the unsafe legacy fallback.
+        var rootA = Path.Combine(_testRoot, "RootA");
+        await CreateDtxFileAsync(
+            Path.Combine(rootA, "Song A", "song.dtx"),
+            "Song A", "Coverage Bot", "Rock", 35);
+
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        Assert.NotNull(_manager.DatabaseService);
+
+        // Seed a legacy global-only watermark (no per-root rows).
+        var legacyGlobal = DateTime.UtcNow.AddHours(-3);
+        await _manager.DatabaseService!
+            .SetLastSuccessfulEnumerationUtcAsync(legacyGlobal);
+        Assert.Null(await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(rootA));
+
+        var canonicalA = _manager.RootPolicy
+            .Validate(new[] { rootA }).CanonicalRoots.Single();
+        var newWatermark = DateTime.UtcNow.AddHours(-1);
+
+        var success = await _manager.DatabaseService!
+            .SetEnumerationWatermarkAtomicallyAsync(
+                newWatermark,
+                new[] { canonicalA });
+
+        Assert.True(success);
+        // Both global and per-root must be at the new watermark — no partial state.
+        var global = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync();
+        Assert.Equal(newWatermark.ToUniversalTime(), global!.Value.ToUniversalTime());
+        var perRootA = await _manager.DatabaseService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
+        Assert.Equal(newWatermark.ToUniversalTime(), perRootA!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public async Task SetEnumerationWatermarkAtomicallyAsync_WhenWriteFails_LeavesNoPartialState()
+    {
+        // Regression: a failed atomic write must not leave the global watermark
+        // committed while per-root rows are absent. The transaction rolls back
+        // as a unit, so the previous watermark is retained and the next
+        // freshness check remains conservative.
+        var rootA = Path.Combine(_testRoot, "RootA");
+        await CreateDtxFileAsync(
+            Path.Combine(rootA, "Song A", "song.dtx"),
+            "Song A", "Coverage Bot", "Rock", 35);
+
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        Assert.NotNull(_manager.DatabaseService);
+
+        // Establish a known baseline watermark.
+        var baseline = DateTime.UtcNow.AddHours(-2);
+        var canonicalA = _manager.RootPolicy
+            .Validate(new[] { rootA }).CanonicalRoots.Single();
+        Assert.True(await _manager.DatabaseService!
+            .SetEnumerationWatermarkAtomicallyAsync(baseline, new[] { canonicalA }));
+
+        // Swap in a broken service that cannot create contexts, simulating a
+        // mid-write crash or storage failure. The atomic method must return
+        // false and leave the baseline watermark intact.
+        var originalService = _manager.DatabaseService;
+        var brokenService = CreateBrokenDatabaseService();
+        ReflectionHelpers.SetPrivateField(_manager, "_databaseService", brokenService);
+        try
+        {
+            var newWatermark = DateTime.UtcNow.AddHours(-1);
+            var success = await brokenService
+                .SetEnumerationWatermarkAtomicallyAsync(
+                    newWatermark,
+                    new[] { canonicalA });
+
+            Assert.False(success);
+        }
+        finally
+        {
+            ReflectionHelpers.SetPrivateField(_manager, "_databaseService", originalService);
+        }
+
+        // The real database must still have the baseline watermark — no partial
+        // state was created by the failed write.
+        var global = await originalService!
+            .GetLastSuccessfulEnumerationUtcAsync();
+        Assert.Equal(baseline.ToUniversalTime(), global!.Value.ToUniversalTime());
+        var perRootA = await originalService!
+            .GetLastSuccessfulEnumerationUtcAsync(canonicalA);
+        Assert.Equal(baseline.ToUniversalTime(), perRootA!.Value.ToUniversalTime());
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenRootCasingChangesOnCaseInsensitivePlatform_WatermarkStillFound()
+    {
+        // Regression: on case-insensitive platforms (Windows, macOS), changing
+        // only the casing of a configured root path must not make its per-root
+        // watermark appear absent. The stable root identity key lowercases the
+        // normalized path so /Songs and /songs produce the same storage key.
+        // Without this, a casing change would zero out the per-root watermark
+        // count and trigger the legacy fallback, potentially masking edits.
+        var rootUpper = Path.Combine(_testRoot, "Songs");
+        var chartPath = Path.Combine(rootUpper, "My Song", "song.dtx");
+        await CreateDtxFileAsync(chartPath, "My Song", "Coverage Bot", "Rock", 35);
+
+        var oldFilesystemTimeUtc = DateTime.UtcNow.AddHours(-3);
+        SetFilesystemTimes(chartPath, oldFilesystemTimeUtc);
+
+        await InitializeAndEnumerateAsync(rootUpper);
+
+        // Age the watermark so the unchanged chart is NOT considered fresh.
+        var watermarkUtc = DateTime.UtcNow.AddHours(-1);
+        await SetLastEnumerationTimestampAsync(watermarkUtc.ToLocalTime());
+        await SetRootEnumerationTimestampAsync(rootUpper, watermarkUtc);
+
+        // On case-insensitive platforms, present the same root with different
+        // casing. The per-root watermark must still be found, so the unchanged
+        // chart is NOT flagged as a change. On case-sensitive platforms (Linux),
+        // different casing is a genuinely different path, so the watermark is
+        // legitimately absent and a rescan is expected.
+        var rootLower = Path.Combine(_testRoot, "songs");
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { rootLower });
+
+        if (OperatingSystem.IsWindows() || OperatingSystem.IsMacOS())
+        {
+            Assert.False(needsEnumeration,
+                "A casing-only change must not invalidate the per-root watermark " +
+                "on case-insensitive platforms.");
+        }
+        else
+        {
+            // On Linux, /Songs and /songs are different directories; the
+            // watermark is legitimately absent and a rescan is the safe
+            // default.
+            Assert.True(needsEnumeration);
+        }
+    }
+
+    [Fact]
     public async Task NeedsEnumerationAsync_WhenARootIsRemovedAndItsRowsRetained_ShouldStillLoadFromCache()
     {
         // Regression: the filesystem file count is scoped to the active roots,

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -465,8 +465,8 @@ public class SongManagerCoverageTests : IDisposable
 
         // A successful atomic write must commit both the global watermark and
         // every supplied per-root watermark. A partial commit (global only)
-        // would trigger the legacy fallback and assign the global timestamp to
-        // roots that were not in the batch.
+        // would leave per-root rows absent, forcing a conservative full rescan
+        // on every startup until the per-root rows catch up.
         var success = await _manager.DatabaseService!
             .SetEnumerationWatermarkAtomicallyAsync(
                 watermark,
@@ -491,7 +491,7 @@ public class SongManagerCoverageTests : IDisposable
         // rows. The atomic write must add per-root rows alongside the global
         // update in one transaction, eliminating the window where a crash after
         // the global write but before the root writes would leave zero per-root
-        // rows and trigger the unsafe legacy fallback.
+        // rows and force a conservative full rescan on every subsequent startup.
         var rootA = Path.Combine(_testRoot, "RootA");
         await CreateDtxFileAsync(
             Path.Combine(rootA, "Song A", "song.dtx"),
@@ -590,8 +590,8 @@ public class SongManagerCoverageTests : IDisposable
         // succeeds, then the per-root INSERT is aborted by a SQLite trigger.
         // The transaction must roll back as a unit so the global watermark is
         // NOT left committed while per-root rows are absent — that partial
-        // state would cause the legacy fallback to assign the global timestamp
-        // to every root, hiding edits on returning roots.
+        // state would force a conservative full rescan on every subsequent
+        // startup until the per-root rows are written.
         var rootA = Path.Combine(_testRoot, "RootA");
         await CreateDtxFileAsync(
             Path.Combine(rootA, "Song A", "song.dtx"),
@@ -654,7 +654,7 @@ public class SongManagerCoverageTests : IDisposable
         // watermark appear absent. The stable root identity key lowercases the
         // normalized path so /Songs and /songs produce the same storage key.
         // Without this, a casing change would zero out the per-root watermark
-        // count and trigger the legacy fallback, potentially masking edits.
+        // count and force a needless conservative full rescan.
         var rootUpper = Path.Combine(_testRoot, "Songs");
         var chartPath = Path.Combine(rootUpper, "My Song", "song.dtx");
         await CreateDtxFileAsync(chartPath, "My Song", "Coverage Bot", "Rock", 35);

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -266,6 +266,57 @@ public class SongManagerCoverageTests : IDisposable
     }
 
     [Fact]
+    public async Task NeedsEnumerationAsync_WithPopulatedRootAndMissingEmptyRoot_ShouldReturnFalse()
+    {
+        // Reviewer regression (item 1): one stable populated root plus one
+        // missing empty configured root must reach steady state. The old
+        // missing-root check fired for the unavailable root whenever another
+        // root had charts, forcing a perpetual full scan.
+        var populatedRoot = Path.Combine(_testRoot, "PopulatedSongs");
+        var populatedFolder = Path.Combine(populatedRoot, "Song");
+        Directory.CreateDirectory(populatedFolder);
+        await CreateDtxFileAsync(
+            Path.Combine(populatedFolder, "song.dtx"),
+            "Populated Song", "Coverage Bot", "Rock", 35);
+
+        await InitializeAndEnumerateAsync(populatedRoot);
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
+
+        var missingRoot = Path.Combine(_testRoot, "MissingSongs");
+
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(
+            new[] { populatedRoot, missingRoot });
+
+        Assert.False(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_AfterEnumerationViaCore_ShouldReturnFalseWithoutManualTimestamp()
+    {
+        // Reviewer regression (item 2): the timestamp must be set by
+        // EnumerateAndImportSongsCoreAsync (the path used by startup and Config
+        // live reload). Before the fix, only the test-only
+        // EnumerateSongsOnlyWithPublicationAsync wrapper set it, so
+        // LastSuccessfulEnumerationUtc was never persisted in production and
+        // every startup was a full scan.
+        var songsRoot = Path.Combine(_testRoot, "CoreTimestampSongs");
+        var songFolder = Path.Combine(songsRoot, "Song");
+        Directory.CreateDirectory(songFolder);
+        await CreateDtxFileAsync(
+            Path.Combine(songFolder, "song.dtx"),
+            "Core Timestamp Song", "Coverage Bot", "Jazz", 40);
+
+        // EnumerateSongsAsync routes through EnumerateAndImportSongsCoreAsync
+        // — the same core used by EnumerateAndImportSongsAsync (startup/reload).
+        // No manual SetLastEnumerationTimestampAsync: the core must set it.
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { songsRoot });
+
+        Assert.False(needsEnumeration);
+    }
+
+    [Fact]
     public async Task NeedsEnumerationAsync_WhenARootIsRemovedAndItsRowsRetained_ShouldStillLoadFromCache()
     {
         // Regression: the filesystem file count is scoped to the active roots,
@@ -1185,13 +1236,20 @@ public class SongManagerCoverageTests : IDisposable
     }
 
     [Fact]
-    public async Task DetectFilesystemChangesAsync_WhenMissingSearchPathHasDatabaseSongs_ShouldReturnTrue()
+    public async Task DetectFilesystemChangesAsync_WhenSecondaryRootMissing_ShouldNotForceRescan()
     {
+        // Regression: a missing/inaccessible configured root must not be treated
+        // as a filesystem change. The old explicit missing-root check fired
+        // whenever any configured root was absent AND the database had charts
+        // from another root, forcing a full scan on every startup — a scan that
+        // could never make the missing root available. The fix probes roots
+        // once and carries only available roots through every downstream check.
         var existingRoot = Path.Combine(_testRoot, "ExistingSongs");
         var existingFolder = Path.Combine(existingRoot, "Song");
         Directory.CreateDirectory(existingFolder);
         await CreateDtxFileAsync(Path.Combine(existingFolder, "song.dtx"), "Existing Song", "Coverage Bot", "Rock", 35);
         await InitializeAndEnumerateAsync(existingRoot);
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         var missingRoot = Path.Combine(_testRoot, "MissingSongs");
 
@@ -1200,7 +1258,7 @@ public class SongManagerCoverageTests : IDisposable
             "DetectFilesystemChangesAsync",
             (object)new[] { missingRoot, existingRoot });
 
-        Assert.True(result);
+        Assert.False(result);
     }
 
     [Fact]

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -104,7 +104,7 @@ public class SongManagerCoverageTests : IDisposable
         await CreateDtxFileAsync(Path.Combine(songFolder, "song.dtx"), "Refresh Song", "Test Bot", "Pop", 40);
 
         await InitializeAndEnumerateAsync(songsRoot);
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
         ClearRootSongs();
 
         await _manager.RefreshSongListFromDatabaseAsync();
@@ -177,7 +177,7 @@ public class SongManagerCoverageTests : IDisposable
         await CreateDtxFileAsync(Path.Combine(songFolder, "cached.dtx"), "Cached Song", "Coverage Bot", "Fusion", 35);
 
         await InitializeAndEnumerateAsync(songsRoot);
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
         ClearRootSongs();
 
         var loaded = await _manager.LoadScoreCacheAsync(new[] { songsRoot });
@@ -258,7 +258,7 @@ public class SongManagerCoverageTests : IDisposable
         await CreateDtxFileAsync(Path.Combine(songFolder, "stable.dtx"), "Stable Song", "Coverage Bot", "Jazz", 40);
 
         await InitializeAndEnumerateAsync(songsRoot);
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { songsRoot });
 
@@ -293,12 +293,91 @@ public class SongManagerCoverageTests : IDisposable
         // The removed root's files still exist on disk; only the configured root
         // set changes. Its rows remain in the database (the import path only
         // removes stale charts under active roots).
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         // Simulate the next startup with the removed root no longer configured.
         var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { retainedRoot });
 
         Assert.False(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenRemovedRootIsDeletedAndItsRowsRetained_ShouldStillLoadFromCache()
+    {
+        // Regression: CheckDatabaseFilesStillExist must scope its existence check to
+        // the active roots. A removed root's charts are retained in the database
+        // (the import path only purges stale charts under active roots), and the
+        // root's files are typically gone (deleted, unmounted, or on an external
+        // drive that was detached). The unscoped check loaded every retained chart
+        // and flagged the removed root's charts as missing on every startup, forcing
+        // a full rescan even though the active library was unchanged.
+        var retainedRoot = Path.Combine(_testRoot, "RetainedSongsKept");
+        var removedRoot = Path.Combine(_testRoot, "RemovedSongsDeleted");
+        var retainedFolder = Path.Combine(retainedRoot, "Retained Song");
+        var removedFolder = Path.Combine(removedRoot, "Removed Song");
+
+        Directory.CreateDirectory(retainedFolder);
+        Directory.CreateDirectory(removedFolder);
+        await CreateDtxFileAsync(Path.Combine(retainedFolder, "retained.dtx"), "Retained Song", "Coverage Bot", "Jazz", 40);
+        await CreateDtxFileAsync(Path.Combine(removedFolder, "removed.dtx"), "Removed Song", "Coverage Bot", "Jazz", 50);
+
+        // Enumerate both roots so the database holds rows for each.
+        var initialized = await _manager.InitializeDatabaseServiceAsync(_testDbPath);
+        Assert.True(initialized);
+        var enumerated = await _manager.EnumerateSongsAsync(new[] { retainedRoot, removedRoot });
+        Assert.True(enumerated >= 2);
+        Assert.NotNull(_manager.DatabaseService);
+
+        // The removed root's files are gone (deleted/unmounted/detached) but its
+        // rows remain in the database (the import path only purges stale charts
+        // under active roots).
+        Directory.Delete(removedRoot, recursive: true);
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
+
+        // Simulate the next startup with the removed root no longer configured.
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { retainedRoot });
+
+        Assert.False(needsEnumeration);
+    }
+
+    [Fact]
+    public async Task NeedsEnumerationAsync_WhenUnrelatedDatabaseWriteFollowsChartEdit_ShouldStillDetectEdit()
+    {
+        // Regression: the cache-freshness threshold must be an explicit
+        // LastSuccessfulEnumerationUtc metadata value, not the SQLite database
+        // file's last-write time. An unrelated SaveChangesAsync (bookmark toggle,
+        // score save) advances the database file mtime; deriving the enumeration
+        // time from it would let that write mask a chart edit that happened between
+        // the enumeration and the write when the file count is unchanged.
+        var songsRoot = Path.Combine(_testRoot, "UnrelatedWriteAfterEdit");
+        var songFolder = Path.Combine(songsRoot, "Song");
+        var songPath = Path.Combine(songFolder, "song.dtx");
+        Directory.CreateDirectory(songFolder);
+        await CreateDtxFileAsync(songPath, "Edit Song", "Coverage Bot", "Rock", 35);
+        await InitializeAndEnumerateAsync(songsRoot);
+        Assert.NotNull(_manager.DatabaseService);
+
+        // Simulate an enumeration that finished 10 minutes ago. Pin both the
+        // metadata threshold and the directory mtimes to that moment so the only
+        // signal that can trip change detection is the chart file edit below.
+        var enumerationTime = DateTime.Now.AddMinutes(-10);
+        await SetLastEnumerationTimestampAsync(enumerationTime);
+        Directory.SetLastWriteTime(songsRoot, enumerationTime.AddMinutes(-1));
+        Directory.SetLastWriteTime(songFolder, enumerationTime.AddMinutes(-1));
+
+        // Modify the chart 5 minutes after the enumeration (file count unchanged).
+        File.SetLastWriteTime(songPath, enumerationTime.AddMinutes(5));
+
+        // Perform an unrelated database write (bookmark toggle) now. Under the old
+        // DB-mtime-based threshold, this advanced the threshold to ~now, which is
+        // after the chart edit, masking it (the 5-minutes-ago edit would appear
+        // older than the now-1minute threshold).
+        var song = (await _manager.DatabaseService!.GetSongsAsync()).Single();
+        await _manager.DatabaseService.SetBookmarkAsync(song.Id, true);
+
+        var needsEnumeration = await _manager.NeedsEnumerationAsync(new[] { songsRoot });
+
+        Assert.True(needsEnumeration);
     }
 
     [Fact]
@@ -312,7 +391,7 @@ public class SongManagerCoverageTests : IDisposable
         await CreateDtxFileAsync(Path.Combine(firstSongFolder, "first.dtx"), "First Song", "Coverage Bot", "Jazz", 40);
 
         await InitializeAndEnumerateAsync(songsRoot);
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         Directory.CreateDirectory(secondSongFolder);
         await CreateDtxFileAsync(Path.Combine(secondSongFolder, "second.dtx"), "Second Song", "Coverage Bot", "Jazz", 55);
@@ -389,7 +468,7 @@ public class SongManagerCoverageTests : IDisposable
 
         ReflectionHelpers.SetPrivateField(_manager, "_currentSearchPaths", new[] { songsRoot });
 
-        var checkTask = ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist");
+        var checkTask = ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist", new object[] { new[] { songsRoot } });
         Assert.NotNull(checkTask);
 
         var changeDetected = await checkTask!;
@@ -798,10 +877,10 @@ public class SongManagerCoverageTests : IDisposable
         File.Delete(chartPath);
         
         ReflectionHelpers.SetPrivateField(_manager, "_currentSearchPaths", new[] { Path.Combine(_testRoot, "NonExistentPath") });
-        
-        var checkTask = ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist");
+
+        var checkTask = ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist", new object[] { new[] { songsRoot } });
         Assert.NotNull(checkTask);
-        
+
         var changeDetected = await checkTask!;
         
         Assert.True(changeDetected);
@@ -846,7 +925,7 @@ public class SongManagerCoverageTests : IDisposable
     [Fact]
     public async Task CheckDatabaseFilesStillExist_WithoutDatabaseService_ShouldReturnFalse()
     {
-        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist");
+        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist", new object[] { new[] { _testRoot } });
 
         Assert.False(result);
     }
@@ -860,7 +939,7 @@ public class SongManagerCoverageTests : IDisposable
         {
             ReflectionHelpers.SetPrivateField(_manager, "_databaseService", CreateBrokenDatabaseServiceWithDatabasePath("\0invalid"));
 
-            var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist");
+            var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(_manager, "CheckDatabaseFilesStillExist", new object[] { new[] { _testRoot } });
 
             Assert.False(result);
         }
@@ -953,96 +1032,6 @@ public class SongManagerCoverageTests : IDisposable
             "CheckDirectoryForChangesAsync",
             "\0invalid",
             DateTime.Now);
-
-        Assert.True(result);
-    }
-
-    [Fact]
-    public async Task CheckSubdirectoriesForChangesAsync_WhenMaxDepthReached_ShouldReturnFalse()
-    {
-        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
-            _manager,
-            "CheckSubdirectoriesForChangesAsync",
-            _testRoot,
-            DateTime.Now,
-            10,
-            10);
-
-        Assert.False(result);
-    }
-
-    [Fact]
-    public async Task CheckSubdirectoriesForChangesAsync_WhenOnlySkippedDirectoriesExist_ShouldReturnFalse()
-    {
-        Directory.CreateDirectory(Path.Combine(_testRoot, "System"));
-        Directory.CreateDirectory(Path.Combine(_testRoot, "Cache"));
-        Directory.CreateDirectory(Path.Combine(_testRoot, ".hidden"));
-
-        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
-            _manager,
-            "CheckSubdirectoriesForChangesAsync",
-            _testRoot,
-            DateTime.Now,
-            0,
-            10);
-
-        Assert.False(result);
-    }
-
-    [Fact]
-    public async Task CheckSubdirectoriesForChangesAsync_WhenSubdirectoryWasModified_ShouldReturnTrue()
-    {
-        var songsRoot = Path.Combine(_testRoot, "SubdirModified");
-        var subdir = Path.Combine(songsRoot, "Pack");
-        Directory.CreateDirectory(subdir);
-        var lastEnumerationTime = DateTime.Now.AddMinutes(-5);
-        Directory.SetLastWriteTime(subdir, DateTime.Now);
-
-        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
-            _manager,
-            "CheckSubdirectoriesForChangesAsync",
-            songsRoot,
-            lastEnumerationTime,
-            0,
-            10);
-
-        Assert.True(result);
-    }
-
-    [Fact]
-    public async Task CheckSubdirectoriesForChangesAsync_WhenSubdirectoryDtxWasModified_ShouldReturnTrue()
-    {
-        var songsRoot = Path.Combine(_testRoot, "SubdirFileModified");
-        var subdir = Path.Combine(songsRoot, "Pack");
-        Directory.CreateDirectory(subdir);
-        var dtxPath = Path.Combine(subdir, "changed.dtx");
-        await CreateDtxFileAsync(dtxPath, "Changed Song", "Coverage Bot", "Rock", 40);
-
-        var lastEnumerationTime = DateTime.Now.AddMinutes(-5);
-        Directory.SetLastWriteTime(subdir, lastEnumerationTime.AddMinutes(-1));
-        File.SetLastWriteTime(dtxPath, DateTime.Now);
-
-        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
-            _manager,
-            "CheckSubdirectoriesForChangesAsync",
-            songsRoot,
-            lastEnumerationTime,
-            0,
-            10);
-
-        Assert.True(result);
-    }
-
-    [Fact]
-    public async Task CheckSubdirectoriesForChangesAsync_WithInvalidPath_ShouldReturnTrue()
-    {
-        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
-            _manager,
-            "CheckSubdirectoriesForChangesAsync",
-            "\0invalid",
-            DateTime.Now,
-            0,
-            10);
 
         Assert.True(result);
     }
@@ -1185,7 +1174,7 @@ public class SongManagerCoverageTests : IDisposable
 
         Directory.CreateDirectory(movedFolder);
         File.Move(originalPath, movedPath);
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
             _manager,
@@ -1225,7 +1214,7 @@ public class SongManagerCoverageTests : IDisposable
         await CreateDtxFileAsync(songPath, "Changed Song", "Coverage Bot", "Rock", 35);
         await InitializeAndEnumerateAsync(songsRoot);
 
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(-10));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(-10));
         File.SetLastWriteTime(songPath, DateTime.Now);
 
         var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
@@ -1357,7 +1346,7 @@ public class SongManagerCoverageTests : IDisposable
         Directory.CreateDirectory(songFolder);
         await CreateDtxFileAsync(Path.Combine(songFolder, "song.dtx"), "Stable Song", "Coverage Bot", "Rock", 35);
         await InitializeAndEnumerateAsync(songsRoot);
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
             _manager,
@@ -1407,7 +1396,7 @@ public class SongManagerCoverageTests : IDisposable
         // score-row inserts above) so GetLastEnumerationTimestampAsync reports a
         // steady-state timestamp in the future. Setting it before the inserts
         // would let SaveChangesAsync overwrite it with the current time.
-        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
 
         // Filesystem still has exactly 1 chart file; database now has 3 score rows
         // but 1 chart row. The cache-freshness check compares chart counts, so it
@@ -1479,6 +1468,76 @@ public class SongManagerCoverageTests : IDisposable
             lastEnumerationTime);
 
         Assert.True(result);
+    }
+
+    // Regression: the chart-inventory scanner must count only the charts full
+    // enumeration would import. A set.def directory containing one referenced
+    // chart plus one unreferenced (backup/loose) chart must report a filesystem
+    // count of 1, matching the database count of 1. The previous recursive-glob
+    // counter ignored set.def and counted both files (filesystem count 2 vs
+    // database count 1), forcing a permanent rescan on every startup.
+    [Fact]
+    public async Task CountDTXFilesAsync_WithSetDefAndUnreferencedChart_ShouldCountOnlyReferenced()
+    {
+        var songsRoot = Path.Combine(_testRoot, "SetDefUnreferenced");
+        var setFolder = Path.Combine(songsRoot, "Song");
+        Directory.CreateDirectory(setFolder);
+
+        // set.def references only referenced.dtx; unreferenced.dtx is a loose
+        // chart in the same directory that enumeration must NOT import.
+        await File.WriteAllTextAsync(Path.Combine(setFolder, "set.def"), """
+#TITLE: SetDef Song
+#L1FILE referenced.dtx
+""");
+        await CreateDtxFileAsync(
+            Path.Combine(setFolder, "referenced.dtx"),
+            "SetDef Song", "Coverage Bot", "Rock", 40);
+        await CreateDtxFileAsync(
+            Path.Combine(setFolder, "unreferenced.dtx"),
+            "Unreferenced", "Coverage Bot", "Rock", 40);
+
+        var count = await ReflectionHelpers.InvokePrivateMethod<Task<int>>(
+            _manager,
+            "CountDTXFilesAsync",
+            (object)new[] { songsRoot });
+
+        Assert.Equal(1, count);
+    }
+
+    // Regression: DetectFilesystemChangesAsync must reach steady state (return
+    // false) after enumerating a set.def directory with an unreferenced chart.
+    // The previous recursive-glob counter permanently mismatched (filesystem 2
+    // vs database 1) and forced a rescan on every startup.
+    [Fact]
+    public async Task DetectFilesystemChangesAsync_WithSetDefAndUnreferencedChart_ShouldReachSteadyState()
+    {
+        var songsRoot = Path.Combine(_testRoot, "SetDefSteadyState");
+        var setFolder = Path.Combine(songsRoot, "Song");
+        Directory.CreateDirectory(setFolder);
+
+        await File.WriteAllTextAsync(Path.Combine(setFolder, "set.def"), """
+#TITLE: SetDef Song
+#L1FILE referenced.dtx
+""");
+        await CreateDtxFileAsync(
+            Path.Combine(setFolder, "referenced.dtx"),
+            "SetDef Song", "Coverage Bot", "Rock", 40);
+        await CreateDtxFileAsync(
+            Path.Combine(setFolder, "unreferenced.dtx"),
+            "Unreferenced", "Coverage Bot", "Rock", 40);
+
+        await InitializeAndEnumerateAsync(songsRoot);
+        // Pin the enumeration timestamp to the future so the only signal that can
+        // trip change detection is the count mismatch (or lack of it).
+        await SetLastEnumerationTimestampAsync(DateTime.Now.AddMinutes(5));
+        ClearRootSongs();
+
+        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
+            _manager,
+            "DetectFilesystemChangesAsync",
+            (object)new[] { songsRoot });
+
+        Assert.False(result);
     }
 
     [Fact]
@@ -1692,10 +1751,18 @@ public class SongManagerCoverageTests : IDisposable
         rootSongs!.Clear();
     }
 
-    private void SetDatabaseLastWriteTime(DateTime lastWriteTime)
+    /// <summary>
+    /// Persists an explicit last-successful-enumeration timestamp into the
+    /// __EnumerationMetadata table, mirroring how UpdateEnumerationTimestampAsync
+    /// records it after a real enumeration. The cache-freshness check reads this
+    /// metadata value (not the database file's last-write time), so tests that need
+    /// to control the freshness threshold must write it here. <paramref name="localTimestamp"/>
+    /// is interpreted as a local time and stored as UTC.
+    /// </summary>
+    private async Task SetLastEnumerationTimestampAsync(DateTime localTimestamp)
     {
         Assert.NotNull(_manager.DatabaseService);
-        File.SetLastWriteTime(_manager.DatabaseService!.DatabasePath, lastWriteTime);
+        await _manager.DatabaseService!.SetLastSuccessfulEnumerationUtcAsync(localTimestamp.ToUniversalTime());
     }
 
     private static SongDatabaseService CreateBrokenDatabaseService()

--- a/DTXMania.Test/Song/SongManagerCoverageTests.cs
+++ b/DTXMania.Test/Song/SongManagerCoverageTests.cs
@@ -1367,6 +1367,120 @@ public class SongManagerCoverageTests : IDisposable
         Assert.False(result);
     }
 
+    // Regression: GetActiveChartCountAsync must count charts, not score rows.
+    // One chart can have many SongScore rows (ChartId + Instrument + PlaySpeedPercent).
+    // Counting score rows would permanently exceed the filesystem file count and
+    // force a full rescan on every startup once a player records results at multiple
+    // speeds or instruments.
+    [Fact]
+    public async Task DetectFilesystemChangesAsync_WithMultipleScoreVariantsOnOneChart_ShouldNotTriggerFullScan()
+    {
+        var songsRoot = Path.Combine(_testRoot, "ScoreVariantStability");
+        var songFolder = Path.Combine(songsRoot, "Song");
+        Directory.CreateDirectory(songFolder);
+        await CreateDtxFileAsync(Path.Combine(songFolder, "song.dtx"), "Stable Song", "Coverage Bot", "Rock", 35);
+        await InitializeAndEnumerateAsync(songsRoot);
+
+        // Simulate a player who has recorded results at multiple play speeds.
+        // The import seeded one DRUMS score row at 100%; add two more variants
+        // at canonical speeds (105, 110) so the chart now has 3 score rows.
+        Assert.NotNull(_manager.DatabaseService);
+        using (var context = _manager.DatabaseService!.CreateContext())
+        {
+            var chart = Assert.Single(context.SongCharts.ToList());
+            context.SongScores.Add(new SongScore
+            {
+                ChartId = chart.Id,
+                Instrument = EInstrumentPart.DRUMS,
+                PlaySpeedPercent = 105,
+            });
+            context.SongScores.Add(new SongScore
+            {
+                ChartId = chart.Id,
+                Instrument = EInstrumentPart.DRUMS,
+                PlaySpeedPercent = 110,
+            });
+            await context.SaveChangesAsync();
+        }
+
+        // Set the database file's last-write time AFTER all writes (including the
+        // score-row inserts above) so GetLastEnumerationTimestampAsync reports a
+        // steady-state timestamp in the future. Setting it before the inserts
+        // would let SaveChangesAsync overwrite it with the current time.
+        SetDatabaseLastWriteTime(DateTime.Now.AddMinutes(5));
+
+        // Filesystem still has exactly 1 chart file; database now has 3 score rows
+        // but 1 chart row. The cache-freshness check compares chart counts, so it
+        // must NOT report a mismatch.
+        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
+            _manager,
+            "DetectFilesystemChangesAsync",
+            (object)new[] { songsRoot });
+
+        Assert.False(result);
+    }
+
+    // Regression: CountDTXFilesAsync must count ALL supported chart extensions,
+    // not just *.dtx. A library containing .gda/.g2d/.bms/.bme/.bml charts would
+    // otherwise have filesystem count 0 (no .dtx files) vs database count > 0,
+    // forcing a full rescan on every startup.
+    [Fact]
+    public async Task CountDTXFilesAsync_WithNonDtxChartFile_ShouldCountIt()
+    {
+        var songsRoot = Path.Combine(_testRoot, "NonDtxCount");
+        var songFolder = Path.Combine(songsRoot, "Song");
+        Directory.CreateDirectory(songFolder);
+        // .gda is in DTXChartParser.SupportedExtensions; no .dtx files present.
+        await File.WriteAllTextAsync(Path.Combine(songFolder, "chart.gda"), """
+#TITLE: GDA Song
+#ARTIST: Coverage Bot
+#BPM: 120
+#DLEVEL: 40
+#00002:11111111
+#00011:01010101
+""");
+
+        var result = await ReflectionHelpers.InvokePrivateMethod<Task<int>>(
+            _manager,
+            "CountDTXFilesAsync",
+            (object)new[] { songsRoot });
+
+        Assert.Equal(1, result);
+    }
+
+    // Regression: CheckDirectoryForChangesAsync must scan ALL supported chart
+    // extensions, not just *.dtx. A modified .bms chart would otherwise be missed
+    // when the total file count is unchanged.
+    [Fact]
+    public async Task CheckDirectoryForChangesAsync_WhenNonDtxChartWasModified_ShouldReturnTrue()
+    {
+        var songsRoot = Path.Combine(_testRoot, "NonDtxModified");
+        var songFolder = Path.Combine(songsRoot, "Song");
+        Directory.CreateDirectory(songFolder);
+        // .bms is in DTXChartParser.SupportedExtensions.
+        var bmsPath = Path.Combine(songFolder, "chart.bms");
+        await File.WriteAllTextAsync(bmsPath, """
+#TITLE: BMS Song
+#ARTIST: Coverage Bot
+#BPM: 120
+#DLEVEL: 40
+#00002:11111111
+#00011:01010101
+""");
+
+        var lastEnumerationTime = DateTime.Now.AddMinutes(-5);
+        Directory.SetLastWriteTime(songsRoot, lastEnumerationTime.AddMinutes(-1));
+        File.SetLastWriteTime(bmsPath, DateTime.Now);
+
+        var result = await ReflectionHelpers.InvokePrivateMethod<Task<bool>>(
+            _manager,
+            "CheckDirectoryForChangesAsync",
+            songsRoot,
+            lastEnumerationTime);
+
+        Assert.True(result);
+    }
+
     [Fact]
     public async Task FindMovedFileAsync_WhenSearchPathStateIsInvalid_ShouldReturnNull()
     {

--- a/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
+++ b/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
@@ -121,16 +121,45 @@ public sealed class SongManagerLibrarySnapshotTests : IDisposable
     }
 
     [Fact]
-    public void SetCurrentSearchPaths_WithEmptyInput_ShouldClearActiveRoots()
+    public void SetCurrentSearchPaths_ShouldKeepPublishedSnapshotCoherentUntilFullPublication()
     {
         _manager.RootPolicy = new SongRootPolicy(
             SongRootPolicy.CreateComparer(ignoreCase: true));
-        _manager.SetCurrentSearchPaths(["/roots/one", "/ROOTS/ONE"]);
-        Assert.Equal(["/roots/one"], _manager.GetLibrarySnapshot().ActiveRoots);
+        var rootNode = CreateScoreNode("Published");
+        _manager.PublishEnumeration(CreateBatch(["/roots/published"], [rootNode]));
+        var before = _manager.GetLibrarySnapshot();
+
+        _manager.SetCurrentSearchPaths(["/roots/pending", "/ROOTS/PENDING"]);
+
+        var after = _manager.GetLibrarySnapshot();
+
+        Assert.Equal(before.Version, after.Version);
+        Assert.Equal(before.RootSongs, after.RootSongs);
+        Assert.Equal(before.ActiveRoots, after.ActiveRoots);
+        Assert.Equal(before.EnumeratedFileCount, after.EnumeratedFileCount);
+        Assert.Equal(before.DiscoveredScoreCount, after.DiscoveredScoreCount);
+    }
+
+    [Fact]
+    public void SetCurrentSearchPaths_WithEmptyInput_ShouldPublishEmptyLibrary()
+    {
+        _manager.PublishEnumeration(CreateBatch(
+            ["/roots/published"],
+            [CreateScoreNode("Published")]));
+        var before = _manager.GetLibrarySnapshot();
+        SongLibrarySnapshot? published = null;
+        _manager.SongLibraryPublished += (_, args) => published = args.Snapshot;
 
         _manager.SetCurrentSearchPaths(Array.Empty<string>());
 
-        Assert.Empty(_manager.GetLibrarySnapshot().ActiveRoots);
+        var after = _manager.GetLibrarySnapshot();
+        Assert.Equal(before.Version + 1, after.Version);
+        Assert.Empty(after.RootSongs);
+        Assert.Empty(after.ActiveRoots);
+        Assert.Equal(0, after.EnumeratedFileCount);
+        Assert.Equal(0, after.DiscoveredScoreCount);
+        Assert.NotNull(published);
+        Assert.Equal(after.Version, published!.Version);
     }
 
     [Fact]

--- a/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
+++ b/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
@@ -1,0 +1,196 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song;
+
+[Collection("SongManager")]
+[Trait("Category", "Unit")]
+public sealed class SongManagerLibrarySnapshotTests : IDisposable
+{
+    private readonly SongManager _manager;
+
+    public SongManagerLibrarySnapshotTests()
+    {
+        SongManager.ResetInstanceForTesting();
+        _manager = SongManager.Instance;
+    }
+
+    [Fact]
+    public void GetLibrarySnapshot_ShouldNotAdvancePublicationVersionOrExposeLiveRootList()
+    {
+        var firstNode = CreateScoreNode("First");
+        _manager.PublishEnumeration(CreateBatch(["/roots/one"], [firstNode]));
+
+        var firstSnapshot = _manager.GetLibrarySnapshot();
+        var secondSnapshot = _manager.GetLibrarySnapshot();
+        var rootSongsView = _manager.RootSongs;
+
+        Assert.Equal(firstSnapshot.Version, secondSnapshot.Version);
+        Assert.NotSame(firstSnapshot.RootSongs, secondSnapshot.RootSongs);
+        Assert.NotSame(firstSnapshot.RootSongs, rootSongsView);
+        var mutableRoots = Assert.IsAssignableFrom<IList<SongListNode>>(
+            rootSongsView);
+        Assert.Throws<NotSupportedException>(() =>
+            mutableRoots.Add(CreateScoreNode("Mutated")));
+
+        _manager.PublishEnumeration(CreateBatch(["/roots/two"], [CreateScoreNode("Second")]));
+
+        Assert.Equal([firstNode], firstSnapshot.RootSongs);
+        Assert.Equal([firstNode], rootSongsView);
+        Assert.Equal(["/roots/one"], firstSnapshot.ActiveRoots);
+    }
+
+    [Fact]
+    public void PublishEmptyLibrary_ShouldPublishOneNewVersionWithEmptyHierarchyAndRoots()
+    {
+        _manager.PublishEnumeration(CreateBatch(
+            ["/roots/one"],
+            [CreateScoreNode("First")]));
+        var before = _manager.GetLibrarySnapshot();
+        SongLibrarySnapshot? published = null;
+        _manager.SongLibraryPublished += (_, args) => published = args.Snapshot;
+
+        _manager.PublishEmptyLibrary();
+
+        var after = _manager.GetLibrarySnapshot();
+        Assert.Equal(before.Version + 1, after.Version);
+        Assert.Empty(after.RootSongs);
+        Assert.Empty(after.ActiveRoots);
+        Assert.Equal(0, after.EnumeratedFileCount);
+        Assert.Equal(0, after.DiscoveredScoreCount);
+        Assert.NotNull(published);
+        Assert.Equal(after.Version, published!.Version);
+        Assert.Empty(published.RootSongs);
+        Assert.Empty(published.ActiveRoots);
+    }
+
+    [Fact]
+    public void PublishEnumeration_ShouldRaiseOneCoherentVersionedSnapshot()
+    {
+        var rootNode = CreateScoreNode("Published");
+        SongLibrarySnapshot? published = null;
+        var eventCount = 0;
+        _manager.SongLibraryPublished += (_, args) =>
+        {
+            eventCount++;
+            published = args.Snapshot;
+        };
+
+        _manager.PublishEnumeration(CreateBatch(
+            ["/roots/one", "/roots/two"],
+            [rootNode]));
+
+        var current = _manager.GetLibrarySnapshot();
+        Assert.Equal(1, eventCount);
+        Assert.NotNull(published);
+        Assert.Equal(current.Version, published!.Version);
+        Assert.Equal([rootNode], published.RootSongs);
+        Assert.Equal(["/roots/one", "/roots/two"], published.ActiveRoots);
+        Assert.Equal(0, published.EnumeratedFileCount);
+        Assert.Equal(0, published.DiscoveredScoreCount);
+    }
+
+    [Fact]
+    public void SongLibrarySnapshot_ShouldCopyAndFreezeConstructorCollections()
+    {
+        var rootNode = CreateScoreNode("Stable");
+        var roots = new List<SongListNode> { rootNode };
+        var activeRoots = new List<string> { "/roots/one" };
+
+        var snapshot = new SongLibrarySnapshot(
+            Version: 42,
+            RootSongs: roots,
+            ActiveRoots: activeRoots,
+            EnumeratedFileCount: 3,
+            DiscoveredScoreCount: 2);
+        roots.Clear();
+        activeRoots[0] = "/roots/mutated";
+
+        Assert.Equal([rootNode], snapshot.RootSongs);
+        Assert.Equal(["/roots/one"], snapshot.ActiveRoots);
+        Assert.Throws<NotSupportedException>(() =>
+            Assert.IsAssignableFrom<IList<string>>(snapshot.ActiveRoots)
+                .Add("/roots/extra"));
+    }
+
+    [Fact]
+    public void SetCurrentSearchPaths_WithEmptyInput_ShouldClearActiveRoots()
+    {
+        _manager.RootPolicy = new SongRootPolicy(
+            SongRootPolicy.CreateComparer(ignoreCase: true));
+        _manager.SetCurrentSearchPaths(["/roots/one", "/ROOTS/ONE"]);
+        Assert.Equal(["/roots/one"], _manager.GetLibrarySnapshot().ActiveRoots);
+
+        _manager.SetCurrentSearchPaths(Array.Empty<string>());
+
+        Assert.Empty(_manager.GetLibrarySnapshot().ActiveRoots);
+    }
+
+    [Fact]
+    public async Task SnapshotIteration_ShouldRemainStableWhileAnotherThreadPublishes()
+    {
+        var firstNode = CreateScoreNode("First");
+        _manager.PublishEnumeration(CreateBatch(["/roots/one"], [firstNode]));
+        var stableSnapshot = _manager.GetLibrarySnapshot();
+
+        using var iterationStarted = new ManualResetEventSlim(false);
+        using var releaseIteration = new ManualResetEventSlim(false);
+        var iterationTask = Task.Run(() =>
+        {
+            var titles = new List<string>();
+            foreach (var node in stableSnapshot.RootSongs)
+            {
+                iterationStarted.Set();
+                releaseIteration.Wait();
+                titles.Add(node.Title);
+            }
+
+            return titles.ToArray();
+        });
+        Assert.True(iterationStarted.Wait(TimeSpan.FromSeconds(1)));
+        _manager.PublishEnumeration(CreateBatch(
+            ["/roots/two"],
+            [CreateScoreNode("Second")]));
+        releaseIteration.Set();
+        var enumeratedTitles = await iterationTask;
+
+        Assert.Equal(["First"], enumeratedTitles);
+        Assert.Equal([firstNode], stableSnapshot.RootSongs);
+        Assert.Equal(["/roots/one"], stableSnapshot.ActiveRoots);
+    }
+
+    public void Dispose()
+    {
+        SongManager.ResetInstanceForTesting();
+    }
+
+    private static SongEnumerationBatch CreateBatch(
+        IReadOnlyList<string> activeRoots,
+        IReadOnlyList<SongListNode> rootNodes)
+    {
+        return new SongEnumerationBatch
+        {
+            ActiveRoots = activeRoots,
+            DiscoveredChartPaths = new HashSet<string>(StringComparer.Ordinal),
+            Candidates = new List<SongImportCandidate>(),
+            RootNodes = rootNodes.ToList(),
+            PendingSongs = new List<PendingSongNode>(),
+            Errors = new List<SongEnumerationError>(),
+            DiscoveryAndParsingDuration = TimeSpan.Zero,
+            IsComplete = true,
+        };
+    }
+
+    private static SongListNode CreateScoreNode(string title) => new()
+    {
+        Type = NodeType.Score,
+        Title = title,
+    };
+}

--- a/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
+++ b/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
@@ -204,6 +204,48 @@ public sealed class SongManagerLibrarySnapshotTests : IDisposable
             stableSnapshot.ActiveRoots);
     }
 
+    [Fact]
+    public void SongLibrarySnapshot_Deconstruct_ShouldExposeAllConstructorFields()
+    {
+        var rootNode = CreateScoreNode("Deconstructed");
+        var snapshot = new SongLibrarySnapshot(
+            version: 17,
+            rootSongs: new List<SongListNode> { rootNode },
+            activeRoots: new List<string> { "/roots/one", "/roots/two" },
+            enumeratedFileCount: 9,
+            discoveredScoreCount: 5);
+
+        var (version, rootSongs, activeRoots, enumeratedFileCount, discoveredScoreCount) = snapshot;
+
+        Assert.Equal(17, version);
+        Assert.Equal([rootNode], rootSongs);
+        Assert.Equal(["/roots/one", "/roots/two"], activeRoots);
+        Assert.Equal(9, enumeratedFileCount);
+        Assert.Equal(5, discoveredScoreCount);
+    }
+
+    [Fact]
+    public void SongLibraryPublishedEventArgs_Constructor_ShouldRejectNullSnapshot()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new SongLibraryPublishedEventArgs(null!));
+    }
+
+    [Fact]
+    public void SongLibraryPublishedEventArgs_ShouldExposeThePublishedSnapshot()
+    {
+        var snapshot = new SongLibrarySnapshot(
+            version: 3,
+            rootSongs: new List<SongListNode> { CreateScoreNode("Event") },
+            activeRoots: new List<string> { "/roots/one" },
+            enumeratedFileCount: 1,
+            discoveredScoreCount: 1);
+
+        var args = new SongLibraryPublishedEventArgs(snapshot);
+
+        Assert.Same(snapshot, args.Snapshot);
+    }
+
     public void Dispose()
     {
         SongManager.ResetInstanceForTesting();

--- a/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
+++ b/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
@@ -105,11 +105,11 @@ public sealed class SongManagerLibrarySnapshotTests : IDisposable
         var activeRoots = new List<string> { "/roots/one" };
 
         var snapshot = new SongLibrarySnapshot(
-            Version: 42,
-            RootSongs: roots,
-            ActiveRoots: activeRoots,
-            EnumeratedFileCount: 3,
-            DiscoveredScoreCount: 2);
+            version: 42,
+            rootSongs: roots,
+            activeRoots: activeRoots,
+            enumeratedFileCount: 3,
+            discoveredScoreCount: 2);
         roots.Clear();
         activeRoots[0] = "/roots/mutated";
 

--- a/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
+++ b/DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs
@@ -44,7 +44,9 @@ public sealed class SongManagerLibrarySnapshotTests : IDisposable
 
         Assert.Equal([firstNode], firstSnapshot.RootSongs);
         Assert.Equal([firstNode], rootSongsView);
-        Assert.Equal(["/roots/one"], firstSnapshot.ActiveRoots);
+        Assert.Equal(
+            [System.IO.Path.GetFullPath("/roots/one")],
+            firstSnapshot.ActiveRoots);
     }
 
     [Fact]
@@ -92,7 +94,12 @@ public sealed class SongManagerLibrarySnapshotTests : IDisposable
         Assert.NotNull(published);
         Assert.Equal(current.Version, published!.Version);
         Assert.Equal([rootNode], published.RootSongs);
-        Assert.Equal(["/roots/one", "/roots/two"], published.ActiveRoots);
+        Assert.Equal(
+            [
+                System.IO.Path.GetFullPath("/roots/one"),
+                System.IO.Path.GetFullPath("/roots/two"),
+            ],
+            published.ActiveRoots);
         Assert.Equal(0, published.EnumeratedFileCount);
         Assert.Equal(0, published.DiscoveredScoreCount);
     }
@@ -192,7 +199,9 @@ public sealed class SongManagerLibrarySnapshotTests : IDisposable
 
         Assert.Equal(["First"], enumeratedTitles);
         Assert.Equal([firstNode], stableSnapshot.RootSongs);
-        Assert.Equal(["/roots/one"], stableSnapshot.ActiveRoots);
+        Assert.Equal(
+            [System.IO.Path.GetFullPath("/roots/one")],
+            stableSnapshot.ActiveRoots);
     }
 
     public void Dispose()

--- a/DTXMania.Test/Song/SongRootPolicyAdditionalTests.cs
+++ b/DTXMania.Test/Song/SongRootPolicyAdditionalTests.cs
@@ -18,8 +18,11 @@ public sealed class SongRootPolicyAdditionalTests
         var policy = SongRootPolicy.ForCurrentPlatform();
 
         Assert.NotNull(policy);
-        // The current platform (Windows or macOS) uses a case-insensitive comparer.
-        Assert.True(policy.Comparer.Equals("/Songs", "/SONGS"));
+        // Windows and macOS use case-insensitive path comparison; Linux uses
+        // case-sensitive. Derive the expectation from the same condition the
+        // policy uses so the test is correct on every supported platform.
+        var expectIgnoreCase = OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+        Assert.Equal(expectIgnoreCase, policy.Comparer.Equals("/Songs", "/SONGS"));
     }
 
     [Fact]

--- a/DTXMania.Test/Song/SongRootPolicyAdditionalTests.cs
+++ b/DTXMania.Test/Song/SongRootPolicyAdditionalTests.cs
@@ -1,0 +1,184 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song;
+
+[Trait("Category", "Unit")]
+public sealed class SongRootPolicyAdditionalTests
+{
+    [Fact]
+    public void ForCurrentPlatform_ShouldReturnPolicyWithAComparer()
+    {
+        var policy = SongRootPolicy.ForCurrentPlatform();
+
+        Assert.NotNull(policy);
+        // The current platform (Windows or macOS) uses a case-insensitive comparer.
+        Assert.True(policy.Comparer.Equals("/Songs", "/SONGS"));
+    }
+
+    [Fact]
+    public void Validate_WithNullRoots_ShouldThrowArgumentNullException()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+        Assert.Throws<ArgumentNullException>(() => policy.Validate(null!));
+    }
+
+    [Fact]
+    public void Constructor_WithNullComparer_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SongRootPolicy(null!));
+    }
+
+    [Fact]
+    public void NormalizeWindowsDrivePath_WithDotSegments_ShouldCollapseToCanonicalRoot()
+    {
+        // A Windows drive path with redundant "." segments must collapse so the
+        // duplicate/overlap checks compare against the canonical form.
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        var result = policy.Validate([@"C:\Songs\.\Pack", @"C:\Songs\Pack"]);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, d =>
+            !d.IsWarning &&
+            d.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void NormalizeWindowsDrivePath_WithParentSegmentResolvingToRoot_ShouldProduceDriveRoot()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        var result = policy.Validate([@"C:\Songs", @"C:\Songs\..\.."]);
+
+        // C:\Songs\..\.. resolves to C:\ which is an ancestor of C:\Songs -> overlap.
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, d =>
+            !d.IsWarning &&
+            d.Message.Contains("overlap", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void NormalizeWindowsDrivePath_RootOnly_ShouldBeAcceptedAsCanonical()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        var result = policy.Validate([@"C:\"]);
+
+        Assert.True(result.IsValid);
+        Assert.Equal(new[] { @"C:\" }, result.CanonicalRoots);
+    }
+
+    [Fact]
+    public void Validate_WithDuplicateWindowsDrivePathsCaseInsensitive_ShouldReportDuplicate()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        var result = policy.Validate([@"D:\Songs", @"d:\songs"]);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, d =>
+            !d.IsWarning &&
+            d.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void IsAncestor_WithWindowsDriveParent_ShouldDetectChildRelationship()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        Assert.True(policy.IsAncestor(@"C:\Songs", @"C:\Songs\Pack"));
+    }
+
+    [Fact]
+    public void IsAncestor_WithDifferentWindowsDrives_ShouldNotMatch()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        Assert.False(policy.IsAncestor(@"C:\Songs", @"D:\Songs\Pack"));
+    }
+
+    [Fact]
+    public void IsAncestor_WhenParentEqualsChild_ShouldNotMatchAsAncestor()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+        // A path is not a strict ancestor of itself.
+        Assert.False(policy.IsAncestor("/songs", "/songs"));
+    }
+
+    [Fact]
+    public void Validate_WhenRootOverlapsAsChildOfExisting_ShouldReportOverlap()
+    {
+        // The overlap check tests both directions (existing ancestor of new, and
+        // new ancestor of existing). Supply the ancestor second so the
+        // "new ancestor of existing" branch is exercised.
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+        var result = policy.Validate(["/songs/pack", "/songs"]);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, d =>
+            !d.IsWarning &&
+            d.Message.Contains("overlap", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_WhenAllRootsAreValidAndPresent_ShouldProduceNoDiagnostics()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var first = Path.Combine(root, "first");
+            var second = Path.Combine(root, "second");
+            Directory.CreateDirectory(first);
+            Directory.CreateDirectory(second);
+            var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+            var result = policy.Validate([first, second]);
+
+            Assert.True(result.IsValid);
+            Assert.Empty(result.Diagnostics);
+            Assert.Equal(
+                new[] { Path.GetFullPath(first), Path.GetFullPath(second) },
+                result.CanonicalRoots);
+        });
+    }
+
+    [Fact]
+    public void Probe_WhenPathIsAFileNotADirectory_ShouldReturnMissing()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var filePath = Path.Combine(root, "not-a-directory");
+            File.WriteAllText(filePath, "x");
+            var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+            Assert.Equal(SongRootAvailability.Missing, policy.Probe(filePath));
+        });
+    }
+
+    private static void WithTemporaryDirectory(Action<string> action)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            nameof(SongRootPolicyAdditionalTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            action(root);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongRootPolicyTests.cs
+++ b/DTXMania.Test/Song/SongRootPolicyTests.cs
@@ -225,6 +225,183 @@ public sealed class SongRootPolicyTests
         });
     }
 
+    [Fact]
+    public void Validate_WhenRootIsBlank_ShouldReportNonWarningDiagnosticWithoutAddingCanonicalRoot()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+        var result = policy.Validate(["/policy/Songs", "   "]);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.CanonicalRoots);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            !diagnostic.IsWarning &&
+            diagnostic.Message.Contains("blank", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_WhenRootCannotBeNormalized_ShouldReportInvalidDiagnosticWithoutAddingCanonicalRoot()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+        // A NUL character is an illegal path character that Path.GetFullPath rejects.
+        var result = policy.Validate(["/policy/Songs", "/bad\0root"]);
+
+        Assert.False(result.IsValid);
+        Assert.Single(result.CanonicalRoots);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            !diagnostic.IsWarning &&
+            diagnostic.Message.Contains("invalid", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_WhenConfiguredRootIsMissing_ShouldReportWarningAndKeepRootValid()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var missing = Path.Combine(root, "does-not-exist");
+            var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+            var result = policy.Validate([missing]);
+
+            Assert.True(result.IsValid);
+            Assert.Equal([Path.GetFullPath(missing)], result.CanonicalRoots);
+            Assert.Contains(result.Diagnostics, diagnostic =>
+                diagnostic.IsWarning &&
+                diagnostic.Message.Contains("does not exist", StringComparison.OrdinalIgnoreCase));
+        });
+    }
+
+    [Fact]
+    public void Validate_WhenConfiguredRootIsInaccessible_ShouldReportWarningAndKeepRootValid()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var restricted = Path.Combine(root, "restricted");
+            Directory.CreateDirectory(restricted);
+            if (!TryDenyEnumeration(restricted))
+            {
+                // Running as root or on a filesystem that ignores POSIX permission bits
+                // (e.g. a FAT mount) cannot produce an inaccessible directory; skip the
+                // assertion rather than reporting a false failure.
+                return;
+            }
+
+            try
+            {
+                var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+                var result = policy.Validate([restricted]);
+
+                Assert.True(result.IsValid);
+                Assert.Equal([restricted], result.CanonicalRoots);
+                Assert.Contains(result.Diagnostics, diagnostic =>
+                    diagnostic.IsWarning &&
+                    diagnostic.Message.Contains("inaccessible", StringComparison.OrdinalIgnoreCase));
+            }
+            finally
+            {
+                RestoreEnumeration(restricted);
+            }
+        });
+    }
+
+    [Fact]
+    public void Probe_WhenRootIsInaccessible_ShouldReturnInaccessible()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var restricted = Path.Combine(root, "restricted");
+            Directory.CreateDirectory(restricted);
+            if (!TryDenyEnumeration(restricted))
+                return;
+
+            try
+            {
+                var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+                Assert.Equal(
+                    SongRootAvailability.Inaccessible,
+                    policy.Probe(restricted));
+            }
+            finally
+            {
+                RestoreEnumeration(restricted);
+            }
+        });
+    }
+
+    [Fact]
+    public void IsAncestor_WhenPathsCannotBeNormalized_ShouldReturnFalse()
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+        Assert.False(policy.IsAncestor("/bad\0parent", "/child"));
+        Assert.False(policy.IsAncestor("/parent", "/bad\0child"));
+    }
+
+    [Fact]
+    public void NormalizeWindowsDrivePath_ShouldResolveParentSegmentDuringOverlapCheck()
+    {
+        // A Windows-style drive path with a parent (..) segment must collapse before
+        // the overlap check so a child of the resolved root is detected as overlapping.
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(true));
+
+        var result = policy.Validate([@"C:\Songs", @"C:\Songs\..\Songs\Pack"]);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            !diagnostic.IsWarning &&
+            diagnostic.Message.Contains("overlap", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void CreateComparer_WhenIgnoreCaseIsFalse_ShouldProduceAnOrdinalComparer()
+    {
+        var comparer = SongRootPolicy.CreateComparer(ignoreCase: false);
+
+        Assert.NotEqual(comparer, StringComparer.OrdinalIgnoreCase);
+        Assert.False(comparer.Equals("/Songs", "/SONGS"));
+    }
+
+    private static bool TryDenyEnumeration(string directory)
+    {
+        // Remove all permissions so enumeration fails with EACCES for non-root
+        // callers. Uses chmod so the test does not depend on a Mono.Unix binding.
+        return RunChmod("000", directory);
+    }
+
+    private static void RestoreEnumeration(string directory)
+    {
+        // Best-effort restore; the temporary directory is deleted by the caller.
+        RunChmod("755", directory);
+    }
+
+    private static bool RunChmod(string mode, string path)
+    {
+        try
+        {
+            var info = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "/bin/chmod",
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            info.ArgumentList.Add(mode);
+            info.ArgumentList.Add(path);
+            using var process = System.Diagnostics.Process.Start(info);
+            if (process == null)
+                return false;
+            process.WaitForExit();
+            return process.ExitCode == 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static void WithTemporaryDirectory(Action<string> action)
     {
         var root = Path.Combine(

--- a/DTXMania.Test/Song/SongRootPolicyTests.cs
+++ b/DTXMania.Test/Song/SongRootPolicyTests.cs
@@ -167,6 +167,33 @@ public sealed class SongRootPolicyTests
     }
 
     [Fact]
+    public void SetSongRoots_WhenNoRootsAreSupplied_ShouldRejectTheEmptyConfiguration()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var existingRoot = Path.Combine(root, "existing");
+            Directory.CreateDirectory(existingRoot);
+            var configFile = Path.Combine(root, "Config.ini");
+            var manager = new ConfigManager(
+                new SongRootPolicy(SongRootPolicy.CreateComparer(false)));
+            manager.Config.SongRoots.Clear();
+            manager.Config.SongRoots.Add(existingRoot);
+            manager.Config.DTXPath = existingRoot;
+
+            var result = manager.SetSongRoots(configFile, Array.Empty<string>());
+
+            Assert.Equal(SongRootUpdateStatus.ValidationFailed, result.Status);
+            Assert.Empty(result.CanonicalRoots);
+            Assert.Contains(result.Diagnostics, diagnostic =>
+                !diagnostic.IsWarning &&
+                diagnostic.Message.Contains("at least one", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(new[] { existingRoot }, manager.Config.SongRoots);
+            Assert.Equal(existingRoot, manager.Config.DTXPath);
+            Assert.False(File.Exists(configFile));
+        });
+    }
+
+    [Fact]
     public void SetSongRoots_WhenImmediatePersistenceFails_ShouldRestoreMemoryAndNotRaiseEvent()
     {
         WithTemporaryDirectory(root =>

--- a/DTXMania.Test/Song/SongRootPolicyTests.cs
+++ b/DTXMania.Test/Song/SongRootPolicyTests.cs
@@ -1,0 +1,215 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Song;
+using Xunit;
+
+namespace DTXMania.Test.Song;
+
+[Trait("Category", "Unit")]
+public sealed class SongRootPolicyTests
+{
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void DuplicatePolicy_ShouldFollowInjectedCaseMode(
+        bool ignoreCase,
+        bool expectedDuplicate)
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(ignoreCase));
+
+        var result = policy.Validate(["/policy/Songs", "/policy/SONGS"]);
+
+        Assert.Equal(!expectedDuplicate, result.IsValid);
+        Assert.Equal(expectedDuplicate, result.Diagnostics.Any(
+            diagnostic => !diagnostic.IsWarning &&
+                diagnostic.Message.Contains("duplicate", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Theory]
+    [InlineData(true, "/Users/me/Songs", "/Users/me/SONGS/Extra", true)]
+    [InlineData(true, @"C:\Songs", @"c:\songs\Pack", true)]
+    [InlineData(false, "/songs", "/Songs/Pack", false)]
+    public void Validate_ShouldRejectOverlappingRootsUsingInjectedSegmentComparison(
+        bool ignoreCase,
+        string parent,
+        string child,
+        bool expectedOverlap)
+    {
+        var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(ignoreCase));
+
+        var result = policy.Validate([parent, child]);
+
+        Assert.Equal(!expectedOverlap, result.IsValid);
+        Assert.Equal(expectedOverlap, result.Diagnostics.Any(
+            diagnostic => !diagnostic.IsWarning &&
+                diagnostic.Message.Contains("overlap", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void Validate_ShouldNormalizeAndPreserveFirstOccurrenceOrder()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var first = Path.Combine(root, "first");
+            var second = Path.Combine(root, "second");
+            var suppliedRoots = new List<string>
+            {
+                Path.Combine(first, "."),
+                second,
+            };
+            var policy = new SongRootPolicy(SongRootPolicy.CreateComparer(false));
+
+            var result = policy.Validate(suppliedRoots);
+            suppliedRoots[0] = second;
+
+            Assert.True(result.IsValid);
+            Assert.Equal(
+                [Path.GetFullPath(first), Path.GetFullPath(second)],
+                result.CanonicalRoots);
+        });
+    }
+
+    [Fact]
+    public void Probe_ShouldDistinguishAvailableAndMissingRootsWithoutCreatingDirectories()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var available = Path.Combine(root, "available");
+            var missing = Path.Combine(root, "missing");
+            Directory.CreateDirectory(available);
+            var policy = SongRootPolicy.ForCurrentPlatform();
+
+            Assert.Equal(
+                SongRootAvailability.Available,
+                policy.Probe(Path.GetFullPath(available)));
+            Assert.Equal(
+                SongRootAvailability.Missing,
+                policy.Probe(Path.GetFullPath(missing)));
+            Assert.False(Directory.Exists(missing));
+        });
+    }
+
+    [Fact]
+    public void SetSongRoots_ShouldPersistCanonicalRootsBeforeRaisingOneEvent()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var oldRoot = Path.Combine(root, "old");
+            var firstRoot = Path.Combine(root, "first");
+            var secondRoot = Path.Combine(root, "second");
+            Directory.CreateDirectory(oldRoot);
+            Directory.CreateDirectory(firstRoot);
+            Directory.CreateDirectory(secondRoot);
+            var configFile = Path.Combine(root, "Config.ini");
+            var manager = new ConfigManager(
+                new SongRootPolicy(SongRootPolicy.CreateComparer(false)));
+            manager.Config.SongRoots.Clear();
+            manager.Config.SongRoots.Add(oldRoot);
+            manager.Config.DTXPath = oldRoot;
+            SongRootsChangedEventArgs? raised = null;
+            var eventCount = 0;
+            manager.SongRootsChanged += (_, args) =>
+            {
+                eventCount++;
+                raised = args;
+                Assert.True(File.Exists(configFile));
+            };
+
+            var result = manager.SetSongRoots(
+                configFile,
+                [Path.Combine(firstRoot, "."), secondRoot]);
+
+            Assert.Equal(SongRootUpdateStatus.Updated, result.Status);
+            Assert.Equal(
+                [Path.GetFullPath(firstRoot), Path.GetFullPath(secondRoot)],
+                manager.Config.SongRoots);
+            Assert.Equal(Path.GetFullPath(firstRoot), manager.Config.DTXPath);
+            Assert.Equal(1, eventCount);
+            Assert.NotNull(raised);
+            Assert.Equal([Path.GetFullPath(oldRoot)], raised!.OldRoots);
+            Assert.Equal(
+                [Path.GetFullPath(firstRoot), Path.GetFullPath(secondRoot)],
+                raised.NewRoots);
+            Assert.Contains($"SongRoot.0={Path.GetFullPath(firstRoot)}", File.ReadAllText(configFile));
+            Assert.Contains($"SongRoot.1={Path.GetFullPath(secondRoot)}", File.ReadAllText(configFile));
+        });
+    }
+
+    [Fact]
+    public void SetSongRoots_WhenCanonicalOrderedRootsAreUnchanged_ShouldNotWriteOrRaiseEvent()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var songsRoot = Path.Combine(root, "songs");
+            Directory.CreateDirectory(songsRoot);
+            var configFile = Path.Combine(root, "Config.ini");
+            var manager = new ConfigManager(
+                new SongRootPolicy(SongRootPolicy.CreateComparer(false)));
+            manager.Config.SongRoots.Clear();
+            manager.Config.SongRoots.Add(songsRoot);
+            manager.Config.DTXPath = songsRoot;
+            var eventCount = 0;
+            manager.SongRootsChanged += (_, _) => eventCount++;
+
+            var result = manager.SetSongRoots(
+                configFile,
+                [Path.Combine(songsRoot, ".")]);
+
+            Assert.Equal(SongRootUpdateStatus.Unchanged, result.Status);
+            Assert.False(File.Exists(configFile));
+            Assert.Equal(0, eventCount);
+        });
+    }
+
+    [Fact]
+    public void SetSongRoots_WhenImmediatePersistenceFails_ShouldRestoreMemoryAndNotRaiseEvent()
+    {
+        WithTemporaryDirectory(root =>
+        {
+            var oldRoot = Path.Combine(root, "old");
+            var newRoot = Path.Combine(root, "new");
+            Directory.CreateDirectory(oldRoot);
+            Directory.CreateDirectory(newRoot);
+            var blockingFile = Path.Combine(root, "not-a-directory");
+            File.WriteAllText(blockingFile, "block");
+            var configFile = Path.Combine(blockingFile, "Config.ini");
+            var manager = new ConfigManager(
+                new SongRootPolicy(SongRootPolicy.CreateComparer(false)));
+            manager.Config.SongRoots.Clear();
+            manager.Config.SongRoots.Add(oldRoot);
+            manager.Config.DTXPath = oldRoot;
+            var eventCount = 0;
+            manager.SongRootsChanged += (_, _) => eventCount++;
+
+            var result = manager.SetSongRoots(configFile, [newRoot]);
+
+            Assert.Equal(SongRootUpdateStatus.PersistenceFailed, result.Status);
+            Assert.Equal([oldRoot], manager.Config.SongRoots);
+            Assert.Equal(oldRoot, manager.Config.DTXPath);
+            Assert.Equal(0, eventCount);
+        });
+    }
+
+    private static void WithTemporaryDirectory(Action<string> action)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            nameof(SongRootPolicyTests),
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            action(root);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/DTXMania.Test/Song/SongRootPolicyTests.cs
+++ b/DTXMania.Test/Song/SongRootPolicyTests.cs
@@ -113,17 +113,20 @@ public sealed class SongRootPolicyTests
             manager.Config.DTXPath = oldRoot;
             SongRootsChangedEventArgs? raised = null;
             var eventCount = 0;
+            var configFileExistedWhenRaised = false;
             manager.SongRootsChanged += (_, args) =>
             {
                 eventCount++;
                 raised = args;
-                Assert.True(File.Exists(configFile));
+                configFileExistedWhenRaised = File.Exists(configFile);
             };
 
             var result = manager.SetSongRoots(
                 configFile,
                 [Path.Combine(firstRoot, "."), secondRoot]);
 
+            Assert.True(configFileExistedWhenRaised,
+                "The config file should exist when SongRootsChanged is raised.");
             Assert.Equal(SongRootUpdateStatus.Updated, result.Status);
             Assert.Equal(
                 [Path.GetFullPath(firstRoot), Path.GetFullPath(secondRoot)],

--- a/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
@@ -17,6 +17,7 @@ using DTXMania.Game.Lib.Stage.Config;
 using DTXMania.Test.TestData;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Xna.Framework.Graphics;
+using Microsoft.Xna.Framework.Input;
 using Moq;
 using Xunit;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
@@ -314,6 +315,98 @@ public class ConfigStageNxImportTests : IDisposable
     }
 
     [Fact]
+    public async Task ApplyViaSongFolderPanel_WhenReloadStarts_ShouldCloseAsCommittedSaveAndLeaveCoordinatorRunning()
+    {
+        var first = Path.Combine(Path.GetTempPath(), $"hpa191-panel-first-{Guid.NewGuid():N}");
+        var second = Path.Combine(Path.GetTempPath(), $"hpa191-panel-second-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(first);
+        Directory.CreateDirectory(second);
+        try
+        {
+            var configData = new ConfigData();
+            configData.SongRoots.Clear();
+            configData.SongRoots.Add(first);
+            configData.DTXPath = first;
+            var config = new Mock<IConfigManager>();
+            config.SetupGet(manager => manager.Config).Returns(configData);
+            config.Setup(manager => manager.SetSongRoots(
+                    It.IsAny<string>(),
+                    It.Is<IReadOnlyList<string>>(roots =>
+                        roots.SequenceEqual(new[] { first, second }))))
+                .Returns(new SongRootUpdateResult(
+                    SongRootUpdateStatus.Updated,
+                    new[] { first, second },
+                    Array.Empty<SongRootDiagnostic>()));
+
+            var picker = new Mock<IFolderPickerService>();
+            picker.Setup(service => service.PickFolderAsync(first, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(FolderPickerResult.Selected(second)));
+            var reloadStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var reloadCompletion = new TaskCompletionSource<SongLibraryReloadResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var (stage, inputManager) = CreateStage(
+                config.Object,
+                new DelegateSongLibraryReloadService((roots, _, _) =>
+                {
+                    Assert.Equal(new[] { first, second }, roots);
+                    reloadStarted.TrySetResult(true);
+                    return reloadCompletion.Task;
+                }),
+                (_, _) => Task.FromResult(new NxImportResult()),
+                () => Task.CompletedTask);
+            using (inputManager)
+            {
+                ReflectionHelpers.SetPrivateField(stage, "_songFolderPicker", picker.Object);
+                InitializeStageMenu(stage, includePanels: true);
+                var panel = ReflectionHelpers.GetPrivateField<SongFolderPanel>(
+                    stage,
+                    "_songFolderPanel")!;
+                var events = new List<string>();
+                panel.Saved += (_, _) => events.Add("Saved");
+                panel.Closed += (_, _) => events.Add("Closed");
+
+                ReflectionHelpers.InvokePrivateMethod(stage, "OpenPanel", panel);
+                PressPanel(panel, Keys.Down);
+                PressPanel(panel, Keys.Enter);
+                await Task.Yield();
+                panel.Update(0, new KeyboardState(), new KeyboardState());
+
+                for (var index = 0; index < 5; index++)
+                    PressPanel(panel, Keys.Down);
+                PressPanel(panel, Keys.Enter);
+
+                await reloadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+                Assert.Equal(SongFolderApplyStatus.Started, panel.LastApplyStatus);
+                Assert.False(panel.IsActive);
+                Assert.Equal(new[] { "Saved", "Closed" }, events);
+                Assert.Null(ReflectionHelpers.GetPrivateField<IConfigOverlayPanel>(
+                    stage,
+                    "_activePanel"));
+                Assert.True(GetCoordinator(stage).IsBusy);
+
+                panel.Activate();
+                Assert.Equal(new[] { first, second }, panel.DraftRoots);
+
+                reloadCompletion.TrySetResult(new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.Published,
+                    UnavailableRootCount: 0,
+                    EnumeratedFileCount: 2,
+                    DiscoveredScoreCount: 2));
+                Assert.True(await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000));
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(first))
+                Directory.Delete(first, recursive: true);
+            if (Directory.Exists(second))
+                Directory.Delete(second, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task StartNxScoreImport_WhenNotRunning_ShouldSetStatusAndCompleteImport()
     {
         var manager = SongManager.Instance;
@@ -574,6 +667,9 @@ public class ConfigStageNxImportTests : IDisposable
             BindingFlags.Instance | BindingFlags.NonPublic);
         return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
     }
+
+    private static void PressPanel(SongFolderPanel panel, Keys key) =>
+        panel.Update(0, new KeyboardState(key), new KeyboardState());
 
     private static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
         ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(

--- a/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
 using DTXMania.Game.Lib.Config;
@@ -52,6 +55,35 @@ public class ConfigStageNxImportTests : IDisposable
         return (new ConfigStage(game, () => availability), configManager, inputManager);
     }
 
+    private static (ConfigStage Stage, InputManagerCompat InputManager) CreateStage(
+        IConfigManager configManager,
+        ISongLibraryReloadService reloadService,
+        Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> nxImportAsync,
+        Func<Task> refreshSongListAsync,
+        Func<Func<Task<ConfigSongOperationCompletion>>, Task<ConfigSongOperationCompletion>>? backgroundRunner = null,
+        Func<Task, Action<Task>, Task>? continuationRegistrar = null)
+    {
+        var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+        var availability = new FfmpegRuntimeAvailability(
+            IsAvailable: true,
+            DiagnosticReason: null,
+            BinaryFolder: null);
+        return (
+            new ConfigStage(
+                game,
+                () => availability,
+                () => new Mock<IFolderPickerService>().Object,
+                reloadService,
+                nxImportAsync,
+                refreshSongListAsync,
+                backgroundRunner ?? (work => Task.Run(work)),
+                continuationRegistrar),
+            inputManager);
+    }
+
     private static void InitializeStageMenu(ConfigStage stage, bool includePanels = false)
     {
         // Config is truth; only the item list (and optionally the system panel) need setup.
@@ -83,24 +115,39 @@ public class ConfigStageNxImportTests : IDisposable
     }
 
     [Fact]
-        public void OnDeactivate_WhileImportRunning_ShouldCancelImport()
-        {
-            var (stage, _, inputManager) = CreateStage();
+    public async Task Deactivate_ShouldCancelWithoutBlocking()
+    {
+        var config = new ConfigManager();
+        var importStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var importCompletion = new TaskCompletionSource<NxImportResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (stage, inputManager) = CreateStage(
+            config,
+            new DelegateSongLibraryReloadService(),
+            (_, _) =>
+            {
+                importStarted.TrySetResult(true);
+                return importCompletion.Task;
+            },
+            () => Task.CompletedTask);
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
-
-            // Start the import — this creates and stores a CancellationTokenSource.
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
+            await importStarted.Task;
 
-            // The CTS should have been created.
-            var cts = ReflectionHelpers.GetPrivateField<System.Threading.CancellationTokenSource>(stage, "_importCts");
+            var cts = ReflectionHelpers.GetPrivateField<CancellationTokenSource>(stage, "_songOperationCts");
             Assert.NotNull(cts);
 
-            // Deactivate should cancel the token.
+            var stopwatch = Stopwatch.StartNew();
             ReflectionHelpers.InvokePrivateMethod(stage, "OnDeactivate");
+            stopwatch.Stop();
 
             Assert.True(cts.IsCancellationRequested);
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1));
+
+            importCompletion.TrySetResult(new NxImportResult());
         }
     }
 
@@ -112,32 +159,124 @@ public class ConfigStageNxImportTests : IDisposable
         {
             InitializeStageMenu(stage, includePanels: false);
 
-            // Before starting, no CTS.
-            Assert.Null(ReflectionHelpers.GetPrivateField<System.Threading.CancellationTokenSource>(stage, "_importCts"));
+            Assert.Null(ReflectionHelpers.GetPrivateField<CancellationTokenSource>(stage, "_songOperationCts"));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
 
-            // After starting, CTS should exist and not be cancelled.
-            var cts = ReflectionHelpers.GetPrivateField<System.Threading.CancellationTokenSource>(stage, "_importCts");
+            var cts = ReflectionHelpers.GetPrivateField<CancellationTokenSource>(stage, "_songOperationCts");
             Assert.NotNull(cts);
             Assert.False(cts.IsCancellationRequested);
         }
     }
 
     [Fact]
-    public void StartNxScoreImport_WhenAlreadyRunning_ShouldReturnEarly()
+    public async Task NxImportAndReload_ShouldNotOverlap()
     {
-        var (stage, _, inputManager) = CreateStage();
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add("/old");
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(manager => manager.Config).Returns(configData);
+        var importStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var importCompletion = new TaskCompletionSource<NxImportResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (stage, inputManager) = CreateStage(
+            config.Object,
+            new DelegateSongLibraryReloadService(),
+            (_, _) =>
+            {
+                importStarted.TrySetResult(true);
+                return importCompletion.Task;
+            },
+            () => Task.CompletedTask);
         using (inputManager)
         {
             InitializeStageMenu(stage, includePanels: false);
-            ReflectionHelpers.SetPrivateField(stage, "_importRunning", true);
-            ReflectionHelpers.SetPrivateField(stage, "_importStatus", "Existing status");
-
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
+            await importStarted.Task;
 
-            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_importRunning"));
-            Assert.Equal("Existing status", ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
+            var result = ApplySongRoots(stage, new[] { "/new" });
+
+            Assert.Equal(SongFolderApplyStatus.Busy, result.Status);
+            config.Verify(manager => manager.SetSongRoots(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Never);
+
+            importCompletion.TrySetResult(new NxImportResult());
+            Assert.True(await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000));
+        }
+    }
+
+    [Fact]
+    public void UnchangedApply_ShouldNotAcquirePersistOrScan()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa191-unchanged");
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add(root);
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(manager => manager.Config).Returns(configData);
+        var reloadCalls = 0;
+        var (stage, inputManager) = CreateStage(
+            config.Object,
+            new DelegateSongLibraryReloadService((_, _, _) =>
+            {
+                reloadCalls++;
+                return Task.FromResult(new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.Published, 0, 0, 0));
+            }),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask);
+        using (inputManager)
+        {
+            var result = ApplySongRoots(stage, new[] { root });
+
+            Assert.Equal(SongFolderApplyStatus.Unchanged, result.Status);
+            Assert.False(GetCoordinator(stage).IsBusy);
+            Assert.Equal(0, reloadCalls);
+            config.Verify(manager => manager.SetSongRoots(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task ReorderOnlyApply_ShouldImportOnce()
+    {
+        var first = Path.Combine(Path.GetTempPath(), "hpa191-first");
+        var second = Path.Combine(Path.GetTempPath(), "hpa191-second");
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add(first);
+        configData.SongRoots.Add(second);
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(manager => manager.Config).Returns(configData);
+        config.Setup(manager => manager.SetSongRoots(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .Returns(new SongRootUpdateResult(
+                SongRootUpdateStatus.Updated,
+                new[] { second, first },
+                Array.Empty<SongRootDiagnostic>()));
+        var reloadCalls = 0;
+        var (stage, inputManager) = CreateStage(
+            config.Object,
+            new DelegateSongLibraryReloadService((_, _, _) =>
+            {
+                reloadCalls++;
+                return Task.FromResult(new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.Published, 0, 2, 2));
+            }),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask);
+        using (inputManager)
+        {
+            var result = ApplySongRoots(stage, new[] { second, first });
+
+            Assert.Equal(SongFolderApplyStatus.Started, result.Status);
+            Assert.True(await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000));
+            Assert.Equal(1, reloadCalls);
+            config.Verify(manager => manager.SetSongRoots(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Once);
         }
     }
 
@@ -154,11 +293,9 @@ public class ConfigStageNxImportTests : IDisposable
 
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
 
-            Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_importRunning"));
             Assert.Equal("Importing NX scores...", ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
 
-            // Poll until the fire-and-forget task completes.
-            var completed = await WaitUntilImportCompletesAsync(stage, timeoutMs: 5000);
+            var completed = await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000);
             Assert.True(completed, "Import did not complete within timeout");
 
             var status = ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus");
@@ -182,7 +319,7 @@ public class ConfigStageNxImportTests : IDisposable
 
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
 
-            var completed = await WaitUntilImportCompletesAsync(stage, timeoutMs: 5000);
+            var completed = await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000);
             Assert.True(completed, "Import did not complete within timeout");
 
             Assert.StartsWith("NX import failed:", ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
@@ -202,7 +339,7 @@ public class ConfigStageNxImportTests : IDisposable
 
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
 
-            var completed = await WaitUntilImportCompletesAsync(stage, timeoutMs: 5000);
+            var completed = await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000);
             Assert.True(completed, "Import did not complete within timeout");
 
             Assert.Equal("NX import unavailable (no database)",
@@ -305,7 +442,7 @@ public class ConfigStageNxImportTests : IDisposable
             Assert.Empty(manager.RootSongs);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
-            var completed = await WaitUntilImportCompletesAsync(stage, timeoutMs: 5000);
+            var completed = await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000);
             Assert.True(completed, "Import did not complete within timeout");
 
             // After import + refresh, RootSongs should contain the chart.
@@ -317,16 +454,145 @@ public class ConfigStageNxImportTests : IDisposable
         }
     }
 
-    private static async Task<bool> WaitUntilImportCompletesAsync(ConfigStage stage, int timeoutMs)
+    [Fact]
+    public async Task WorkerProgress_ShouldUpdateOnlyWhenDrained()
+    {
+        var config = new ConfigManager();
+        IProgress<NxImportProgress>? progress = null;
+        var importStarted = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var importCompletion = new TaskCompletionSource<NxImportResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (stage, inputManager) = CreateStage(
+            config,
+            new DelegateSongLibraryReloadService(),
+            (reportedProgress, _) =>
+            {
+                progress = reportedProgress;
+                importStarted.TrySetResult(true);
+                return importCompletion.Task;
+            },
+            () => Task.CompletedTask);
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+            ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
+            await importStarted.Task;
+
+            progress!.Report(new NxImportProgress { Imported = 2, Scanned = 3 });
+
+            Assert.Equal("Importing NX scores...",
+                ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
+
+            DrainOperationUpdates(stage);
+
+            Assert.Equal("Importing... 2 imported / 3 scanned",
+                ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
+
+            importCompletion.TrySetResult(new NxImportResult());
+            Assert.True(await WaitUntilOperationCompletesAsync(stage, timeoutMs: 5000));
+        }
+    }
+
+    [Fact]
+    public async Task EveryTerminalPath_ShouldDisposeAndReleaseOnce()
+    {
+        var config = new ConfigManager();
+        var (constructionStage, constructionInput) = CreateStage(
+            config,
+            new DelegateSongLibraryReloadService(),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask,
+            _ => throw new InvalidOperationException("construction failed"));
+        using (constructionInput)
+        {
+            InitializeStageMenu(constructionStage, includePanels: false);
+            ReflectionHelpers.InvokePrivateMethod(constructionStage, "StartNxScoreImport");
+            Assert.False(GetCoordinator(constructionStage).IsBusy);
+        }
+
+        var terminal = new TaskCompletionSource<ConfigSongOperationCompletion>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (registrationStage, registrationInput) = CreateStage(
+            new ConfigManager(),
+            new DelegateSongLibraryReloadService(),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask,
+            _ => terminal.Task,
+            (_, _) => throw new InvalidOperationException("registration failed"));
+        using (registrationInput)
+        {
+            InitializeStageMenu(registrationStage, includePanels: false);
+            ReflectionHelpers.InvokePrivateMethod(registrationStage, "StartNxScoreImport");
+            Assert.True(GetCoordinator(registrationStage).IsBusy);
+
+            terminal.TrySetResult(new ConfigSongOperationCompletion("done"));
+            Assert.True(await WaitUntilOperationCompletesAsync(registrationStage, timeoutMs: 5000));
+            Assert.False(GetCoordinator(registrationStage).IsBusy);
+        }
+    }
+
+    private static SongFolderApplyResult ApplySongRoots(
+        ConfigStage stage,
+        IReadOnlyList<string> roots)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            "ApplySongRoots",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
+    }
+
+    private static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
+        ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(
+            stage,
+            "_songOperationCoordinator");
+
+    private static void DrainOperationUpdates(ConfigStage stage) =>
+        ReflectionHelpers.InvokePrivateMethod(stage, "OnUpdate", 0d);
+
+    private static async Task<bool> WaitUntilOperationCompletesAsync(ConfigStage stage, int timeoutMs)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         while (sw.ElapsedMilliseconds < timeoutMs)
         {
-            if (!ReflectionHelpers.GetPrivateField<bool>(stage, "_importRunning"))
+            if (!GetCoordinator(stage).IsBusy)
+            {
+                DrainOperationUpdates(stage);
                 return true;
+            }
             await Task.Delay(50);
         }
         return false;
+    }
+
+    private sealed class DelegateSongLibraryReloadService : ISongLibraryReloadService
+    {
+        private readonly Func<
+            IReadOnlyList<string>,
+            IProgress<SongLibraryReloadProgress>?,
+            CancellationToken,
+            Task<SongLibraryReloadResult>> _reload;
+
+        public DelegateSongLibraryReloadService(
+            Func<
+                IReadOnlyList<string>,
+                IProgress<SongLibraryReloadProgress>?,
+                CancellationToken,
+                Task<SongLibraryReloadResult>>? reload = null)
+        {
+            _reload = reload ?? ((_, _, _) => Task.FromResult(
+                new SongLibraryReloadResult(
+                    SongLibraryReloadOutcome.Published,
+                    UnavailableRootCount: 0,
+                    EnumeratedFileCount: 0,
+                    DiscoveredScoreCount: 0)));
+        }
+
+        public Task<SongLibraryReloadResult> ReloadAsync(
+            IReadOnlyList<string> configuredRoots,
+            IProgress<SongLibraryReloadProgress>? progress,
+            CancellationToken cancellationToken) =>
+            _reload(configuredRoots, progress, cancellationToken);
     }
 
     private static SpriteBatch CreateUninitializedSpriteBatch()

--- a/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageNxImportTests.cs
@@ -61,7 +61,8 @@ public class ConfigStageNxImportTests : IDisposable
         Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> nxImportAsync,
         Func<Task> refreshSongListAsync,
         Func<Func<Task<ConfigSongOperationCompletion>>, Task<ConfigSongOperationCompletion>>? backgroundRunner = null,
-        Func<Task, Action<Task>, Task>? continuationRegistrar = null)
+        Func<Task, Action<Task>, Task>? continuationRegistrar = null,
+        Func<CancellationTokenSource>? cancellationTokenSourceFactory = null)
     {
         var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
         var game = ReflectionHelpers.CreateGame();
@@ -80,7 +81,8 @@ public class ConfigStageNxImportTests : IDisposable
                 nxImportAsync,
                 refreshSongListAsync,
                 backgroundRunner ?? (work => Task.Run(work)),
-                continuationRegistrar),
+                continuationRegistrar,
+                cancellationTokenSourceFactory),
             inputManager);
     }
 
@@ -166,6 +168,37 @@ public class ConfigStageNxImportTests : IDisposable
             var cts = ReflectionHelpers.GetPrivateField<CancellationTokenSource>(stage, "_songOperationCts");
             Assert.NotNull(cts);
             Assert.False(cts.IsCancellationRequested);
+        }
+    }
+
+    [Fact]
+    public void StartNxScoreImport_WhenCtsConstructionFails_ShouldReleaseLeaseWithoutStartingWorker()
+    {
+        var importCalls = 0;
+        var (stage, inputManager) = CreateStage(
+            new ConfigManager(),
+            new DelegateSongLibraryReloadService(),
+            (_, _) =>
+            {
+                importCalls++;
+                return Task.FromResult(new NxImportResult());
+            },
+            () => Task.CompletedTask,
+            cancellationTokenSourceFactory: () =>
+                throw new InvalidOperationException("cts setup failed"));
+        using (inputManager)
+        {
+            InitializeStageMenu(stage, includePanels: false);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "StartNxScoreImport");
+
+            Assert.False(GetCoordinator(stage).IsBusy);
+            Assert.Null(ReflectionHelpers.GetPrivateField<CancellationTokenSource>(
+                stage,
+                "_songOperationCts"));
+            Assert.Equal("NX import could not be started.",
+                ReflectionHelpers.GetPrivateField<string>(stage, "_importStatus"));
+            Assert.Equal(0, importCalls);
         }
     }
 

--- a/DTXMania.Test/Stage/ConfigStageSongFolderFormatTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageSongFolderFormatTests.cs
@@ -1,0 +1,388 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework.Input;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Stage;
+
+[Trait("Category", "Unit")]
+public sealed class ConfigStageSongFolderFormatTests
+{
+    [Fact]
+    public void FormatSongLibraryReloadProgress_WithOperation_ShouldIncludeOperationAndCounts()
+    {
+        var progress = new SongLibraryReloadProgress(
+            CurrentOperation: "Scanning",
+            ProcessedCount: 5,
+            DiscoveredSongs: 10,
+            CurrentFile: null,
+            CurrentDirectory: null);
+
+        var result = InvokeStatic<string>("FormatSongLibraryReloadProgress", progress);
+
+        Assert.Equal("Reloading songs: Scanning (5 processed / 10 discovered)", result);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadProgress_WithBlankOperation_ShouldShowCountsOnly()
+    {
+        var progress = new SongLibraryReloadProgress(
+            CurrentOperation: "   ",
+            ProcessedCount: 5,
+            DiscoveredSongs: 10,
+            CurrentFile: null,
+            CurrentDirectory: null);
+
+        var result = InvokeStatic<string>("FormatSongLibraryReloadProgress", progress);
+
+        Assert.Equal("Reloading songs: 5 processed / 10 discovered", result);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadProgress_WithNullOperation_ShouldShowCountsOnly()
+    {
+        var progress = new SongLibraryReloadProgress(
+            CurrentOperation: null,
+            ProcessedCount: 0,
+            DiscoveredSongs: 0,
+            CurrentFile: null,
+            CurrentDirectory: null);
+
+        var result = InvokeStatic<string>("FormatSongLibraryReloadProgress", progress);
+
+        Assert.Equal("Reloading songs: 0 processed / 0 discovered", result);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_Published_ShouldShowChartCount()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Published,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 100,
+            DiscoveredScoreCount: 50);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Reloaded 50 song charts.", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_PublishedWithSingleUnavailableRoot_ShouldWarnSingular()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Published,
+            UnavailableRootCount: 1,
+            EnumeratedFileCount: 100,
+            DiscoveredScoreCount: 50);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Reloaded 50 song charts. (1 configured root unavailable)", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_PublishedWithMultipleUnavailableRoots_ShouldWarnPlural()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Published,
+            UnavailableRootCount: 2,
+            EnumeratedFileCount: 100,
+            DiscoveredScoreCount: 50);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Reloaded 50 song charts. (2 configured roots unavailable)", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_NoActiveRoots_ShouldExplainKeepingCurrentList()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.NoActiveRoots,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("No configured song folders are available; keeping the current song list.", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_Busy_ShouldExplainKeepingCurrentList()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Busy,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Song library reload is busy; keeping the current song list.", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_Cancelled_ShouldExplainKeepingCurrentList()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Cancelled,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Song folder reload cancelled; keeping the current song list.", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_PartialSuccessRestartRequired_ShouldExplainRestart()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.PartialSuccessRestartRequired,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Song folders were saved, but publication needs a restart.", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_FailedWithMessage_ShouldIncludeMessage()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Failed,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0,
+            "Permission denied");
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Song folder reload failed; keeping the current song list: Permission denied", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_FailedWithoutMessage_ShouldEndWithPeriod()
+    {
+        var result = new SongLibraryReloadResult(
+            SongLibraryReloadOutcome.Failed,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0,
+            FailureMessage: null);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Song folder reload failed; keeping the current song list.", status);
+    }
+
+    [Fact]
+    public void FormatSongLibraryReloadResult_UnknownOutcome_ShouldUseFallbackMessage()
+    {
+        var result = new SongLibraryReloadResult(
+            (SongLibraryReloadOutcome)999,
+            UnavailableRootCount: 0,
+            EnumeratedFileCount: 0,
+            DiscoveredScoreCount: 0);
+
+        var status = InvokeStatic<string>("FormatSongLibraryReloadResult", result);
+
+        Assert.Equal("Song folder reload failed; keeping the current song list.", status);
+    }
+
+    [Fact]
+    public void MapSongFolderApplyStatus_ShouldMapAllKnownStatuses()
+    {
+        Assert.Equal(
+            SongFolderApplyStatus.Updated,
+            InvokeStatic<SongFolderApplyStatus>("MapSongFolderApplyStatus", SongRootUpdateStatus.Updated));
+        Assert.Equal(
+            SongFolderApplyStatus.Unchanged,
+            InvokeStatic<SongFolderApplyStatus>("MapSongFolderApplyStatus", SongRootUpdateStatus.Unchanged));
+        Assert.Equal(
+            SongFolderApplyStatus.ValidationFailed,
+            InvokeStatic<SongFolderApplyStatus>("MapSongFolderApplyStatus", SongRootUpdateStatus.ValidationFailed));
+        Assert.Equal(
+            SongFolderApplyStatus.PersistenceFailed,
+            InvokeStatic<SongFolderApplyStatus>("MapSongFolderApplyStatus", SongRootUpdateStatus.PersistenceFailed));
+    }
+
+    [Fact]
+    public void MapSongFolderApplyStatus_WhenUnknown_ShouldFallBackToPersistenceFailed()
+    {
+        Assert.Equal(
+            SongFolderApplyStatus.PersistenceFailed,
+            InvokeStatic<SongFolderApplyStatus>("MapSongFolderApplyStatus", (SongRootUpdateStatus)999));
+    }
+
+    [Fact]
+    public void ApplySongRoots_WhenConfigManagerThrows_ShouldReturnPersistenceFailedWithMessage()
+    {
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add("/old");
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(manager => manager.Config).Returns(configData);
+        config.Setup(manager => manager.SetSongRoots(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .Throws(new InvalidOperationException("Config write failed"));
+        var (stage, inputManager) = CreateStage(
+            config.Object,
+            new DelegateSongLibraryReloadService(),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask);
+        using (inputManager)
+        {
+            var result = ApplySongRoots(stage, new[] { "/new" });
+
+            Assert.Equal(SongFolderApplyStatus.PersistenceFailed, result.Status);
+            Assert.Contains(result.Diagnostics, d => d.Message.Contains("Unable to save song folders"));
+            Assert.Contains(result.Diagnostics, d => d.Message.Contains("Config write failed"));
+            Assert.False(GetCoordinator(stage).IsBusy);
+        }
+    }
+
+    [Fact]
+    public void ApplySongRoots_WhenSetSongRootsReturnsUnchanged_ShouldMapToUnchanged()
+    {
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add("/same");
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(manager => manager.Config).Returns(configData);
+        config.Setup(manager => manager.SetSongRoots(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .Returns(new SongRootUpdateResult(
+                SongRootUpdateStatus.Unchanged,
+                new[] { "/same" },
+                Array.Empty<SongRootDiagnostic>()));
+        var (stage, inputManager) = CreateStage(
+            config.Object,
+            new DelegateSongLibraryReloadService(),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask);
+        using (inputManager)
+        {
+            var result = ApplySongRoots(stage, new[] { "/other" });
+
+            Assert.Equal(SongFolderApplyStatus.Unchanged, result.Status);
+            Assert.False(GetCoordinator(stage).IsBusy);
+        }
+    }
+
+    [Fact]
+    public void ApplySongRoots_WhenSetSongRootsReturnsValidationFailed_ShouldMapToValidationFailed()
+    {
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add("/old");
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(manager => manager.Config).Returns(configData);
+        config.Setup(manager => manager.SetSongRoots(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>()))
+            .Returns(new SongRootUpdateResult(
+                SongRootUpdateStatus.ValidationFailed,
+                new[] { "/new" },
+                new[] { new SongRootDiagnostic("/new", "Invalid path", IsWarning: false) }));
+        var (stage, inputManager) = CreateStage(
+            config.Object,
+            new DelegateSongLibraryReloadService(),
+            (_, _) => Task.FromResult(new NxImportResult()),
+            () => Task.CompletedTask);
+        using (inputManager)
+        {
+            var result = ApplySongRoots(stage, new[] { "/new" });
+
+            Assert.Equal(SongFolderApplyStatus.ValidationFailed, result.Status);
+            Assert.False(GetCoordinator(stage).IsBusy);
+        }
+    }
+
+    private static (ConfigStage Stage, InputManagerCompat InputManager) CreateStage(
+        IConfigManager configManager,
+        ISongLibraryReloadService reloadService,
+        Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> nxImportAsync,
+        Func<Task> refreshSongListAsync)
+    {
+        var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+        var availability = new FfmpegRuntimeAvailability(
+            IsAvailable: true,
+            DiagnosticReason: null,
+            BinaryFolder: null);
+        return (
+            new ConfigStage(
+                game,
+                () => availability,
+                () => new Mock<IFolderPickerService>().Object,
+                reloadService,
+                nxImportAsync,
+                refreshSongListAsync,
+                work => Task.Run(work),
+                continuationRegistrar: null),
+            inputManager);
+    }
+
+    private static SongFolderApplyResult ApplySongRoots(
+        ConfigStage stage,
+        IReadOnlyList<string> roots)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            "ApplySongRoots",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
+    }
+
+    private static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
+        ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(
+            stage,
+            "_songOperationCoordinator");
+
+    private static T InvokeStatic<T>(string methodName, params object?[] args)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            methodName,
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(null, args)!;
+    }
+
+    private sealed class DelegateSongLibraryReloadService : ISongLibraryReloadService
+    {
+        public Task<SongLibraryReloadResult> ReloadAsync(
+            IReadOnlyList<string> configuredRoots,
+            IProgress<SongLibraryReloadProgress>? progress,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new SongLibraryReloadResult(
+                SongLibraryReloadOutcome.Published,
+                UnavailableRootCount: 0,
+                EnumeratedFileCount: 0,
+                DiscoveredScoreCount: 0));
+    }
+}

--- a/DTXMania.Test/Stage/ConfigStageSongFolderFormatTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageSongFolderFormatTests.cs
@@ -18,6 +18,7 @@ using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework.Input;
 using Moq;
 using Xunit;
+using static DTXMania.Test.Stage.ConfigStageTestFactory;
 
 namespace DTXMania.Test.Stage;
 
@@ -250,7 +251,7 @@ public sealed class ConfigStageSongFolderFormatTests
             .Throws(new InvalidOperationException("Config write failed"));
         var (stage, inputManager) = CreateStage(
             config.Object,
-            new DelegateSongLibraryReloadService(),
+            new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0),
             (_, _) => Task.FromResult(new NxImportResult()),
             () => Task.CompletedTask);
         using (inputManager)
@@ -281,7 +282,7 @@ public sealed class ConfigStageSongFolderFormatTests
                 Array.Empty<SongRootDiagnostic>()));
         var (stage, inputManager) = CreateStage(
             config.Object,
-            new DelegateSongLibraryReloadService(),
+            new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0),
             (_, _) => Task.FromResult(new NxImportResult()),
             () => Task.CompletedTask);
         using (inputManager)
@@ -310,7 +311,7 @@ public sealed class ConfigStageSongFolderFormatTests
                 new[] { new SongRootDiagnostic("/new", "Invalid path", IsWarning: false) }));
         var (stage, inputManager) = CreateStage(
             config.Object,
-            new DelegateSongLibraryReloadService(),
+            new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0),
             (_, _) => Task.FromResult(new NxImportResult()),
             () => Task.CompletedTask);
         using (inputManager)
@@ -320,69 +321,5 @@ public sealed class ConfigStageSongFolderFormatTests
             Assert.Equal(SongFolderApplyStatus.ValidationFailed, result.Status);
             Assert.False(GetCoordinator(stage).IsBusy);
         }
-    }
-
-    private static (ConfigStage Stage, InputManagerCompat InputManager) CreateStage(
-        IConfigManager configManager,
-        ISongLibraryReloadService reloadService,
-        Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>> nxImportAsync,
-        Func<Task> refreshSongListAsync)
-    {
-        var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
-        var game = ReflectionHelpers.CreateGame();
-        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
-        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
-        var availability = new FfmpegRuntimeAvailability(
-            IsAvailable: true,
-            DiagnosticReason: null,
-            BinaryFolder: null);
-        return (
-            new ConfigStage(
-                game,
-                () => availability,
-                () => new Mock<IFolderPickerService>().Object,
-                reloadService,
-                nxImportAsync,
-                refreshSongListAsync,
-                work => Task.Run(work),
-                continuationRegistrar: null),
-            inputManager);
-    }
-
-    private static SongFolderApplyResult ApplySongRoots(
-        ConfigStage stage,
-        IReadOnlyList<string> roots)
-    {
-        var method = typeof(ConfigStage).GetMethod(
-            "ApplySongRoots",
-            BindingFlags.Instance | BindingFlags.NonPublic);
-        return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
-    }
-
-    private static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
-        ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(
-            stage,
-            "_songOperationCoordinator");
-
-    private static T InvokeStatic<T>(string methodName, params object?[] args)
-    {
-        var method = typeof(ConfigStage).GetMethod(
-            methodName,
-            BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.NotNull(method);
-        return (T)method!.Invoke(null, args)!;
-    }
-
-    private sealed class DelegateSongLibraryReloadService : ISongLibraryReloadService
-    {
-        public Task<SongLibraryReloadResult> ReloadAsync(
-            IReadOnlyList<string> configuredRoots,
-            IProgress<SongLibraryReloadProgress>? progress,
-            CancellationToken cancellationToken) =>
-            Task.FromResult(new SongLibraryReloadResult(
-                SongLibraryReloadOutcome.Published,
-                UnavailableRootCount: 0,
-                EnumeratedFileCount: 0,
-                DiscoveredScoreCount: 0));
     }
 }

--- a/DTXMania.Test/Stage/ConfigStageSongOperationAdditionalTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageSongOperationAdditionalTests.cs
@@ -1,0 +1,456 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Test.TestData;
+using Microsoft.Xna.Framework.Input;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Stage;
+
+[Trait("Category", "Unit")]
+public sealed class ConfigStageSongOperationAdditionalTests
+{
+    [Theory]
+    [InlineData(1, "1 folder")]
+    [InlineData(0, "0 folders")]
+    [InlineData(3, "3 folders")]
+    public void FormatSongFolderCount_ShouldSingularizeOneAndPluralizeOthers(
+        int count, string expected)
+    {
+        Assert.Equal(expected, InvokeStatic("FormatSongFolderCount", count));
+    }
+
+    [Fact]
+    public void ApplySongRoots_WhenCoordinatorIsBusy_ShouldReturnBusyWithoutPersisting()
+    {
+        var configData = new ConfigData();
+        configData.SongRoots.Clear();
+        configData.SongRoots.Add("/old");
+        var config = new Mock<IConfigManager>();
+        config.SetupGet(m => m.Config).Returns(configData);
+        config.Setup(m => m.SetSongRoots(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()))
+            .Returns(new SongRootUpdateResult(
+                SongRootUpdateStatus.Updated,
+                new[] { "/new" },
+                Array.Empty<SongRootDiagnostic>()));
+        var (stage, inputManager) = CreateStage(config.Object);
+        using (inputManager)
+        {
+            // Pre-acquire the coordinator lease so ApplySongRoots sees a busy state.
+            var coordinator = GetCoordinator(stage);
+            var lease = coordinator.TryAcquire(ConfigSongOperationKind.NxScoreImport);
+            Assert.NotNull(lease);
+            using (lease)
+            {
+                var result = ApplySongRoots(stage, new[] { "/new" });
+
+                Assert.Equal(SongFolderApplyStatus.Busy, result.Status);
+                Assert.Contains(result.Diagnostics, d =>
+                    d.Message.Contains("Another song operation", StringComparison.Ordinal));
+            }
+
+            // SetSongRoots must not have been called while busy.
+            config.Verify(m => m.SetSongRoots(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>()), Times.Never);
+        }
+    }
+
+    [Fact]
+    public async Task ApplySongRoots_WhenSetSongRootsReturnsUpdated_ShouldStartReloadAndReturnStarted()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"dtx-config-started-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var configData = new ConfigData();
+            configData.SongRoots.Clear();
+            configData.SongRoots.Add("/old");
+            var config = new Mock<IConfigManager>();
+            config.SetupGet(m => m.Config).Returns(configData);
+            config.Setup(m => m.SetSongRoots(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()))
+                .Callback<string, IReadOnlyList<string>>((_, roots) =>
+                {
+                    configData.SongRoots.Clear();
+                    configData.SongRoots.AddRange(roots);
+                })
+                .Returns(new SongRootUpdateResult(
+                    SongRootUpdateStatus.Updated,
+                    new[] { tempRoot },
+                    Array.Empty<SongRootDiagnostic>()));
+            var reloadService = new DelegateReloadService(
+                SongLibraryReloadOutcome.Published,
+                unavailableRootCount: 0,
+                discoveredScoreCount: 5);
+            var (stage, inputManager) = CreateStage(
+                config.Object,
+                reloadService);
+            using (inputManager)
+            {
+                var result = ApplySongRoots(stage, new[] { tempRoot });
+
+                Assert.Equal(SongFolderApplyStatus.Started, result.Status);
+
+                // Wait for the background operation to complete and drain its update.
+                await WaitForTerminalUpdateAsync(stage);
+                DrainSongOperationUpdates(stage);
+
+                var folderStatus = GetPrivateField<string>(stage, "_songFolderStatus");
+                Assert.Contains("Reloaded", folderStatus, StringComparison.Ordinal);
+                Assert.False(GetCoordinator(stage).IsBusy);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ApplySongRoots_WhenBackgroundRunnerReturnsNullTask_ShouldReturnPersistenceFailed()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), $"dtx-config-null-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var configData = new ConfigData();
+            configData.SongRoots.Clear();
+            configData.SongRoots.Add("/old");
+            var config = new Mock<IConfigManager>();
+            config.SetupGet(m => m.Config).Returns(configData);
+            config.Setup(m => m.SetSongRoots(It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()))
+                .Returns(new SongRootUpdateResult(
+                    SongRootUpdateStatus.Updated,
+                    new[] { tempRoot },
+                    Array.Empty<SongRootDiagnostic>()));
+            // A runner that returns null causes StartSongOperation to return false.
+            var (stage, inputManager) = CreateStage(
+                config.Object,
+                new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0),
+                backgroundRunner: _ => null!);
+            using (inputManager)
+            {
+                var result = ApplySongRoots(stage, new[] { tempRoot });
+
+                Assert.Equal(SongFolderApplyStatus.PersistenceFailed, result.Status);
+                Assert.Contains(result.Diagnostics, d =>
+                    d.Message.Contains("reload could not be started", StringComparison.Ordinal));
+                Assert.False(GetCoordinator(stage).IsBusy);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempRoot))
+                Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void CompleteSongOperation_WhenTaskIsCanceled_ShouldEnqueueCancelledStatus()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            var coordinator = GetCoordinator(stage);
+            var lease = coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload)!;
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var canceledTask = Task.FromCanceled<ConfigSongOperationCompletion>(cts.Token);
+
+            InvokePrivate(
+                stage,
+                "CompleteSongOperation",
+                canceledTask,
+                0,
+                lease,
+                cts,
+                ConfigSongOperationKind.SongFolderReload);
+
+            DrainSongOperationUpdates(stage);
+            var status = GetPrivateField<string>(stage, "_songFolderStatus");
+            Assert.Contains("cancelled", status, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void CompleteSongOperation_WhenTaskIsFaulted_ShouldEnqueueFailureStatus()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            var coordinator = GetCoordinator(stage);
+            var lease = coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload)!;
+            using var cts = new CancellationTokenSource();
+            var faultedTask = Task.FromException<ConfigSongOperationCompletion>(
+                new InvalidOperationException("reload exploded"));
+
+            InvokePrivate(
+                stage,
+                "CompleteSongOperation",
+                faultedTask,
+                0,
+                lease,
+                cts,
+                ConfigSongOperationKind.SongFolderReload);
+
+            DrainSongOperationUpdates(stage);
+            var status = GetPrivateField<string>(stage, "_songFolderStatus");
+            Assert.Contains("reload exploded", status, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void CompleteSongOperation_WhenTaskSucceeds_ShouldEnqueueCompletionStatus()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            var coordinator = GetCoordinator(stage);
+            var lease = coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload)!;
+            using var cts = new CancellationTokenSource();
+            var successTask = Task.FromResult(
+                new ConfigSongOperationCompletion("Reloaded 3 song charts."));
+
+            InvokePrivate(
+                stage,
+                "CompleteSongOperation",
+                successTask,
+                0,
+                lease,
+                cts,
+                ConfigSongOperationKind.SongFolderReload);
+
+            DrainSongOperationUpdates(stage);
+            var status = GetPrivateField<string>(stage, "_songFolderStatus");
+            Assert.Equal("Reloaded 3 song charts.", status);
+        }
+    }
+
+    [Fact]
+    public void CompleteSongOperation_WhenTaskIsCanceledForNxImport_ShouldEnqueueNxCancelledStatus()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            var coordinator = GetCoordinator(stage);
+            var lease = coordinator.TryAcquire(ConfigSongOperationKind.NxScoreImport)!;
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var canceledTask = Task.FromCanceled<ConfigSongOperationCompletion>(cts.Token);
+
+            InvokePrivate(
+                stage,
+                "CompleteSongOperation",
+                canceledTask,
+                0,
+                lease,
+                cts,
+                ConfigSongOperationKind.NxScoreImport);
+
+            DrainSongOperationUpdates(stage);
+            var importStatus = GetPrivateField<string>(stage, "_importStatus");
+            Assert.Contains("NX import cancelled", importStatus, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void DrainSongOperationUpdates_WhenUpdateGenerationDiffers_ShouldDiscardStaleUpdate()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            var coordinator = GetCoordinator(stage);
+            var lease = coordinator.TryAcquire(ConfigSongOperationKind.SongFolderReload)!;
+            using var cts = new CancellationTokenSource();
+
+            // Enqueue an update from a prior activation generation.
+            EnqueueSongOperationUpdate(
+                stage,
+                activationGeneration: 0,
+                lease,
+                ConfigSongOperationKind.SongFolderReload,
+                "stale status",
+                isTerminal: false);
+
+            // Bump the activation generation so the stale update is discarded.
+            SetPrivateField(stage, "_activationGeneration", 1);
+            DrainSongOperationUpdates(stage);
+
+            var status = GetPrivateField<string>(stage, "_songFolderStatus");
+            Assert.DoesNotContain("stale status", status);
+
+            lease.Dispose();
+        }
+    }
+
+    [Fact]
+    public void CancelSongOperationForDeactivation_WhenOperationIsActive_ShouldCancelItsToken()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            using var cts = new CancellationTokenSource();
+            SetPrivateField(stage, "_songOperationCts", cts);
+            SetPrivateField(stage, "_activationGeneration", 0);
+
+            InvokePrivate(stage, "CancelSongOperationForDeactivation");
+
+            Assert.True(cts.IsCancellationRequested);
+            // The activation generation is bumped to invalidate stale updates.
+            Assert.Equal(1, GetPrivateField<int>(stage, "_activationGeneration"));
+        }
+    }
+
+    [Fact]
+    public void CancelSongOperationForDeactivation_WhenCtsIsAlreadyDisposed_ShouldNotThrow()
+    {
+        var (stage, inputManager) = CreateStage();
+        using (inputManager)
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Dispose();
+            SetPrivateField(stage, "_songOperationCts", cts);
+
+            // The ObjectDisposedException catch must suppress the error.
+            var exception = Record.Exception(() =>
+                InvokePrivate(stage, "CancelSongOperationForDeactivation"));
+            Assert.Null(exception);
+        }
+    }
+
+    #region Helpers
+
+    private static (ConfigStage Stage, InputManagerCompat InputManager) CreateStage(
+        IConfigManager? configManager = null,
+        ISongLibraryReloadService? reloadService = null,
+        Func<Func<Task<ConfigSongOperationCompletion>>, Task<ConfigSongOperationCompletion>>? backgroundRunner = null)
+    {
+        configManager ??= new ConfigManager();
+        reloadService ??= new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0);
+        var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+        var availability = new FfmpegRuntimeAvailability(
+            IsAvailable: true,
+            DiagnosticReason: null,
+            BinaryFolder: null);
+        return (
+            new ConfigStage(
+                game,
+                () => availability,
+                () => new Mock<IFolderPickerService>().Object,
+                reloadService,
+                (_, _) => Task.FromResult(new NxImportResult()),
+                () => Task.CompletedTask,
+                backgroundRunner ?? (work => Task.Run(work)),
+                continuationRegistrar: null),
+            inputManager);
+    }
+
+    private static SongFolderApplyResult ApplySongRoots(
+        ConfigStage stage, IReadOnlyList<string> roots)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            "ApplySongRoots", BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
+    }
+
+    private static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
+        ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(
+            stage, "_songOperationCoordinator");
+
+    private static void DrainSongOperationUpdates(ConfigStage stage) =>
+        InvokePrivate(stage, "DrainSongOperationUpdates");
+
+    private static void EnqueueSongOperationUpdate(
+        ConfigStage stage,
+        int activationGeneration,
+        ConfigSongOperationLease lease,
+        ConfigSongOperationKind kind,
+        string status,
+        bool isTerminal)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            "EnqueueSongOperationUpdate", BindingFlags.Instance | BindingFlags.NonPublic);
+        method!.Invoke(stage,
+            new object[] { activationGeneration, lease, kind, status, isTerminal });
+    }
+
+    private static async Task WaitForTerminalUpdateAsync(ConfigStage stage, int timeoutMs = 3000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (GetCoordinator(stage).IsBusy)
+        {
+            if (DateTime.UtcNow >= deadline)
+                throw new TimeoutException("The song operation did not complete in time.");
+            await Task.Yield();
+        }
+    }
+
+    private static string InvokeStatic(string name, params object[] args)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            name, BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (string)method!.Invoke(null, args)!;
+    }
+
+    private static void InvokePrivate(ConfigStage stage, string name, params object?[] args)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        method!.Invoke(stage, args);
+    }
+
+    private static T GetPrivateField<T>(object target, string name) =>
+        ReflectionHelpers.GetPrivateField<T>(target, name);
+
+    private static void SetPrivateField(object target, string name, object? value) =>
+        ReflectionHelpers.SetPrivateField(target, name, value);
+
+    private sealed class DelegateReloadService : ISongLibraryReloadService
+    {
+        private readonly SongLibraryReloadOutcome _outcome;
+        private readonly int _unavailableRootCount;
+        private readonly int _discoveredScoreCount;
+
+        public DelegateReloadService(
+            SongLibraryReloadOutcome outcome,
+            int unavailableRootCount,
+            int discoveredScoreCount)
+        {
+            _outcome = outcome;
+            _unavailableRootCount = unavailableRootCount;
+            _discoveredScoreCount = discoveredScoreCount;
+        }
+
+        public Task<SongLibraryReloadResult> ReloadAsync(
+            IReadOnlyList<string> configuredRoots,
+            IProgress<SongLibraryReloadProgress>? progress,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new SongLibraryReloadResult(
+                _outcome,
+                _unavailableRootCount,
+                EnumeratedFileCount: 0,
+                _discoveredScoreCount));
+    }
+
+    #endregion
+}

--- a/DTXMania.Test/Stage/ConfigStageSongOperationAdditionalTests.cs
+++ b/DTXMania.Test/Stage/ConfigStageSongOperationAdditionalTests.cs
@@ -18,6 +18,7 @@ using DTXMania.Test.TestData;
 using Microsoft.Xna.Framework.Input;
 using Moq;
 using Xunit;
+using static DTXMania.Test.Stage.ConfigStageTestFactory;
 
 namespace DTXMania.Test.Stage;
 
@@ -31,7 +32,7 @@ public sealed class ConfigStageSongOperationAdditionalTests
     public void FormatSongFolderCount_ShouldSingularizeOneAndPluralizeOthers(
         int count, string expected)
     {
-        Assert.Equal(expected, InvokeStatic("FormatSongFolderCount", count));
+        Assert.Equal(expected, InvokeStatic<string>("FormatSongFolderCount", count));
     }
 
     [Fact]
@@ -335,46 +336,6 @@ public sealed class ConfigStageSongOperationAdditionalTests
 
     #region Helpers
 
-    private static (ConfigStage Stage, InputManagerCompat InputManager) CreateStage(
-        IConfigManager? configManager = null,
-        ISongLibraryReloadService? reloadService = null,
-        Func<Func<Task<ConfigSongOperationCompletion>>, Task<ConfigSongOperationCompletion>>? backgroundRunner = null)
-    {
-        configManager ??= new ConfigManager();
-        reloadService ??= new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0);
-        var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
-        var game = ReflectionHelpers.CreateGame();
-        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
-        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
-        var availability = new FfmpegRuntimeAvailability(
-            IsAvailable: true,
-            DiagnosticReason: null,
-            BinaryFolder: null);
-        return (
-            new ConfigStage(
-                game,
-                () => availability,
-                () => new Mock<IFolderPickerService>().Object,
-                reloadService,
-                (_, _) => Task.FromResult(new NxImportResult()),
-                () => Task.CompletedTask,
-                backgroundRunner ?? (work => Task.Run(work)),
-                continuationRegistrar: null),
-            inputManager);
-    }
-
-    private static SongFolderApplyResult ApplySongRoots(
-        ConfigStage stage, IReadOnlyList<string> roots)
-    {
-        var method = typeof(ConfigStage).GetMethod(
-            "ApplySongRoots", BindingFlags.Instance | BindingFlags.NonPublic);
-        return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
-    }
-
-    private static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
-        ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(
-            stage, "_songOperationCoordinator");
-
     private static void DrainSongOperationUpdates(ConfigStage stage) =>
         InvokePrivate(stage, "DrainSongOperationUpdates");
 
@@ -403,14 +364,6 @@ public sealed class ConfigStageSongOperationAdditionalTests
         }
     }
 
-    private static string InvokeStatic(string name, params object[] args)
-    {
-        var method = typeof(ConfigStage).GetMethod(
-            name, BindingFlags.Static | BindingFlags.NonPublic);
-        Assert.NotNull(method);
-        return (string)method!.Invoke(null, args)!;
-    }
-
     private static void InvokePrivate(ConfigStage stage, string name, params object?[] args)
     {
         var method = typeof(ConfigStage).GetMethod(
@@ -424,33 +377,6 @@ public sealed class ConfigStageSongOperationAdditionalTests
 
     private static void SetPrivateField(object target, string name, object? value) =>
         ReflectionHelpers.SetPrivateField(target, name, value);
-
-    private sealed class DelegateReloadService : ISongLibraryReloadService
-    {
-        private readonly SongLibraryReloadOutcome _outcome;
-        private readonly int _unavailableRootCount;
-        private readonly int _discoveredScoreCount;
-
-        public DelegateReloadService(
-            SongLibraryReloadOutcome outcome,
-            int unavailableRootCount,
-            int discoveredScoreCount)
-        {
-            _outcome = outcome;
-            _unavailableRootCount = unavailableRootCount;
-            _discoveredScoreCount = discoveredScoreCount;
-        }
-
-        public Task<SongLibraryReloadResult> ReloadAsync(
-            IReadOnlyList<string> configuredRoots,
-            IProgress<SongLibraryReloadProgress>? progress,
-            CancellationToken cancellationToken) =>
-            Task.FromResult(new SongLibraryReloadResult(
-                _outcome,
-                _unavailableRootCount,
-                EnumeratedFileCount: 0,
-                _discoveredScoreCount));
-    }
 
     #endregion
 }

--- a/DTXMania.Test/Stage/ConfigStageTestFactory.cs
+++ b/DTXMania.Test/Stage/ConfigStageTestFactory.cs
@@ -1,0 +1,113 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using DTXMania.Game;
+using DTXMania.Game.Lib.Config;
+using DTXMania.Game.Lib.Input;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.Stage.Config;
+using DTXMania.Test.TestData;
+using Moq;
+using Xunit;
+
+namespace DTXMania.Test.Stage;
+
+/// <summary>
+/// Shared factory and reflection helpers for ConfigStage test suites.
+/// Centralizes the duplicated CreateStage/ApplySongRoots/GetCoordinator/InvokeStatic
+/// scaffolding so every ConfigStage test file uses the same construction path.
+/// </summary>
+internal static class ConfigStageTestFactory
+{
+    internal static (ConfigStage Stage, InputManagerCompat InputManager) CreateStage(
+        IConfigManager? configManager = null,
+        ISongLibraryReloadService? reloadService = null,
+        Func<IProgress<NxImportProgress>?, CancellationToken, Task<NxImportResult>>? nxImportAsync = null,
+        Func<Task>? refreshSongListAsync = null,
+        Func<Func<Task<ConfigSongOperationCompletion>>, Task<ConfigSongOperationCompletion>>? backgroundRunner = null)
+    {
+        configManager ??= new ConfigManager();
+        reloadService ??= new DelegateReloadService(SongLibraryReloadOutcome.Published, 0, 0);
+        var effectiveNxImportAsync = nxImportAsync
+            ?? ((_, _) => Task.FromResult(new NxImportResult()));
+        var effectiveRefreshSongListAsync = refreshSongListAsync
+            ?? (() => Task.CompletedTask);
+        var effectiveBackgroundRunner = backgroundRunner
+            ?? (work => Task.Run(work));
+        var inputManager = new InputManagerCompat(new ConfigManager(), new TestMidiDeviceBackend());
+        var game = ReflectionHelpers.CreateGame();
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), configManager);
+        ReflectionHelpers.SetProperty(game, nameof(BaseGame.InputManager), inputManager);
+        var availability = new FfmpegRuntimeAvailability(
+            IsAvailable: true,
+            DiagnosticReason: null,
+            BinaryFolder: null);
+        return (
+            new ConfigStage(
+                game,
+                () => availability,
+                () => new Mock<IFolderPickerService>().Object,
+                reloadService,
+                effectiveNxImportAsync,
+                effectiveRefreshSongListAsync,
+                effectiveBackgroundRunner,
+                continuationRegistrar: null),
+            inputManager);
+    }
+
+    internal static SongFolderApplyResult ApplySongRoots(
+        ConfigStage stage, IReadOnlyList<string> roots)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            "ApplySongRoots", BindingFlags.Instance | BindingFlags.NonPublic);
+        return Assert.IsType<SongFolderApplyResult>(method!.Invoke(stage, new object[] { roots }));
+    }
+
+    internal static ConfigSongOperationCoordinator GetCoordinator(ConfigStage stage) =>
+        ReflectionHelpers.GetPrivateField<ConfigSongOperationCoordinator>(
+            stage, "_songOperationCoordinator");
+
+    internal static T InvokeStatic<T>(string methodName, params object?[] args)
+    {
+        var method = typeof(ConfigStage).GetMethod(
+            methodName, BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(null, args)!;
+    }
+
+    /// <summary>
+    /// A reload service stub that returns a fixed result without performing any work.
+    /// </summary>
+    internal sealed class DelegateReloadService : ISongLibraryReloadService
+    {
+        private readonly SongLibraryReloadOutcome _outcome;
+        private readonly int _unavailableRootCount;
+        private readonly int _discoveredScoreCount;
+
+        public DelegateReloadService(
+            SongLibraryReloadOutcome outcome,
+            int unavailableRootCount,
+            int discoveredScoreCount)
+        {
+            _outcome = outcome;
+            _unavailableRootCount = unavailableRootCount;
+            _discoveredScoreCount = discoveredScoreCount;
+        }
+
+        public Task<SongLibraryReloadResult> ReloadAsync(
+            IReadOnlyList<string> configuredRoots,
+            IProgress<SongLibraryReloadProgress>? progress,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new SongLibraryReloadResult(
+                _outcome,
+                _unavailableRootCount,
+                EnumeratedFileCount: 0,
+                _discoveredScoreCount));
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
@@ -537,6 +537,46 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void CheckSongInitializationCompletion_WhenPriorActivationCompletesAfterSynchronousReactivation_ShouldDiscardQueuedResult()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            var currentNode = Score("Current", 101, "/library/current/current.dtx");
+            var staleNode = Score("Stale", 100, "/library/stale/stale.dtx");
+            var currentSnapshot = Snapshot(101, new[] { currentNode }, new[] { "/library/current" });
+            var staleSnapshot = Snapshot(100, new[] { staleNode }, new[] { "/library/stale" });
+            var completions = GetPrivateField<
+                System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult>>(
+                stage,
+                "_pendingSongInitializationResults")!;
+
+            // Model a late worker from activation 100 arriving after activation 101 took the
+            // already-initialized synchronous path, so there is no current initializer task.
+            SetPrivateField(stage, "_activationVersion", 101);
+            SetPrivateField(stage, "_activeSongInitializationGeneration", 0L);
+            SetPrivateField(stage, "_songInitializationTask", null!);
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+            SetPrivateField(stage, "_appliedLibrarySnapshot", currentSnapshot);
+            SetPrivateField(stage, "_appliedLibraryPublicationVersion", 101L);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { currentNode });
+            display.CurrentList = new List<SongListNode> { currentNode };
+            completions.Enqueue(new SongSelectionStage.SongInitializationResult(
+                100,
+                17,
+                staleSnapshot,
+                new[] { staleNode }));
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.Empty(completions);
+            Assert.Same(currentSnapshot, GetPrivateField<SongLibrarySnapshot>(
+                stage,
+                "_appliedLibrarySnapshot"));
+            Assert.Equal(new[] { currentNode }, display.CurrentList);
+        }
+
+        [Fact]
         public void OnSongLibraryPublished_AfterDeactivation_ShouldIgnoreTheNotification()
         {
             var stage = CreateStage();

--- a/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
@@ -60,6 +60,58 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void InitializeSongList_WhenReentrySnapshotRemovesCurrentBox_ShouldClearStaleNavigation()
+        {
+            var songManager = SongManager.Instance;
+            var rootSongs = GetPrivateField<List<SongListNode>>(songManager, "_rootSongs")!;
+            var originalRoots = rootSongs.ToList();
+            var originalActiveRoots = GetPrivateField<string[]>(songManager, "_currentSearchPaths")!;
+            var originalVersion = GetPrivateField<long>(songManager, "_publicationVersion");
+            var originalInitialized = GetPrivateField<bool>(songManager, "_isInitialized");
+            var oldSong = Score("Old", 41, "/library/old/BOX/old.dtx");
+            var oldBox = Box("BOX", "/library/old/BOX", oldSong);
+            var replacement = Score("Replacement", 42, "/library/new/replacement.dtx");
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode>
+                {
+                    new() { Type = NodeType.BackBox, Title = ".." },
+                    oldSong
+                }
+            };
+
+            try
+            {
+                AttachCoreUi(stage, display: display);
+                SetPrivateField(stage, "_currentSongList", oldBox.Children);
+                SetPrivateField(stage, "_currentBreadcrumb", "BOX");
+                SetPrivateField(stage, "_selectedSong", oldSong);
+                GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!.Push(
+                    new SongListNode { Children = new List<SongListNode> { oldBox }, Title = "" });
+                rootSongs.Clear();
+                rootSongs.Add(replacement);
+                SetPrivateField(songManager, "_currentSearchPaths", new[] { "/library/new" });
+                SetPrivateField(songManager, "_publicationVersion", 61L);
+                SetPrivateField(songManager, "_isInitialized", true);
+
+                InvokePrivateMethod(stage, "InitializeSongList");
+
+                Assert.Empty(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+                Assert.Equal("", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+                Assert.Equal(new[] { replacement }, display.CurrentList);
+            }
+            finally
+            {
+                rootSongs.Clear();
+                rootSongs.AddRange(originalRoots);
+                SetPrivateField(songManager, "_currentSearchPaths", originalActiveRoots);
+                SetPrivateField(songManager, "_publicationVersion", originalVersion);
+                SetPrivateField(songManager, "_isInitialized", originalInitialized);
+            }
+        }
+
+        [Fact]
         public void ReconcileLibrarySnapshot_WhenSelectedBoxIsRetainedByDirectoryPath_ShouldSelectTheNewBox()
         {
             var firstOldBox = Box("First", "/library/one/FIRST");
@@ -245,6 +297,42 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void SongLibraryPublished_WhenPriorActivationHandlerRuns_ShouldIgnoreIt()
+        {
+            var songManager = SongManager.Instance;
+            var originalHandler = GetPrivateField<EventHandler<SongLibraryPublishedEventArgs>>(
+                songManager,
+                "SongLibraryPublished");
+            var stage = CreateStage();
+
+            try
+            {
+                SetPrivateField(songManager, "SongLibraryPublished", null);
+                SetPrivateField(stage, "_activationVersion", 41);
+                InvokePrivateMethod(stage, "SubscribeLibraryPublications");
+                var priorActivationHandler = GetPrivateField<EventHandler<SongLibraryPublishedEventArgs>>(
+                    songManager,
+                    "SongLibraryPublished");
+                Assert.NotNull(priorActivationHandler);
+
+                SetPrivateField(stage, "_activationVersion", 42);
+                InvokePrivateMethod(stage, "SubscribeLibraryPublications");
+                SetPrivateField(stage, "_pendingLibraryPublicationVersion", 0L);
+
+                priorActivationHandler!(songManager,
+                    new SongLibraryPublishedEventArgs(
+                        Snapshot(73, Array.Empty<SongListNode>(), Array.Empty<string>())));
+
+                Assert.Equal(0L, GetPrivateField<long>(stage, "_pendingLibraryPublicationVersion"));
+            }
+            finally
+            {
+                InvokePrivateMethod(stage, "UnsubscribeLibraryPublications");
+                SetPrivateField(songManager, "SongLibraryPublished", originalHandler);
+            }
+        }
+
+        [Fact]
         public void ApplyPendingLibraryPublication_ShouldFetchAndApplyTheCurrentManagerSnapshotOnTheUpdateThread()
         {
             var songManager = SongManager.Instance;
@@ -343,6 +431,49 @@ namespace DTXMania.Test.Stage
 
             Assert.Same(selected, display.SelectedSong);
             Assert.Same(appliedSnapshot, GetPrivateField<SongLibrarySnapshot>(stage, "_appliedLibrarySnapshot"));
+        }
+
+        [Fact]
+        public void CheckSongInitializationCompletion_WhenNewerSnapshotArrives_ShouldReconcileNestedSelection()
+        {
+            var oldSong = Score("Old", 1, "/library/shared/BOX/old.dtx");
+            var oldBox = Box("BOX", "/library/shared/BOX", oldSong);
+            var replacementSong = Score("Replacement", 1, "/library/shared/BOX/replacement.dtx");
+            var replacementBox = Box("BOX", "/library/shared/BOX", replacementSong);
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode>
+                {
+                    new() { Type = NodeType.BackBox, Title = ".." },
+                    oldSong
+                }
+            };
+            AttachCoreUi(stage, display: display);
+            display.SelectedIndex = 1;
+            SetPrivateField(stage, "_currentSongList", oldBox.Children);
+            SetPrivateField(stage, "_currentBreadcrumb", "BOX");
+            SetPrivateField(stage, "_selectedSong", oldSong);
+            GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!.Push(
+                new SongListNode { Children = new List<SongListNode> { oldBox }, Title = "" });
+
+            var appliedSnapshot = Snapshot(81, new[] { oldBox }, new[] { "/library/shared" });
+            var newerSnapshot = Snapshot(82, new[] { replacementBox }, new[] { "/library/shared" });
+            SetPrivateField(stage, "_appliedLibrarySnapshot", appliedSnapshot);
+            SetPrivateField(stage, "_appliedLibraryPublicationVersion", 81L);
+            SetPrivateField(stage, "_backgroundLibrarySnapshot", newerSnapshot);
+            SetPrivateField(stage, "_songInitializationTask",
+                Task.FromResult(new List<SongListNode> { replacementBox }));
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.Same(replacementBox.Children,
+                GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Single(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+            Assert.Equal("BOX", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Same(replacementSong, display.SelectedSong);
+            Assert.Equal(82L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.UI.Components;
+using Moq;
+using Xunit;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage
+{
+    [Collection("SongManager")]
+    [Trait("Category", "Unit")]
+    public class SongSelectionPublicationTests
+    {
+        [Fact]
+        public void ReconcileLibrarySnapshot_WhenBoxAndChartRemain_ShouldRestoreNavigationSelectionAndPreviewRoots()
+        {
+            var rootPath = "/library/one";
+            var boxPath = "/library/one/BOX";
+            var oldSong = Score("Old", 42, "/library/one/BOX/old.dtx");
+            var oldBox = Box("BOX", boxPath, oldSong);
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode>
+                {
+                    new() { Type = NodeType.BackBox, Title = ".." },
+                    oldSong
+                }
+            };
+            var preview = new PreviewImagePanel();
+            AttachCoreUi(stage, display: display, previewPanel: preview);
+            display.SelectedIndex = 1;
+            SetPrivateField(stage, "_currentSongList", oldBox.Children);
+            SetPrivateField(stage, "_currentBreadcrumb", "BOX");
+            SetPrivateField(stage, "_selectedSong", oldSong);
+            GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!.Push(
+                new SongListNode { Children = new List<SongListNode> { oldBox }, Title = "" });
+
+            var retainedSong = Score("Retained", 42, "/library/one/BOX/retained.dtx");
+            var retainedBox = Box("BOX", boxPath, retainedSong);
+            var snapshot = Snapshot(11, new[] { retainedBox }, new[] { rootPath });
+
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", snapshot);
+
+            Assert.Same(retainedBox.Children, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+            Assert.Single(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+            Assert.Equal("BOX", GetPrivateField<string>(stage, "_currentBreadcrumb"));
+            Assert.Equal(NodeType.BackBox, display.CurrentList[0].Type);
+            Assert.Same(retainedSong, display.SelectedSong);
+            Assert.Equal(new[] { rootPath }, preview.ActiveSongRootPaths);
+        }
+
+        [Fact]
+        public void ReconcileLibrarySnapshot_WhenSelectedBoxIsRetainedByDirectoryPath_ShouldSelectTheNewBox()
+        {
+            var firstOldBox = Box("First", "/library/one/FIRST");
+            var selectedOldBox = Box("Selected", "/library/one/SELECTED");
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode> { firstOldBox, selectedOldBox }
+            };
+            AttachCoreUi(stage, display: display);
+            display.SelectedIndex = 1;
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { firstOldBox, selectedOldBox });
+            SetPrivateField(stage, "_selectedSong", selectedOldBox);
+
+            var firstReplacementBox = Box("First replacement", "/library/one/FIRST");
+            var selectedReplacementBox = Box("Selected replacement", "/library/one/SELECTED");
+            var snapshot = Snapshot(
+                111,
+                new[] { firstReplacementBox, selectedReplacementBox },
+                new[] { "/library/one" });
+
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", snapshot);
+
+            Assert.Same(selectedReplacementBox, display.SelectedSong);
+        }
+
+        [Fact]
+        public void ReconcileLibrarySnapshot_WhenCurrentBoxIsRemoved_ShouldResetNavigationAtRootAndClearOldPresentation()
+        {
+            var oldSong = Score("Old", 42, "/library/one/BOX/old.dtx");
+            var oldBox = Box("BOX", "/library/one/BOX", oldSong);
+            var stage = CreateStage();
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode>
+                {
+                    new() { Type = NodeType.BackBox, Title = ".." },
+                    oldSong
+                }
+            };
+            var preview = new PreviewImagePanel();
+            var oldTexture = new Mock<ITexture>();
+            AttachCoreUi(stage, display: display, previewPanel: preview);
+            SetPrivateField(preview, "_currentSong", oldSong);
+            SetPrivateField(preview, "_currentPreviewTexture", oldTexture.Object);
+            SetPrivateField(stage, "_currentSongList", oldBox.Children);
+            SetPrivateField(stage, "_selectedSong", oldSong);
+            GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!.Push(
+                new SongListNode { Children = new List<SongListNode> { oldBox }, Title = "" });
+
+            var replacement = Score("Replacement", 77, "/library/one/replacement.dtx");
+            var snapshot = Snapshot(12, new[] { replacement }, new[] { "/library/one" });
+
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", snapshot);
+
+            Assert.Empty(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+            Assert.Single(GetPrivateField<List<SongListNode>>(stage, "_currentSongList")!);
+            Assert.Same(replacement, display.CurrentList.Single());
+            Assert.Null(GetPrivateField<SongListNode>(preview, "_currentSong"));
+            oldTexture.Verify(texture => texture.RemoveReference(), Times.Once);
+        }
+
+        [Fact]
+        public void ReconcileLibrarySnapshot_WhenSelectedChartIsRetainedByDatabaseIdentity_ShouldSelectNewNode()
+        {
+            var oldSong = Score("Old title", 42, "/library/one/old.dtx");
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { oldSong } };
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { oldSong });
+            SetPrivateField(stage, "_selectedSong", oldSong);
+
+            var replacement = Score("Renamed", 42, "/library/one/renamed.dtx");
+            var snapshot = Snapshot(13, new[] { replacement }, new[] { "/library/one" });
+
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", snapshot);
+
+            Assert.Same(replacement, display.SelectedSong);
+        }
+
+        [Fact]
+        public void ReconcileLibrarySnapshot_WhenSelectedChartIsRemoved_ShouldResetSelectionAndClearPreview()
+        {
+            var oldSong = Score("Old", 42, "/library/one/old.dtx");
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { oldSong } };
+            var preview = new PreviewImagePanel();
+            var oldTexture = new Mock<ITexture>();
+            AttachCoreUi(stage, display: display, previewPanel: preview);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { oldSong });
+            SetPrivateField(stage, "_selectedSong", oldSong);
+            SetPrivateField(preview, "_currentSong", oldSong);
+            SetPrivateField(preview, "_currentPreviewTexture", oldTexture.Object);
+
+            var replacement = Score("Replacement", 77, "/library/one/replacement.dtx");
+            var snapshot = Snapshot(14, new[] { replacement }, new[] { "/library/one" });
+
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", snapshot);
+
+            Assert.Same(replacement, display.SelectedSong);
+            Assert.Null(GetPrivateField<SongListNode>(preview, "_currentSong"));
+            oldTexture.Verify(texture => texture.RemoveReference(), Times.Once);
+        }
+
+        [Fact]
+        public void PopulateBookmarksList_WhenCachedRowsAreOutsideActiveRoots_ShouldHideThemWithoutDiscardingCache()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            var active = Score("Active", 1, "/library/active/active.dtx");
+            var inactive = Score("Inactive", 2, "/library/inactive/inactive.dtx");
+            var cached = new List<SongListNode> { active, inactive };
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+                Snapshot(15, new[] { active }, new[] { "/library/active" }));
+            SetPrivateField(stage, "_bookmarkNodes", cached);
+
+            InvokePrivateMethod(stage, "PopulateBookmarksList");
+
+            Assert.Equal(new[] { active }, display.CurrentList);
+            Assert.Equal(2, cached.Count);
+        }
+
+        [Fact]
+        public void PopulateBookmarksList_WhenRootIsReadded_ShouldMakeTheRetainedCachedRowVisibleAgain()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            var active = Score("Active", 1, "/library/active/active.dtx");
+            var readded = Score("Readded", 2, "/library/readded/readded.dtx");
+            var cached = new List<SongListNode> { active, readded };
+            SetPrivateField(stage, "_bookmarkNodes", cached);
+
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+                Snapshot(151, new[] { active }, new[] { "/library/active" }));
+            InvokePrivateMethod(stage, "PopulateBookmarksList");
+            Assert.Equal(new[] { active }, display.CurrentList);
+
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+                Snapshot(152, new[] { active, readded }, new[] { "/library/active", "/library/readded" }));
+            InvokePrivateMethod(stage, "PopulateBookmarksList");
+
+            Assert.Equal(new[] { active, readded }, display.CurrentList);
+            Assert.Equal(2, cached.Count);
+        }
+
+        [Fact]
+        public void PopulateRecentPlaysList_WhenCachedRowsAreOutsideActiveRoots_ShouldHideThemWithoutDiscardingCache()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            var active = Score("Active", 1, "/library/active/active.dtx");
+            var inactive = Score("Inactive", 2, "/library/inactive/inactive.dtx");
+            var cached = new List<SongListNode> { active, inactive };
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+                Snapshot(16, new[] { active }, new[] { "/library/active" }));
+            SetPrivateField(stage, "_recentPlayNodes", cached);
+
+            InvokePrivateMethod(stage, "PopulateRecentPlaysList");
+
+            Assert.Equal(new[] { active }, display.CurrentList);
+            Assert.Equal(2, cached.Count);
+        }
+
+        [Fact]
+        public void OnSongLibraryPublished_WhenVersionsArriveOutOfOrder_ShouldCaptureOnlyTheHighestPendingVersion()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { Score("Existing", 1, "/library/existing.dtx") } };
+            AttachCoreUi(stage, display: display);
+            var before = display.CurrentList;
+            SetPrivateField(stage, "_libraryPublicationActive", 1);
+            SetPrivateField(stage, "_pendingLibraryPublicationVersion", 0L);
+
+            InvokePrivateMethod(stage, "OnSongLibraryPublished", null!, new SongLibraryPublishedEventArgs(Snapshot(20, Array.Empty<SongListNode>(), Array.Empty<string>())));
+            InvokePrivateMethod(stage, "OnSongLibraryPublished", null!, new SongLibraryPublishedEventArgs(Snapshot(22, Array.Empty<SongListNode>(), Array.Empty<string>())));
+            InvokePrivateMethod(stage, "OnSongLibraryPublished", null!, new SongLibraryPublishedEventArgs(Snapshot(21, Array.Empty<SongListNode>(), Array.Empty<string>())));
+
+            Assert.Equal(22L, GetPrivateField<long>(stage, "_pendingLibraryPublicationVersion"));
+            Assert.Same(before, display.CurrentList);
+        }
+
+        [Fact]
+        public void ApplyPendingLibraryPublication_ShouldFetchAndApplyTheCurrentManagerSnapshotOnTheUpdateThread()
+        {
+            var songManager = SongManager.Instance;
+            var rootSongs = GetPrivateField<List<SongListNode>>(songManager, "_rootSongs")!;
+            var originalRoots = rootSongs.ToList();
+            var originalActiveRoots = GetPrivateField<string[]>(songManager, "_currentSearchPaths")!;
+            var originalVersion = GetPrivateField<long>(songManager, "_publicationVersion");
+            var newestNode = Score("Newest", 88, "/library/newest/newest.dtx");
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+
+            try
+            {
+                AttachCoreUi(stage, display: display);
+                rootSongs.Clear();
+                rootSongs.Add(newestNode);
+                SetPrivateField(songManager, "_currentSearchPaths", new[] { "/library/newest" });
+                SetPrivateField(songManager, "_publicationVersion", 31L);
+                SetPrivateField(stage, "_libraryPublicationActive", 1);
+                SetPrivateField(stage, "_pendingLibraryPublicationVersion", 31L);
+
+                InvokePrivateMethod(stage, "ApplyPendingLibraryPublication");
+
+                Assert.Equal(31L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
+                Assert.Same(newestNode, display.CurrentList.Single());
+                Assert.Equal(new[] { "/library/newest" },
+                    GetPrivateField<SongLibrarySnapshot>(stage, "_appliedLibrarySnapshot")!.ActiveRoots);
+            }
+            finally
+            {
+                rootSongs.Clear();
+                rootSongs.AddRange(originalRoots);
+                SetPrivateField(songManager, "_currentSearchPaths", originalActiveRoots);
+                SetPrivateField(songManager, "_publicationVersion", originalVersion);
+            }
+        }
+
+        [Fact]
+        public void CompleteTabListRefreshConsumption_WhenAsyncCacheCompletesDuringReconciliation_ShouldKeepRefreshPending()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_tabListNeedsRefresh", true);
+            SetPrivateField(stage, "_asyncTabListRefreshVersion", 4);
+
+            var consumedVersion = InvokePrivateMethod<int>(stage, "BeginTabListRefreshConsumption");
+            InvokePrivateMethod(stage, "RequestAsyncTabListRefresh");
+            InvokePrivateMethod(stage, "CompleteTabListRefreshConsumption", consumedVersion);
+
+            Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
+        }
+
+        [Fact]
+        public void PopulateBookmarksList_WhenCachedChartIsRemovedFromPublishedSnapshot_ShouldHideButRetainTheCacheRow()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            var retained = Score("Retained", 1, "/library/active/retained.dtx");
+            var removed = Score("Removed", 2, "/library/active/removed.dtx");
+            var cached = new List<SongListNode> { retained, removed };
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+                Snapshot(32, new[] { retained }, new[] { "/library/active" }));
+            SetPrivateField(stage, "_bookmarkNodes", cached);
+
+            InvokePrivateMethod(stage, "PopulateBookmarksList");
+
+            Assert.Equal(new[] { retained }, display.CurrentList);
+            Assert.Equal(2, cached.Count);
+        }
+
+        [Fact]
+        public void CheckSongInitializationCompletion_WhenNewerPublicationIsAlreadyApplied_ShouldNotResetRestoredSelection()
+        {
+            var stage = CreateStage();
+            var first = Score("First", 1, "/library/new/first.dtx");
+            var selected = Score("Selected", 2, "/library/new/selected.dtx");
+            var oldNode = Score("Old", 3, "/library/old/old.dtx");
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode> { first, selected }
+            };
+            AttachCoreUi(stage, display: display);
+            display.SelectedIndex = 1;
+
+            var appliedSnapshot = Snapshot(51, new[] { first, selected }, new[] { "/library/new" });
+            var staleSnapshot = Snapshot(50, new[] { oldNode }, new[] { "/library/old" });
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { first, selected });
+            SetPrivateField(stage, "_selectedSong", selected);
+            SetPrivateField(stage, "_appliedLibrarySnapshot", appliedSnapshot);
+            SetPrivateField(stage, "_appliedLibraryPublicationVersion", 51L);
+            SetPrivateField(stage, "_backgroundLibrarySnapshot", staleSnapshot);
+            SetPrivateField(stage, "_songInitializationTask", Task.FromResult(new List<SongListNode> { oldNode }));
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.Same(selected, display.SelectedSong);
+            Assert.Same(appliedSnapshot, GetPrivateField<SongLibrarySnapshot>(stage, "_appliedLibrarySnapshot"));
+        }
+
+        [Fact]
+        public void OnSongLibraryPublished_AfterDeactivation_ShouldIgnoreTheNotification()
+        {
+            var stage = CreateStage();
+            SetPrivateField(stage, "_libraryPublicationActive", 0);
+            SetPrivateField(stage, "_pendingLibraryPublicationVersion", 0L);
+
+            InvokePrivateMethod(stage, "OnSongLibraryPublished", null!, new SongLibraryPublishedEventArgs(Snapshot(23, Array.Empty<SongListNode>(), Array.Empty<string>())));
+
+            Assert.Equal(0L, GetPrivateField<long>(stage, "_pendingLibraryPublicationVersion"));
+        }
+
+        [Fact]
+        public void ResolveLibraryEmptyState_ShouldDistinguishNoRootsFromRootsWithoutSupportedCharts()
+        {
+            var stage = CreateStage();
+            var noRoots = Snapshot(24, Array.Empty<SongListNode>(), Array.Empty<string>());
+            var noSupportedCharts = Snapshot(25, Array.Empty<SongListNode>(), new[] { "/library/active" });
+
+            var noRootsResult = InvokePrivateMethod<object>(stage, "ResolveLibraryEmptyState", noRoots);
+            var noChartsResult = InvokePrivateMethod<object>(stage, "ResolveLibraryEmptyState", noSupportedCharts);
+
+            Assert.Equal("NoActiveRoots", noRootsResult!.ToString());
+            Assert.Equal("NoSupportedCharts", noChartsResult!.ToString());
+        }
+
+        [Fact]
+        public async Task ReconcileLibrarySnapshot_WhenOldSnapshotIsProjectedDuringNewPublication_ShouldLeaveUiOnNewestVersion()
+        {
+            var oldNode = Score("Old", 42, "/library/old/old.dtx");
+            var oldSnapshot = Snapshot(26, new[] { oldNode }, new[] { "/library/old" });
+            var newestNode = Score("Newest", 99, "/library/new/new.dtx");
+            var newestSnapshot = Snapshot(27, new[] { newestNode }, new[] { "/library/new" });
+            var stage = CreateStage();
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { oldNode } };
+            AttachCoreUi(stage, display: display);
+            SetPrivateField(stage, "_currentSongList", new List<SongListNode> { oldNode });
+            SetPrivateField(stage, "_selectedSong", oldNode);
+
+            var oldSnapshotReader = Task.Run(() =>
+            {
+                for (var i = 0; i < 100; i++)
+                {
+                    var projected = InvokePrivateMethod<List<SongListNode>>(
+                        stage,
+                        "FilterNodesForActiveRoots",
+                        oldSnapshot.RootSongs,
+                        oldSnapshot.ActiveRoots);
+                    BookmarkStateReconciler.Apply(oldSnapshot.RootSongs, 42, isBookmarked: true);
+                    Assert.Equal(new[] { oldNode }, projected);
+                }
+            });
+
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", newestSnapshot);
+            await oldSnapshotReader;
+
+            Assert.Equal(27L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
+            Assert.Equal(new[] { newestNode }, display.CurrentList);
+            Assert.DoesNotContain(oldNode, display.CurrentList);
+        }
+
+        private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)
+        {
+            var box = new SongListNode
+            {
+                Type = NodeType.Box,
+                Title = title,
+                DirectoryPath = directoryPath,
+                Children = children.ToList()
+            };
+            foreach (var child in box.Children)
+                child.Parent = box;
+            return box;
+        }
+
+        private static SongListNode Score(string title, int songId, string chartPath)
+        {
+            var chart = new SongChart { FilePath = chartPath };
+            var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
+            chart.Song = song;
+            chart.SongId = songId;
+            return new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = title,
+                DatabaseSongId = songId,
+                DatabaseSong = song,
+                DatabaseChart = chart
+            };
+        }
+
+        private static SongLibrarySnapshot Snapshot(
+            long version,
+            IReadOnlyList<SongListNode> roots,
+            IReadOnlyList<string> activeRoots) =>
+            new(version, roots, activeRoots, EnumeratedFileCount: roots.Count, DiscoveredScoreCount: roots.Count);
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
@@ -537,6 +538,109 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public async Task Deactivate_WhenCancelledInitializerCompletesLate_ShouldDiscardOnlyItsInactiveGeneration()
+        {
+            var stage = CreateStage();
+            var currentNode = Score("Current", 311, "/library/current/current.dtx");
+            var staleNode = Score("Stale", 310, "/library/stale/stale.dtx");
+            var staleSnapshot = Snapshot(310, new[] { staleNode }, new[] { "/library/stale" });
+            var display = new SongListDisplay
+            {
+                CurrentList = new List<SongListNode> { currentNode }
+            };
+            AttachCoreUi(stage, display: display);
+            var completions = GetPrivateField<
+                System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult>>(
+                stage,
+                "_pendingSongInitializationResults")!;
+            var workerStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseWorker = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var worker = Task.Run(async () =>
+            {
+                workerStarted.TrySetResult(true);
+                await releaseWorker.Task;
+                completions.Enqueue(new SongSelectionStage.SongInitializationResult(
+                    310,
+                    17,
+                    staleSnapshot,
+                    new[] { staleNode }));
+                return new List<SongListNode> { staleNode };
+            });
+
+            SetPrivateField(stage, "_activationVersion", 310);
+            SetPrivateField(stage, "_activeSongInitializationGeneration", 17L);
+            SetPrivateField(stage, "_songInitializationTask", worker);
+            SetPrivateField(stage, "_cancellationTokenSource", new CancellationTokenSource());
+            await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            stage.Deactivate();
+            releaseWorker.TrySetResult(true);
+            await worker.WaitAsync(TimeSpan.FromSeconds(1));
+            await WaitForSongInitializationQueueAsync(completions, results => results.Length == 0);
+
+            Assert.Empty(completions);
+            Assert.Equal(new[] { currentNode }, display.CurrentList);
+            Assert.Null(GetPrivateField<SongLibrarySnapshot>(stage, "_appliedLibrarySnapshot"));
+        }
+
+        [Fact]
+        public async Task Deactivate_WhenCancelledInitializerCompletesLate_ShouldPreserveNewerGenerationRecords()
+        {
+            var stage = CreateStage();
+            var staleNode = Score("Stale", 320, "/library/stale/stale.dtx");
+            var newerNode = Score("Newer", 321, "/library/newer/newer.dtx");
+            var staleSnapshot = Snapshot(320, new[] { staleNode }, new[] { "/library/stale" });
+            var newerSnapshot = Snapshot(321, new[] { newerNode }, new[] { "/library/newer" });
+            var completions = GetPrivateField<
+                System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult>>(
+                stage,
+                "_pendingSongInitializationResults")!;
+            var workerStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseWorker = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var worker = Task.Run(async () =>
+            {
+                workerStarted.TrySetResult(true);
+                await releaseWorker.Task;
+                completions.Enqueue(new SongSelectionStage.SongInitializationResult(
+                    320,
+                    23,
+                    staleSnapshot,
+                    new[] { staleNode }));
+                return new List<SongListNode> { staleNode };
+            });
+
+            SetPrivateField(stage, "_activationVersion", 320);
+            SetPrivateField(stage, "_activeSongInitializationGeneration", 23L);
+            SetPrivateField(stage, "_songInitializationTask", worker);
+            SetPrivateField(stage, "_cancellationTokenSource", new CancellationTokenSource());
+            await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            stage.Deactivate();
+            completions.Enqueue(new SongSelectionStage.SongInitializationResult(
+                321,
+                24,
+                newerSnapshot,
+                new[] { newerNode }));
+            releaseWorker.TrySetResult(true);
+            await worker.WaitAsync(TimeSpan.FromSeconds(1));
+            await WaitForSongInitializationQueueAsync(
+                completions,
+                results => results.Length == 1 &&
+                           results[0].ActivationVersion == 321 &&
+                           results[0].Generation == 24);
+
+            var remaining = Assert.Single(completions);
+            Assert.Equal(321, remaining.ActivationVersion);
+            Assert.Equal(24L, remaining.Generation);
+            Assert.Same(newerSnapshot, remaining.Snapshot);
+            Assert.Equal(new[] { newerNode }, remaining.SongList);
+        }
+
+        [Fact]
         public void CheckSongInitializationCompletion_WhenPriorActivationCompletesAfterSynchronousReactivation_ShouldDiscardQueuedResult()
         {
             var stage = CreateStage();
@@ -653,6 +757,22 @@ namespace DTXMania.Test.Stage
                 generation,
                 snapshot,
                 songList));
+        }
+
+        private static async Task WaitForSongInitializationQueueAsync(
+            System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult> completions,
+            Func<SongSelectionStage.SongInitializationResult[], bool> condition)
+        {
+            for (var attempt = 0; attempt < 100; attempt++)
+            {
+                if (condition(completions.ToArray()))
+                    return;
+
+                await Task.Delay(10);
+            }
+
+            Assert.True(condition(completions.ToArray()),
+                "The expected SongSelection initialization completion queue state was not observed.");
         }
 
         private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)

--- a/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
@@ -515,7 +515,7 @@ namespace DTXMania.Test.Stage
                     oldSnapshot,
                     new[] { oldNode }));
             });
-            await oldWorkerPassedTokenCheck.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await oldWorkerPassedTokenCheck.Task.WaitAsync(TimeSpan.FromSeconds(3));
 
             // A later activation completes and installs its own task/snapshot first.
             SetPrivateField(stage, "_activationVersion", 72);
@@ -528,7 +528,7 @@ namespace DTXMania.Test.Stage
             // The old worker is released last. Its record must be discarded instead of being
             // paired with the newer activation's completed task.
             releaseOldWorker.SetResult(true);
-            await oldWorker.WaitAsync(TimeSpan.FromSeconds(1));
+            await oldWorker.WaitAsync(TimeSpan.FromSeconds(3));
 
             InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
 
@@ -573,11 +573,11 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_activeSongInitializationGeneration", 17L);
             SetPrivateField(stage, "_songInitializationTask", worker);
             SetPrivateField(stage, "_cancellationTokenSource", new CancellationTokenSource());
-            await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3));
 
             stage.Deactivate();
             releaseWorker.TrySetResult(true);
-            await worker.WaitAsync(TimeSpan.FromSeconds(1));
+            await worker.WaitAsync(TimeSpan.FromSeconds(3));
             await WaitForSongInitializationQueueAsync(completions, results => results.Length == 0);
 
             Assert.Empty(completions);
@@ -617,7 +617,7 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_activeSongInitializationGeneration", 23L);
             SetPrivateField(stage, "_songInitializationTask", worker);
             SetPrivateField(stage, "_cancellationTokenSource", new CancellationTokenSource());
-            await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(3));
 
             stage.Deactivate();
             completions.Enqueue(new SongSelectionStage.SongInitializationResult(
@@ -626,7 +626,7 @@ namespace DTXMania.Test.Stage
                 newerSnapshot,
                 new[] { newerNode }));
             releaseWorker.TrySetResult(true);
-            await worker.WaitAsync(TimeSpan.FromSeconds(1));
+            await worker.WaitAsync(TimeSpan.FromSeconds(3));
             await WaitForSongInitializationQueueAsync(
                 completions,
                 results => results.Length == 1 &&
@@ -763,7 +763,7 @@ namespace DTXMania.Test.Stage
             System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult> completions,
             Func<SongSelectionStage.SongInitializationResult[], bool> condition)
         {
-            for (var attempt = 0; attempt < 100; attempt++)
+            for (var attempt = 0; attempt < 600; attempt++)
             {
                 if (condition(completions.ToArray()))
                     return;
@@ -809,6 +809,6 @@ namespace DTXMania.Test.Stage
             long version,
             IReadOnlyList<SongListNode> roots,
             IReadOnlyList<string> activeRoots) =>
-            new(version, roots, activeRoots, EnumeratedFileCount: roots.Count, DiscoveredScoreCount: roots.Count);
+            new(version, roots, activeRoots, enumeratedFileCount: roots.Count, discoveredScoreCount: roots.Count);
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionPublicationTests.cs
@@ -423,7 +423,9 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_selectedSong", selected);
             SetPrivateField(stage, "_appliedLibrarySnapshot", appliedSnapshot);
             SetPrivateField(stage, "_appliedLibraryPublicationVersion", 51L);
-            SetPrivateField(stage, "_backgroundLibrarySnapshot", staleSnapshot);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_activeSongInitializationGeneration", 1L);
+            EnqueueSongInitializationResult(stage, 0, 1, staleSnapshot, new[] { oldNode });
             SetPrivateField(stage, "_songInitializationTask", Task.FromResult(new List<SongListNode> { oldNode }));
             SetPrivateField(stage, "_songInitializationProcessed", false);
 
@@ -461,7 +463,9 @@ namespace DTXMania.Test.Stage
             var newerSnapshot = Snapshot(82, new[] { replacementBox }, new[] { "/library/shared" });
             SetPrivateField(stage, "_appliedLibrarySnapshot", appliedSnapshot);
             SetPrivateField(stage, "_appliedLibraryPublicationVersion", 81L);
-            SetPrivateField(stage, "_backgroundLibrarySnapshot", newerSnapshot);
+            SetPrivateField(stage, "_activationVersion", 0);
+            SetPrivateField(stage, "_activeSongInitializationGeneration", 1L);
+            EnqueueSongInitializationResult(stage, 0, 1, newerSnapshot, new[] { replacementBox });
             SetPrivateField(stage, "_songInitializationTask",
                 Task.FromResult(new List<SongListNode> { replacementBox }));
             SetPrivateField(stage, "_songInitializationProcessed", false);
@@ -474,6 +478,62 @@ namespace DTXMania.Test.Stage
             Assert.Equal("BOX", GetPrivateField<string>(stage, "_currentBreadcrumb"));
             Assert.Same(replacementSong, display.SelectedSong);
             Assert.Equal(82L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
+        }
+
+        [Fact]
+        public async Task CheckSongInitializationCompletion_WhenOldActivationCompletesAfterNewCompletion_ShouldUseNewSnapshot()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display: display);
+            var oldNode = Score("Old", 91, "/library/old/old.dtx");
+            var newNode = Score("New", 92, "/library/new/new.dtx");
+            var oldSnapshot = Snapshot(91, new[] { oldNode }, new[] { "/library/old" });
+            var newSnapshot = Snapshot(92, new[] { newNode }, new[] { "/library/new" });
+            var oldWorkerPassedTokenCheck = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseOldWorker = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var newWorker = new TaskCompletionSource<List<SongListNode>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            SetPrivateField(stage, "_activationVersion", 71);
+            var completions = GetPrivateField<
+                System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult>>(
+                stage,
+                "_pendingSongInitializationResults")!;
+            var oldWorker = Task.Run(async () =>
+            {
+                // Model the prior initializer after it has passed its activation check but
+                // before it publishes its immutable completion record.
+                oldWorkerPassedTokenCheck.TrySetResult(true);
+                await releaseOldWorker.Task;
+                completions.Enqueue(new SongSelectionStage.SongInitializationResult(
+                    71,
+                    1,
+                    oldSnapshot,
+                    new[] { oldNode }));
+            });
+            await oldWorkerPassedTokenCheck.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            // A later activation completes and installs its own task/snapshot first.
+            SetPrivateField(stage, "_activationVersion", 72);
+            SetPrivateField(stage, "_activeSongInitializationGeneration", 2L);
+            EnqueueSongInitializationResult(stage, 72, 2, newSnapshot, new[] { newNode });
+            SetPrivateField(stage, "_songInitializationTask", newWorker.Task);
+            SetPrivateField(stage, "_songInitializationProcessed", false);
+            newWorker.SetResult(new List<SongListNode> { newNode });
+
+            // The old worker is released last. Its record must be discarded instead of being
+            // paired with the newer activation's completed task.
+            releaseOldWorker.SetResult(true);
+            await oldWorker.WaitAsync(TimeSpan.FromSeconds(1));
+
+            InvokePrivateMethod(stage, "CheckSongInitializationCompletion");
+
+            Assert.Equal(92L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
+            Assert.Equal(new[] { newNode }, display.CurrentList);
+            Assert.Empty(completions);
         }
 
         [Fact]
@@ -535,6 +595,24 @@ namespace DTXMania.Test.Stage
             Assert.Equal(27L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
             Assert.Equal(new[] { newestNode }, display.CurrentList);
             Assert.DoesNotContain(oldNode, display.CurrentList);
+        }
+
+        private static void EnqueueSongInitializationResult(
+            SongSelectionStage stage,
+            int activationVersion,
+            long generation,
+            SongLibrarySnapshot? snapshot,
+            IReadOnlyList<SongListNode> songList)
+        {
+            var completions = GetPrivateField<
+                System.Collections.Concurrent.ConcurrentQueue<SongSelectionStage.SongInitializationResult>>(
+                stage,
+                "_pendingSongInitializationResults")!;
+            completions.Enqueue(new SongSelectionStage.SongInitializationResult(
+                activationVersion,
+                generation,
+                snapshot,
+                songList));
         }
 
         private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -210,6 +210,31 @@ namespace DTXMania.Test.Stage
             }
         }
 
+        [Fact]
+        public void ToggleBookmarkForSelectedSong_WhenAppliedSnapshotExists_ReconcilesThatSnapshotInsteadOfANewerManagerView()
+        {
+            var stage = CreateStage();
+            var selectedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "Selected", IsBookmarked = false };
+            var appliedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "Applied", IsBookmarked = false };
+            var selectedNode = new SongListNode { Type = NodeType.Score, Title = "Selected", DatabaseSongId = 42, DatabaseSong = selectedSong };
+            var appliedNode = new SongListNode { Type = NodeType.Score, Title = "Applied", DatabaseSongId = 42, DatabaseSong = appliedSong };
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { selectedNode } };
+            var snapshot = new SongLibrarySnapshot(
+                Version: 101,
+                RootSongs: new[] { appliedNode },
+                ActiveRoots: new[] { "/library/active" },
+                EnumeratedFileCount: 1,
+                DiscoveredScoreCount: 1);
+
+            AttachCoreUi(stage, display);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
+            SetPrivateField(stage, "_appliedLibrarySnapshot", snapshot);
+
+            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+            Assert.True(appliedSong.IsBookmarked);
+        }
+
         // Guards the "&& !newState" condition: bookmarking ON while on the Bookmarks tab must
         // flip the flag but must NOT remove the row (only an un-bookmark removes it).
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -511,10 +511,19 @@ namespace DTXMania.Test.Stage
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.Single(nodes);
 
-            // Settle the write; the chained load fires and (no DB connected) overwrites with
-            // an empty list.
+            // Settle the write. Its worker continuation only queues a reload request, so the
+            // stage-owned cache stays unchanged until the update path consumes that request.
             tcs.SetResult(true);
             await Task.Delay(400);
+
+            nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.Single(nodes);
+
+            // First update-thread pass begins the deferred load; the second applies its
+            // completion (the no-DB loader returns an empty list).
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
+            await Task.Delay(400);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
             nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.Empty(nodes);

--- a/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs
@@ -45,6 +45,23 @@ namespace DTXMania.Test.Stage
             return display;
         }
 
+        private static async Task WaitForQueueCountAsync(
+            SongSelectionStage stage, string fieldName, int timeoutMs = 3000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (true)
+            {
+                var queue = GetPrivateField<System.Collections.ICollection>(
+                    stage, fieldName);
+                if (queue != null && queue.Count > 0)
+                    return;
+                if (DateTime.UtcNow >= deadline)
+                    throw new TimeoutException(
+                        $"The '{fieldName}' queue was not populated within {timeoutMs}ms.");
+                await Task.Delay(10);
+            }
+        }
+
         [Fact]
         public void ToggleBookmarkForSelectedSong_OnScoreNode_FlipsBookmarkFlag()
         {
@@ -211,28 +228,46 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
-        public void ToggleBookmarkForSelectedSong_WhenAppliedSnapshotExists_ReconcilesThatSnapshotInsteadOfANewerManagerView()
+        public void ToggleBookmark_WhenAppliedSnapshotExists_ShouldReconcileAppliedSongAndLeaveManagerViewBystanderUnchanged()
         {
             var stage = CreateStage();
             var selectedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "Selected", IsBookmarked = false };
             var appliedSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "Applied", IsBookmarked = false };
+            // A manager-view bystander sharing the same song id must NOT be reconciled
+            // when an applied snapshot owns the canonical view for this toggle.
+            var bystanderSong = new DTXMania.Game.Lib.Song.Entities.Song { Id = 42, Title = "Bystander", IsBookmarked = false };
             var selectedNode = new SongListNode { Type = NodeType.Score, Title = "Selected", DatabaseSongId = 42, DatabaseSong = selectedSong };
             var appliedNode = new SongListNode { Type = NodeType.Score, Title = "Applied", DatabaseSongId = 42, DatabaseSong = appliedSong };
+            var bystanderNode = new SongListNode { Type = NodeType.Score, Title = "Bystander", DatabaseSongId = 42, DatabaseSong = bystanderSong };
             var display = new SongListDisplay { CurrentList = new List<SongListNode> { selectedNode } };
             var snapshot = new SongLibrarySnapshot(
-                Version: 101,
-                RootSongs: new[] { appliedNode },
-                ActiveRoots: new[] { "/library/active" },
-                EnumeratedFileCount: 1,
-                DiscoveredScoreCount: 1);
+                version: 101,
+                rootSongs: new[] { appliedNode },
+                activeRoots: new[] { "/library/active" },
+                enumeratedFileCount: 1,
+                discoveredScoreCount: 1);
 
             AttachCoreUi(stage, display);
             SetPrivateField(stage, "_activeTab", SongSelectionTab.AllSongs);
             SetPrivateField(stage, "_appliedLibrarySnapshot", snapshot);
 
-            InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+            var roots = GetPrivateField<List<SongListNode>>(SongManager.Instance, "_rootSongs");
+            var savedRoots = roots.ToList();
+            roots.Clear();
+            roots.Add(bystanderNode);
 
-            Assert.True(appliedSong.IsBookmarked);
+            try
+            {
+                InvokePrivateMethod(stage, "ToggleBookmarkForSelectedSong");
+
+                Assert.True(appliedSong.IsBookmarked);     // reconciled via the applied snapshot
+                Assert.False(bystanderSong.IsBookmarked);  // manager-view bystander untouched
+            }
+            finally
+            {
+                roots.Clear();
+                roots.AddRange(savedRoots);
+            }
         }
 
         // Guards the "&& !newState" condition: bookmarking ON while on the Bookmarks tab must
@@ -514,7 +549,7 @@ namespace DTXMania.Test.Stage
             // Settle the write. Its worker continuation only queues a reload request, so the
             // stage-owned cache stays unchanged until the update path consumes that request.
             tcs.SetResult(true);
-            await Task.Delay(400);
+            await WaitForQueueCountAsync(stage, "_pendingBookmarkLoadRequests");
 
             nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.Single(nodes);
@@ -522,7 +557,7 @@ namespace DTXMania.Test.Stage
             // First update-thread pass begins the deferred load; the second applies its
             // completion (the no-DB loader returns an empty list).
             InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
-            await Task.Delay(400);
+            await WaitForQueueCountAsync(stage, "_pendingTabLoadCompletions");
             InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
             nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");

--- a/DTXMania.Test/Stage/SongSelectionStageCxNeonCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCxNeonCoverageTests.cs
@@ -1,4 +1,3 @@
-using System.Runtime.Serialization;
 using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Stage;
@@ -16,7 +15,7 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void DrawTabBar_WithOnlyThemedTabFont_ShouldUseThemeColorsAndMeasureEveryLabel()
         {
-            var stage = CreateUninitializedStage();
+            var stage = SongSelectionStageTestFactory.CreateStage();
             var tabFont = new Mock<IFont>();
             tabFont.Setup(value => value.MeasureString(It.IsAny<string>()))
                 .Returns(new Vector2(40, 16));
@@ -72,7 +71,7 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void Deactivate_WithAllDisplayFontsLoaded_ShouldReleaseAndClearEachReference()
         {
-            var stage = CreateUninitializedStage();
+            var stage = SongSelectionStageTestFactory.CreateStage();
             var bodyFont = new Mock<IFont>();
             var tabFont = new Mock<IFont>();
             var historyFont = new Mock<IFont>();
@@ -90,11 +89,5 @@ namespace DTXMania.Test.Stage
             Assert.Null(ReflectionHelpers.GetPrivateField<IFont>(stage, "_historyFont"));
         }
 
-        private static SongSelectionStage CreateUninitializedStage()
-        {
-#pragma warning disable SYSLIB0050
-            return (SongSelectionStage)FormatterServices.GetUninitializedObject(typeof(SongSelectionStage));
-#pragma warning restore SYSLIB0050
-        }
     }
 }

--- a/DTXMania.Test/Stage/SongSelectionStageCxNeonCoverageTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageCxNeonCoverageTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace DTXMania.Test.Stage
 {
     [Trait("Category", "Unit")]
+    [Collection("SongManager")]
     public class SongSelectionStageCxNeonCoverageTests
     {
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageFontLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFontLifecycleTests.cs
@@ -4,7 +4,6 @@ using DTXMania.Game.Lib.Resources;
 using Microsoft.Xna.Framework.Graphics;
 using Moq;
 using System;
-using System.Runtime.Serialization;
 using Xunit;
 using DTXMania.Test.TestData;
 
@@ -16,7 +15,7 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void Deactivate_WhenFontLoaded_ShouldReleaseFontReference()
         {
-            var stage = CreateUninitializedStage();
+            var stage = SongSelectionStageTestFactory.CreateStage();
             var mockFont = new Mock<IFont>();
             ReflectionHelpers.SetPrivateField(stage, "_font", mockFont.Object);
 
@@ -47,13 +46,6 @@ namespace DTXMania.Test.Stage
             // Graphics resources should be null after cleanup in catch block
             Assert.Null(ReflectionHelpers.GetPrivateField<SpriteBatch>(stage, "_spriteBatch"));
             Assert.Null(ReflectionHelpers.GetPrivateField<Texture2D>(stage, "_whitePixel"));
-        }
-
-        private static SongSelectionStage CreateUninitializedStage()
-        {
-#pragma warning disable SYSLIB0050
-            return (SongSelectionStage)FormatterServices.GetUninitializedObject(typeof(SongSelectionStage));
-#pragma warning restore SYSLIB0050
         }
 
         private class TestableSongSelectionStage : SongSelectionStage

--- a/DTXMania.Test/Stage/SongSelectionStageFontLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageFontLifecycleTests.cs
@@ -10,6 +10,7 @@ using DTXMania.Test.TestData;
 namespace DTXMania.Test.Stage
 {
     [Trait("Category", "Unit")]
+    [Collection("SongManager")]
     public class SongSelectionStageFontLifecycleTests
     {
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageIdentityTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageIdentityTests.cs
@@ -22,7 +22,7 @@ public sealed class SongSelectionStageIdentityTests
 
         var result = InvokeStatic<string?>("GetStableBoxPath", node);
 
-        Assert.Equal("/library/one/BOX", result);
+        Assert.Equal(SongPathIdentity.Normalize("/library/one/BOX"), result);
     }
 
     [Fact]
@@ -60,7 +60,7 @@ public sealed class SongSelectionStageIdentityTests
 
         var result = InvokeStatic<string?>("GetStableSelectionIdentity", node);
 
-        Assert.Equal("box:/library/one/BOX", result);
+        Assert.Equal($"box:{SongPathIdentity.Normalize("/library/one/BOX")}", result);
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public sealed class SongSelectionStageIdentityTests
 
         var result = InvokeStatic<string?>("GetStableSelectionIdentity", node);
 
-        Assert.Equal("chart:/library/song.dtx", result);
+        Assert.Equal($"chart:{SongPathIdentity.Normalize("/library/song.dtx")}", result);
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public sealed class SongSelectionStageIdentityTests
             .ToList();
 
         Assert.Contains("song:42", candidates);
-        Assert.Contains("chart:/library/song.dtx", candidates);
+        Assert.Contains($"chart:{SongPathIdentity.Normalize("/library/song.dtx")}", candidates);
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class SongSelectionStageIdentityTests
             .ToList();
 
         Assert.Single(candidates);
-        Assert.Equal("chart:/library/song.dtx", candidates[0]);
+        Assert.Equal($"chart:{SongPathIdentity.Normalize("/library/song.dtx")}", candidates[0]);
     }
 
     [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStageIdentityTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageIdentityTests.cs
@@ -1,0 +1,320 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using Xunit;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage;
+
+[Trait("Category", "Unit")]
+public sealed class SongSelectionStageIdentityTests
+{
+    [Fact]
+    public void GetStableBoxPath_WhenNodeIsBoxWithValidPath_ShouldReturnNormalizedPath()
+    {
+        var node = Box("BOX", "/library/one/BOX");
+
+        var result = InvokeStatic<string?>("GetStableBoxPath", node);
+
+        Assert.Equal("/library/one/BOX", result);
+    }
+
+    [Fact]
+    public void GetStableBoxPath_WhenNodeIsNull_ShouldReturnNull()
+    {
+        var result = InvokeStatic<string?>("GetStableBoxPath", new object?[] { null });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetStableBoxPath_WhenNodeIsNotBox_ShouldReturnNull()
+    {
+        var node = Score("Song", 1, "/library/song.dtx");
+
+        var result = InvokeStatic<string?>("GetStableBoxPath", node);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetStableBoxPath_WhenBoxPathCannotBeNormalized_ShouldReturnNull()
+    {
+        var node = Box("BOX", "/bad\0path");
+
+        var result = InvokeStatic<string?>("GetStableBoxPath", node);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetStableSelectionIdentity_WhenBoxNode_ShouldReturnBoxIdentity()
+    {
+        var node = Box("BOX", "/library/one/BOX");
+
+        var result = InvokeStatic<string?>("GetStableSelectionIdentity", node);
+
+        Assert.Equal("box:/library/one/BOX", result);
+    }
+
+    [Fact]
+    public void GetStableSelectionIdentity_WhenScoreWithDatabaseId_ShouldReturnSongIdentity()
+    {
+        var node = Score("Song", 42, "/library/song.dtx");
+
+        var result = InvokeStatic<string?>("GetStableSelectionIdentity", node);
+
+        Assert.Equal("song:42", result);
+    }
+
+    [Fact]
+    public void GetStableSelectionIdentity_WhenScoreWithoutDatabaseId_ShouldReturnChartIdentity()
+    {
+        var chart = new SongChart { FilePath = "/library/song.dtx" };
+        var node = new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "Song",
+            DatabaseChart = chart,
+        };
+
+        var result = InvokeStatic<string?>("GetStableSelectionIdentity", node);
+
+        Assert.Equal("chart:/library/song.dtx", result);
+    }
+
+    [Fact]
+    public void GetStableSelectionIdentity_WhenNodeIsNull_ShouldReturnNull()
+    {
+        var result = InvokeStatic<string?>("GetStableSelectionIdentity", new object?[] { null });
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetStableSelectionIdentity_WhenScoreHasNoIdOrChartPath_ShouldReturnNull()
+    {
+        var node = new SongListNode { Type = NodeType.Score, Title = "Empty" };
+
+        var result = InvokeStatic<string?>("GetStableSelectionIdentity", node);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetScoreIdentityCandidates_WhenScoreWithDatabaseId_ShouldYieldSongAndChartIdentities()
+    {
+        var node = Score("Song", 42, "/library/song.dtx");
+
+        var candidates = InvokeStatic<IEnumerable<string>>("GetScoreIdentityCandidates", node)
+            .ToList();
+
+        Assert.Contains("song:42", candidates);
+        Assert.Contains("chart:/library/song.dtx", candidates);
+    }
+
+    [Fact]
+    public void GetScoreIdentityCandidates_WhenScoreWithoutDatabaseId_ShouldYieldOnlyChartIdentity()
+    {
+        var chart = new SongChart { FilePath = "/library/song.dtx" };
+        var node = new SongListNode { Type = NodeType.Score, DatabaseChart = chart };
+
+        var candidates = InvokeStatic<IEnumerable<string>>("GetScoreIdentityCandidates", node)
+            .ToList();
+
+        Assert.Single(candidates);
+        Assert.Equal("chart:/library/song.dtx", candidates[0]);
+    }
+
+    [Fact]
+    public void GetScoreIdentityCandidates_WhenNodeIsNotScore_ShouldYieldNothing()
+    {
+        var node = Box("BOX", "/library/BOX");
+
+        var candidates = InvokeStatic<IEnumerable<string>>("GetScoreIdentityCandidates", node)
+            .ToList();
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void HasPublishedScoreIdentity_WhenIdentityIsPublished_ShouldReturnTrue()
+    {
+        var node = Score("Song", 42, "/library/song.dtx");
+        var identities = new HashSet<string>(StringComparer.Ordinal) { "song:42" };
+
+        var result = InvokeStatic<bool>("HasPublishedScoreIdentity", node, identities);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void HasPublishedScoreIdentity_WhenIdentityIsNotPublished_ShouldReturnFalse()
+    {
+        var node = Score("Song", 42, "/library/song.dtx");
+        var identities = new HashSet<string>(StringComparer.Ordinal) { "song:99" };
+
+        var result = InvokeStatic<bool>("HasPublishedScoreIdentity", node, identities);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void GetNodeChartPaths_WhenNodeHasDatabaseChart_ShouldReturnChartPath()
+    {
+        var chart = new SongChart { FilePath = "/library/song.dtx" };
+        var node = new SongListNode { DatabaseChart = chart };
+
+        var paths = InvokeStatic<IEnumerable<string>>("GetNodeChartPaths", node)
+            .ToList();
+
+        Assert.Single(paths);
+        Assert.Equal("/library/song.dtx", paths[0]);
+    }
+
+    [Fact]
+    public void GetNodeChartPaths_WhenNodeHasSongWithMultipleCharts_ShouldReturnAllChartPaths()
+    {
+        var song = new SongEntity
+        {
+            Charts = new List<SongChart>
+            {
+                new() { FilePath = "/library/song1.dtx" },
+                new() { FilePath = "/library/song2.dtx" },
+            },
+        };
+        var node = new SongListNode { DatabaseSong = song };
+
+        var paths = InvokeStatic<IEnumerable<string>>("GetNodeChartPaths", node)
+            .ToList();
+
+        Assert.Equal(2, paths.Count);
+    }
+
+    [Fact]
+    public void GetNodeChartPaths_WhenNodeHasOnlyDirectoryPath_ShouldReturnDirectoryPath()
+    {
+        var node = new SongListNode { DirectoryPath = "/library/box" };
+
+        var paths = InvokeStatic<IEnumerable<string>>("GetNodeChartPaths", node)
+            .ToList();
+
+        Assert.Single(paths);
+        Assert.Equal("/library/box", paths[0]);
+    }
+
+    [Fact]
+    public void NodeIsUnderAnyActiveRoot_WhenChartUnderRoot_ShouldReturnTrue()
+    {
+        var node = Score("Song", 1, "/library/songs/song.dtx");
+        var roots = new[] { "/library/songs" };
+
+        var result = InvokeStatic<bool>("NodeIsUnderAnyActiveRoot", node, roots);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void NodeIsUnderAnyActiveRoot_WhenChartOutsideRoots_ShouldReturnFalse()
+    {
+        var node = Score("Song", 1, "/other/song.dtx");
+        var roots = new[] { "/library/songs" };
+
+        var result = InvokeStatic<bool>("NodeIsUnderAnyActiveRoot", node, roots);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void NodeIsUnderAnyActiveRoot_WhenChartPathCannotBeNormalized_ShouldSkipThatPath()
+    {
+        var chart = new SongChart { FilePath = "/bad\0path" };
+        var node = new SongListNode
+        {
+            Type = NodeType.Score,
+            DatabaseChart = chart,
+            DirectoryPath = "/library/songs/fallback",
+        };
+        var roots = new[] { "/library/songs" };
+
+        var result = InvokeStatic<bool>("NodeIsUnderAnyActiveRoot", node, roots);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsPublishedScore_WhenTreeHasScore_ShouldReturnTrue()
+    {
+        var song = Score("Song", 1, "/song.dtx");
+        var box = Box("BOX", "/library/BOX", song);
+
+        var result = InvokeStatic<bool>("ContainsPublishedScore", new object[] { new[] { box } });
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void ContainsPublishedScore_WhenTreeOnlyHasEmptyBoxes_ShouldReturnFalse()
+    {
+        var box = Box("BOX", "/library/BOX");
+
+        var result = InvokeStatic<bool>("ContainsPublishedScore", new object[] { new[] { box } });
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void ContainsPublishedScore_WhenNodesAreEmpty_ShouldReturnFalse()
+    {
+        var result = InvokeStatic<bool>(
+            "ContainsPublishedScore",
+            new object[] { Array.Empty<SongListNode>() });
+
+        Assert.False(result);
+    }
+
+    private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)
+    {
+        var box = new SongListNode
+        {
+            Type = NodeType.Box,
+            Title = title,
+            DirectoryPath = directoryPath,
+            Children = children.ToList(),
+        };
+        foreach (var child in box.Children)
+            child.Parent = box;
+        return box;
+    }
+
+    private static SongListNode Score(string title, int songId, string chartPath)
+    {
+        var chart = new SongChart { FilePath = chartPath };
+        var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        chart.SongId = songId;
+        return new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = title,
+            DatabaseSongId = songId,
+            DatabaseSong = song,
+            DatabaseChart = chart,
+        };
+    }
+
+    private static T InvokeStatic<T>(string methodName, params object?[] args)
+    {
+        var method = typeof(SongSelectionStage).GetMethod(
+            methodName,
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(null, args)!;
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStageIdentityTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageIdentityTests.cs
@@ -9,6 +9,7 @@ using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage;
 using Xunit;
 using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
 
 namespace DTXMania.Test.Stage;
 
@@ -277,36 +278,6 @@ public sealed class SongSelectionStageIdentityTests
             new object[] { Array.Empty<SongListNode>() });
 
         Assert.False(result);
-    }
-
-    private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)
-    {
-        var box = new SongListNode
-        {
-            Type = NodeType.Box,
-            Title = title,
-            DirectoryPath = directoryPath,
-            Children = children.ToList(),
-        };
-        foreach (var child in box.Children)
-            child.Parent = box;
-        return box;
-    }
-
-    private static SongListNode Score(string title, int songId, string chartPath)
-    {
-        var chart = new SongChart { FilePath = chartPath };
-        var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
-        chart.Song = song;
-        chart.SongId = songId;
-        return new SongListNode
-        {
-            Type = NodeType.Score,
-            Title = title,
-            DatabaseSongId = songId,
-            DatabaseSong = song,
-            DatabaseChart = chart,
-        };
     }
 
     private static T InvokeStatic<T>(string methodName, params object?[] args)

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -1428,7 +1428,7 @@ namespace DTXMania.Test.Stage
             Assert.Same(uiFont.Object, playHistoryPanel.ManagedFont);
             Assert.Equal(75, playHistoryPanel.PlaySpeedPercent);
             Assert.True(previewImagePanel!.Visible);
-            Assert.Equal("SongsRoot", GetPrivateField<string>(previewImagePanel, "_songsRootPath"));
+            Assert.Empty(previewImagePanel.ActiveSongRootPaths);
             Assert.Equal(7, mainPanel.Children.Count);
             Assert.Same(titleLabel, mainPanel.Children[0]);
             Assert.Same(breadcrumbLabel, mainPanel.Children[1]);

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -2437,6 +2437,26 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public void ApplyLibrarySnapshot_ShouldRetainTheCoherentSnapshotUsedForUiProjection()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            var song = CreateScoreNode("Snapshot Song");
+            var snapshot = new SongLibrarySnapshot(
+                Version: 91,
+                RootSongs: new[] { song },
+                ActiveRoots: new[] { "/library/active" },
+                EnumeratedFileCount: 1,
+                DiscoveredScoreCount: 1);
+
+            AttachCoreUi(stage, display: display);
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshot", snapshot);
+
+            Assert.Same(snapshot, GetPrivateField<SongLibrarySnapshot>(stage, "_appliedLibrarySnapshot"));
+            Assert.Equal(91L, GetPrivateField<long>(stage, "_appliedLibraryPublicationVersion"));
+        }
+
+        [Fact]
         public void InitializeSongList_WhenSongManagerIsNotInitialized_ShouldStartBackgroundTaskAndKeepDisplayEmpty()
         {
             var stage = CreateStage();

--- a/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageLogicTests.cs
@@ -2443,11 +2443,11 @@ namespace DTXMania.Test.Stage
             var display = new SongListDisplay();
             var song = CreateScoreNode("Snapshot Song");
             var snapshot = new SongLibrarySnapshot(
-                Version: 91,
-                RootSongs: new[] { song },
-                ActiveRoots: new[] { "/library/active" },
-                EnumeratedFileCount: 1,
-                DiscoveredScoreCount: 1);
+                version: 91,
+                rootSongs: new[] { song },
+                activeRoots: new[] { "/library/active" },
+                enumeratedFileCount: 1,
+                discoveredScoreCount: 1);
 
             AttachCoreUi(stage, display: display);
             InvokePrivateMethod(stage, "ApplyLibrarySnapshot", snapshot);

--- a/DTXMania.Test/Stage/SongSelectionStageRootFilterAdditionalTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageRootFilterAdditionalTests.cs
@@ -263,8 +263,9 @@ public sealed class SongSelectionStageRootFilterAdditionalTests
     {
         var stage = CreateStage();
 
-        Assert.Throws<TargetInvocationException>(() =>
+        var thrown = Assert.Throws<TargetInvocationException>(() =>
             InvokePrivateMethod(stage, "ApplyLibrarySnapshotCore", new object?[] { null, true }));
+        Assert.IsType<ArgumentNullException>(thrown.InnerException);
     }
 
     [Fact]
@@ -272,8 +273,9 @@ public sealed class SongSelectionStageRootFilterAdditionalTests
     {
         var stage = CreateStage();
 
-        Assert.Throws<TargetInvocationException>(() =>
+        var thrown = Assert.Throws<TargetInvocationException>(() =>
             InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", new object?[] { null }));
+        Assert.IsType<ArgumentNullException>(thrown.InnerException);
     }
 
     [Fact]
@@ -289,36 +291,6 @@ public sealed class SongSelectionStageRootFilterAdditionalTests
     }
 
     #region Helpers
-
-    private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)
-    {
-        var box = new SongListNode
-        {
-            Type = NodeType.Box,
-            Title = title,
-            DirectoryPath = directoryPath,
-            Children = children.ToList(),
-        };
-        foreach (var child in box.Children)
-            child.Parent = box;
-        return box;
-    }
-
-    private static SongListNode Score(string title, int songId, string chartPath)
-    {
-        var chart = new SongChart { FilePath = chartPath };
-        var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
-        chart.Song = song;
-        chart.SongId = songId;
-        return new SongListNode
-        {
-            Type = NodeType.Score,
-            Title = title,
-            DatabaseSongId = songId,
-            DatabaseSong = song,
-            DatabaseChart = chart,
-        };
-    }
 
     private static SongLibrarySnapshot Snapshot(
         long version,

--- a/DTXMania.Test/Stage/SongSelectionStageRootFilterAdditionalTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageRootFilterAdditionalTests.cs
@@ -1,0 +1,343 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Game.Lib.UI.Components;
+using Moq;
+using Xunit;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage;
+
+[Collection("SongManager")]
+[Trait("Category", "Unit")]
+public sealed class SongSelectionStageRootFilterAdditionalTests
+{
+    [Fact]
+    public void FilterNodesForActiveRoots_WhenNodesAreNull_ShouldReturnEmptyList()
+    {
+        var stage = CreateStage();
+
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForActiveRoots", null, new[] { "/songs" });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterNodesForActiveRoots_WhenActiveRootsAreNull_ShouldReturnAllNodes()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/songs/test.dtx");
+
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForActiveRoots", new[] { song }, null);
+
+        Assert.Single(result);
+        Assert.Same(song, result[0]);
+    }
+
+    [Fact]
+    public void FilterNodesForActiveRoots_WhenActiveRootsAreEmpty_ShouldReturnEmptyList()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/songs/test.dtx");
+
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForActiveRoots", new[] { song }, Array.Empty<string>());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterNodesForActiveRoots_WhenRootsDoNotNormalize_ShouldReturnEmptyList()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/songs/test.dtx");
+
+        // A NUL character makes SongPathIdentity.TryNormalize fail, so no roots
+        // normalize and the filtered list is empty.
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForActiveRoots", new[] { song }, new[] { "/bad\0root" });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void FilterNodesForActiveRoots_WhenSongIsUnderActiveRoot_ShouldIncludeIt()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/library/active/test.dtx");
+
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForActiveRoots", new[] { song }, new[] { "/library/active" });
+
+        Assert.Single(result);
+        Assert.Same(song, result[0]);
+    }
+
+    [Fact]
+    public void FilterNodesForActiveRoots_WhenSongIsOutsideActiveRoot_ShouldExcludeIt()
+    {
+        var stage = CreateStage();
+        var active = Score("Active", 1, "/library/active/active.dtx");
+        var inactive = Score("Inactive", 2, "/library/inactive/inactive.dtx");
+
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForActiveRoots", new[] { active, inactive }, new[] { "/library/active" });
+
+        Assert.Single(result);
+        Assert.Same(active, result[0]);
+    }
+
+    [Fact]
+    public void FilterNodesForAppliedLibrary_WhenNoSnapshotIsApplied_ShouldReturnRootFilteredNodes()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/songs/test.dtx");
+
+        // Without an applied snapshot, GetAppliedActiveRoots returns null, so
+        // FilterNodesForActiveRoots returns all nodes.
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForAppliedLibrary", new object[] { new[] { song } });
+
+        Assert.Single(result);
+        Assert.Same(song, result[0]);
+    }
+
+    [Fact]
+    public void FilterNodesForAppliedLibrary_WhenSnapshotHasNoScoreIdentities_ShouldReturnEmptyList()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/library/active/test.dtx");
+        // Apply a snapshot with only boxes (no score nodes) so the identity set is empty.
+        var box = Box("Empty", "/library/active/Empty");
+        InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+            Snapshot(30, new[] { box }, new[] { "/library/active" }));
+
+        var result = InvokePrivateMethod<List<SongListNode>>(
+            stage, "FilterNodesForAppliedLibrary", new object[] { new[] { song } });
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetAppliedActiveRoots_WhenNoSnapshotIsApplied_ShouldReturnNull()
+    {
+        var stage = CreateStage();
+
+        var roots = InvokePrivateMethod<IReadOnlyList<string>?>(
+            stage, "GetAppliedActiveRoots");
+
+        Assert.Null(roots);
+    }
+
+    [Fact]
+    public void GetAppliedActiveRoots_WhenSnapshotIsApplied_ShouldReturnSnapshotRoots()
+    {
+        var stage = CreateStage();
+        InvokePrivateMethod(stage, "ApplyLibrarySnapshot",
+            Snapshot(31, Array.Empty<SongListNode>(), new[] { "/library/one", "/library/two" }));
+
+        var roots = InvokePrivateMethod<IReadOnlyList<string>?>(
+            stage, "GetAppliedActiveRoots");
+
+        Assert.Equal(new[] { "/library/one", "/library/two" }, roots);
+    }
+
+    [Fact]
+    public void ClearRemovedSelectionPresentation_ShouldClearSelectionAndPreview()
+    {
+        var stage = CreateStage();
+        var preview = new PreviewImagePanel();
+        var statusPanel = new SongStatusPanel { Visible = true };
+        AttachCoreUi(stage, previewPanel: preview, statusPanel: statusPanel);
+        var song = Score("Selected", 1, "/songs/selected.dtx");
+        SetPrivateField(stage, "_selectedSong", song);
+        SetPrivateField(stage, "_isInStatusPanel", true);
+
+        InvokePrivateMethod(stage, "ClearRemovedSelectionPresentation");
+
+        Assert.Null(GetPrivateField<SongListNode>(stage, "_selectedSong"));
+        Assert.False(GetPrivateField<bool>(stage, "_isInStatusPanel"));
+        Assert.False(statusPanel.Visible);
+    }
+
+    [Fact]
+    public void OnSongLibraryPublishedForActivation_WhenPublicationIsInactive_ShouldIgnoreEvent()
+    {
+        var stage = CreateStage();
+        SetPrivateField(stage, "_libraryPublicationActive", 0);
+        SetPrivateField(stage, "_pendingLibraryPublicationVersion", 0L);
+
+        InvokePrivateMethod(stage, "OnSongLibraryPublishedForActivation",
+            1, new SongLibraryPublishedEventArgs(Snapshot(40, Array.Empty<SongListNode>(), Array.Empty<string>())));
+
+        Assert.Equal(0L, GetPrivateField<long>(stage, "_pendingLibraryPublicationVersion"));
+    }
+
+    [Fact]
+    public void OnSongLibraryPublishedForActivation_WhenActivationVersionDiffers_ShouldIgnoreEvent()
+    {
+        var stage = CreateStage();
+        SetPrivateField(stage, "_libraryPublicationActive", 1);
+        SetPrivateField(stage, "_activationVersion", 5);
+        SetPrivateField(stage, "_pendingLibraryPublicationVersion", 0L);
+
+        // A handler captured for activation version 4 must not update version 5's state.
+        InvokePrivateMethod(stage, "OnSongLibraryPublishedForActivation",
+            4, new SongLibraryPublishedEventArgs(Snapshot(41, Array.Empty<SongListNode>(), Array.Empty<string>())));
+
+        Assert.Equal(0L, GetPrivateField<long>(stage, "_pendingLibraryPublicationVersion"));
+    }
+
+    [Fact]
+    public void OnSongLibraryPublishedForActivation_WhenPublishedVersionIsOlder_ShouldNotOverwritePendingVersion()
+    {
+        var stage = CreateStage();
+        SetPrivateField(stage, "_libraryPublicationActive", 1);
+        SetPrivateField(stage, "_activationVersion", 1);
+        SetPrivateField(stage, "_pendingLibraryPublicationVersion", 50L);
+
+        InvokePrivateMethod(stage, "OnSongLibraryPublishedForActivation",
+            1, new SongLibraryPublishedEventArgs(Snapshot(45, Array.Empty<SongListNode>(), Array.Empty<string>())));
+
+        Assert.Equal(50L, GetPrivateField<long>(stage, "_pendingLibraryPublicationVersion"));
+    }
+
+    [Fact]
+    public void GetPublishedScoreIdentities_WhenTreeContainsScores_ShouldCollectSongAndChartIdentities()
+    {
+        var song = Score("Test", 7, "/library/active/test.dtx");
+        var box = Box("Group", "/library/active/Group", song);
+
+        var identities = InvokeStatic<HashSet<string>>(
+            "GetPublishedScoreIdentities", new object[] { new[] { box } });
+
+        Assert.Contains("song:7", identities);
+        Assert.Contains($"chart:{NormalizePath("/library/active/test.dtx")}", identities);
+    }
+
+    [Fact]
+    public void GetScoreIdentityCandidates_WhenNodeIsNotAScore_ShouldYieldNoIdentities()
+    {
+        var box = Box("Folder", "/library/active/Folder");
+
+        var candidates = InvokeStatic<IEnumerable<string>>(
+            "GetScoreIdentityCandidates", new object[] { box });
+
+        Assert.Empty(candidates);
+    }
+
+    [Fact]
+    public void GetScoreIdentityCandidates_WhenScoreHasNoDatabaseId_ShouldUseChartPathIdentity()
+    {
+        var chart = new SongChart { FilePath = "/library/active/anon.dtx" };
+        var song = new SongEntity { Id = 0, Title = "Anon", Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        var node = new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "Anon",
+            DatabaseSong = song,
+            DatabaseChart = chart,
+        };
+
+        var candidates = InvokeStatic<IEnumerable<string>>(
+            "GetScoreIdentityCandidates", new object[] { node }).ToList();
+
+        // The chart path is yielded from both DatabaseChart and the song's Charts
+        // collection, producing two identical chart: identities.
+        Assert.Equal(2, candidates.Count);
+        Assert.All(candidates, c => Assert.StartsWith("chart:", c));
+    }
+
+    [Fact]
+    public void ApplyLibrarySnapshotCore_WhenSnapshotIsNull_ShouldThrowArgumentNullException()
+    {
+        var stage = CreateStage();
+
+        Assert.Throws<TargetInvocationException>(() =>
+            InvokePrivateMethod(stage, "ApplyLibrarySnapshotCore", new object?[] { null, true }));
+    }
+
+    [Fact]
+    public void ReconcileLibrarySnapshot_WhenSnapshotIsNull_ShouldThrowArgumentNullException()
+    {
+        var stage = CreateStage();
+
+        Assert.Throws<TargetInvocationException>(() =>
+            InvokePrivateMethod(stage, "ReconcileLibrarySnapshot", new object?[] { null }));
+    }
+
+    [Fact]
+    public void ResolveLibraryEmptyState_WhenRootsContainScores_ShouldReturnHasSongs()
+    {
+        var stage = CreateStage();
+        var song = Score("Test", 1, "/library/active/test.dtx");
+        var snapshot = Snapshot(50, new[] { song }, new[] { "/library/active" });
+
+        var result = InvokePrivateMethod<object>(stage, "ResolveLibraryEmptyState", snapshot);
+
+        Assert.Equal("HasSongs", result!.ToString());
+    }
+
+    #region Helpers
+
+    private static SongListNode Box(string title, string directoryPath, params SongListNode[] children)
+    {
+        var box = new SongListNode
+        {
+            Type = NodeType.Box,
+            Title = title,
+            DirectoryPath = directoryPath,
+            Children = children.ToList(),
+        };
+        foreach (var child in box.Children)
+            child.Parent = box;
+        return box;
+    }
+
+    private static SongListNode Score(string title, int songId, string chartPath)
+    {
+        var chart = new SongChart { FilePath = chartPath };
+        var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        chart.SongId = songId;
+        return new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = title,
+            DatabaseSongId = songId,
+            DatabaseSong = song,
+            DatabaseChart = chart,
+        };
+    }
+
+    private static SongLibrarySnapshot Snapshot(
+        long version,
+        IReadOnlyList<SongListNode> roots,
+        IReadOnlyList<string> activeRoots) =>
+        new(version, roots, activeRoots, enumeratedFileCount: roots.Count, discoveredScoreCount: roots.Count);
+
+    private static string NormalizePath(string path)
+    {
+        return SongPathIdentity.TryNormalize(path, out var normalized) ? normalized : path;
+    }
+
+    private static T InvokeStatic<T>(string name, params object[] args)
+    {
+        var method = typeof(SongSelectionStage).GetMethod(
+            name, BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(null, args)!;
+    }
+
+    #endregion
+}

--- a/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
@@ -27,6 +27,23 @@ namespace DTXMania.Test.Stage
             Title = title
         };
 
+        private static async Task WaitForTabLoadCompletionAsync(
+            SongSelectionStage stage, int timeoutMs = 3000)
+        {
+            var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+            while (true)
+            {
+                var queue = GetPrivateField<System.Collections.ICollection>(
+                    stage, "_pendingTabLoadCompletions");
+                if (queue != null && queue.Count > 0)
+                    return;
+                if (DateTime.UtcNow >= deadline)
+                    throw new TimeoutException(
+                        "The recent-plays load did not enqueue a completion within the timeout.");
+                await Task.Delay(10);
+            }
+        }
+
         [Fact]
         public void RefreshSongListForActiveTab_OnRecentTab_ShowsCachedRecentNodes()
         {
@@ -405,7 +422,7 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "BeginRecentPlaysLoad");
             // Do NOT bump version — continuation should be accepted.
 
-            await Task.Delay(300);
+            await WaitForTabLoadCompletionAsync(stage);
 
             // The worker has only queued its immutable result; stage-owned cache state stays
             // unchanged until the update-thread consumer runs.

--- a/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTabTests.cs
@@ -377,8 +377,9 @@ namespace DTXMania.Test.Stage
             // Wait for the thread-pool continuation to complete. With no DB connected,
             // GetRecentlyPlayedNodesAsync returns an empty list almost instantly.
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The stale continuation must NOT have overwritten _recentPlayNodes.
+            // The stale completion must NOT overwrite _recentPlayNodes when consumed.
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_recentPlayNodes");
             Assert.NotNull(nodes);
             Assert.Single(nodes);
@@ -406,8 +407,16 @@ namespace DTXMania.Test.Stage
 
             await Task.Delay(300);
 
-            // The continuation ran with matching version and overwrote _recentPlayNodes
-            // with the empty result from the no-DB load.
+            // The worker has only queued its immutable result; stage-owned cache state stays
+            // unchanged until the update-thread consumer runs.
+            var beforeConsumption = GetPrivateField<List<SongListNode>>(stage, "_recentPlayNodes");
+            Assert.NotNull(beforeConsumption);
+            Assert.Single(beforeConsumption);
+            Assert.Equal("Stale", beforeConsumption[0].Title);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
+
+            // The matching completion was consumed and overwrote _recentPlayNodes with the
+            // empty result from the no-DB load.
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_recentPlayNodes");
             Assert.NotNull(nodes);
             Assert.Empty(nodes);
@@ -517,6 +526,7 @@ namespace DTXMania.Test.Stage
                 InvokePrivateMethod(stage, "BeginRecentPlaysLoad");
 
                 await Task.Delay(500);
+                InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
                 Assert.True(GetPrivateField<bool>(stage, "_recentPlaysLoadFailed"));
                 Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
@@ -553,6 +563,7 @@ namespace DTXMania.Test.Stage
                 SetPrivateField(stage, "_activationVersion", 1);
 
                 await Task.Delay(500);
+                InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
                 Assert.False(GetPrivateField<bool>(stage, "_recentPlaysLoadFailed"));
             }
@@ -576,8 +587,9 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "BeginRecentPlaysLoad");
 
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The success continuation populates _recentPlayNodes (cache-warming)
+            // The success completion populates _recentPlayNodes (cache-warming)
             // but must NOT set _tabListNeedsRefresh on the All Songs tab.
             Assert.False(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
         }
@@ -595,8 +607,9 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "BeginRecentPlaysLoad");
 
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The success continuation must clear the failure flag so the draw
+            // The success completion must clear the failure flag so the draw
             // path shows the normal empty message instead of the error message.
             Assert.False(GetPrivateField<bool>(stage, "_recentPlaysLoadFailed"));
         }
@@ -606,6 +619,88 @@ namespace DTXMania.Test.Stage
         // identical _activationVersion guard; these prove the bookmark load discards stale
         // completions instead of overwriting fresh state, and that DB faults set
         // _bookmarksLoadFailed only when the activation is still current.
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenCompletionArrives_DefersStageMutationUntilOnUpdate()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            var loadStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var loadResult = new TaskCompletionSource<List<SongListNode>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            SetPrivateField(stage, "_loadBookmarkedNodesAsync",
+                new Func<Task<List<SongListNode>>>(() =>
+                {
+                    loadStarted.TrySetResult(true);
+                    return loadResult.Task;
+                }));
+
+            var staleNodes = new List<SongListNode> { ScoreNode("Stale") };
+            SetPrivateField(stage, "_bookmarkNodes", staleNodes);
+            SetPrivateField(stage, "_activationVersion", 17);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_uiManager", null);
+
+            var load = Assert.IsAssignableFrom<Task>(
+                InvokePrivateMethod(stage, "BeginBookmarksLoad"));
+            await loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            loadResult.SetResult(new List<SongListNode> { ScoreNode("Loaded") });
+            await load.WaitAsync(TimeSpan.FromSeconds(1));
+
+            // Worker completion may enqueue data, but it must not mutate stage-owned state.
+            var beforeUpdate = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(beforeUpdate);
+            Assert.Single(beforeUpdate);
+            Assert.Equal("Stale", beforeUpdate[0].Title);
+
+            InvokePrivateMethod(stage, "OnUpdate", 0.016);
+
+            var afterUpdate = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(afterUpdate);
+            Assert.Single(afterUpdate);
+            Assert.Equal("Loaded", afterUpdate[0].Title);
+        }
+
+        [Fact]
+        public async Task BeginBookmarksLoad_WhenActivationChangesBeforeOnUpdate_DiscardsQueuedCompletion()
+        {
+            var stage = CreateStage();
+            var display = new SongListDisplay();
+            AttachCoreUi(stage, display);
+            var loadStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var loadResult = new TaskCompletionSource<List<SongListNode>>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            SetPrivateField(stage, "_loadBookmarkedNodesAsync",
+                new Func<Task<List<SongListNode>>>(() =>
+                {
+                    loadStarted.TrySetResult(true);
+                    return loadResult.Task;
+                }));
+
+            var freshNodes = new List<SongListNode> { ScoreNode("Fresh") };
+            SetPrivateField(stage, "_bookmarkNodes", freshNodes);
+            SetPrivateField(stage, "_activationVersion", 23);
+            SetPrivateField(stage, "_activeTab", SongSelectionTab.Bookmarks);
+            SetPrivateField(stage, "_uiManager", null);
+
+            var load = Assert.IsAssignableFrom<Task>(
+                InvokePrivateMethod(stage, "BeginBookmarksLoad"));
+            await loadStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+            loadResult.SetResult(new List<SongListNode> { ScoreNode("Stale completion") });
+            await load.WaitAsync(TimeSpan.FromSeconds(1));
+
+            // Simulate a new activation after the worker has produced its immutable record.
+            SetPrivateField(stage, "_activationVersion", 24);
+            InvokePrivateMethod(stage, "OnUpdate", 0.016);
+
+            var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
+            Assert.NotNull(nodes);
+            Assert.Single(nodes);
+            Assert.Equal("Fresh", nodes[0].Title);
+        }
 
         [Fact]
         public async Task BeginBookmarksLoad_WhenActivationVersionBumped_ShouldPreserveExistingNodes()
@@ -626,8 +721,9 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_activationVersion", 1);
 
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The stale continuation must NOT have overwritten _bookmarkNodes.
+            // The stale completion must NOT overwrite _bookmarkNodes when consumed.
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.NotNull(nodes);
             Assert.Single(nodes);
@@ -650,9 +746,10 @@ namespace DTXMania.Test.Stage
             // Do NOT bump version — continuation should be accepted.
 
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The continuation ran with matching version and overwrote _bookmarkNodes
-            // with the empty result from the no-DB load.
+            // The matching completion was consumed and overwrote _bookmarkNodes with the
+            // empty result from the no-DB load.
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.NotNull(nodes);
             Assert.Empty(nodes);
@@ -678,6 +775,7 @@ namespace DTXMania.Test.Stage
                 InvokePrivateMethod(stage, "BeginBookmarksLoad");
 
                 await Task.Delay(500);
+                InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
                 Assert.True(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
                 Assert.True(GetPrivateField<bool>(stage, "_tabListNeedsRefresh"));
@@ -714,6 +812,7 @@ namespace DTXMania.Test.Stage
                 SetPrivateField(stage, "_activationVersion", 1);
 
                 await Task.Delay(500);
+                InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
                 Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
             }
@@ -738,8 +837,9 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "BeginBookmarksLoad");
 
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The success continuation must clear the failure flag so the draw
+            // The success completion must clear the failure flag so the draw
             // path shows the normal empty message instead of the error message.
             Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
         }
@@ -786,8 +886,9 @@ namespace DTXMania.Test.Stage
 
             releaseOlderLoad.SetResult(new List<SongListNode>());
             await olderLoad.WaitAsync(TimeSpan.FromSeconds(1));
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The stale continuation must NOT have overwritten _bookmarkNodes with
+            // The stale completion must NOT overwrite _bookmarkNodes with
             // the empty no-DB result.
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.NotNull(nodes);
@@ -821,6 +922,7 @@ namespace DTXMania.Test.Stage
                 SetPrivateField(stage, "_bookmarksLoadVersion", 2);
 
                 await Task.Delay(500);
+                InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
                 Assert.False(GetPrivateField<bool>(stage, "_bookmarksLoadFailed"));
             }
@@ -849,8 +951,9 @@ namespace DTXMania.Test.Stage
             InvokePrivateMethod(stage, "BeginBookmarksLoad");
 
             await Task.Delay(300);
+            InvokePrivateMethod(stage, "ConsumePendingTabLoadWork");
 
-            // The continuation ran un-superseded and overwrote _bookmarkNodes
+            // The completion was consumed un-superseded and overwrote _bookmarkNodes
             // with the empty result from the no-DB load.
             var nodes = GetPrivateField<List<SongListNode>>(stage, "_bookmarkNodes");
             Assert.NotNull(nodes);

--- a/DTXMania.Test/Stage/SongSelectionStageTestFactory.cs
+++ b/DTXMania.Test/Stage/SongSelectionStageTestFactory.cs
@@ -1,7 +1,11 @@
+using System.Collections.Generic;
 using DTXMania.Game;
+using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.UI.Components;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
 using static DTXMania.Test.TestData.ReflectionHelpers;
 
 namespace DTXMania.Test.Stage
@@ -24,6 +28,36 @@ namespace DTXMania.Test.Stage
             SetPrivateField(stage, "_statusPanel", statusPanel ?? new SongStatusPanel());
             SetPrivateField(stage, "_previewImagePanel", previewPanel ?? new PreviewImagePanel());
             SetPrivateField(stage, "_breadcrumbLabel", breadcrumb ?? new UILabel());
+        }
+
+        public static SongListNode Box(string title, string directoryPath, params SongListNode[] children)
+        {
+            var box = new SongListNode
+            {
+                Type = NodeType.Box,
+                Title = title,
+                DirectoryPath = directoryPath,
+                Children = children.ToList(),
+            };
+            foreach (var child in box.Children)
+                child.Parent = box;
+            return box;
+        }
+
+        public static SongListNode Score(string title, int songId, string chartPath)
+        {
+            var chart = new SongChart { FilePath = chartPath };
+            var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
+            chart.Song = song;
+            chart.SongId = songId;
+            return new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = title,
+                DatabaseSongId = songId,
+                DatabaseSong = song,
+                DatabaseChart = chart,
+            };
         }
     }
 }

--- a/DTXMania.Test/Stage/StartupStageLogicTests.cs
+++ b/DTXMania.Test/Stage/StartupStageLogicTests.cs
@@ -213,7 +213,7 @@ namespace DTXMania.Test.Stage
             // async phases waited forever on a task that was never started —
             // startup wedged at 0% CPU. The operation must run however late the
             // first update of the phase arrives.
-            var config = new ConfigData { DTXPath = "LateKickoffSongs" };
+            var config = CreateConfigWithSongRoots("LateKickoffSongs");
             var stage = CreateStage(
                 phase: StartupPhase.ConfigValidation,
                 elapsedTime: 5.0,   // far past the old 0.1s window
@@ -260,7 +260,7 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void PerformPhaseOperationSync_WhenElapsedPastThreshold_ShouldStillRun()
         {
-            var stage = CreateStage(configData: new ConfigData { DTXPath = "after" });
+            var stage = CreateStage(configData: CreateConfigWithSongRoots("after"));
             ReflectionHelpers.SetPrivateField(stage, "_songPaths", new[] { "before" });
 
             ReflectionHelpers.InvokePrivateMethod(stage, "PerformPhaseOperationSync", StartupPhase.ConfigValidation, 0.2);
@@ -272,16 +272,17 @@ namespace DTXMania.Test.Stage
         [Fact]
         public void PerformPhaseOperationSync_ConfigValidation_WithValidConfig_ShouldCaptureSongPath()
         {
-            var stage = CreateStage(configData: new ConfigData
-            {
-                DTXPath = "/songs",
-                ScreenWidth = 1280,
-                ScreenHeight = 720
-            });
+            var config = CreateConfigWithSongRoots("/songs", "/more-songs");
+            config.ScreenWidth = 1280;
+            config.ScreenHeight = 720;
+            var stage = CreateStage(configData: config);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "PerformPhaseOperationSync", StartupPhase.ConfigValidation, 0.0);
+            config.SongRoots[0] = "/mutated-after-snapshot";
 
-            Assert.Equal(new[] { "/songs" }, ReflectionHelpers.GetPrivateField<string[]>(stage, "_songPaths"));
+            Assert.Equal(
+                new[] { "/songs", "/more-songs" },
+                ReflectionHelpers.GetPrivateField<string[]>(stage, "_songPaths"));
         }
 
         [Fact]
@@ -964,6 +965,40 @@ namespace DTXMania.Test.Stage
         }
 
         [Fact]
+        public async Task RunSongLoadAsync_WhenEnumerationHasNoActiveRoots_ShouldPublishEmptyLibrary()
+        {
+            var stage = CreateControlledStage(songPaths: ["MissingRoot"]);
+            stage.NextNeedsEnumerationResult = true;
+            stage.NextEnumerationResult = CreateEnumerationResult(
+                outcome: SongEnumerationOutcome.NoActiveRoots,
+                activeRoots: Array.Empty<string>());
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(
+                stage,
+                "RunSongLoadAsync")!;
+            await task;
+
+            Assert.Equal(1, stage.PublishEmptyLibraryCalls);
+            Assert.Equal(1, stage.EnumerateSongsCalls);
+            Assert.Equal(0, stage.BuildHierarchyCalls);
+        }
+
+        [Fact]
+        public async Task RunSongLoadAsync_WhenNoConfiguredRoots_ShouldPublishEmptyLibraryWithoutEnumeration()
+        {
+            var stage = CreateControlledStage(songPaths: Array.Empty<string>());
+
+            var task = (Task)ReflectionHelpers.InvokePrivateMethod(
+                stage,
+                "RunSongLoadAsync")!;
+            await task;
+
+            Assert.Equal(1, stage.PublishEmptyLibraryCalls);
+            Assert.Equal(0, stage.NeedsEnumerationCalls);
+            Assert.Equal(0, stage.EnumerateSongsCalls);
+        }
+
+        [Fact]
         public async Task RunSongLoadAsync_WhenCacheValid_ShouldBuildDatabaseHierarchyOnce()
         {
             var stage = CreateControlledStage();
@@ -1588,6 +1623,17 @@ namespace DTXMania.Test.Stage
             font.Verify(f => f.DrawString(stage.SpriteBatchStub, "DTXManiaCX v1.0.0 - MonoGame Edition", new Vector2(1070, 2), Color.White), Times.Once);
         }
 
+        private static ConfigData CreateConfigWithSongRoots(params string[] roots)
+        {
+            var config = new ConfigData
+            {
+                DTXPath = roots.FirstOrDefault() ?? string.Empty,
+            };
+            config.SongRoots.Clear();
+            config.SongRoots.AddRange(roots);
+            return config;
+        }
+
         private static StartupStage CreateStage(
             StartupPhase phase = StartupPhase.SystemSounds,
             double elapsedTime = 0.0,
@@ -1834,7 +1880,9 @@ namespace DTXMania.Test.Stage
             TimeSpan? persistenceDuration = null,
             TimeSpan? cleanupDuration = null,
             TimeSpan? hierarchyDuration = null,
-            List<SongListNode>? rootNodes = null)
+            List<SongListNode>? rootNodes = null,
+            SongEnumerationOutcome outcome = SongEnumerationOutcome.ImportedAndPublished,
+            IReadOnlyList<string>? activeRoots = null)
         {
             var paths = Enumerable.Range(1, discoveredCharts)
                 .Select(index => $"/songs/chart-{index}.dtx")
@@ -1869,7 +1917,7 @@ namespace DTXMania.Test.Stage
                 .ToList();
             var batch = new SongEnumerationBatch
             {
-                ActiveRoots = new[] { "/songs" },
+                ActiveRoots = activeRoots ?? new[] { "/songs" },
                 DiscoveredChartPaths = new HashSet<string>(
                     paths,
                     SongPathIdentity.CanonicalComparer),
@@ -1894,6 +1942,7 @@ namespace DTXMania.Test.Stage
                 persistenceDuration ?? TimeSpan.Zero,
                 cleanupDuration ?? TimeSpan.Zero);
             return new SongEnumerationResult(
+                outcome,
                 batch,
                 import,
                 hierarchyDuration ?? TimeSpan.Zero);
@@ -1966,6 +2015,8 @@ namespace DTXMania.Test.Stage
             public int BuildHierarchyCalls { get; private set; }
 
             public int SaveSongsDatabaseCalls { get; private set; }
+
+            public int PublishEmptyLibraryCalls { get; private set; }
 
             public SongListNode? PublishedHierarchy { get; set; }
 
@@ -2114,6 +2165,11 @@ namespace DTXMania.Test.Stage
             protected override void MarkSongManagerInitialized()
             {
                 MarkSongManagerInitializedCalled = true;
+            }
+
+            protected override void PublishEmptyLibraryCore()
+            {
+                PublishEmptyLibraryCalls++;
             }
 
             public Task<bool> InvokeInitializeDatabaseServiceCoreWithObserverAsync(

--- a/DTXMania.Test/UI/PreviewImagePanelAdditionalTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelAdditionalTests.cs
@@ -52,44 +52,18 @@ public class PreviewImagePanelAdditionalTests
     }
 
     [Fact]
-    public void ResolveSongDirectoryPath_WhenPathResolutionThrowsAndActiveRootFallbackExists_ShouldReturnActiveRootPath()
+    public void ResolveSongDirectoryPath_WhenPathCannotBeNormalized_ShouldReturnOriginalValue()
     {
         var panel = new PreviewImagePanel();
-        var root = Path.Combine(Path.GetTempPath(), "dtx-preview-catch-root", Guid.NewGuid().ToString("N"));
-        var relative = Path.Combine("genre", "song");
-        var expected = Path.Combine(root, relative);
-        Directory.CreateDirectory(expected);
+        panel.ActiveSongRootPaths = new[] { "/some/active/root" };
 
-        try
-        {
-            panel.ActiveSongRootPaths = new[] { root };
+        // A NUL character in the relative path makes Path.GetFullPath throw,
+        // and the catch block's active-root fallback also cannot resolve it,
+        // so the original value is returned unchanged.
+        var invalidRelative = "genre/song\0";
+        var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", invalidRelative);
 
-            // Force the primary try block to throw by temporarily changing the current
-            // directory to a non-existent path. The catch block's active-root fallback
-            // should still resolve the directory.
-            var originalDir = Environment.CurrentDirectory;
-            try
-            {
-                // Use a NUL character in the relative path to make Path.GetFullPath throw,
-                // triggering the catch block. But we need a valid directory under the root,
-                // so instead we use a path that GetFullPath rejects.
-                var invalidRelative = relative + "\0";
-                var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", invalidRelative);
-
-                // The catch block's fallback also can't resolve a NUL path, so it returns
-                // the original value.
-                Assert.Equal(invalidRelative, resolved);
-            }
-            finally
-            {
-                Environment.CurrentDirectory = originalDir;
-            }
-        }
-        finally
-        {
-            if (Directory.Exists(root))
-                Directory.Delete(root, recursive: true);
-        }
+        Assert.Equal(invalidRelative, resolved);
     }
 
     [Fact]

--- a/DTXMania.Test/UI/PreviewImagePanelAdditionalTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelAdditionalTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Moq;
+using Xunit;
+
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.UI;
+
+[Trait("Category", "UI")]
+public class PreviewImagePanelAdditionalTests
+{
+    [Fact]
+    public void ActiveSongRootPaths_WhenSetToNull_ShouldDefaultToEmptyArray()
+    {
+        var panel = new PreviewImagePanel();
+
+        panel.ActiveSongRootPaths = null;
+
+        Assert.Empty(panel.ActiveSongRootPaths);
+    }
+
+    [Fact]
+    public void ResolveSongDirectoryPath_WhenPathIsAbsolute_ShouldReturnItWithoutRemapping()
+    {
+        var panel = new PreviewImagePanel();
+        var absoluteDir = Path.Combine(Path.GetTempPath(), "dtx-preview-absolute", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(absoluteDir);
+
+        try
+        {
+            // An absolute path must be returned as-is, ignoring ActiveSongRootPaths.
+            panel.ActiveSongRootPaths = new[] { "/some/other/root" };
+
+            var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", absoluteDir);
+
+            Assert.Equal(absoluteDir, resolved);
+        }
+        finally
+        {
+            if (Directory.Exists(absoluteDir))
+                Directory.Delete(absoluteDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSongDirectoryPath_WhenPathResolutionThrowsAndActiveRootFallbackExists_ShouldReturnActiveRootPath()
+    {
+        var panel = new PreviewImagePanel();
+        var root = Path.Combine(Path.GetTempPath(), "dtx-preview-catch-root", Guid.NewGuid().ToString("N"));
+        var relative = Path.Combine("genre", "song");
+        var expected = Path.Combine(root, relative);
+        Directory.CreateDirectory(expected);
+
+        try
+        {
+            panel.ActiveSongRootPaths = new[] { root };
+
+            // Force the primary try block to throw by temporarily changing the current
+            // directory to a non-existent path. The catch block's active-root fallback
+            // should still resolve the directory.
+            var originalDir = Environment.CurrentDirectory;
+            try
+            {
+                // Use a NUL character in the relative path to make Path.GetFullPath throw,
+                // triggering the catch block. But we need a valid directory under the root,
+                // so instead we use a path that GetFullPath rejects.
+                var invalidRelative = relative + "\0";
+                var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", invalidRelative);
+
+                // The catch block's fallback also can't resolve a NUL path, so it returns
+                // the original value.
+                Assert.Equal(invalidRelative, resolved);
+            }
+            finally
+            {
+                Environment.CurrentDirectory = originalDir;
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolveSongDirectoryPath_WhenRelativePathResolvesUnderActiveRoot_ShouldReturnFullPath()
+    {
+        var panel = new PreviewImagePanel();
+        var root = Path.Combine(Path.GetTempPath(), "dtx-preview-active-root", Guid.NewGuid().ToString("N"));
+        var relative = "genre/song";
+        var expected = Path.Combine(root, relative);
+        Directory.CreateDirectory(expected);
+
+        try
+        {
+            panel.ActiveSongRootPaths = new[] { root };
+
+            var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", relative);
+
+            Assert.Equal(Path.GetFullPath(expected), resolved);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ActiveSongRootPaths_WhenSetToNewCollection_ShouldReplacePreviousValue()
+    {
+        var panel = new PreviewImagePanel();
+        panel.ActiveSongRootPaths = new[] { "/old/root" };
+
+        panel.ActiveSongRootPaths = new[] { "/new/root", "/another/root" };
+
+        Assert.Equal(new[] { "/new/root", "/another/root" }, panel.ActiveSongRootPaths);
+    }
+
+    private static T InvokePrivate<T>(object target, string methodName, params object[] args)
+    {
+        var method = target.GetType().GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        return (T)method!.Invoke(target, args)!;
+    }
+}

--- a/DTXMania.Test/UI/PreviewImagePanelTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelTests.cs
@@ -538,7 +538,7 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
-    public void ResolveSongDirectoryPath_WhenRelativeAndSongsRootConfigured_ShouldResolveToExistingDirectory()
+    public void ResolveSongDirectoryPath_WhenRelativeAndActiveRootConfigured_ShouldResolveToExistingDirectory()
     {
         var panel = new PreviewImagePanel();
         var root = Path.Combine(Path.GetTempPath(), "dtx-preview-root", Guid.NewGuid().ToString("N"));
@@ -548,7 +548,7 @@ public class PreviewImagePanelTests
 
         try
         {
-            panel.SongsRootPath = root;
+            panel.ActiveSongRootPaths = [root];
 
             var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", relative);
 
@@ -564,12 +564,45 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
+    public void ResolveSongDirectoryPath_WhenRelativePathExistsUnderMultipleRoots_ShouldUsePublishedRootOrder()
+    {
+        var panel = new PreviewImagePanel();
+        var parent = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-preview-root-order",
+            Guid.NewGuid().ToString("N"));
+        var firstRoot = Path.Combine(parent, "first");
+        var secondRoot = Path.Combine(parent, "second");
+        var relative = Path.Combine("genre", "song");
+        var firstExpected = Path.Combine(firstRoot, relative);
+        Directory.CreateDirectory(firstExpected);
+        Directory.CreateDirectory(Path.Combine(secondRoot, relative));
+
+        try
+        {
+            panel.ActiveSongRootPaths = [firstRoot, secondRoot];
+
+            var resolved = InvokePrivate<string>(
+                panel,
+                "ResolveSongDirectoryPath",
+                relative);
+
+            Assert.Equal(Path.GetFullPath(firstExpected), resolved);
+        }
+        finally
+        {
+            if (Directory.Exists(parent))
+                Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    [Fact]
     public void ResolveSongDirectoryPath_WhenAllFallbacksReceiveInvalidPath_ShouldReturnOriginalValue()
     {
         var panel = new PreviewImagePanel();
         var invalidPath = "invalid\0preview";
 
-        panel.SongsRootPath = Path.GetTempPath();
+        panel.ActiveSongRootPaths = [Path.GetTempPath()];
 
         var resolved = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", invalidPath);
 
@@ -812,7 +845,7 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
-    public void ResolveSongDirectoryPath_WhenRelativePathExistsUnderSongsRootPath_ShouldResolveToThatPath()
+    public void ResolveSongDirectoryPath_WhenRelativePathExistsUnderActiveRoot_ShouldResolveToThatPath()
     {
         var panel = new PreviewImagePanel();
         var root = Path.Combine(Path.GetTempPath(), "dtx-resolve-root", Guid.NewGuid().ToString("N"));
@@ -822,7 +855,7 @@ public class PreviewImagePanelTests
 
         try
         {
-            panel.SongsRootPath = root;
+            panel.ActiveSongRootPaths = [root];
 
             var result = InvokePrivate<string>(panel, "ResolveSongDirectoryPath", relative);
 
@@ -978,14 +1011,15 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
-    public void SongsRootPath_ShouldGetAndSetValue()
+    public void ActiveSongRootPaths_ShouldCopyCallerCollection()
     {
         var panel = new PreviewImagePanel();
-        var rootPath = "/test/songs";
+        var rootPaths = new List<string> { "/test/songs", "/test/more-songs" };
 
-        panel.SongsRootPath = rootPath;
+        panel.ActiveSongRootPaths = rootPaths;
+        rootPaths.Clear();
 
-        Assert.Equal(rootPath, panel.SongsRootPath);
+        Assert.Equal(["/test/songs", "/test/more-songs"], panel.ActiveSongRootPaths);
     }
 
     private static T InvokePrivate<T>(object target, string methodName, params object[] args)

--- a/DTXMania.Test/UI/PreviewImagePanelTests.cs
+++ b/DTXMania.Test/UI/PreviewImagePanelTests.cs
@@ -49,6 +49,27 @@ public class PreviewImagePanelTests
     }
 
     [Fact]
+    public void ClearSelectedSong_ShouldReleasePreviewAndResetSelectionDelay()
+    {
+        var panel = new PreviewImagePanel();
+        var song = new SongListNode { Type = NodeType.Score, Title = "Song" };
+        var preview = new Mock<ITexture>();
+        SetField(panel, "_currentSong", song);
+        SetField(panel, "_currentPreviewTexture", preview.Object);
+        SetField(panel, "_displayDelay", 0.5d);
+
+        var clear = typeof(PreviewImagePanel).GetMethod("ClearSelectedSong");
+
+        Assert.NotNull(clear);
+        clear!.Invoke(panel, null);
+
+        Assert.Null(GetField<SongListNode>(panel, "_currentSong"));
+        Assert.Null(GetField<ITexture>(panel, "_currentPreviewTexture"));
+        Assert.Equal(0d, GetField<double>(panel, "_displayDelay"));
+        preview.Verify(texture => texture.RemoveReference(), Times.Once);
+    }
+
+    [Fact]
     public void Update_ShouldIncreaseDelay_AndShouldDisplayPreviewAfterThreshold()
     {
         var panel = new PreviewImagePanel();

--- a/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
@@ -1,0 +1,848 @@
+# HPA-191 Configurable Multiple Song Folders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let players persist, edit, and live-reload an ordered list of song-library roots while preserving atomic HPA-192 publication, retained user data, and a coherent active Song Select stage.
+
+**Architecture:** Configuration owns the ordered `SongRoots` list and keeps `DTXPath` only as a compatibility mirror. `SongManager` owns comparer-aware root identity and publishes copied, versioned library snapshots rather than live collection wrappers. Config uses one operation coordinator for NX score import and song-root reload; Song Select consumes publication notifications only on the update thread.
+
+**Tech Stack:** .NET 8, C# 12, MonoGame 3.8, Entity Framework Core SQLite, xUnit, WinForms on Windows, `osascript` Standard Additions on macOS.
+
+## Global Constraints
+
+- DTXCreator is out of scope.
+- Do not change chart parsing, `set.def`, `box.def`, database schema, or synthetic root navigation.
+- `SongRoots` is the configured-root source of truth; `DTXPath` is serialization/migration compatibility only.
+- Keep Config.ini parsing section-agnostic and split each assignment on the first `=` only.
+- Create only `AppPaths.GetDefaultSongsPath()` automatically; never create a missing custom root.
+- Root comparison is ordinal-ignore-case on Windows/macOS and ordinal on Linux/other platforms, through a testable comparer seam.
+- `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
+- Parent/child overlap uses segment-wise comparison through the root comparer; do not use `Path.GetRelativePath` for this policy.
+- Physical-target deduplication for symlinks, junctions, aliases, bind mounts, or inodes remains out of scope.
+- Never expose `_rootSongs` or `_currentSearchPaths` through a live collection wrapper.
+- Publish hierarchy, active roots, counts, and publication version as one coherent snapshot.
+- Startup may explicitly publish an empty library without database cleanup; a normal live reload with zero active roots must not import or publish.
+- Any changed ordered root list, including reorder-only changes, performs one full HPA-192 scan; an unchanged list performs none.
+- HPA-192 enumeration-batch root failures are authoritative for roots actually rejected at scan time.
+- Database commit through hierarchy publication is a non-cancellable terminal section.
+- Config NX score import and song-root reload share one exclusive, throw-safe operation lifecycle.
+- Worker threads may report progress into a queue; only the game update thread mutates Config or Song Select UI state.
+- Runtime `Config.DTXPath` reads are forbidden outside an explicit serialization/migration compatibility allowlist.
+- Platform picker implementation files must not compile into the opposite platform project.
+- The slices land in order: **1a → 1b → 2 → 3a → 3b**.
+- Each slice must remain reviewable within three engineer days. Split a slice rather than broadening it.
+
+---
+
+## File Structure
+
+### New shared production files
+
+- `DTXMania.Game/Lib/Config/SongRootConfigModels.cs` — persistence statuses, diagnostics, and immutable change-event snapshots.
+- `DTXMania.Game/Lib/Song/SongRootPolicy.cs` — normalization, testable comparer construction, deduplication, overlap validation, and availability probing.
+- `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs` — immutable publication snapshot and event arguments.
+- `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs` — common Config overlay lifecycle.
+- `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs` — picker interface/result contract.
+- `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs` — isolated draft-list UI.
+- `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs` — one exclusive Config song-operation lease.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs` — orchestration statuses and progress snapshots.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs` — HPA-192 adapter and result mapping.
+
+### New platform files
+
+- `DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs`
+- `DTXMania.Game/Platform/Mac/MacFolderPickerService.cs`
+- `DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs`
+- `DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs`
+
+The Windows and macOS projects must exclude the opposite platform directory/factory file through explicit `<Compile Remove=...>` entries.
+
+### Primary modified production files
+
+- `DTXMania.Game/Lib/Config/ConfigData.cs`
+- `DTXMania.Game/Lib/Config/IConfigManager.cs`
+- `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- `DTXMania.Game/Lib/Song/SongImportModels.cs`
+- `DTXMania.Game/Lib/Song/SongManager.cs`
+- `DTXMania.Game/Lib/Stage/StartupStage.cs`
+- `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- `DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs`
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
+- `DTXMania.Game/DTXMania.Game.Windows.csproj`
+- `DTXMania.Game/DTXMania.Game.Mac.csproj`
+
+### New focused tests
+
+- `DTXMania.Test/Config/SongRootConfigTests.cs`
+- `DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs`
+- `DTXMania.Test/Song/SongRootPolicyTests.cs`
+- `DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs`
+- `DTXMania.Test/Config/SongFolderPanelTests.cs`
+- `DTXMania.Test/Config/FolderPickerContractTests.cs`
+- `DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs`
+- `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
+- `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
+
+Existing tests remain the regression home where the behavior already belongs, especially `ConfigManagerTests`, `StartupStageLogicTests`, `SongManagerBulkEnumerationTests`, `ConfigStageNxImportTests`, `PreviewImagePanelTests`, and `SongSelectionStageLogicTests`.
+
+---
+
+## Slice 1a — Configuration Model and Persistence
+
+### Task 1A: Persist Ordered Song Roots Without Runtime Consumer Changes
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Config/SongRootConfigModels.cs`
+- Create: `DTXMania.Test/Config/SongRootConfigTests.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigData.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- Modify: `DTXMania.Test/Config/ConfigDataTests.cs`
+- Modify: `DTXMania.Test/Config/ConfigManagerTests.cs`
+
+**Interfaces:**
+
+```csharp
+public enum SongRootUpdateStatus
+{
+    Updated,
+    Unchanged,
+    ValidationFailed,
+    PersistenceFailed
+}
+
+public sealed record SongRootDiagnostic(
+    string Path,
+    string Message,
+    bool IsWarning);
+
+public sealed record SongRootUpdateResult(
+    SongRootUpdateStatus Status,
+    IReadOnlyList<string> CanonicalRoots,
+    IReadOnlyList<SongRootDiagnostic> Diagnostics);
+
+public sealed class SongRootsChangedEventArgs : EventArgs
+{
+    public IReadOnlyList<string> OldRoots { get; }
+    public IReadOnlyList<string> NewRoots { get; }
+}
+```
+
+This slice defines the models and file format but does not add Config UI or live reload. The final comparer-aware `SetSongRoots` implementation is completed in Slice 1b after `SongRootPolicy` exists.
+
+- [ ] **Step 1: Add red tests for default, repeated load, and indexed parsing**
+
+Add tests named:
+
+```text
+DefaultConfig_ShouldContainManagedSongRootAndMirror
+LoadConfig_ShouldClearSongRootsBeforeSecondParse
+LoadConfig_ShouldReadIndexedRootsInNumericOrder
+LoadConfig_ShouldUseLastDuplicateIndexAndWarn
+LoadConfig_ShouldPreferIndexedRootsOverLegacyDTXPath
+LoadConfig_ShouldMigrateLegacyDTXPathAndPersistIndexedRoot
+SaveConfig_ShouldWriteDenseIndexesAndFirstRootMirror
+```
+
+Use temporary Config.ini files. Include an INI with unrelated section headers and prove `SongRoot.*` remains global because the current parser does not track sections.
+
+- [ ] **Step 2: Run the focused red tests**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongRootConfigTests|FullyQualifiedName~ConfigManagerTests|FullyQualifiedName~ConfigDataTests"
+```
+
+Expected: failures because `SongRoots` and indexed serialization do not exist.
+
+- [ ] **Step 3: Add the ConfigData and load/save model**
+
+Add to `ConfigData`:
+
+```csharp
+public List<string> SongRoots { get; } = new();
+```
+
+At the start of every `LoadConfig`, call `Config.SongRoots.Clear()` beside the existing MIDI-threshold clearing. Parse `SongRoot.<non-negative integer>` into a temporary index/value map, then finalize the list after all lines are read. Keep `[Section]` lines ignored exactly as today.
+
+Finalize with this precedence:
+
+1. Accepted indexed roots in ascending index order.
+2. Legacy `DTXPath` migrated into one root.
+3. Managed default root.
+
+Save dense `SongRoot.0..N` entries and write `DTXPath` as the first root.
+
+- [ ] **Step 4: Remove unconditional custom-root creation**
+
+Replace the current `EnsureDirectorySafe(Config.DTXPath)` behavior with managed-default-only creation. Add tests proving:
+
+- missing custom roots remain strings in Config;
+- no custom directory is created during load, migration, or save;
+- the managed default is created when selected as fallback;
+- directories created by older versions are not deleted.
+
+- [ ] **Step 5: Correct pending-save path clearing**
+
+When an explicit full config save succeeds, clear `_pendingSavePath` only when its normalized path equals the file just written. A save to another path must leave the pending marker intact.
+
+Add tests:
+
+```text
+SaveConfig_ShouldClearMatchingPendingPath
+SaveConfig_ShouldRetainDifferentPendingPath
+FlushPendingSave_ShouldRetryAfterFailure
+```
+
+- [ ] **Step 6: Add immutable persistence/event model tests**
+
+Construct `SongRootsChangedEventArgs` from mutable source lists, mutate the sources, and prove the event snapshots remain unchanged. Do not raise the event from load/reset.
+
+- [ ] **Step 7: Run Slice 1a gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongRootConfigTests|FullyQualifiedName~ConfigManagerTests|FullyQualifiedName~ConfigDataTests"
+
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+```
+
+Expected: all focused tests pass and the macOS game project builds.
+
+- [ ] **Step 8: Commit Slice 1a**
+
+```bash
+git add DTXMania.Game/Lib/Config \
+  DTXMania.Test/Config/ConfigDataTests.cs \
+  DTXMania.Test/Config/ConfigManagerTests.cs \
+  DTXMania.Test/Config/SongRootConfigTests.cs
+git commit -m "feat: persist ordered song roots"
+```
+
+**Review gate:** verify the serialized format, repeated-load clearing, section-agnostic behavior, custom-directory behavior removal, and pending-save path handling before starting Slice 1b.
+
+---
+
+## Slice 1b — Root Policy, SongManager Snapshots, and Startup Consumers
+
+### Task 1B: Centralize Root Identity and Publish Safe Library Snapshots
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Song/SongRootPolicy.cs`
+- Create: `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs`
+- Create: `DTXMania.Test/Song/SongRootPolicyTests.cs`
+- Create: `DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs`
+- Create: `DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs`
+- Modify: `DTXMania.Game/Lib/Config/IConfigManager.cs`
+- Modify: `DTXMania.Game/Lib/Config/ConfigManager.cs`
+- Modify: `DTXMania.Game/Lib/Song/SongImportModels.cs`
+- Modify: `DTXMania.Game/Lib/Song/SongManager.cs`
+- Modify: `DTXMania.Game/Lib/Stage/StartupStage.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
+- Modify: relevant existing SongManager, startup, and preview tests.
+
+**Interfaces:**
+
+```csharp
+internal sealed class SongRootPolicy
+{
+    internal SongRootPolicy(StringComparer comparer);
+    internal static SongRootPolicy ForCurrentPlatform();
+    internal static StringComparer CreateComparer(bool ignoreCase);
+
+    internal SongRootValidationResult Validate(IReadOnlyList<string> roots);
+    internal bool IsAncestor(string parent, string child);
+    internal SongRootAvailability Probe(string normalizedRoot);
+}
+
+public sealed record SongLibrarySnapshot(
+    long Version,
+    IReadOnlyList<SongListNode> RootSongs,
+    IReadOnlyList<string> ActiveRoots,
+    int EnumeratedFileCount,
+    int DiscoveredScoreCount);
+
+public sealed class SongLibraryPublishedEventArgs : EventArgs
+{
+    public SongLibrarySnapshot Snapshot { get; }
+}
+```
+
+`SongManager.GetLibrarySnapshot()` returns copied root and root-path arrays captured under `_lockObject`. `RootSongs` may remain as a compatibility property only if it returns the copied snapshot list, never `_rootSongs.AsReadOnly()`.
+
+- [ ] **Step 1: Write the comparer and overlap red tests**
+
+Add theory coverage that executes both policies on every host:
+
+```csharp
+[Theory]
+[InlineData(true, true)]
+[InlineData(false, false)]
+public void DuplicatePolicy_ShouldFollowInjectedCaseMode(
+    bool ignoreCase,
+    bool expectedDuplicate)
+```
+
+Add explicit parent/child matrices including:
+
+```text
+/Users/me/Songs + /Users/me/SONGS/Extra
+C:\Songs + c:\songs\Pack
+/songs + /Songs/Pack under ordinal mode
+```
+
+Assert overlap compares path segments through the injected comparer and does not call `Path.GetRelativePath`.
+
+- [ ] **Step 2: Implement `SongRootPolicy`**
+
+The policy must:
+
+1. Normalize absolute paths with `SongPathIdentity.Normalize`.
+2. Preserve first occurrence and configured order.
+3. Detect duplicate roots through the injected comparer.
+4. Split normalized roots into root/segment components and compare each segment through the same comparer.
+5. Reject same-path and parent/child overlap symmetrically.
+6. Probe existence/access without creating directories.
+
+Use `CreateComparer(true)` for ignore-case tests and `CreateComparer(false)` for ordinal tests. `ForCurrentPlatform()` selects the production mode.
+
+- [ ] **Step 3: Complete the typed Config setter**
+
+Add to `IConfigManager`:
+
+```csharp
+SongRootUpdateResult SetSongRoots(
+    string configFilePath,
+    IReadOnlyList<string> roots);
+
+event EventHandler<SongRootsChangedEventArgs>? SongRootsChanged;
+```
+
+`ConfigManager.SetSongRoots` validates through `SongRootPolicy`, writes the complete config immediately, rolls back memory on persistence failure, raises one event after success, and returns `Unchanged` without writing or raising when the canonical ordered list is equal.
+
+- [ ] **Step 4: Replace live library views with coherent snapshots**
+
+Under `_lockObject`, capture:
+
+```csharp
+new SongLibrarySnapshot(
+    ++_publicationVersion,
+    _rootSongs.ToArray(),
+    _currentSearchPaths.ToArray(),
+    EnumeratedFileCount,
+    DiscoveredScoreCount)
+```
+
+Required changes:
+
+- `GetLibrarySnapshot()` returns a copied snapshot.
+- `PublishEnumeration` replaces hierarchy/roots/counts, increments one version, then raises `SongLibraryPublished` outside the lock.
+- `PublishEmptyLibrary` clears hierarchy, active roots, and counts in one version and raises the same event.
+- `SetCurrentSearchPaths(Array.Empty<string>())` clears `_currentSearchPaths`; remove the current empty-input early return.
+- defensive deduplication in `SetCurrentSearchPaths` and `CreateBatchBuilder` uses `SongRootPolicy`.
+
+Do not mutate a previously published root list after it has been handed to a consumer.
+
+- [ ] **Step 5: Add zero-active-root import behavior**
+
+Extend `SongEnumerationResult` with an explicit outcome such as:
+
+```csharp
+public enum SongEnumerationOutcome
+{
+    ImportedAndPublished,
+    NoActiveRoots
+}
+```
+
+When `BuildEnumerationBatchAsync` returns a complete batch with no active roots:
+
+- do not call `ImportSongsCoreAsync`;
+- do not call `PublishEnumeration`;
+- return `NoActiveRoots` with batch root-failure errors available to callers;
+- always release the enumeration slot.
+
+A clean startup with no available roots calls `PublishEmptyLibrary()` explicitly after deciding not to clean/import.
+
+- [ ] **Step 6: Migrate startup and preview consumers**
+
+`StartupStage` snapshots `Config.SongRoots`, uses the shared policy, and chooses cache/enumeration paths from the accepted roots. `SongSelectionStage` initializes from one `SongLibrarySnapshot`.
+
+Replace `PreviewImagePanel.SongsRootPath` with:
+
+```csharp
+public IReadOnlyList<string> ActiveSongRootPaths { get; set; }
+```
+
+Absolute chart paths remain authoritative. Relative fallback tries active roots in order.
+
+- [ ] **Step 7: Add architecture and concurrency regression tests**
+
+Tests must prove:
+
+- `RootSongs`/`GetLibrarySnapshot` remain stable while another thread publishes;
+- filter projection and `BookmarkStateReconciler.Apply` cannot observe collection modification;
+- root list and active roots share one publication version;
+- empty publication clears both;
+- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync` receive deduplicated roots;
+- no production `Config.DTXPath` read remains outside Config serialization/migration allowlist.
+
+The architecture test should scan `DTXMania.Game/**/*.cs` and list the allowed files explicitly so a future runtime read fails the test.
+
+- [ ] **Step 8: Run Slice 1b gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongRootPolicyTests|FullyQualifiedName~SongManagerLibrarySnapshotTests|FullyQualifiedName~SongManagerBulkEnumerationTests|FullyQualifiedName~StartupStageLogicTests|FullyQualifiedName~PreviewImagePanelTests|FullyQualifiedName~DTXPathCompatibilityArchitectureTests"
+
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+```
+
+- [ ] **Step 9: Commit Slice 1b**
+
+```bash
+git add DTXMania.Game/Lib/Song \
+  DTXMania.Game/Lib/Config \
+  DTXMania.Game/Lib/Stage/StartupStage.cs \
+  DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+  DTXMania.Test
+git commit -m "feat: publish versioned song library snapshots"
+```
+
+**Review gate:** no live `RootSongs` wrapper, no empty-root stale snapshot, no platform-dependent untested comparer branch, and no runtime `DTXPath` consumer.
+
+---
+
+## Slice 2 — Cross-Platform SongFolderPanel
+
+### Task 2: Add Draft Editing and Platform Folder Selection
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs`
+- Create: platform picker/factory files listed in File Structure.
+- Create: `DTXMania.Test/Config/SongFolderPanelTests.cs`
+- Create: `DTXMania.Test/Config/FolderPickerContractTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs`
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- Modify: both platform `.csproj` files.
+- Modify: `DTXMania.Test/Config/ConfigStageLogicTests.cs`
+
+**Interfaces:**
+
+```csharp
+public interface IConfigOverlayPanel
+{
+    bool IsActive { get; }
+    event EventHandler? Saved;
+    event EventHandler? Closed;
+    void Activate();
+    void Deactivate();
+    void Update(double deltaTime, KeyboardState current, KeyboardState previous);
+    void Draw(SpriteBatch spriteBatch, IFont? font, IFont? boldFont,
+        Texture2D? whitePixel, int virtualWidth, int virtualHeight);
+}
+
+public interface IFolderPickerService
+{
+    Task<FolderPickerResult> PickFolderAsync(
+        string? initialDirectory,
+        CancellationToken cancellationToken);
+}
+```
+
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`. `ConfigStage._activePanel` uses the generalized interface.
+
+- [ ] **Step 1: Add panel-lifecycle and draft red tests**
+
+Cover:
+
+```text
+Activate_ShouldCopyConfiguredRoots
+CancelAndBack_ShouldDiscardDraft
+Add_ShouldAppendSelectedFolder
+PickerCancellation_ShouldNotMutateDraft
+Remove_ShouldProtectLastRoot
+MoveUpAndMoveDown_ShouldPreserveSelection
+StructuralError_ShouldKeepPanelOpen
+AvailabilityWarning_ShouldAllowApply
+Saved_ShouldFireBeforeClosed
+```
+
+Use an injected fake picker and fake apply delegate. The panel never receives `IConfigManager`.
+
+- [ ] **Step 2: Add `IConfigOverlayPanel` and adapt key panels**
+
+Move only the common lifecycle members into the new interface. Preserve the existing key-panel requirement that `Saved` fires before `Closed`.
+
+Run existing key assignment tests immediately after this refactor.
+
+- [ ] **Step 3: Implement `SongFolderPanel`**
+
+The panel owns:
+
+- a copied draft root list;
+- selected row/action indexes;
+- async picker state and activation generation;
+- structural diagnostics and availability warnings;
+- a Config-owned apply delegate.
+
+Use the root policy for validation. Picker completion may modify draft state only if the captured panel generation is current.
+
+- [ ] **Step 4: Add platform picker implementations**
+
+Windows:
+
+- use `FolderBrowserDialog`;
+- own STA dispatch in the platform service;
+- return Selected/Cancelled/Failed without blocking the game update thread.
+
+macOS:
+
+- invoke `/usr/bin/osascript` with `ProcessStartInfo.ArgumentList`;
+- use `choose folder` and `default location` only when valid;
+- await exit asynchronously;
+- distinguish normal user cancellation from authorization/privacy failure;
+- include stderr only in structured diagnostics.
+
+Do not launch real dialogs in unit tests.
+
+- [ ] **Step 5: Isolate platform compilation**
+
+Add explicit compile exclusions:
+
+```xml
+<!-- Windows project -->
+<Compile Remove="Platform/Mac/**/*.cs" />
+<Compile Remove="Platform/FolderPickerServiceFactory.Mac.cs" />
+
+<!-- Mac project -->
+<Compile Remove="Platform/Windows/**/*.cs" />
+<Compile Remove="Platform/FolderPickerServiceFactory.Windows.cs" />
+```
+
+The exact glob may be adjusted to the final directory layout, but each project must compile only one factory and one native implementation.
+
+- [ ] **Step 6: Wire Config navigation with temporary restart behavior**
+
+Replace read-only **DTX Folder** with a `NavigationConfigItem` named **Song Folders**. Display `1 folder` or `<n> folders`.
+
+For Slice 2, the Config-owned delegate calls `SetSongRoots`. On `Updated`, close the panel and show a restart-required status. On `Unchanged`, close without status. On failure, keep the panel open.
+
+- [ ] **Step 7: Run Slice 2 gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongFolderPanelTests|FullyQualifiedName~FolderPickerContractTests|FullyQualifiedName~ConfigStageLogicTests|FullyQualifiedName~KeyAssign"
+
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
+```
+
+- [ ] **Step 8: Commit Slice 2**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Config \
+  DTXMania.Game/Lib/Stage/KeyAssign \
+  DTXMania.Game/Lib/Stage/ConfigStage.cs \
+  DTXMania.Game/Platform \
+  DTXMania.Game/*.csproj \
+  DTXMania.Test/Config
+git commit -m "feat: add song folder configuration panel"
+```
+
+**Review gate:** panel draft isolation, platform build isolation, async picker lifecycle, and restart persistence through Startup.
+
+---
+
+## Slice 3a — Config Operation Coordinator and Live Reload
+
+### Task 3A: Serialize Config Song Operations and Start One Live Reload
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs`
+- Create: `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs`
+- Create: `DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs`
+- Create: `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
+- Modify: `DTXMania.Test/Stage/ConfigStageNxImportTests.cs`
+- Modify: relevant SongManager bulk-enumeration tests.
+
+**Interfaces:**
+
+```csharp
+internal enum ConfigSongOperationKind
+{
+    NxScoreImport,
+    SongFolderReload
+}
+
+internal sealed class ConfigSongOperationLease : IDisposable
+{
+    public ConfigSongOperationKind Kind { get; }
+}
+
+internal interface ISongLibraryReloadService
+{
+    Task<SongLibraryReloadResult> ReloadAsync(
+        IReadOnlyList<string> configuredRoots,
+        IProgress<SongLibraryReloadProgress>? progress,
+        CancellationToken cancellationToken);
+}
+```
+
+Persistence and orchestration results remain separate. Config maps `SongRootUpdateResult` into a panel-facing orchestration result that may additionally be `Busy` or `Started`.
+
+- [ ] **Step 1: Write coordinator red tests**
+
+Cover:
+
+```text
+TryAcquire_ShouldAllowOneOwner
+TryAcquire_ShouldRejectDifferentOperationWhileBusy
+Dispose_ShouldReleaseExactlyOnce
+ThrowDuringOperationConstruction_ShouldReleaseLease
+TerminalContinuationRegistrationFailure_ShouldReleaseLease
+```
+
+Use an injectable continuation/task factory to force each synchronous handoff failure.
+
+- [ ] **Step 2: Implement a scoped coordinator**
+
+The coordinator owns one atomic state. A lease releases through `Dispose()` exactly once. Do not expose check-then-set booleans.
+
+`ConfigStage` uses one method for song-root Apply:
+
+```text
+validate/compare
+→ acquire lease
+→ persist roots
+→ create CTS
+→ construct reload task
+→ register observation/progress/terminal release
+→ store operation handle
+→ return Started to panel
+```
+
+All synchronous steps remain inside one `try/finally`. `Saved` only reports that the draft was accepted; it does not acquire, transfer, or release the lease.
+
+- [ ] **Step 3: Implement the reload adapter**
+
+`SongLibraryReloadService` calls the existing HPA-192 operation once with the configured roots.
+
+Result mapping:
+
+- occupied lower-level enumeration slot → `Busy`;
+- `SongEnumerationOutcome.NoActiveRoots` → `NoAvailableRoots`, old hierarchy retained;
+- successful import/publication → `Success`;
+- pre-commit cancellation/failure → old hierarchy retained;
+- unexpected post-commit publication failure → partial-success/restart-required.
+
+For completed enumeration, count unavailable roots from `Batch.Errors.Where(error => error.IsRootFailure)`. A shallow preflight may provide early UI warnings, but it cannot override the batch result.
+
+- [ ] **Step 4: Migrate NX import onto the same lifecycle**
+
+Remove `_importRunning` check-then-set ownership. NX import must:
+
+- acquire `ConfigSongOperationKind.NxScoreImport`;
+- use the same activation generation;
+- enqueue progress/status rather than writing `_importStatus` from a worker;
+- cancel on Config deactivation;
+- attach an observation continuation;
+- dispose CTS and release lease exactly once in the terminal continuation.
+
+Both operations must reject each other with a concise status.
+
+- [ ] **Step 5: Add update-thread status marshalling**
+
+Use a thread-safe queue of immutable operation updates. `ConfigStage.OnUpdate` drains only updates whose activation generation is current. Deactivation increments the generation before cancellation.
+
+Never wait synchronously for filesystem or SQLite work during stage teardown.
+
+- [ ] **Step 6: Preserve the commit-to-publication terminal section**
+
+Ensure HPA-192 does not check cancellation after database commit and before `FinalizePendingNodes`/`PublishEnumeration`. Add a regression test where cancellation arrives after commit and publication still completes successfully.
+
+- [ ] **Step 7: Add operation integration tests**
+
+Required tests:
+
+```text
+UnchangedApply_ShouldNotAcquirePersistOrScan
+BusyApply_ShouldNotPersist
+ReorderOnlyApply_ShouldInvokeImporterOnce
+NoActiveRoots_ShouldRetainCurrentSnapshot
+BatchRootFailures_ShouldDriveWarningCount
+NxImportAndReload_ShouldNotOverlap
+Deactivate_ShouldCancelWithoutBlocking
+WorkerProgress_ShouldReachUIOnlyThroughUpdateDrain
+EveryTerminalPath_ShouldDisposeCtsAndReleaseLeaseOnce
+```
+
+- [ ] **Step 8: Run Slice 3a gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~ConfigSongOperationCoordinatorTests|FullyQualifiedName~SongLibraryReloadServiceTests|FullyQualifiedName~ConfigStageNxImportTests|FullyQualifiedName~SongManagerBulkEnumerationTests"
+```
+
+- [ ] **Step 9: Commit Slice 3a**
+
+```bash
+git add DTXMania.Game/Lib/Stage/Config \
+  DTXMania.Game/Lib/Stage/ConfigStage.cs \
+  DTXMania.Game/Lib/Song \
+  DTXMania.Test/Config \
+  DTXMania.Test/Stage/ConfigStageNxImportTests.cs \
+  DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
+git commit -m "feat: live reload configured song roots"
+```
+
+**Review gate:** no split lease ownership, no worker-thread UI writes, no NX/reload overlap, and no normal publication for a zero-active-root batch.
+
+---
+
+## Slice 3b — Active Song Select Reconciliation and Retained Views
+
+### Task 3B: Reconcile Runtime Publication on the Update Thread
+
+**Files:**
+- Create: `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
+- Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
+- Modify: existing Song Selection, bookmark, recent, and preview tests.
+
+**Interfaces:**
+
+`SongSelectionStage` subscribes to `SongManager.SongLibraryPublished` on activation and unsubscribes on deactivation. The event handler stores only the newest pending publication version; it never changes UI collections.
+
+- [ ] **Step 1: Write publication-reconciliation red tests**
+
+Create scenarios for:
+
+```text
+PublicationWhileActive_ShouldApplyOnUpdateThread
+PublicationInsideRetainedBox_ShouldRestoreNavigation
+PublicationInsideRemovedBox_ShouldResetToRoot
+PublicationWithRetainedSelection_ShouldRestoreByStableIdentity
+PublicationRemovingSelection_ShouldStopPreviewAndClearPanels
+PublicationOnBookmarks_ShouldFilterToActiveRoots
+PublicationOnRecent_ShouldFilterToActiveRoots
+MultiplePublications_ShouldApplyNewestVersionOnly
+NotificationAfterDeactivate_ShouldBeIgnored
+```
+
+Use test snapshots with stable chart/database identities and distinct publication versions.
+
+- [ ] **Step 2: Add event subscription and pending-version state**
+
+On activation:
+
+- capture one `SongLibrarySnapshot`;
+- subscribe to publication;
+- remember current activation version.
+
+The event handler atomically records the highest pending version only. On deactivation, unsubscribe before disposing stage resources.
+
+- [ ] **Step 3: Reconcile one coherent snapshot in `OnUpdate`**
+
+When a pending version exceeds the applied version:
+
+1. fetch one current `SongLibrarySnapshot`;
+2. ignore it if superseded or stage generation changed;
+3. replace root-list and active-root state from that snapshot;
+4. restore navigation by stable path/database identity if possible;
+5. restore selected chart by stable chart/database identity if possible;
+6. otherwise reset deterministically to root/first item;
+7. rebuild filter, Bookmarks, Recent, breadcrumb, preview roots, and empty state;
+8. stop preview and clear status/history when selection disappeared;
+9. mark the snapshot version as applied.
+
+Do not mix `RootSongs` from one version with active roots from another.
+
+- [ ] **Step 4: Filter Bookmarks and Recent to active roots**
+
+Database-backed tab loaders must filter chart paths through the active-root snapshot from the same publication version. Off-root rows remain stored and reappear after a successful root re-add.
+
+- [ ] **Step 5: Implement deliberate empty states**
+
+Distinguish:
+
+```text
+No active roots:
+No song folders are currently available. Open Config to reconnect or change them.
+
+Active roots with no supported charts:
+No songs were found in the active song folders.
+```
+
+Keep copy in one testable resolver method so future localization does not duplicate conditions.
+
+- [ ] **Step 6: Add concurrent-publication regression coverage**
+
+Run filter projection and bookmark reconciliation against a copied snapshot while publishing another version. Assert no `InvalidOperationException`, no background-thread mutation, and final UI data all references the newest applied version.
+
+- [ ] **Step 7: Run Slice 3b gate**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --filter "FullyQualifiedName~SongSelectionPublicationTests|FullyQualifiedName~SongSelectionStageLogicTests|FullyQualifiedName~SongSelectionStageBookmark|FullyQualifiedName~PreviewImagePanelTests"
+```
+
+- [ ] **Step 8: Commit Slice 3b**
+
+```bash
+git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+  DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs \
+  DTXMania.Test/Stage \
+  DTXMania.Test/UI
+git commit -m "feat: reconcile live song library publication"
+```
+
+**Review gate:** active Song Select never enumerates a live backing list, applies publication only on the update thread, and keeps hierarchy/tabs/previews on one version.
+
+---
+
+## Final Verification
+
+- [ ] **Run the complete unit suite**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj -c Release
+```
+
+Expected: zero failed tests.
+
+- [ ] **Build both game targets**
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Release
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Release
+```
+
+Expected: both builds succeed; each compiles only its own picker implementation.
+
+- [ ] **Run production consumer audit**
+
+```bash
+rg "Config\??\.DTXPath|ConfigData\.DTXPath|\.DTXPath" DTXMania.Game --glob '*.cs'
+```
+
+Expected: matches only the compatibility property plus Config load/save/migration code allowed by `DTXPathCompatibilityArchitectureTests`.
+
+- [ ] **Manual smoke checks**
+
+1. Migrate an existing one-root Config.ini and verify roots persist after restart.
+2. Add a second local root, reorder, Apply, and verify one reload.
+3. Configure one missing removable root plus one available root; verify available songs load and warning count matches scan errors.
+4. Remove a root; verify songs/bookmarks/recent disappear from active views but return after re-add.
+5. Leave Config during reload and enter Song Select; verify post-publication reconciliation without stale selection or crash.
+6. Start NX score import and attempt Apply; verify Busy and no config write.
+7. Test picker cancellation on Windows and macOS.
+
+- [ ] **Final commit/checkpoint**
+
+Do not squash slice commits until all review gates pass. The final PR should show the five bounded implementation checkpoints clearly enough to bisect regressions.

--- a/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-191-song-folders.md
@@ -2,51 +2,58 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Let players persist, edit, and live-reload an ordered list of song-library roots while preserving atomic HPA-192 publication, retained user data, and a coherent active Song Select stage.
+**Goal:** Let players persist, edit, and live-reload an ordered list of song-library roots while preserving HPA-192 atomic publication, retained user data, and a coherent active Song Select stage.
 
-**Architecture:** Configuration owns the ordered `SongRoots` list and keeps `DTXPath` only as a compatibility mirror. `SongManager` owns comparer-aware root identity and publishes copied, versioned library snapshots rather than live collection wrappers. Config uses one operation coordinator for NX score import and song-root reload; Song Select consumes publication notifications only on the update thread.
+**Architecture:** Configuration owns ordered `SongRoots` and keeps `DTXPath` only as a compatibility mirror. `SongManager` centralizes comparer-aware root identity and publishes copied, versioned `SongLibrarySnapshot` values. Config serializes NX score import and song-root reload through one scoped operation coordinator; Song Select consumes publication only on the update thread.
 
-**Tech Stack:** .NET 8, C# 12, MonoGame 3.8, Entity Framework Core SQLite, xUnit, WinForms on Windows, `osascript` Standard Additions on macOS.
+**Tech Stack:** .NET 8, C# 12, MonoGame 3.8, Entity Framework Core SQLite, xUnit, WinForms on Windows, `/usr/bin/osascript` Standard Additions on macOS.
 
 ## Global Constraints
 
 - DTXCreator is out of scope.
-- Do not change chart parsing, `set.def`, `box.def`, database schema, or synthetic root navigation.
+- Do not change chart parsing, `set.def`, `box.def`, database schema, or root-navigation semantics.
 - `SongRoots` is the configured-root source of truth; `DTXPath` is serialization/migration compatibility only.
-- Keep Config.ini parsing section-agnostic and split each assignment on the first `=` only.
+- Config.ini parsing remains section-agnostic and splits on the first `=` only.
 - Create only `AppPaths.GetDefaultSongsPath()` automatically; never create a missing custom root.
-- Root comparison is ordinal-ignore-case on Windows/macOS and ordinal on Linux/other platforms, through a testable comparer seam.
+- Root comparison is ordinal-ignore-case on Windows/macOS and ordinal on Linux/other platforms, through an injectable test seam.
 - `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
 - Parent/child overlap uses segment-wise comparison through the root comparer; do not use `Path.GetRelativePath` for this policy.
 - Physical-target deduplication for symlinks, junctions, aliases, bind mounts, or inodes remains out of scope.
 - Never expose `_rootSongs` or `_currentSearchPaths` through a live collection wrapper.
-- Publish hierarchy, active roots, counts, and publication version as one coherent snapshot.
-- Startup may explicitly publish an empty library without database cleanup; a normal live reload with zero active roots must not import or publish.
-- Any changed ordered root list, including reorder-only changes, performs one full HPA-192 scan; an unchanged list performs none.
-- HPA-192 enumeration-batch root failures are authoritative for roots actually rejected at scan time.
+- Hierarchy, active roots, counts, and publication version change as one coherent snapshot.
+- Startup may explicitly publish an empty library without cleanup. A normal live reload with zero active roots must not import or publish.
+- Any changed ordered root list, including reorder-only changes, performs one full HPA-192 scan; unchanged lists perform none.
+- HPA-192 enumeration-batch root failures are authoritative for roots rejected at scan time.
 - Database commit through hierarchy publication is a non-cancellable terminal section.
 - Config NX score import and song-root reload share one exclusive, throw-safe operation lifecycle.
-- Worker threads may report progress into a queue; only the game update thread mutates Config or Song Select UI state.
-- Runtime `Config.DTXPath` reads are forbidden outside an explicit serialization/migration compatibility allowlist.
-- Platform picker implementation files must not compile into the opposite platform project.
-- The slices land in order: **1a → 1b → 2 → 3a → 3b**.
-- Each slice must remain reviewable within three engineer days. Split a slice rather than broadening it.
+- Worker threads report immutable progress updates; only the game update thread changes Config or Song Select UI state.
+- Runtime `Config.DTXPath` reads are forbidden outside an explicit compatibility allowlist.
+- Platform picker source must not compile into the opposite platform target.
+- Slices land in order: **1a → 1b → 2 → 3a → 3b**.
+- Each slice must remain reviewable within three engineer days.
+
+## Branch and PR Strategy
+
+1. Merge documentation PR #109 first.
+2. Create a fresh implementation branch from updated `main`; do not add production code to the documentation PR.
+3. Use one implementation PR with five clearly separated slice commits and review gates.
+4. Do not squash during implementation; retain slice boundaries until the complete feature passes final verification.
 
 ---
 
-## File Structure
+## File Map
 
-### New shared production files
+### New shared files
 
-- `DTXMania.Game/Lib/Config/SongRootConfigModels.cs` — persistence statuses, diagnostics, and immutable change-event snapshots.
-- `DTXMania.Game/Lib/Song/SongRootPolicy.cs` — normalization, testable comparer construction, deduplication, overlap validation, and availability probing.
-- `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs` — immutable publication snapshot and event arguments.
-- `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs` — common Config overlay lifecycle.
-- `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs` — picker interface/result contract.
+- `DTXMania.Game/Lib/Config/SongRootConfigModels.cs` — persistence statuses, diagnostics, and immutable event snapshots.
+- `DTXMania.Game/Lib/Song/SongRootPolicy.cs` — normalization, comparer construction, deduplication, overlap validation, and availability probing.
+- `DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs` — copied publication snapshot and event args.
+- `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs` — generalized Config overlay lifecycle.
+- `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs` — picker and panel-apply contracts.
 - `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs` — isolated draft-list UI.
-- `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs` — one exclusive Config song-operation lease.
-- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs` — orchestration statuses and progress snapshots.
-- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs` — HPA-192 adapter and result mapping.
+- `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs` — exclusive scoped lease.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs` — reload progress/result contracts.
+- `DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs` — HPA-192 adapter.
 
 ### New platform files
 
@@ -55,9 +62,7 @@
 - `DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs`
 - `DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs`
 
-The Windows and macOS projects must exclude the opposite platform directory/factory file through explicit `<Compile Remove=...>` entries.
-
-### Primary modified production files
+### Primary modified files
 
 - `DTXMania.Game/Lib/Config/ConfigData.cs`
 - `DTXMania.Game/Lib/Config/IConfigManager.cs`
@@ -72,25 +77,11 @@ The Windows and macOS projects must exclude the opposite platform directory/fact
 - `DTXMania.Game/DTXMania.Game.Windows.csproj`
 - `DTXMania.Game/DTXMania.Game.Mac.csproj`
 
-### New focused tests
-
-- `DTXMania.Test/Config/SongRootConfigTests.cs`
-- `DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs`
-- `DTXMania.Test/Song/SongRootPolicyTests.cs`
-- `DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs`
-- `DTXMania.Test/Config/SongFolderPanelTests.cs`
-- `DTXMania.Test/Config/FolderPickerContractTests.cs`
-- `DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs`
-- `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
-- `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
-
-Existing tests remain the regression home where the behavior already belongs, especially `ConfigManagerTests`, `StartupStageLogicTests`, `SongManagerBulkEnumerationTests`, `ConfigStageNxImportTests`, `PreviewImagePanelTests`, and `SongSelectionStageLogicTests`.
-
 ---
 
 ## Slice 1a — Configuration Model and Persistence
 
-### Task 1A: Persist Ordered Song Roots Without Runtime Consumer Changes
+### Task 1A: Persist Ordered Song Roots
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Config/SongRootConfigModels.cs`
@@ -100,7 +91,7 @@ Existing tests remain the regression home where the behavior already belongs, es
 - Modify: `DTXMania.Test/Config/ConfigDataTests.cs`
 - Modify: `DTXMania.Test/Config/ConfigManagerTests.cs`
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 public enum SongRootUpdateStatus
@@ -128,25 +119,26 @@ public sealed class SongRootsChangedEventArgs : EventArgs
 }
 ```
 
-This slice defines the models and file format but does not add Config UI or live reload. The final comparer-aware `SetSongRoots` implementation is completed in Slice 1b after `SongRootPolicy` exists.
+This slice adds the stored model and compatibility behavior. The comparer-aware setter is completed in Slice 1b after `SongRootPolicy` exists.
 
-- [ ] **Step 1: Add red tests for default, repeated load, and indexed parsing**
+- [ ] **Step 1: Write red tests for the persisted format**
 
-Add tests named:
+Add tests:
 
 ```text
 DefaultConfig_ShouldContainManagedSongRootAndMirror
 LoadConfig_ShouldClearSongRootsBeforeSecondParse
 LoadConfig_ShouldReadIndexedRootsInNumericOrder
-LoadConfig_ShouldUseLastDuplicateIndexAndWarn
+LoadConfig_ShouldUseLastDuplicateIndex
 LoadConfig_ShouldPreferIndexedRootsOverLegacyDTXPath
 LoadConfig_ShouldMigrateLegacyDTXPathAndPersistIndexedRoot
 SaveConfig_ShouldWriteDenseIndexesAndFirstRootMirror
+LoadConfig_ShouldRemainSectionAgnostic
 ```
 
-Use temporary Config.ini files. Include an INI with unrelated section headers and prove `SongRoot.*` remains global because the current parser does not track sections.
+Use temporary Config.ini files. Include unrelated `[System]` and `[Other]` headers and prove keys remain global.
 
-- [ ] **Step 2: Run the focused red tests**
+- [ ] **Step 2: Run the red tests**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
@@ -155,38 +147,40 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj \
 
 Expected: failures because `SongRoots` and indexed serialization do not exist.
 
-- [ ] **Step 3: Add the ConfigData and load/save model**
+- [ ] **Step 3: Implement load/save and migration**
 
-Add to `ConfigData`:
+Add:
 
 ```csharp
 public List<string> SongRoots { get; } = new();
 ```
 
-At the start of every `LoadConfig`, call `Config.SongRoots.Clear()` beside the existing MIDI-threshold clearing. Parse `SongRoot.<non-negative integer>` into a temporary index/value map, then finalize the list after all lines are read. Keep `[Section]` lines ignored exactly as today.
+At every `LoadConfig` start, call `Config.SongRoots.Clear()` beside `MidiVelocityThresholds.Clear()`. Collect `SongRoot.<non-negative integer>` entries during parsing and finalize after all lines are read.
 
-Finalize with this precedence:
+Precedence:
 
-1. Accepted indexed roots in ascending index order.
-2. Legacy `DTXPath` migrated into one root.
-3. Managed default root.
+1. accepted indexed roots in numeric order;
+2. migrated legacy `DTXPath`;
+3. managed default root.
 
-Save dense `SongRoot.0..N` entries and write `DTXPath` as the first root.
+Save dense `SongRoot.0..N` and mirror the first root into `DTXPath`.
 
-- [ ] **Step 4: Remove unconditional custom-root creation**
+- [ ] **Step 4: Remove custom-root auto-creation**
 
-Replace the current `EnsureDirectorySafe(Config.DTXPath)` behavior with managed-default-only creation. Add tests proving:
+Replace unconditional `EnsureDirectorySafe(Config.DTXPath)` with managed-default-only creation.
 
-- missing custom roots remain strings in Config;
-- no custom directory is created during load, migration, or save;
-- the managed default is created when selected as fallback;
-- directories created by older versions are not deleted.
+Tests must prove:
 
-- [ ] **Step 5: Correct pending-save path clearing**
+- missing custom paths remain configured;
+- load/migration/save never creates them;
+- managed default creation still works;
+- old directories are not deleted.
 
-When an explicit full config save succeeds, clear `_pendingSavePath` only when its normalized path equals the file just written. A save to another path must leave the pending marker intact.
+- [ ] **Step 5: Correct pending-save clearing**
 
-Add tests:
+After a full save, clear `_pendingSavePath` only when its normalized path equals the path just written. A save to another file must retain the pending marker.
+
+Add:
 
 ```text
 SaveConfig_ShouldClearMatchingPendingPath
@@ -194,38 +188,38 @@ SaveConfig_ShouldRetainDifferentPendingPath
 FlushPendingSave_ShouldRetryAfterFailure
 ```
 
-- [ ] **Step 6: Add immutable persistence/event model tests**
+- [ ] **Step 6: Verify immutable model snapshots**
 
-Construct `SongRootsChangedEventArgs` from mutable source lists, mutate the sources, and prove the event snapshots remain unchanged. Do not raise the event from load/reset.
+Construct event args/results from mutable lists, mutate the originals, and assert exposed values are unchanged. Use copied read-only arrays, not caller-owned lists.
 
-- [ ] **Step 7: Run Slice 1a gate**
+- [ ] **Step 7: Run the Slice 1a gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongRootConfigTests|FullyQualifiedName~ConfigManagerTests|FullyQualifiedName~ConfigDataTests"
-
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 ```
 
-Expected: all focused tests pass and the macOS game project builds.
-
-- [ ] **Step 8: Commit Slice 1a**
+- [ ] **Step 8: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Config \
+git add \
+  DTXMania.Game/Lib/Config/SongRootConfigModels.cs \
+  DTXMania.Game/Lib/Config/ConfigData.cs \
+  DTXMania.Game/Lib/Config/ConfigManager.cs \
+  DTXMania.Test/Config/SongRootConfigTests.cs \
   DTXMania.Test/Config/ConfigDataTests.cs \
-  DTXMania.Test/Config/ConfigManagerTests.cs \
-  DTXMania.Test/Config/SongRootConfigTests.cs
+  DTXMania.Test/Config/ConfigManagerTests.cs
 git commit -m "feat: persist ordered song roots"
 ```
 
-**Review gate:** verify the serialized format, repeated-load clearing, section-agnostic behavior, custom-directory behavior removal, and pending-save path handling before starting Slice 1b.
+**Gate:** indexed format, repeated-load clearing, section-agnostic parsing, custom-directory behavior removal, and pending-save correctness.
 
 ---
 
-## Slice 1b — Root Policy, SongManager Snapshots, and Startup Consumers
+## Slice 1b — Root Policy, Safe SongManager Snapshots, and Consumers
 
-### Task 1B: Centralize Root Identity and Publish Safe Library Snapshots
+### Task 1B: Centralize Root Identity and Publication
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Song/SongRootPolicy.cs`
@@ -240,9 +234,9 @@ git commit -m "feat: persist ordered song roots"
 - Modify: `DTXMania.Game/Lib/Stage/StartupStage.cs`
 - Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
 - Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
-- Modify: relevant existing SongManager, startup, and preview tests.
+- Modify: focused existing SongManager/startup/preview tests.
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 internal sealed class SongRootPolicy
@@ -269,11 +263,11 @@ public sealed class SongLibraryPublishedEventArgs : EventArgs
 }
 ```
 
-`SongManager.GetLibrarySnapshot()` returns copied root and root-path arrays captured under `_lockObject`. `RootSongs` may remain as a compatibility property only if it returns the copied snapshot list, never `_rootSongs.AsReadOnly()`.
+All snapshot lists are copied and wrapped read-only. Published node graphs are not structurally mutated after publication.
 
-- [ ] **Step 1: Write the comparer and overlap red tests**
+- [ ] **Step 1: Write root-policy red tests**
 
-Add theory coverage that executes both policies on every host:
+Execute both policies on every CI host:
 
 ```csharp
 [Theory]
@@ -284,30 +278,21 @@ public void DuplicatePolicy_ShouldFollowInjectedCaseMode(
     bool expectedDuplicate)
 ```
 
-Add explicit parent/child matrices including:
+Add overlap cases:
 
 ```text
 /Users/me/Songs + /Users/me/SONGS/Extra
 C:\Songs + c:\songs\Pack
-/songs + /Songs/Pack under ordinal mode
+/songs + /Songs/Pack in ordinal mode
 ```
 
-Assert overlap compares path segments through the injected comparer and does not call `Path.GetRelativePath`.
+- [ ] **Step 2: Implement segment-wise `SongRootPolicy`**
 
-- [ ] **Step 2: Implement `SongRootPolicy`**
+The policy must normalize, preserve first occurrence/order, detect duplicates, and compare root/path segments using the injected comparer. Do not delegate overlap to `Path.GetRelativePath`.
 
-The policy must:
+`ForCurrentPlatform()` uses the production OS policy; tests use `CreateComparer(true/false)`.
 
-1. Normalize absolute paths with `SongPathIdentity.Normalize`.
-2. Preserve first occurrence and configured order.
-3. Detect duplicate roots through the injected comparer.
-4. Split normalized roots into root/segment components and compare each segment through the same comparer.
-5. Reject same-path and parent/child overlap symmetrically.
-6. Probe existence/access without creating directories.
-
-Use `CreateComparer(true)` for ignore-case tests and `CreateComparer(false)` for ordinal tests. `ForCurrentPlatform()` selects the production mode.
-
-- [ ] **Step 3: Complete the typed Config setter**
+- [ ] **Step 3: Complete `SetSongRoots`**
 
 Add to `IConfigManager`:
 
@@ -319,34 +304,36 @@ SongRootUpdateResult SetSongRoots(
 event EventHandler<SongRootsChangedEventArgs>? SongRootsChanged;
 ```
 
-`ConfigManager.SetSongRoots` validates through `SongRootPolicy`, writes the complete config immediately, rolls back memory on persistence failure, raises one event after success, and returns `Unchanged` without writing or raising when the canonical ordered list is equal.
+Validate through `SongRootPolicy`, persist immediately, roll memory back on failure, raise one event after success, and return `Unchanged` without write/event for an equal canonical ordered list.
 
-- [ ] **Step 4: Replace live library views with coherent snapshots**
+- [ ] **Step 4: Replace live SongManager views**
 
-Under `_lockObject`, capture:
+Make `SetCurrentSearchPaths` `internal` for direct tests while keeping it non-public.
+
+Publication methods, not reads, increment `_publicationVersion`:
 
 ```csharp
-new SongLibrarySnapshot(
-    ++_publicationVersion,
-    _rootSongs.ToArray(),
-    _currentSearchPaths.ToArray(),
-    EnumeratedFileCount,
-    DiscoveredScoreCount)
+private SongLibrarySnapshot CreateSnapshotLocked() =>
+    new(
+        _publicationVersion,
+        Array.AsReadOnly(_rootSongs.ToArray()),
+        Array.AsReadOnly(_currentSearchPaths.ToArray()),
+        EnumeratedFileCount,
+        DiscoveredScoreCount);
 ```
 
-Required changes:
+Required behavior:
 
-- `GetLibrarySnapshot()` returns a copied snapshot.
-- `PublishEnumeration` replaces hierarchy/roots/counts, increments one version, then raises `SongLibraryPublished` outside the lock.
-- `PublishEmptyLibrary` clears hierarchy, active roots, and counts in one version and raises the same event.
-- `SetCurrentSearchPaths(Array.Empty<string>())` clears `_currentSearchPaths`; remove the current empty-input early return.
-- defensive deduplication in `SetCurrentSearchPaths` and `CreateBatchBuilder` uses `SongRootPolicy`.
+- `GetLibrarySnapshot()` reads the current version without incrementing it.
+- `PublishEnumeration` replaces hierarchy/roots/counts, increments once, captures one snapshot, then raises `SongLibraryPublished` outside the lock.
+- `PublishEmptyLibrary` clears hierarchy/roots/counts, increments once, and publishes one empty snapshot.
+- empty input to `SetCurrentSearchPaths` clears active roots.
+- `RootSongs`, if retained, returns the copied snapshot list rather than `_rootSongs.AsReadOnly()`.
+- `SetCurrentSearchPaths` and `CreateBatchBuilder` use `SongRootPolicy` deduplication.
 
-Do not mutate a previously published root list after it has been handed to a consumer.
+- [ ] **Step 5: Add a non-null zero-active-root result**
 
-- [ ] **Step 5: Add zero-active-root import behavior**
-
-Extend `SongEnumerationResult` with an explicit outcome such as:
+Update models:
 
 ```csharp
 public enum SongEnumerationOutcome
@@ -354,20 +341,21 @@ public enum SongEnumerationOutcome
     ImportedAndPublished,
     NoActiveRoots
 }
+
+public sealed record SongEnumerationResult(
+    SongEnumerationOutcome Outcome,
+    SongEnumerationBatch Batch,
+    SongBulkImportResult Import,
+    TimeSpan HierarchyDuration);
 ```
 
-When `BuildEnumerationBatchAsync` returns a complete batch with no active roots:
+Add `SongBulkImportResult.Empty` with empty read-only chart map, zero counts, and zero durations. When a complete batch has no active roots, return `NoActiveRoots` with `Empty`; do not import or publish, and always release the enumeration slot.
 
-- do not call `ImportSongsCoreAsync`;
-- do not call `PublishEnumeration`;
-- return `NoActiveRoots` with batch root-failure errors available to callers;
-- always release the enumeration slot.
-
-A clean startup with no available roots calls `PublishEmptyLibrary()` explicitly after deciding not to clean/import.
+Startup with no accepted roots calls `PublishEmptyLibrary()` explicitly.
 
 - [ ] **Step 6: Migrate startup and preview consumers**
 
-`StartupStage` snapshots `Config.SongRoots`, uses the shared policy, and chooses cache/enumeration paths from the accepted roots. `SongSelectionStage` initializes from one `SongLibrarySnapshot`.
+`StartupStage` snapshots `Config.SongRoots`. `SongSelectionStage` initializes from one `SongLibrarySnapshot`.
 
 Replace `PreviewImagePanel.SongsRootPath` with:
 
@@ -375,62 +363,70 @@ Replace `PreviewImagePanel.SongsRootPath` with:
 public IReadOnlyList<string> ActiveSongRootPaths { get; set; }
 ```
 
-Absolute chart paths remain authoritative. Relative fallback tries active roots in order.
+Absolute chart path remains authoritative; relative fallback tries active roots in order.
 
-- [ ] **Step 7: Add architecture and concurrency regression tests**
+- [ ] **Step 7: Add architecture and concurrency tests**
 
-Tests must prove:
+Prove:
 
-- `RootSongs`/`GetLibrarySnapshot` remain stable while another thread publishes;
-- filter projection and `BookmarkStateReconciler.Apply` cannot observe collection modification;
-- root list and active roots share one publication version;
+- snapshots remain stable while another thread publishes;
+- filter and bookmark reconciliation cannot observe collection mutation;
+- hierarchy and active roots share one version;
 - empty publication clears both;
-- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync` receive deduplicated roots;
-- no production `Config.DTXPath` read remains outside Config serialization/migration allowlist.
+- cache/database/enumeration callers use aligned deduplication;
+- no production `Config.DTXPath` read remains outside an explicit allowlist.
 
-The architecture test should scan `DTXMania.Game/**/*.cs` and list the allowed files explicitly so a future runtime read fails the test.
-
-- [ ] **Step 8: Run Slice 1b gate**
+- [ ] **Step 8: Run the Slice 1b gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongRootPolicyTests|FullyQualifiedName~SongManagerLibrarySnapshotTests|FullyQualifiedName~SongManagerBulkEnumerationTests|FullyQualifiedName~StartupStageLogicTests|FullyQualifiedName~PreviewImagePanelTests|FullyQualifiedName~DTXPathCompatibilityArchitectureTests"
-
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 ```
 
-- [ ] **Step 9: Commit Slice 1b**
+- [ ] **Step 9: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Song \
-  DTXMania.Game/Lib/Config \
+git add \
+  DTXMania.Game/Lib/Song/SongRootPolicy.cs \
+  DTXMania.Game/Lib/Song/SongLibrarySnapshot.cs \
+  DTXMania.Game/Lib/Song/SongImportModels.cs \
+  DTXMania.Game/Lib/Song/SongManager.cs \
+  DTXMania.Game/Lib/Config/IConfigManager.cs \
+  DTXMania.Game/Lib/Config/ConfigManager.cs \
   DTXMania.Game/Lib/Stage/StartupStage.cs \
   DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
-  DTXMania.Test
+  DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs \
+  DTXMania.Test/Song/SongRootPolicyTests.cs \
+  DTXMania.Test/Song/SongManagerLibrarySnapshotTests.cs \
+  DTXMania.Test/Config/DTXPathCompatibilityArchitectureTests.cs \
+  DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs \
+  DTXMania.Test/Stage/StartupStageLogicTests.cs \
+  DTXMania.Test/UI/PreviewImagePanelTests.cs
 git commit -m "feat: publish versioned song library snapshots"
 ```
 
-**Review gate:** no live `RootSongs` wrapper, no empty-root stale snapshot, no platform-dependent untested comparer branch, and no runtime `DTXPath` consumer.
+**Gate:** no live root wrapper, no stale active roots after empty publication, both comparer modes tested, and no runtime `DTXPath` consumer.
 
 ---
 
 ## Slice 2 — Cross-Platform SongFolderPanel
 
-### Task 2: Add Draft Editing and Platform Folder Selection
+### Task 2: Add Draft Editing and Platform Pickers
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs`
 - Create: `DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs`
 - Create: `DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs`
-- Create: platform picker/factory files listed in File Structure.
+- Create: four platform files listed above.
 - Create: `DTXMania.Test/Config/SongFolderPanelTests.cs`
 - Create: `DTXMania.Test/Config/FolderPickerContractTests.cs`
 - Modify: `DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs`
 - Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
-- Modify: both platform `.csproj` files.
+- Modify: both game `.csproj` files.
 - Modify: `DTXMania.Test/Config/ConfigStageLogicTests.cs`
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 public interface IConfigOverlayPanel
@@ -451,115 +447,81 @@ public interface IFolderPickerService
         string? initialDirectory,
         CancellationToken cancellationToken);
 }
+
+internal enum SongFolderApplyStatus
+{
+    Updated,
+    Unchanged,
+    Busy,
+    ValidationFailed,
+    PersistenceFailed,
+    Started
+}
 ```
 
-`IKeyAssignPanel` inherits `IConfigOverlayPanel`. `ConfigStage._activePanel` uses the generalized interface.
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`.
 
-- [ ] **Step 1: Add panel-lifecycle and draft red tests**
+- [ ] **Step 1: Write panel red tests**
 
-Cover:
+Cover isolated draft, Add, Remove-last protection, Move Up/Down, Cancel/Back, structural errors, availability warnings, picker cancellation/failure, stale picker generation, and `Saved` before `Closed`.
 
-```text
-Activate_ShouldCopyConfiguredRoots
-CancelAndBack_ShouldDiscardDraft
-Add_ShouldAppendSelectedFolder
-PickerCancellation_ShouldNotMutateDraft
-Remove_ShouldProtectLastRoot
-MoveUpAndMoveDown_ShouldPreserveSelection
-StructuralError_ShouldKeepPanelOpen
-AvailabilityWarning_ShouldAllowApply
-Saved_ShouldFireBeforeClosed
-```
+- [ ] **Step 2: Generalize overlay lifecycle**
 
-Use an injected fake picker and fake apply delegate. The panel never receives `IConfigManager`.
-
-- [ ] **Step 2: Add `IConfigOverlayPanel` and adapt key panels**
-
-Move only the common lifecycle members into the new interface. Preserve the existing key-panel requirement that `Saved` fires before `Closed`.
-
-Run existing key assignment tests immediately after this refactor.
+Extract only common members into `IConfigOverlayPanel`; preserve existing key-panel semantics and run key-assignment tests.
 
 - [ ] **Step 3: Implement `SongFolderPanel`**
 
-The panel owns:
+The panel owns copied draft state and receives a fakeable picker, root policy, and Config-owned apply delegate. It never holds `IConfigManager`.
 
-- a copied draft root list;
-- selected row/action indexes;
-- async picker state and activation generation;
-- structural diagnostics and availability warnings;
-- a Config-owned apply delegate.
+- [ ] **Step 4: Implement platform pickers**
 
-Use the root policy for validation. Picker completion may modify draft state only if the captured panel generation is current.
+Windows uses `FolderBrowserDialog` on an owned STA dispatcher. macOS uses `/usr/bin/osascript`, `ProcessStartInfo.ArgumentList`, asynchronous exit, and distinct cancellation vs authorization failure mapping.
 
-- [ ] **Step 4: Add platform picker implementations**
+- [ ] **Step 5: Isolate compilation**
 
-Windows:
+Add explicit `<Compile Remove=...>` entries so each target compiles exactly one picker implementation and factory.
 
-- use `FolderBrowserDialog`;
-- own STA dispatch in the platform service;
-- return Selected/Cancelled/Failed without blocking the game update thread.
+- [ ] **Step 6: Wire Config with restart-required behavior**
 
-macOS:
+Replace **DTX Folder** with **Song Folders**, showing `1 folder` or `<n> folders`. Slice 2 apply calls `SetSongRoots`; `Updated` closes with restart-required status, `Unchanged` closes silently, failures keep the panel open.
 
-- invoke `/usr/bin/osascript` with `ProcessStartInfo.ArgumentList`;
-- use `choose folder` and `default location` only when valid;
-- await exit asynchronously;
-- distinguish normal user cancellation from authorization/privacy failure;
-- include stderr only in structured diagnostics.
-
-Do not launch real dialogs in unit tests.
-
-- [ ] **Step 5: Isolate platform compilation**
-
-Add explicit compile exclusions:
-
-```xml
-<!-- Windows project -->
-<Compile Remove="Platform/Mac/**/*.cs" />
-<Compile Remove="Platform/FolderPickerServiceFactory.Mac.cs" />
-
-<!-- Mac project -->
-<Compile Remove="Platform/Windows/**/*.cs" />
-<Compile Remove="Platform/FolderPickerServiceFactory.Windows.cs" />
-```
-
-The exact glob may be adjusted to the final directory layout, but each project must compile only one factory and one native implementation.
-
-- [ ] **Step 6: Wire Config navigation with temporary restart behavior**
-
-Replace read-only **DTX Folder** with a `NavigationConfigItem` named **Song Folders**. Display `1 folder` or `<n> folders`.
-
-For Slice 2, the Config-owned delegate calls `SetSongRoots`. On `Updated`, close the panel and show a restart-required status. On `Unchanged`, close without status. On failure, keep the panel open.
-
-- [ ] **Step 7: Run Slice 2 gate**
+- [ ] **Step 7: Run the Slice 2 gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongFolderPanelTests|FullyQualifiedName~FolderPickerContractTests|FullyQualifiedName~ConfigStageLogicTests|FullyQualifiedName~KeyAssign"
-
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
 ```
 
-- [ ] **Step 8: Commit Slice 2**
+- [ ] **Step 8: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Stage/Config \
-  DTXMania.Game/Lib/Stage/KeyAssign \
+git add \
+  DTXMania.Game/Lib/Stage/Config/IConfigOverlayPanel.cs \
+  DTXMania.Game/Lib/Stage/Config/FolderPickerModels.cs \
+  DTXMania.Game/Lib/Stage/Config/SongFolderPanel.cs \
+  DTXMania.Game/Lib/Stage/KeyAssign/IKeyAssignPanel.cs \
   DTXMania.Game/Lib/Stage/ConfigStage.cs \
-  DTXMania.Game/Platform \
-  DTXMania.Game/*.csproj \
-  DTXMania.Test/Config
+  DTXMania.Game/Platform/Windows/WindowsFolderPickerService.cs \
+  DTXMania.Game/Platform/Mac/MacFolderPickerService.cs \
+  DTXMania.Game/Platform/FolderPickerServiceFactory.Windows.cs \
+  DTXMania.Game/Platform/FolderPickerServiceFactory.Mac.cs \
+  DTXMania.Game/DTXMania.Game.Windows.csproj \
+  DTXMania.Game/DTXMania.Game.Mac.csproj \
+  DTXMania.Test/Config/SongFolderPanelTests.cs \
+  DTXMania.Test/Config/FolderPickerContractTests.cs \
+  DTXMania.Test/Config/ConfigStageLogicTests.cs
 git commit -m "feat: add song folder configuration panel"
 ```
 
-**Review gate:** panel draft isolation, platform build isolation, async picker lifecycle, and restart persistence through Startup.
+**Gate:** isolated draft, async picker lifecycle, platform build isolation, and persisted roots consumed after restart.
 
 ---
 
-## Slice 3a — Config Operation Coordinator and Live Reload
+## Slice 3a — Config Coordinator and Live Reload
 
-### Task 3A: Serialize Config Song Operations and Start One Live Reload
+### Task 3A: Serialize Config Song Operations
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs`
@@ -569,9 +531,9 @@ git commit -m "feat: add song folder configuration panel"
 - Create: `DTXMania.Test/Config/SongLibraryReloadServiceTests.cs`
 - Modify: `DTXMania.Game/Lib/Stage/ConfigStage.cs`
 - Modify: `DTXMania.Test/Stage/ConfigStageNxImportTests.cs`
-- Modify: relevant SongManager bulk-enumeration tests.
+- Modify: `DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs`
 
-**Interfaces:**
+**Produces:**
 
 ```csharp
 internal enum ConfigSongOperationKind
@@ -594,215 +556,168 @@ internal interface ISongLibraryReloadService
 }
 ```
 
-Persistence and orchestration results remain separate. Config maps `SongRootUpdateResult` into a panel-facing orchestration result that may additionally be `Busy` or `Started`.
+Persistence results remain in Config; orchestration adds Busy/Started without changing `IConfigManager` concerns.
 
 - [ ] **Step 1: Write coordinator red tests**
 
-Cover:
+Cover single ownership, cross-operation Busy, exactly-once release, task-construction throw, continuation-registration throw, and repeated Dispose.
+
+- [ ] **Step 2: Implement the scoped coordinator**
+
+Replace check-then-set booleans with atomic lease acquisition. One Config method owns:
 
 ```text
-TryAcquire_ShouldAllowOneOwner
-TryAcquire_ShouldRejectDifferentOperationWhileBusy
-Dispose_ShouldReleaseExactlyOnce
-ThrowDuringOperationConstruction_ShouldReleaseLease
-TerminalContinuationRegistrationFailure_ShouldReleaseLease
-```
-
-Use an injectable continuation/task factory to force each synchronous handoff failure.
-
-- [ ] **Step 2: Implement a scoped coordinator**
-
-The coordinator owns one atomic state. A lease releases through `Dispose()` exactly once. Do not expose check-then-set booleans.
-
-`ConfigStage` uses one method for song-root Apply:
-
-```text
-validate/compare
+compare/validate
 → acquire lease
-→ persist roots
+→ persist
 → create CTS
-→ construct reload task
-→ register observation/progress/terminal release
-→ store operation handle
-→ return Started to panel
+→ construct operation task
+→ register progress and terminal observation
+→ transfer release to terminal continuation
+→ return Started
 ```
 
-All synchronous steps remain inside one `try/finally`. `Saved` only reports that the draft was accepted; it does not acquire, transfer, or release the lease.
+All synchronous steps stay inside one `try/finally`. `SongFolderPanel.Saved` does not transfer lease ownership.
 
-- [ ] **Step 3: Implement the reload adapter**
+- [ ] **Step 3: Implement reload result mapping**
 
-`SongLibraryReloadService` calls the existing HPA-192 operation once with the configured roots.
+Call HPA-192 once.
 
-Result mapping:
+Map:
 
-- occupied lower-level enumeration slot → `Busy`;
-- `SongEnumerationOutcome.NoActiveRoots` → `NoAvailableRoots`, old hierarchy retained;
-- successful import/publication → `Success`;
-- pre-commit cancellation/failure → old hierarchy retained;
+- occupied enumeration slot → Busy;
+- `NoActiveRoots` → retain old hierarchy;
+- success → published snapshot;
+- pre-commit cancel/failure → retain old hierarchy;
 - unexpected post-commit publication failure → partial-success/restart-required.
 
-For completed enumeration, count unavailable roots from `Batch.Errors.Where(error => error.IsRootFailure)`. A shallow preflight may provide early UI warnings, but it cannot override the batch result.
+For completed enumeration, derive unavailable count from `Batch.Errors.Where(e => e.IsRootFailure)`. Preflight may show an early warning but never overrides batch truth.
 
-- [ ] **Step 4: Migrate NX import onto the same lifecycle**
+- [ ] **Step 4: Migrate NX import fully**
 
-Remove `_importRunning` check-then-set ownership. NX import must:
+Remove `_importRunning` ownership and worker writes to `_importStatus`. NX import uses the same coordinator, activation generation, immutable update queue, task observation, CTS disposal, and terminal release.
 
-- acquire `ConfigSongOperationKind.NxScoreImport`;
-- use the same activation generation;
-- enqueue progress/status rather than writing `_importStatus` from a worker;
-- cancel on Config deactivation;
-- attach an observation continuation;
-- dispose CTS and release lease exactly once in the terminal continuation.
+- [ ] **Step 5: Marshal progress on the update thread**
 
-Both operations must reject each other with a concise status.
+Worker continuations enqueue immutable updates tagged with activation generation. `ConfigStage.OnUpdate` drains current-generation updates only. Deactivation increments generation, requests cancellation, and never waits synchronously.
 
-- [ ] **Step 5: Add update-thread status marshalling**
+- [ ] **Step 6: Protect commit-to-publication**
 
-Use a thread-safe queue of immutable operation updates. `ConfigStage.OnUpdate` drains only updates whose activation generation is current. Deactivation increments the generation before cancellation.
+Add a regression test proving cancellation after database commit cannot prevent finalization/publication.
 
-Never wait synchronously for filesystem or SQLite work during stage teardown.
+- [ ] **Step 7: Run operation tests**
 
-- [ ] **Step 6: Preserve the commit-to-publication terminal section**
-
-Ensure HPA-192 does not check cancellation after database commit and before `FinalizePendingNodes`/`PublishEnumeration`. Add a regression test where cancellation arrives after commit and publication still completes successfully.
-
-- [ ] **Step 7: Add operation integration tests**
-
-Required tests:
+Required cases:
 
 ```text
 UnchangedApply_ShouldNotAcquirePersistOrScan
 BusyApply_ShouldNotPersist
-ReorderOnlyApply_ShouldInvokeImporterOnce
+ReorderOnlyApply_ShouldImportOnce
 NoActiveRoots_ShouldRetainCurrentSnapshot
 BatchRootFailures_ShouldDriveWarningCount
 NxImportAndReload_ShouldNotOverlap
 Deactivate_ShouldCancelWithoutBlocking
-WorkerProgress_ShouldReachUIOnlyThroughUpdateDrain
-EveryTerminalPath_ShouldDisposeCtsAndReleaseLeaseOnce
+WorkerProgress_ShouldUpdateOnlyWhenDrained
+EveryTerminalPath_ShouldDisposeAndReleaseOnce
 ```
 
-- [ ] **Step 8: Run Slice 3a gate**
+- [ ] **Step 8: Run the Slice 3a gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~ConfigSongOperationCoordinatorTests|FullyQualifiedName~SongLibraryReloadServiceTests|FullyQualifiedName~ConfigStageNxImportTests|FullyQualifiedName~SongManagerBulkEnumerationTests"
 ```
 
-- [ ] **Step 9: Commit Slice 3a**
+- [ ] **Step 9: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Stage/Config \
+git add \
+  DTXMania.Game/Lib/Stage/Config/ConfigSongOperationCoordinator.cs \
+  DTXMania.Game/Lib/Stage/Config/SongLibraryReloadModels.cs \
+  DTXMania.Game/Lib/Stage/Config/SongLibraryReloadService.cs \
   DTXMania.Game/Lib/Stage/ConfigStage.cs \
-  DTXMania.Game/Lib/Song \
-  DTXMania.Test/Config \
+  DTXMania.Test/Config/ConfigSongOperationCoordinatorTests.cs \
+  DTXMania.Test/Config/SongLibraryReloadServiceTests.cs \
   DTXMania.Test/Stage/ConfigStageNxImportTests.cs \
   DTXMania.Test/Song/SongManagerBulkEnumerationTests.cs
 git commit -m "feat: live reload configured song roots"
 ```
 
-**Review gate:** no split lease ownership, no worker-thread UI writes, no NX/reload overlap, and no normal publication for a zero-active-root batch.
+**Gate:** no split lease ownership, no worker-thread UI writes, no NX/reload overlap, and no live publication for a zero-active-root batch.
 
 ---
 
-## Slice 3b — Active Song Select Reconciliation and Retained Views
+## Slice 3b — Active Song Select Reconciliation
 
-### Task 3B: Reconcile Runtime Publication on the Update Thread
+### Task 3B: Apply Publications on the Update Thread
 
 **Files:**
 - Create: `DTXMania.Test/Stage/SongSelectionPublicationTests.cs`
 - Modify: `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
 - Modify: `DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs`
-- Modify: existing Song Selection, bookmark, recent, and preview tests.
+- Modify: `DTXMania.Test/Stage/SongSelectionStageLogicTests.cs`
+- Modify: `DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs`
+- Modify: `DTXMania.Test/UI/PreviewImagePanelTests.cs`
 
-**Interfaces:**
+**Consumes:** `SongLibraryPublished` and `GetLibrarySnapshot()` from Slice 1b.
 
-`SongSelectionStage` subscribes to `SongManager.SongLibraryPublished` on activation and unsubscribes on deactivation. The event handler stores only the newest pending publication version; it never changes UI collections.
+- [ ] **Step 1: Write reconciliation red tests**
 
-- [ ] **Step 1: Write publication-reconciliation red tests**
+Cover active publication, retained/removed box navigation, retained/removed selected chart, Bookmarks, Recent, multiple publications, and post-deactivation notification.
 
-Create scenarios for:
+- [ ] **Step 2: Subscribe safely**
 
-```text
-PublicationWhileActive_ShouldApplyOnUpdateThread
-PublicationInsideRetainedBox_ShouldRestoreNavigation
-PublicationInsideRemovedBox_ShouldResetToRoot
-PublicationWithRetainedSelection_ShouldRestoreByStableIdentity
-PublicationRemovingSelection_ShouldStopPreviewAndClearPanels
-PublicationOnBookmarks_ShouldFilterToActiveRoots
-PublicationOnRecent_ShouldFilterToActiveRoots
-MultiplePublications_ShouldApplyNewestVersionOnly
-NotificationAfterDeactivate_ShouldBeIgnored
-```
+Subscribe on activation and unsubscribe on deactivation. The event handler records only the highest pending version; it never mutates UI collections.
 
-Use test snapshots with stable chart/database identities and distinct publication versions.
+- [ ] **Step 3: Reconcile one snapshot in `OnUpdate`**
 
-- [ ] **Step 2: Add event subscription and pending-version state**
+When pending version exceeds applied version:
 
-On activation:
-
-- capture one `SongLibrarySnapshot`;
-- subscribe to publication;
-- remember current activation version.
-
-The event handler atomically records the highest pending version only. On deactivation, unsubscribe before disposing stage resources.
-
-- [ ] **Step 3: Reconcile one coherent snapshot in `OnUpdate`**
-
-When a pending version exceeds the applied version:
-
-1. fetch one current `SongLibrarySnapshot`;
-2. ignore it if superseded or stage generation changed;
-3. replace root-list and active-root state from that snapshot;
-4. restore navigation by stable path/database identity if possible;
-5. restore selected chart by stable chart/database identity if possible;
-6. otherwise reset deterministically to root/first item;
+1. fetch one current snapshot;
+2. verify activation/version;
+3. replace roots and active paths;
+4. restore navigation by stable path/database identity when possible;
+5. restore selected chart by stable identity when possible;
+6. otherwise reset deterministically;
 7. rebuild filter, Bookmarks, Recent, breadcrumb, preview roots, and empty state;
-8. stop preview and clear status/history when selection disappeared;
-9. mark the snapshot version as applied.
+8. stop preview and clear panels when selection disappeared;
+9. mark the version applied.
 
-Do not mix `RootSongs` from one version with active roots from another.
+Never mix hierarchy from one version with active roots from another.
 
-- [ ] **Step 4: Filter Bookmarks and Recent to active roots**
+- [ ] **Step 4: Filter retained tabs by active roots**
 
-Database-backed tab loaders must filter chart paths through the active-root snapshot from the same publication version. Off-root rows remain stored and reappear after a successful root re-add.
+Bookmarks and Recent hide off-active-root rows without deleting database records. Re-add makes retained rows visible again.
 
-- [ ] **Step 5: Implement deliberate empty states**
+- [ ] **Step 5: Add explicit empty-state resolver**
 
-Distinguish:
+Return distinct states for no active roots versus active roots containing no supported charts. Keep condition resolution in one testable method.
 
-```text
-No active roots:
-No song folders are currently available. Open Config to reconnect or change them.
+- [ ] **Step 6: Add concurrent-publication coverage**
 
-Active roots with no supported charts:
-No songs were found in the active song folders.
-```
+Run filter projection and bookmark reconciliation on an old copied snapshot while publishing a new one. Assert no collection-modified exception and final UI uses only the newest version.
 
-Keep copy in one testable resolver method so future localization does not duplicate conditions.
-
-- [ ] **Step 6: Add concurrent-publication regression coverage**
-
-Run filter projection and bookmark reconciliation against a copied snapshot while publishing another version. Assert no `InvalidOperationException`, no background-thread mutation, and final UI data all references the newest applied version.
-
-- [ ] **Step 7: Run Slice 3b gate**
+- [ ] **Step 7: Run the Slice 3b gate**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj \
   --filter "FullyQualifiedName~SongSelectionPublicationTests|FullyQualifiedName~SongSelectionStageLogicTests|FullyQualifiedName~SongSelectionStageBookmark|FullyQualifiedName~PreviewImagePanelTests"
 ```
 
-- [ ] **Step 8: Commit Slice 3b**
+- [ ] **Step 8: Commit explicit files**
 
 ```bash
-git add DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
+git add \
+  DTXMania.Game/Lib/Stage/SongSelectionStage.cs \
   DTXMania.Game/Lib/Song/Components/PreviewImagePanel.cs \
-  DTXMania.Test/Stage \
-  DTXMania.Test/UI
+  DTXMania.Test/Stage/SongSelectionPublicationTests.cs \
+  DTXMania.Test/Stage/SongSelectionStageLogicTests.cs \
+  DTXMania.Test/Stage/SongSelectionStageBookmarkToggleTests.cs \
+  DTXMania.Test/UI/PreviewImagePanelTests.cs
 git commit -m "feat: reconcile live song library publication"
 ```
 
-**Review gate:** active Song Select never enumerates a live backing list, applies publication only on the update thread, and keeps hierarchy/tabs/previews on one version.
+**Gate:** active Song Select enumerates only copied snapshots, applies publication only on update, and keeps hierarchy/tabs/previews on one version.
 
 ---
 
@@ -816,33 +731,38 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj -c Release
 
 Expected: zero failed tests.
 
-- [ ] **Build both game targets**
+- [ ] **Build both targets**
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Release
 dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Release
 ```
 
-Expected: both builds succeed; each compiles only its own picker implementation.
+Expected: both succeed and compile only their own picker implementation.
 
-- [ ] **Run production consumer audit**
+- [ ] **Run the compatibility audit**
 
 ```bash
 rg "Config\??\.DTXPath|ConfigData\.DTXPath|\.DTXPath" DTXMania.Game --glob '*.cs'
 ```
 
-Expected: matches only the compatibility property plus Config load/save/migration code allowed by `DTXPathCompatibilityArchitectureTests`.
+Expected: only allowlisted Config compatibility code.
 
-- [ ] **Manual smoke checks**
+- [ ] **Manual smoke matrix**
 
-1. Migrate an existing one-root Config.ini and verify roots persist after restart.
-2. Add a second local root, reorder, Apply, and verify one reload.
-3. Configure one missing removable root plus one available root; verify available songs load and warning count matches scan errors.
-4. Remove a root; verify songs/bookmarks/recent disappear from active views but return after re-add.
-5. Leave Config during reload and enter Song Select; verify post-publication reconciliation without stale selection or crash.
-6. Start NX score import and attempt Apply; verify Busy and no config write.
-7. Test picker cancellation on Windows and macOS.
+1. Migrate an existing one-root Config.ini and restart.
+2. Add/reorder two local roots and verify one reload.
+3. Combine one unavailable removable root with one available root and compare warning count with batch root failures.
+4. Remove/re-add a root and verify retained scores, Bookmarks, and Recent.
+5. Leave Config during reload and enter Song Select; verify deterministic post-publication reconciliation.
+6. Start NX import and attempt Apply; verify Busy and no write.
+7. Cancel platform pickers on Windows and macOS.
 
-- [ ] **Final commit/checkpoint**
+## Plan Self-Review Checklist
 
-Do not squash slice commits until all review gates pass. The final PR should show the five bounded implementation checkpoints clearly enough to bisect regressions.
+- [x] Every design acceptance criterion maps to a slice and test gate.
+- [x] Both comparer branches are testable on every CI host.
+- [x] Publication version increments only during publication.
+- [x] Zero-active-root results keep a non-null empty import result.
+- [x] Commit commands stage explicit files only.
+- [x] No placeholders or undefined cross-slice interfaces remain.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -41,8 +41,7 @@ the game through boot-only startup state.
   frameworks from shared game code.
 - Reject configurations that would scan the same textual subtree more than
   once under the selected root-comparison policy.
-- Keep startup behavior deterministic when some or all configured roots are
-  unavailable.
+- Keep startup deterministic when some or all configured roots are unavailable.
 - Serialize Config-initiated song-library mutation operations so NX score import
   and song-folder reload cannot write or rebuild the library concurrently.
 
@@ -88,8 +87,8 @@ Three root states are distinguished throughout the design:
 - **Available roots:** configured roots that currently exist and pass a minimal
   access probe.
 - **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy. Active roots change only after a successful publication, or during
-  a clean startup that intentionally publishes an empty active library.
+  hierarchy. Active roots change only after successful publication, or during a
+  clean startup that intentionally publishes an empty active library.
 
 Configured roots and active roots may temporarily differ. For example, a player
 can save new roots and then encounter a failed reload; Song Select must continue
@@ -331,27 +330,56 @@ refactor.
 - A commit delegate owned by `ConfigStage`:
 
 ```csharp
-Func<IReadOnlyList<string>, SongRootUpdateResult> commitRoots
+Func<IReadOnlyList<string>, SongFolderCommitResult> commitRoots
 ```
 
 The panel owns a private draft list. Opening, reordering, adding, removing, or
 cancelling does not mutate `ConfigData`.
 
-On **Apply**:
+The Config-owned delegate is the only commit owner. For a draft snapshot it:
 
-1. The panel validates its draft.
-2. The panel passes an immutable draft snapshot to the Config-owned delegate.
-3. The delegate is the only caller of `IConfigManager.SetSongRoots`.
-4. Validation or persistence failure is returned to the panel; the panel stays
-   open and shows the error.
-5. On `Updated` or `Unchanged`, the panel stores the immutable committed
-   snapshot, raises `Saved`, then raises `Closed`.
-6. `ConfigStage` reads the committed snapshot during `Saved`. It starts a reload
-   only for `Updated`; `Unchanged` closes without a scan.
+1. Canonicalizes and compares against the current configured snapshot.
+2. Returns `Unchanged` without acquiring an operation slot or writing.
+3. For a changed list, attempts to reserve the Config operation slot as
+   `SongFolderReload` **before** calling `SetSongRoots`.
+4. Returns `Busy` without persisting when NX import or another reload owns the
+   slot.
+5. Calls `IConfigManager.SetSongRoots` only after the slot is reserved.
+6. Releases the slot immediately when validation or persistence fails.
+7. Retains the reserved slot on `Updated` so the `Saved` handler can start the
+   matching reload without a race.
+
+On **Apply**, the panel passes an immutable draft snapshot to that delegate.
+Validation, persistence, or busy failure keeps the panel open and displays the
+returned diagnostic. On `Updated` or `Unchanged`, the panel stores the immutable
+committed snapshot, raises `Saved`, then raises `Closed`.
+
+`ConfigStage` reads the committed snapshot during `Saved`:
+
+- `Unchanged`: no operation slot is held and no reload starts.
+- `Updated`: the reload starts using the already-reserved slot. The handler must
+  either attach the reload task or release the slot before returning; it must
+  not leave a reserved slot orphaned if task construction fails.
 
 The panel never holds `IConfigManager` and never persists roots independently.
-This prevents double commits and keeps event ordering consistent with existing
-Config panels.
+
+The panel-level result distinguishes orchestration from persistence:
+
+```csharp
+public enum SongFolderCommitStatus
+{
+    Updated,
+    Unchanged,
+    Busy,
+    ValidationFailed,
+    PersistenceFailed
+}
+
+public sealed record SongFolderCommitResult(
+    SongFolderCommitStatus Status,
+    IReadOnlyList<string> CanonicalRoots,
+    IReadOnlyList<SongRootDiagnostic> Diagnostics);
+```
 
 Supported actions:
 
@@ -403,9 +431,7 @@ construction, or native picker types. Headless tests inject a deterministic fake
 picker. A future native `NSOpenPanel` helper may replace AppleScript without
 changing the shared interface.
 
-## Commit and Persistence Flow
-
-Applying roots is an explicit user commit and requires immediate persistence.
+## Config Persistence API
 
 `IConfigManager` gains:
 
@@ -415,7 +441,7 @@ SongRootUpdateResult SetSongRoots(
     IReadOnlyList<string> roots);
 ```
 
-The result contract is:
+This persistence-level result remains independent of Config's `Busy` status:
 
 ```csharp
 public enum SongRootUpdateStatus
@@ -438,7 +464,7 @@ public sealed record SongRootUpdateResult(
 ```
 
 The implementation may adjust concrete type names but must preserve those four
-outcomes and immutable snapshots.
+persistence outcomes and immutable snapshots.
 
 The operation:
 
@@ -480,26 +506,29 @@ reorder-only path. HPA-192 remains the sole importer and publication authority.
 
 ### Apply sequence
 
-1. `SongFolderPanel` validates and commits its draft.
-2. `ConfigManager.SetSongRoots` atomically persists the canonical ordered list.
-3. `Saved` fires before `Closed`; Config captures the committed snapshot.
-4. `Unchanged` closes with no reload.
-5. `Updated` acquires the Config song-operation slot and displays reload status.
-6. The reload service probes all configured roots.
-7. When at least one root is available, one enumeration/import starts with only
+1. The panel validates its draft locally.
+2. Config's commit delegate detects `Unchanged` or reserves the
+   `SongFolderReload` operation slot for a changed list.
+3. A busy slot returns `Busy`; roots are not persisted and the panel stays open.
+4. With the slot reserved, `ConfigManager.SetSongRoots` atomically persists the
+   canonical ordered list.
+5. Validation/persistence failure releases the slot and keeps the panel open.
+6. `Updated` stores the committed snapshot and raises `Saved` before `Closed`.
+7. Config's `Saved` handler starts reload using the existing slot reservation.
+8. The reload service probes all configured roots.
+9. When at least one root is available, one enumeration/import starts with only
    those roots.
-8. The old hierarchy remains active while discovery and persistence run.
-9. On successful commit, finalization and publication replace the hierarchy and
-   active-root snapshot atomically.
-10. Config reports folder, chart, unavailable-folder, and error counts. Logical
+10. The old hierarchy remains active while discovery and persistence run.
+11. On successful commit, finalization and publication replace the hierarchy and
+    active-root snapshot atomically.
+12. Config reports folder, chart, unavailable-folder, and error counts. Logical
     song counts remain structured-log detail rather than user-facing copy.
 
 Unavailable configured roots are omitted from the scan and listed as warnings.
 Their database records remain outside active import cleanup.
 
-When no configured root is available, Config skips the importer and retains the
-current active hierarchy. The roots remain saved and Config reports that the
-current library is retained until a later successful reload or restart.
+When no configured root is available, Config skips the importer, retains the
+current active hierarchy, reports the warning, and releases the operation slot.
 
 ### Config operation mutual exclusion
 
@@ -509,13 +538,14 @@ current library is retained until a later successful reload or restart.
 None | NxScoreImport | SongFolderReload
 ```
 
-Both `StartNxScoreImport` and song-folder Apply must acquire this slot before
-starting work and release it only in their terminal continuation.
+Both `StartNxScoreImport` and changed-root Apply must reserve this slot before
+performing persistence or database work and release it only in their terminal
+continuation.
 
 Required behavior:
 
-- Apply while NX import is running is rejected with a clear status; roots are
-  not re-persisted and no reload starts.
+- Apply while NX import is running returns `Busy`; roots are not persisted and
+  no reload starts.
 - NX import while reload is running is rejected with a clear status.
 - A second reload is rejected while reload is active.
 - Existing `SongManager` enumeration-slot rejection is converted to a `Busy`
@@ -533,20 +563,19 @@ The HPA-192 transaction commit through hierarchy publication is treated as a
 non-cancellable terminal section:
 
 - Cancellation is honored during probing, discovery, parsing, matching, and
-  persistence before the database commit.
-- Once the bulk import commits successfully, the caller must not perform another
+  persistence before database commit.
+- Once bulk import commits successfully, the caller must not perform another
   cancellation check before `FinalizePendingNodes` and `PublishEnumeration`.
 - A cancellation request arriving after commit is ignored until publication
   completes; the result is success, not cancellation.
-- This rule prevents the database from reflecting the new active-root cleanup
-  while the old hierarchy remains published solely because cancellation arrived
-  in the commit-to-publish gap.
+- This prevents the database from reflecting new active-root cleanup while the
+  old hierarchy remains solely because cancellation arrived in the
+  commit-to-publish gap.
 
 If an unexpected finalization or publication exception occurs after commit, the
 old hierarchy remains atomically intact, but the database may already reflect
 the new import. Report a distinct partial-success failure requiring restart;
-do not claim rollback. This is an exceptional recovery path, not normal
-cancellation behavior.
+do not claim rollback.
 
 ### Config deactivation
 
@@ -560,6 +589,7 @@ Use the same pattern as `StartupStage`:
 - Cancel the operation CTS.
 - Attach an execute-synchronously observation continuation.
 - Observe any fault and dispose the CTS only after task termination.
+- Release the Config operation slot in that terminal continuation.
 - Suppress UI/status writes from stale generations.
 
 The game-wide `SongManager` operation may finish after Config deactivates. A
@@ -570,11 +600,12 @@ feedback is suppressed.
 
 Before database commit, failure or cancellation means:
 
-- Persisted configured roots remain saved.
+- Persisted configured roots remain saved when persistence had already
+  succeeded.
 - Database transaction rolls back.
 - Previous active hierarchy and active-root snapshot remain published.
 - No partial hierarchy is exposed.
-- Config reports that the saved roots will be retried on startup or Apply.
+- Config reports that saved roots will be retried on startup or Apply.
 
 After database commit, cancellation no longer changes the success path. An
 unexpected post-commit publication failure uses the partial-success recovery
@@ -612,7 +643,7 @@ Known consumers include:
 - `ConfigStage`: replace the read-only DTX Folder item.
 - `SongSelectionStage` / `PreviewImagePanel`: remove the single
   `SongsRootPath` fallback.
-- Any E2E fixture or runtime helper that supplies the production configuration.
+- Any E2E fixture or runtime helper that supplies production configuration.
 
 ### Preview resolution
 
@@ -639,20 +670,19 @@ Product rule:
 - All Songs uses the published active hierarchy.
 - Bookmarks and Recent filter database-backed results to the current active-root
   snapshot.
-- If a reload fails and the previous hierarchy stays active, the previous roots'
-  Bookmarks and Recent entries remain visible because those roots are still
-  active.
-- After a successful removal reload, off-root Bookmarks and Recent entries are
+- If reload fails and the previous hierarchy stays active, previous roots'
+  Bookmarks and Recent entries remain visible because those roots remain active.
+- After successful removal reload, off-root Bookmarks and Recent entries are
   hidden but retained.
 - Re-adding and successfully publishing the root makes retained entries visible
-  again with their user-owned data intact.
+  again with user-owned data intact.
 
 ## Empty Library UX
 
 Song Select must show a deliberate empty state rather than a blank list:
 
-- Configured roots exist but none are active/available: **No song folders are
-  currently available. Open Config to reconnect or change them.**
+- No active roots and no configured root is currently available: **No song
+  folders are currently available. Open Config to reconnect or change them.**
 - At least one active root exists but contains no supported charts: **No songs
   were found in the active song folders.**
 
@@ -671,7 +701,7 @@ The existing HPA-192 contracts remain in force:
 - Charts and songs outside those roots are retained.
 - Bookmarks, score-speed variants, play counts, recent timestamps, ranks,
   full-combo state, and performance history remain user-owned.
-- The replacement hierarchy is published only after transaction commit.
+- Replacement hierarchy is published only after transaction commit.
 
 HPA-191 prevents textual parent/child overlaps before they reach `SongManager`.
 The importer is not responsible for resolving physical aliases or choosing
@@ -709,8 +739,7 @@ Config user-facing examples:
 
 ### Configuration unit tests
 
-- Default config contains exactly the managed default root and mirrors it to
-  `DTXPath`.
+- Default config contains exactly managed default root and mirrors `DTXPath`.
 - Indexed roots round-trip in order and rewrite densely.
 - Legacy `DTXPath` migrates to one indexed root and persists immediately.
 - Legacy default `Songs` migration still resolves to `DTXFiles`.
@@ -726,7 +755,7 @@ Config user-facing examples:
 - Managed default root is created when restored.
 - Persistence failure restores old roots and emits no event.
 - Successful update raises one event with immutable snapshots.
-- `Unchanged`, `ValidationFailed`, and `PersistenceFailed` results are distinct.
+- Persistence result statuses are distinct.
 
 ### Config and panel tests
 
@@ -736,24 +765,27 @@ Config user-facing examples:
 - Add, remove, reorder, Apply, Cancel, and Back are deterministic.
 - Async picker cancellation/failure does not mutate the draft.
 - Stale picker completion cannot update a reactivated/disposed panel.
-- Structural errors keep the panel open; availability warnings may be applied.
+- Structural errors keep panel open; availability warnings may be applied.
 - Last configured root cannot be removed without adding another.
-- Config's commit delegate is the only `SetSongRoots` caller.
+- Config's delegate is the only `SetSongRoots` caller.
+- Busy changed-root Apply does not persist.
+- Persistence failure releases the reserved slot, keeps panel open, and starts
+  no reload.
 - `Saved` fires before `Closed` after successful commit.
-- Persistence failure keeps the panel open and starts no reload.
-- Active overlay polymorphism continues supporting existing key panels.
+- Updated `Saved` handler cannot orphan the reserved slot.
+- Active overlay polymorphism continues supporting key panels.
 
 ### Operation and reload tests
 
-- Unchanged ordered roots perform no write and no scan.
+- Unchanged ordered roots perform no write, slot acquisition, or scan.
 - Reorder-only changed roots perform exactly one full importer call.
-- One successful Apply invokes importer once with available roots in order.
+- Successful Apply invokes importer once with available roots in order.
 - Unavailable roots are skipped without blocking available roots.
-- No available roots skip import and retain existing hierarchy.
-- Apply is rejected while NX import runs.
+- No available roots skip import, retain hierarchy, and release the slot.
+- Apply is rejected without persistence while NX import runs.
 - NX import is rejected while reload runs.
-- Lower-level enumeration busy is mapped to a user-visible Busy result.
-- Leaving Config cancels and asynchronously observes the active operation.
+- Lower-level enumeration busy maps to a user-visible Busy result.
+- Leaving Config cancels and asynchronously observes active operation.
 - Stale generation continuations cannot write Config UI state.
 - Pre-commit failure/cancellation preserves old hierarchy.
 - Cancellation after commit cannot suppress publication and reports success.
@@ -762,16 +794,16 @@ Config user-facing examples:
 ### Startup and runtime integration tests
 
 - Startup consumes `SongRoots`, not compatibility `DTXPath`.
-- Every production `DTXPath` consumer is removed or explicitly compatibility-only.
+- Every production `DTXPath` consumer is removed or compatibility-only.
 - Multiple roots appear in configured order.
-- Root aliases are imported once under the selected root comparer.
+- Root aliases are imported once under selected root comparer.
 - Charts under distinct roots are imported once each.
-- Root N preview fallback resolves using active roots, not configured root zero.
+- Root N preview fallback uses active roots, not configured root zero.
 - Removed-root songs disappear from active hierarchy after success but remain in
   SQLite with scores/bookmarks intact.
 - Bookmarks and Recent hide off-active-root rows and restore them after re-add.
 - Missing removable root does not block another root.
-- No available roots publish an empty active library without database cleanup.
+- No available roots publish empty active library without database cleanup.
 - Distinct Song Select empty states are selected correctly.
 - Windows and macOS compile with only their picker implementation.
 - Existing HPA-192 cancellation, retention, and performance tests remain green.
@@ -783,13 +815,13 @@ Slice 3**. Each is intended to fit within three engineer days.
 
 ### Slice 1: Canonical multi-root configuration and consumer migration
 
-- Add `SongRoots`, indexed INI format, compatibility mirror, migration, result
-  contract, immutable event snapshots, and immediate persistence.
-- Add internal `SongRootPolicy` with the explicit root comparer, overlap
-  validation, normalization, and availability probing.
-- Align `SongManager` defensive root deduplication with the root policy.
-- Update startup to consume root snapshots and publish an empty active library
-  when no root is available.
+- Add `SongRoots`, indexed INI format, compatibility mirror, migration,
+  persistence result, immutable event snapshots, and immediate persistence.
+- Add internal `SongRootPolicy` with explicit root comparer, overlap validation,
+  normalization, and availability probing.
+- Align `SongManager` defensive root deduplication with root policy.
+- Update startup to consume snapshots and publish empty active library when no
+  root is available.
 - Audit and migrate all production `DTXPath` consumers, including active-root
   preview fallback and active-root snapshot exposure.
 - Add configuration, startup, preview, and consumer-audit tests.
@@ -805,7 +837,7 @@ Depends on Slice 1.
 - Replace **DTX Folder** with **Song Folders** and implement draft editing.
 - Commit through Config's single commit delegate and `SetSongRoots`.
 - Show temporary `restart required` status after `Updated` until Slice 3.
-- Verify the persisted roots are consumed by Startup on the next launch.
+- Verify persisted roots are consumed by Startup on next launch.
 - Add panel, picker-threading, and platform-boundary tests.
 
 ### Slice 3: Live reload and retained-data integration
@@ -813,7 +845,8 @@ Depends on Slice 1.
 Depends on Slices 1 and 2.
 
 - Add `ISongLibraryReloadService`.
-- Add Config operation mutual exclusion shared by NX import and reload.
+- Add Config operation mutual exclusion shared by NX import and reload, with
+  reservation before changed-root persistence.
 - Add progress, unavailable-root summaries, non-blocking cancellation
   observation, commit-to-publish terminal semantics, and failure feedback.
 - Add active-root filtering for Bookmarks/Recent and deliberate empty-state UX.
@@ -824,34 +857,35 @@ Depends on Slices 1 and 2.
 ## Acceptance Criteria
 
 - Existing one-path `DTXPath` configurations migrate without library loss.
-- A fresh install has one managed default song root.
+- Fresh install has one managed default song root.
 - Config allows adding, removing, and reordering roots on Windows and macOS.
 - Ordered roots survive restart and are read by startup after Slice 2.
-- Root duplicate comparison is explicitly ignore-case on Windows/macOS and
-  ordinal on Linux; chart canonical identity remains ordinal.
+- Root duplicate comparison is ignore-case on Windows/macOS and ordinal on
+  Linux; chart canonical identity remains ordinal.
 - Duplicate and textual parent/child-overlapping roots cannot be applied.
 - Missing custom roots remain configured and are never created automatically.
 - Previously auto-created custom directories are not deleted by migration.
-- Unchanged roots do not scan; any changed ordered list performs at most one full
-  scan, including reorder-only changes.
+- Unchanged roots do not acquire slot or scan; any changed ordered list performs
+  at most one full scan, including reorder-only changes.
+- Busy changed-root Apply does not persist the draft.
 - Every available root is scanned in configured order.
 - NX import and song reload cannot run concurrently from Config.
 - Busy lower-level enumeration is reported without an unhandled exception.
 - One unavailable root does not prevent available roots from loading.
-- A successful reload replaces active hierarchy atomically.
-- Pre-commit failure or cancellation never exposes a partial hierarchy.
+- Successful reload replaces active hierarchy atomically.
+- Pre-commit failure or cancellation never exposes partial hierarchy.
 - Cancellation after commit cannot suppress hierarchy publication.
-- Config deactivation never blocks the game thread waiting for reload/import.
-- No available root during Apply retains the previous active hierarchy.
-- No available root during startup reaches Title with an empty active library
-  and leaves SQLite untouched.
+- Config deactivation never blocks game thread waiting for reload/import.
+- No available root during Apply retains previous active hierarchy.
+- No available root during startup reaches Title with empty active library and
+  leaves SQLite untouched.
 - Preview fallback under any active root resolves correctly.
-- Removing a root hides its songs, Bookmarks, and Recent entries after successful
-  reload while preserving their database records and user-owned data.
+- Removing a root hides songs, Bookmarks, and Recent after successful reload
+  while preserving database records and user-owned data.
 - Re-adding a root restores retained user data and active views.
 - Song Select distinguishes unavailable folders from available-but-empty roots.
-- `DTXPath` remains a compatibility mirror only; every runtime consumer uses
-  configured or active root snapshots as appropriate.
-- Symlink/junction/physical-target deduplication is explicitly outside scope.
+- `DTXPath` remains compatibility mirror only; every runtime consumer uses
+  configured or active snapshots as appropriate.
+- Symlink/junction/physical-target deduplication is outside scope.
 - No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
   included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -2,126 +2,137 @@
 
 **Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
 **Date:** 2026-08-01  
-**Status:** Revised after second-pass design review
+**Status:** Revised after third-pass design review
 
 ## Context
 
-DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath`,
-writes it as `DTXPath=` in `Config.ini`, displays it as a read-only **DTX
-Folder** item in `ConfigStage`, and wraps it in a one-element array during
-startup.
+DTXManiaCX currently has one configured song-library root:
 
-The lower-level song system is already substantially multi-root capable:
+- `ConfigData.DTXPath` is serialized as `DTXPath=`.
+- `ConfigStage` shows a read-only **DTX Folder** item.
+- `StartupStage` wraps the path in a one-element array.
+- `SongSelectionStage` gives `PreviewImagePanel` one fallback root.
 
-- `SongManager` accepts ordered arrays of search roots.
-- Enumeration normalizes and deduplicates roots.
-- Root traversal order is preserved in the published hierarchy.
-- HPA-192 bulk import and stale cleanup are scoped to the active roots supplied
-  to a completed import.
-- Rows outside active roots are retained, protecting bookmarks, score variants,
-  play history, ranks, full-combo state, and performance history when a library
-  is removed or unavailable.
+The lower-level song system already accepts ordered root arrays. HPA-192 owns
+filesystem traversal, bulk persistence, retained-data cleanup, hierarchy
+finalization, and publication after database commit. HPA-191 therefore does not
+add another importer or a database schema migration.
 
-HPA-191 therefore does not introduce another importer or a database schema
-migration. It makes the ordered root list a first-class configuration value,
-adds safe Config editing and platform folder selection, migrates every runtime
-consumer away from the single-root compatibility property, and performs one
-atomic live reload without routing the game through boot-only `StartupStage`
-state.
+The work is to make ordered roots a first-class configuration value, expose safe
+cross-platform editing, align every runtime consumer, and support live
+publication while stages are active.
+
+Several current implementation details affect the design:
+
+- `SongPathIdentity.CanonicalComparer` is ordinal, while
+  `LegacyAliasComparer` is ignore-case on Windows/macOS and ordinal elsewhere.
+- `SongManager.SetCurrentSearchPaths` and enumeration-batch root deduplication
+  currently use the ordinal comparer.
+- `SongManager.RootSongs` currently returns `_rootSongs.AsReadOnly()`, which is a
+  live wrapper over a list mutated by `PublishEnumeration`.
+- `SetCurrentSearchPaths` currently ignores empty arrays, so it cannot clear a
+  stale active-root snapshot.
+- `NormalizeConfigPaths` currently creates every custom `DTXPath` directory.
+- `ConfigStage` NX import uses a separate `_importRunning` flag and writes status
+  from a background task.
+- No production stage currently observes `EnumerationCompleted`.
+
+Those behaviors are safe enough during startup-only publication, but they are
+not sufficient for an in-game library reload.
 
 ## Goals
 
 - Allow players to add, remove, and reorder song-library roots from Config.
-- Persist one or more ordered roots while migrating existing `DTXPath`
-  configurations without library loss.
-- Apply valid changes immediately and perform at most one live reload.
-- Preserve the currently published hierarchy until a replacement library has
-  committed and published successfully.
-- Preserve database rows and user-owned state for removed or temporarily
-  unavailable roots.
-- Support Windows and macOS folder selection without platform UI dependencies
-  in shared game code.
-- Reject textual duplicate or parent/child root combinations that would scan the
-  same subtree more than once under the selected root-comparison policy.
-- Keep startup deterministic when some or all configured roots are unavailable.
-- Serialize Config-initiated library mutation operations so NX score import and
-  song-folder reload cannot race.
-- Keep an already-active Song Select stage coherent when a reload publishes
-  after Config has deactivated.
+- Persist one or more ordered roots while migrating legacy `DTXPath` safely.
+- Perform at most one full reload for a changed ordered root list.
+- Keep the old published hierarchy until a replacement commits and publishes.
+- Preserve bookmarks, scores, variants, history, and other user data belonging
+  to removed or temporarily unavailable roots.
+- Keep Config-initiated NX import and song-folder reload mutually exclusive.
+- Make publication safe while Song Select and other consumers are active.
+- Keep configured, available, and active roots distinct.
+- Keep every implementation slice within roughly three engineer days.
 
 ## Non-goals
 
 - DTXCreator changes.
-- Chart parser, `set.def`, or `box.def` semantic changes.
+- Parser, `set.def`, or `box.def` semantic changes.
 - Song database schema changes.
-- Filesystem watchers or automatic reload when removable media mounts.
-- Rescanning after each individual draft edit.
-- A database-only reorder fast path. Any changed ordered root list performs one
-  full enumeration/import in HPA-191.
-- Editing or creating chart files from Config.
-- Synthetic top-level boxes for each configured root.
+- Filesystem watchers or automatic mounting detection.
+- Scanning after every draft edit.
+- A database-only reorder fast path.
+- Synthetic top-level root boxes.
 - Merging same-named folders or songs across roots.
-- Deleting retained records for removed roots.
-- Resolving filesystem aliases to physical targets. Symlinks, junctions, bind
-  mounts, aliases, and case-sensitive macOS volumes may expose one target through
-  distinct paths; realpath/inode-based deduplication is deferred.
-- General-purpose file-picker infrastructure beyond folder selection.
-- Replacing the macOS AppleScript adapter with a native `NSOpenPanel` helper.
-- Linux-specific picker integration. The configuration and reload contracts
-  remain platform-neutral, but HPA-191 targets the existing Windows and macOS
-  projects.
+- Deleting retained rows for removed roots.
+- Resolving symlinks, junctions, aliases, bind mounts, or physical filesystem
+  targets. Textually different paths may still reach the same physical folder.
+- Linux-specific folder-picker UI.
+- Replacing the initial macOS AppleScript adapter with `NSOpenPanel`.
 
-## Chosen Approach
+## Root State Model
 
-Add an ordered `SongRoots` collection as the sole configured-root source of
-truth. Keep `DTXPath` only as a serialized compatibility mirror of the first
-root. A Config overlay edits a private draft and commits through one
-Config-owned delegate. An asynchronous platform picker supplies new paths.
-After the changed list is persisted atomically, a focused reload service invokes
-the existing HPA-192 enumeration/import path once.
+The design distinguishes three ordered snapshots:
 
-The old hierarchy remains active until the complete replacement batch commits,
-finalizes, and publishes. Failure or cancellation before commit cannot expose a
-partial list.
+- **Configured roots:** normalized paths persisted in `Config.ini`.
+- **Available roots:** configured roots that appear accessible at a particular
+  check.
+- **Active roots:** roots represented by the currently published hierarchy.
 
-The design distinguishes three root states:
+Configured and active roots may differ. For example, Config may persist a new
+root list and then encounter a pre-commit reload failure. Runtime surfaces that
+represent the published library must continue using the old active snapshot.
 
-- **Configured roots:** ordered normalized paths persisted in `Config.ini`.
-- **Available roots:** configured roots that currently exist and pass a shallow
-  access probe.
-- **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy.
+## Chosen Architecture
 
-Configured and active roots may differ after a failed reload. Runtime surfaces
-that represent the published library must use the active-root snapshot, not the
-new configured list.
+1. `ConfigData` gains ordered `SongRoots`; `DTXPath` becomes a compatibility
+   mirror of the first root.
+2. An internal `SongRootPolicy` owns normalization, duplicate comparison,
+   overlap detection, and availability classification.
+3. `SongManager` exposes copied, versioned library snapshots. It never hands out
+   a live view of the mutable root list.
+4. `SongFolderPanel` edits an isolated draft and delegates Apply to one
+   Config-owned operation.
+5. That Config operation owns the entire changed-root sequence: lease
+   acquisition, persistence, reload task construction, terminal observation,
+   and lease release.
+6. HPA-192 remains the importer and commit/publication authority.
+7. Song Select observes publication versions and reconciles on the update
+   thread.
 
 ## Alternatives Considered
 
 ### Save and require restart
 
-This is the smallest change but leaves the active library stale and provides
-weak confirmation. It is rejected for the completed feature. Slice 2 uses a
-temporary restart-required state until Slice 3 lands.
+This is the temporary Slice 2 behavior but not the completed feature. It leaves
+the active library stale and gives weak confirmation.
 
-### Transition Config through StartupStage
+### Re-enter StartupStage
 
-`StartupStage` owns boot phases, activation generations, timing summaries, and
-exactly-once startup telemetry. Re-entering it for a user operation would couple
-unrelated lifecycles and make telemetry ambiguous. It is rejected.
+Rejected. Startup owns boot-only phases, activation generations, timing traces,
+and exactly-once telemetry.
 
-### Rebuild from SQLite for reorder-only changes
+### Reorder from SQLite without parsing
 
-The hierarchy builder could potentially republish roots in a new order without
-parsing charts. HPA-191 deliberately does not add that branch. Apply is an
-explicit refresh and one full scan also observes filesystem changes made while
-the panel was open. A future measured optimization may specialize reorder-only
-changes.
+Deferred. Any changed ordered list performs one full scan in HPA-191. This also
+observes filesystem changes made while Config was open.
 
-### Store one delimited value
+### Transfer a lease through `Saved` event handling
 
-A delimiter conflicts with legal path characters and complicates escaping and
-hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
+Rejected after review. The previous draft acquired a lease in the panel commit
+delegate, persisted roots, raised `Saved`, and transferred release ownership to
+a reload continuation constructed by another handler. Although `try/finally`
+and failure injection could make that correct, the ownership boundary was
+unnecessarily subtle.
+
+The final design keeps acquire, persist, reload construction, continuation
+registration, and release ownership in one Config method. `Saved` remains a UI
+lifecycle notification only.
+
+### Collapse orchestration and persistence result types
+
+Rejected. `Busy` belongs to Config operation coordination and must not leak into
+`IConfigManager`. The types remain separate but are composed rather than
+repeating independent logic.
 
 ## Configuration Contract
 
@@ -133,21 +144,17 @@ hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
 public List<string> SongRoots { get; } = new();
 ```
 
-The property remains get-only. Load, reset, and successful updates clear and
-refill the existing collection instead of replacing its reference. Consumers
-must never retain or mutate the live list. Startup, UI, events, and reload
-boundaries receive copied immutable snapshots.
+The collection is get-only. Load, reset, and successful updates clear and refill
+it rather than replacing the list reference. Consumers receive copied immutable
+snapshots and must never retain or mutate the live list.
 
-`DTXPath` remains for source and downgrade compatibility only:
+`DTXPath` remains for serialization and downgrade compatibility only:
 
-- After load, reset, or a successful update, it equals the first normalized
-  configured root.
-- Startup, Config, reload, active views, previews, and all other runtime behavior
-  consume configured or active root snapshots instead.
-- Direct mutation of `DTXPath` is not a supported runtime update mechanism.
+- It always mirrors the first configured root after load/reset/update.
+- Runtime behavior consumes configured or active root snapshots instead.
+- Direct mutation is not a supported update mechanism.
 
-At least one configured root is required. Availability is not required; the
-only root may be a disconnected removable or network location.
+At least one configured root is required, but it may currently be unavailable.
 
 ### Persisted format
 
@@ -158,286 +165,126 @@ SongRoot.0=C:\DTX\Main
 SongRoot.1=D:\Community Charts
 ```
 
+The existing INI parser is section-agnostic: section headers are presentation
+only and keys are globally parsed. HPA-191 must not add section-scoped parsing
+for `SongRoot.*` unless the entire configuration parser is redesigned in a
+separate issue.
+
 Rules:
 
-1. `SongRoot.<index>` uses a non-negative decimal integer.
+1. `SongRoot.<index>` uses a non-negative decimal index.
 2. Entries load in ascending numeric order; gaps are allowed.
-3. Malformed suffixes, negative indexes, and blank values are ignored with a
+3. Blank values, malformed suffixes, and negative indexes are ignored with a
    warning.
 4. Duplicate indexes use the last parsed value and emit a warning.
-5. Values may contain `=` because parsing splits on the first `=` only.
+5. Values may contain `=` because parsing splits only on the first `=`.
 6. Save rewrites indexes densely from zero.
-7. `DTXPath` mirrors the first root.
-8. At least one structurally valid indexed entry makes `SongRoot.*`
-   authoritative.
-9. With no valid indexed entry, load migrates legacy `DTXPath` into a one-root
-   list.
-10. If neither representation yields a valid path, load restores the managed
-    default.
+7. Indexed roots are authoritative when at least one structurally valid entry
+   exists.
+8. Otherwise legacy `DTXPath` is migrated into one root.
+9. If neither representation yields a valid path, restore the managed default.
+10. `DTXPath` is serialized as the first normalized root.
 
-A successful legacy migration is immediately persisted through the existing
-atomic temp-file replacement.
+At the beginning of every `LoadConfig`, clear `SongRoots` before parsing, just as
+`MidiVelocityThresholds` is cleared today. Loading twice into the same manager
+must not accumulate prior roots.
 
-### Downgrade compatibility caveat
+A successful migration is persisted immediately through the existing atomic
+temp-file replacement.
 
-The `DTXPath` mirror is best-effort compatibility, not a guarantee that older
-build behavior is safe. If the first root is an unavailable removable or
-network path and the user runs a pre-HPA-191 build, that older build may execute
-its unconditional directory-creation behavior and create an empty directory at
-that path. HPA-191 cannot prevent behavior after a downgrade; ordering a stable
-local root first reduces that risk.
+### Legacy default migration
 
-### Legacy path migration
-
-The existing known-default migration from `Songs` to the managed `DTXFiles`
-location remains. It applies to the fallback legacy value before it becomes
-`SongRoots[0]`. Indexed custom roots are not remapped merely because their final
-segment is named `Songs`.
-
-Previous builds may already have created empty custom directories while a
-removable or network root was unavailable. HPA-191 does not delete or move such
-folders.
+The known legacy default forms of `Songs` continue migrating to the managed
+`DTXFiles` directory. Indexed custom paths ending in `Songs` are not remapped.
 
 ### Deliberate removal of custom-root auto-creation
 
-Today `NormalizeConfigPaths` unconditionally calls
-`EnsureDirectorySafe(Config.DTXPath)`, creating every configured custom path at
-load. Slice 1 deliberately removes that behavior.
+Slice 1a deliberately removes the current unconditional
+`EnsureDirectorySafe(Config.DTXPath)` behavior.
 
 After HPA-191:
 
-- The game may create only `AppPaths.GetDefaultSongsPath()` when the managed
-  default is selected or restored as fallback.
-- Missing custom roots are retained as unavailable configuration values.
-- No load, migration, Apply, startup, or availability probe creates a custom
-  directory.
-- Existing directories created by older versions are left untouched.
+- Only `AppPaths.GetDefaultSongsPath()` may be created automatically when it is
+  selected or restored as fallback.
+- Missing custom roots remain configured but unavailable.
+- Load, migration, Apply, startup, and availability checks never create custom
+  folders.
+- Empty folders previously created by old builds are not deleted.
 
-This is an intentional product behavior change, not merely an implementation
-detail of the multi-root format.
+This is an intentional product behavior change.
 
-## Root Path Identity and Validation
+### Downgrade mirror caveat
 
-Root identity is intentionally separate from HPA-192 chart identity.
-`SongPathIdentity.CanonicalComparer` remains ordinal for exact persisted chart
-identity.
+`DTXPath` is best-effort compatibility. If its first root is an unavailable
+removable/network path and the user runs an older build, that build may recreate
+an empty directory through its legacy unconditional behavior. HPA-191 cannot
+control behavior after downgrade.
 
-### Shared root policy
+## SongRootPolicy
 
-Add internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. Config
-load, Config UI, `SetSongRoots`, startup, defensive `SongManager` root
-deduplication, overlap checks, and availability probing all use this policy.
+### Testable comparer selection
 
-`SongRootPolicy.RootComparer` uses
-`SongPathIdentity.LegacyAliasComparer`:
+`LegacyAliasComparer` is resolved from the running OS, so both comparison
+branches cannot be covered reliably by platform CI alone. `SongRootPolicy`
+therefore has an explicit test seam:
 
-- Windows and macOS: ordinal ignore-case.
-- Linux and other platforms: ordinal case-sensitive.
+```csharp
+internal sealed class SongRootPolicy
+{
+    internal SongRootPolicy(StringComparer rootComparer);
 
-On a case-sensitive macOS volume, case-only root variants are still treated as
-duplicates for HPA-191. Physical-case and real-target discovery are out of
-scope.
+    internal static StringComparer CreateRootComparer(bool ignoreCase) =>
+        ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
 
-`SongPathIdentity` remains internal. No public exposure is necessary because the
-policy and consumers live in the shared assembly; tests use the repository's
-internal-test access pattern.
+    internal static SongRootPolicy PlatformDefault { get; }
+}
+```
 
-### Canonicalization
+Production creates `PlatformDefault` using Windows/macOS ignore-case behavior.
+Tests instantiate both comparer modes on every CI platform. The policy is
+internal; no public API exposure is required.
 
-For each non-blank input:
+### Normalization
 
-1. Expand supported home-relative forms through `AppPaths`.
-2. Resolve legacy relative paths against the existing app-data base.
-3. Convert to an absolute full path.
-4. Normalize separators and trailing separators with
+For each input:
+
+1. Reject blank values.
+2. Expand supported home-relative forms through `AppPaths`.
+3. Resolve legacy relative values against the existing app-data base.
+4. Convert to a full absolute path.
+5. Normalize separators and trim ending separators through
    `SongPathIdentity.Normalize`.
-5. Compare roots with `SongRootPolicy.RootComparer`.
-6. Persist the normalized absolute value.
+6. Compare roots with the policy comparer.
+7. Persist the normalized absolute value.
 
-Root order controls traversal and root-level presentation order.
+### Duplicate policy
 
-### Defensive SongManager alignment
+- Windows/macOS mode: case-insensitive.
+- Linux/ordinal mode: case-sensitive.
+- Preserve first occurrence and authored order.
 
-`SongManager.SetCurrentSearchPaths`, enumeration-batch root creation, and every
-other defensive root deduplication point must use
-`SongRootPolicy.RootComparer`, not the ordinal chart comparer. Direct callers
-must not reintroduce aliases that Config rejects.
+This root policy does not change ordinal chart identity.
 
-This is a deliberate behavior change for all `SetCurrentSearchPaths` callers,
-including startup cache/database paths such as `LoadScoreCacheAsync`,
-`BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync`. On Windows
-and macOS, roots differing only by case will now collapse to one root in those
-paths as well as during fresh enumeration.
+### Overlap policy
 
-Slice 1 must add focused coverage for `SetCurrentSearchPaths` behavior and its
-snapshot, plus caller-path tests for cache load, database hierarchy rebuild, and
-enumeration decisions. The comparer change must not rely only on Config-panel
-integration tests.
+Root-overlap validation must not call
+`SongPathIdentity.IsUnderNormalizedRoot` or rely on `Path.GetRelativePath`.
+Those APIs follow platform path semantics that disagree with the chosen
+ignore-case macOS root policy.
 
-### Blocking structural errors
+Implement dedicated segment-wise comparison:
 
-Apply is blocked by:
+1. Parse the normalized root prefix/volume/share and remaining path segments.
+2. Compare root prefixes and each segment with `RootComparer`.
+3. Equality is a duplicate.
+4. If every segment of the shorter root matches the corresponding segment of
+   the longer root, the shorter root is an ancestor and the pair is rejected.
+5. Perform the check symmetrically.
 
-- No roots.
-- Blank or syntactically invalid paths.
-- Duplicates under `SongRootPolicy.RootComparer`.
-- Parent/child overlap in either direction after normalization.
+Tests cover case-differing parent/child paths in ignore-case mode, including the
+macOS policy case `/Users/me/Songs` and `/Users/me/SONGS/Extra`.
 
-Overlap segment comparison uses the same root comparer. Authored order does not
-make overlap valid.
-
-Hand-edited invalid configuration must not prevent startup. Load processes
-entries in numeric order; the first accepted root wins and later duplicate or
-overlapping entries are dropped with warnings. If all are rejected, the managed
-default is restored.
-
-Symlink, junction, mount, and alias targets are not resolved. Two textually
-different non-overlapping paths reaching the same physical directory may both
-scan in v1.
-
-### Availability warnings
-
-Missing and inaccessible roots are warnings, not structural failures. They stay
-configured so removable and network libraries can return later.
-
-The shallow probe:
-
-- Checks directory existence.
-- Attempts to begin a shallow directory enumeration.
-- Catches path, I/O, and authorization failures and returns a diagnostic.
-- Never recursively scans charts and never creates directories.
-
-Only available roots are supplied to startup or live reload. A root may still
-fail during scanning if availability changes; that follows the reload failure
-contract.
-
-## Config User Experience
-
-### System menu entry
-
-Replace **DTX Folder** with a navigation item named **Song Folders**. Its value
-is `1 folder` or `<n> folders`. The description says folders are scanned in the
-displayed order and Apply reloads once.
-
-### Overlay abstraction
-
-Introduce `IConfigOverlayPanel` with the common lifecycle currently carried by
-`IKeyAssignPanel`:
-
-- `IsActive`
-- `Closed`
-- `Saved`
-- `Activate()` / `Deactivate()`
-- `Update(...)`
-- `Draw(...)`
-
-`IKeyAssignPanel` inherits it and keeps the existing `Saved`-before-`Closed`
-contract. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
-targeted boundary correction, not a broad UI rewrite.
-
-### SongFolderPanel ownership
-
-`SongFolderPanel` receives:
-
-- An immutable configured-root snapshot.
-- `IFolderPickerService`.
-- The shared validation policy.
-- A Config-owned commit delegate:
-
-```csharp
-Func<IReadOnlyList<string>, SongFolderCommitResult> commitRoots
-```
-
-The panel owns a private draft. Add, remove, reorder, Back, and Cancel never
-mutate configuration.
-
-The delegate is the only commit owner:
-
-1. Canonicalize and compare the draft with the current configured snapshot.
-2. Return `Unchanged` without acquiring a slot or writing.
-3. For a changed list, reserve the Config operation slot as
-   `SongFolderReload` before persistence.
-4. Return `Busy` without persisting if NX import or another reload owns the
-   slot.
-5. Call `SetSongRoots` only while holding the reservation.
-6. Release the slot immediately on validation or persistence failure.
-7. Retain the reservation on `Updated` for handoff to the reload task.
-
-On Apply, failure or `Busy` keeps the panel open with a diagnostic. On `Updated`
-or `Unchanged`, the panel stores an immutable committed snapshot, raises
-`Saved`, then `Closed`.
-
-The panel never holds `IConfigManager` and never persists independently.
-
-```csharp
-public enum SongFolderCommitStatus
-{
-    Updated,
-    Unchanged,
-    Busy,
-    ValidationFailed,
-    PersistenceFailed
-}
-
-public sealed record SongFolderCommitResult(
-    SongFolderCommitStatus Status,
-    IReadOnlyList<string> CanonicalRoots,
-    IReadOnlyList<SongRootDiagnostic> Diagnostics);
-```
-
-Supported actions:
-
-- **Add Folder**
-- **Remove** while one draft root remains
-- **Move Up** / **Move Down**
-- **Apply**
-- **Cancel**
-
-Structural errors keep the panel open. Availability warnings do not disable
-Apply. Picker cancellation is a no-op; picker failure leaves the draft
-unchanged.
-
-## Platform Folder Picker
-
-Shared code uses:
-
-```csharp
-public interface IFolderPickerService
-{
-    Task<FolderPickerResult> PickFolderAsync(
-        string? initialDirectory,
-        CancellationToken cancellationToken);
-}
-```
-
-The result distinguishes Selected, Cancelled, Unavailable, and Failed. While a
-picker is active, repeat Add actions are ignored. Completion updates panel state
-only when its activation generation remains current.
-
-### Windows
-
-`FolderBrowserDialog` is acceptable because the Windows project already enables
-WinForms. The platform implementation owns STA dispatch; shared update code does
-not assume it runs on an STA thread. The dialog starts from the selected root or
-managed default when valid.
-
-### macOS
-
-Invoke `osascript` using Standard Additions `choose folder`, with a clear prompt
-and `default location` when the initial directory exists. Build arguments with
-`ProcessStartInfo.ArgumentList`, never shell interpolation. Await exit
-asynchronously, distinguish the standard user-cancel error, terminate on
-cancellation when safe, and log stderr for non-cancellation failures.
-
-The first invocation may display macOS system consent or privacy UI depending on
-the host process and selected location. The product must not promise a specific
-System Settings pane. Cancellation remains a normal `Cancelled` result;
-permission or authorization denial is `Failed` with a concise user message and
-structured diagnostic.
-
-Shared code must not reference WinForms, AppleScript construction, or native
-picker types. Headless tests inject a deterministic fake. A future
-`NSOpenPanel` helper may replace the adapter without changing the interface.
+Physical aliases remain outside scope.
 
 ## Config Persistence API
 
@@ -461,466 +308,584 @@ public enum SongRootUpdateStatus
 public sealed record SongRootUpdateResult(
     SongRootUpdateStatus Status,
     IReadOnlyList<string> CanonicalRoots,
-    IReadOnlyList<SongRootDiagnostic> Diagnostics)
+    IReadOnlyList<SongRootDiagnostic> Diagnostics);
+```
+
+The method:
+
+1. Validates/canonicalizes the complete list.
+2. Returns `Unchanged` without writing when ordered roots are equal.
+3. Captures prior `SongRoots` and `DTXPath` snapshots.
+4. Clears/refills `SongRoots` and updates `DTXPath` in memory.
+5. Writes the complete configuration atomically.
+6. Restores prior in-memory state if persistence fails.
+7. Raises `SongRootsChanged` only after persistence succeeds.
+8. Returns copied immutable snapshots.
+
+After a successful explicit save, clear `_pendingSavePath` only when it denotes
+the same normalized config file that was just written. A pending save for a
+different path must not be silently discarded.
+
+Event subscriber exceptions are isolated and cannot roll back persisted state.
+
+## Safe SongManager Snapshots
+
+### Root list
+
+The existing `RootSongs` getter must no longer return `_rootSongs.AsReadOnly()`.
+That wrapper is live and can throw `InvalidOperationException` when
+`PublishEnumeration` mutates the backing list during external enumeration.
+
+Use one of these equivalent contracts:
+
+```csharp
+public IReadOnlyList<SongListNode> RootSongs
 {
-    public bool IsSuccess =>
-        Status is SongRootUpdateStatus.Updated
-            or SongRootUpdateStatus.Unchanged;
+    get
+    {
+        lock (_lockObject)
+            return _rootSongs.ToArray();
+    }
 }
 ```
 
-The persistence operation:
+or a mandatory `GetRootSongsSnapshot()` API. Existing runtime consumers are
+migrated to the copied snapshot contract.
 
-1. Validates and canonicalizes the complete list.
-2. Captures prior `SongRoots` and `DTXPath` snapshots.
-3. Clears/refills `SongRoots` and updates the mirror in memory.
-4. Writes the complete config through atomic temp-file replacement.
-5. Clears the deferred-save marker on success because all settings were written.
-6. Restores prior in-memory values if persistence fails.
-7. Raises `SongRootsChanged` only after persistence succeeds.
-8. Returns `Unchanged` without write or event for an equal ordered list.
+### Composite publication snapshot
 
-Event args carry copied immutable old/new snapshots. Subscriber exceptions are
-isolated and cannot roll back accepted configuration.
+Add a coherent versioned snapshot:
 
-## Live Library Reload
+```csharp
+public sealed record SongLibrarySnapshot(
+    long Version,
+    IReadOnlyList<SongListNode> RootSongs,
+    IReadOnlyList<string> ActiveRoots);
 
-### Boundary
+public SongLibrarySnapshot GetPublishedLibrarySnapshot();
+```
 
-Introduce `ISongLibraryReloadService` so `ConfigStage` does not directly own raw
-singleton orchestration.
+The method copies root nodes and active roots under the same `_lockObject` and
+returns one publication version. Consumers must not combine separately-read
+roots and active paths.
 
-The production service:
+### Publication event
 
-- Probes the persisted configured snapshot.
-- Adapts `EnumerationProgress` to Config status.
-- Calls `SongManager.EnumerateAndImportSongsAsync` exactly once for every changed
-  ordered list, including reorder-only changes.
-- Returns active roots, aggregate counts, unavailable warnings, Busy,
-  cancellation, pre-commit failure, or post-commit partial failure.
-- Allows one in-flight reload.
+Publish a notification only after the new hierarchy and active roots are both
+installed:
 
-It does not call `NeedsEnumerationAsync` or create another cache/reorder path.
+```csharp
+public event EventHandler<SongLibraryPublishedEventArgs>? SongLibraryPublished;
+```
 
-### Apply sequence
+The event carries the monotonically increasing version and copied active-root
+snapshot. Handlers must not mutate game UI directly.
 
-1. Panel validates the draft locally.
-2. Config's delegate returns `Unchanged` or reserves `SongFolderReload`.
-3. A busy slot returns `Busy`; no persistence occurs.
-4. With the slot reserved, `SetSongRoots` persists the canonical list.
-5. Failure releases the slot and keeps the panel open.
-6. `Updated` raises `Saved` before `Closed`.
-7. The `Saved` handler starts reload using the reservation.
-8. Reload probes configured roots.
-9. With at least one available root, it starts one enumeration/import.
-10. The previous hierarchy stays active during discovery and persistence.
-11. Commit, finalization, and publication replace hierarchy and active roots.
-12. Config reports folder, chart, unavailable-folder, and error counts.
+`EnumerationCompleted` may remain for compatibility, but HPA-191 uses the
+explicit publication event.
 
-If no root is available, import is skipped, the previous hierarchy is retained,
-a warning is shown, and the operation slot is released.
+### Publication implementation
 
-### Config operation mutual exclusion
+Under `_lockObject`:
 
-`ConfigStage` owns:
+1. Replace root contents.
+2. Replace `_currentSearchPaths` with a copied active-root array.
+3. Update compatibility counts.
+4. Increment publication version.
+5. Capture event data.
+
+Invoke subscribers after releasing the lock, with per-subscriber exception
+isolation.
+
+### Empty publication
+
+Add a dedicated `PublishEmptyLibrary()` operation that:
+
+- clears root nodes;
+- assigns `_currentSearchPaths = Array.Empty<string>()`;
+- resets relevant counts;
+- increments publication version; and
+- raises the same publication event.
+
+Also remove or revise `SetCurrentSearchPaths`'s empty-array early return so an
+explicit empty snapshot cannot leave stale roots. Empty publication must not
+call database import or stale cleanup.
+
+### Concurrency coverage
+
+Tests must prove that:
+
+- a filter projection can iterate a copied root snapshot while another thread
+  publishes a replacement;
+- bookmark reconciliation can iterate a copied snapshot during publication;
+- no collection-modified exception occurs;
+- a snapshot remains stable after later publication; and
+- roots and active paths come from the same version.
+
+## Defensive Root Alignment
+
+`SetCurrentSearchPaths`, enumeration-batch root creation, and every other
+root-deduplication boundary use `SongRootPolicy.RootComparer`.
+
+This deliberately changes startup cache/database behavior as well as fresh
+enumeration. Direct tests cover:
+
+- `SetCurrentSearchPaths` first-occurrence/order behavior;
+- immutable copied current-path snapshots;
+- `LoadScoreCacheAsync`;
+- `BuildSongListFromDatabasePublicAsync`;
+- `NeedsEnumerationAsync`;
+- fresh enumeration; and
+- both comparer modes through the injected policy seam.
+
+## Root Availability and Import Authority
+
+A shallow availability check remains useful only for early UX and the
+all-unavailable decision. It is not authoritative because filesystem state can
+change immediately afterward.
+
+### Preflight responsibilities
+
+- Detect obvious all-unavailable cases without starting a costly reload.
+- Give immediate Config/startup diagnostics.
+- Never create directories.
+
+### Importer responsibilities
+
+When preflight finds at least one apparently available root, pass the complete
+configured snapshot to HPA-192. The enumeration batch is authoritative for:
+
+- normalized active roots;
+- missing/invalid/inaccessible root diagnostics;
+- the final unavailable-root count; and
+- what was actually scanned.
+
+User-facing unavailable counts after an attempted scan come from
+`batch.Errors` entries where `IsRootFailure`, not from preflight results.
+
+After the batch is built, if `ActiveRoots` is empty:
+
+- do not begin database import;
+- do not publish the empty batch through the normal reload path;
+- return a structured `NoAvailableRoots` result with batch diagnostics.
+
+Config retains the old hierarchy. Startup explicitly calls
+`PublishEmptyLibrary()` because clean startup has no prior active library to
+retain.
+
+This guard closes the TOCTOU case where roots disappear after preflight but
+before traversal.
+
+## Config UI
+
+### Menu entry
+
+Replace **DTX Folder** with **Song Folders**. Display `1 folder` or `<n>
+folders`. The description says Apply saves the ordered list and reloads once.
+
+### Overlay abstraction
+
+Introduce `IConfigOverlayPanel` containing the common lifecycle currently on
+`IKeyAssignPanel`. `IKeyAssignPanel` inherits it, preserving
+`Saved`-before-`Closed` behavior.
+
+### SongFolderPanel
+
+The panel receives:
+
+- an immutable configured-root snapshot;
+- `IFolderPickerService`;
+- validation/availability formatting; and
+- a Config-owned apply delegate.
+
+It owns a private draft. Add/remove/reorder/Cancel/Back do not mutate config.
+
+Supported actions:
+
+- **Add Folder**
+- **Remove** while at least one draft root remains
+- **Move Up** / **Move Down**
+- **Apply**
+- **Cancel**
+
+Structural errors keep the panel open. Availability warnings do not block
+Apply.
+
+## Folder Picker
+
+```csharp
+public interface IFolderPickerService
+{
+    Task<FolderPickerResult> PickFolderAsync(
+        string? initialDirectory,
+        CancellationToken cancellationToken);
+}
+```
+
+The result distinguishes Selected, Cancelled, Unavailable, and Failed. A stale
+picker completion cannot update an inactive/reactivated panel.
+
+### Windows
+
+Use `FolderBrowserDialog` behind a platform implementation that owns STA
+dispatch. Shared update code does not assume STA.
+
+### macOS
+
+Use `osascript` Standard Additions `choose folder`, with a prompt and optional
+existing default location. Build arguments with `ProcessStartInfo.ArgumentList`,
+await asynchronously, distinguish normal cancellation, and log stderr for
+failures.
+
+The first invocation may display system consent/privacy UI depending on the
+host process and selected location. Do not promise a particular System Settings
+pane. Authorization denial maps to Failed.
+
+## Config Song Operation Coordinator
+
+Introduce one Config-scoped coordinator/lease:
 
 ```text
 None | NxScoreImport | SongFolderReload
 ```
 
-NX import and changed-root Apply acquire the same slot. Apply while NX import is
-active returns `Busy` without persistence. NX import while reload is active is
-rejected. A second reload is rejected. Lower-level
-`InvalidOperationException` from an occupied SongManager enumeration slot is
-mapped to a user-visible Busy result.
+The coordinator provides atomic acquire and exactly-once release. Future Config
+operations that mutate/rebuild the library use the same coordinator.
 
-### Throw-safe reservation handoff
+### Apply ownership
 
-The reservation-to-task handoff is a strict implementation invariant. Acquiring
-the slot, persisting, raising `Saved`, constructing the reload task, and
-transferring release ownership must use `try/finally` or an equivalent scoped
-lease.
+The panel calls one Config-owned method, conceptually:
 
-Required ownership rule:
+```csharp
+SongFolderApplyResult ApplySongRoots(IReadOnlyList<string> draft);
+```
 
-- Before the reload task is attached, synchronous code owns the lease and must
-  release it in `finally` on every exit or exception.
-- Only after the terminal continuation is attached may release ownership move
-  to that continuation.
-- Task-construction, event-subscriber, or continuation-registration failure
-  cannot orphan the slot.
-- The terminal continuation releases exactly once.
+This method owns the full synchronous handoff:
 
-A dedicated test injects a throw at each handoff point and verifies the next
-operation can acquire the slot.
+1. Canonicalize and compare the draft.
+2. Return Unchanged without acquiring or writing.
+3. Acquire `SongFolderReload`; return Busy without persistence if unavailable.
+4. Call `SetSongRoots`.
+5. On validation/persistence failure, return failure and release in `finally`.
+6. Construct the reload task.
+7. Register terminal observation/release continuation.
+8. Transfer lease ownership to that continuation only after registration
+   succeeds.
+9. Return Updated/ReloadStarted.
+10. Release synchronously in `finally` on every path where ownership was not
+    transferred.
 
-### Cancellation, commit, and publication
+The panel closes and raises `Saved` only after Updated or Unchanged. `Saved` is
+not responsible for constructing the reload task or transferring the lease.
 
-Database commit through hierarchy publication is non-cancellable:
+`SongFolderApplyResult` composes `SongRootUpdateResult` and adds orchestration
+states such as Busy or ReloadStartFailed; it does not duplicate persistence
+logic or add Busy to `IConfigManager`.
 
-- Cancellation is honored during probing, discovery, parsing, matching, and
-  persistence before commit.
-- After commit succeeds, no cancellation check occurs before
-  `FinalizePendingNodes` and `PublishEnumeration`.
-- A request arriving after commit is ignored until publication completes and is
-  reported as success.
+### NX import migration
 
-This prevents the database from reflecting new active-root cleanup while the
-old hierarchy remains solely because cancellation arrived in the commit-to-
-publish gap.
+Slice 3a must migrate `StartNxScoreImport` completely onto the same coordinator:
 
-An unexpected finalization/publication exception after commit reports a distinct
-partial-success/restart-required outcome. It must not claim rollback.
+- replace `_importRunning` check-then-set with atomic lease acquisition;
+- use activation-generation fencing;
+- marshal progress/status updates through an update-thread queue or pending
+  state, never write UI-visible status directly from the worker;
+- observe the task and faults;
+- dispose its CTS only after terminal completion;
+- release the lease exactly once in the terminal continuation; and
+- cancel without synchronously blocking on deactivation.
+
+Merely checking the shared slot while retaining the old fire-and-forget
+lifecycle is insufficient.
+
+## Live Reload
+
+`ISongLibraryReloadService` adapts Config to HPA-192. It:
+
+- accepts an immutable configured snapshot;
+- performs preflight only for early all-unavailable detection;
+- invokes the existing enumeration/import path once for a changed list;
+- maps lower-level enumeration-busy exceptions to Busy;
+- reports progress through thread-safe state;
+- returns success, NoAvailableRoots, Busy, cancellation, pre-commit failure, or
+  post-commit partial failure.
+
+### Commit/publication terminal section
+
+Cancellation is honored before database commit. After commit succeeds, no
+cancellation check may occur before hierarchy finalization/publication. A late
+request is reported as success after publication.
+
+Unexpected finalization/publication failure after commit reports a distinct
+partial-success/restart-required result and never claims rollback.
 
 ### Config deactivation
 
-Leaving Config requests cancellation but never blocks the update thread waiting
-for filesystem or SQLite work.
+Deactivation:
 
-Use the `StartupStage` retirement pattern:
+- increments activation generation;
+- requests cancellation;
+- attaches an execute-synchronously observation continuation;
+- observes faults;
+- disposes CTS after termination;
+- releases lease in terminal continuation; and
+- suppresses stale UI writes.
 
-- Increment an activation generation.
-- Cancel the operation CTS.
-- Attach an execute-synchronously observation continuation.
-- Observe faults and dispose the CTS only after termination.
-- Release the operation lease in the terminal continuation.
-- Suppress Config UI/status writes from stale generations.
-
-A post-commit reload may finish and publish after Config deactivates.
+It never waits synchronously for filesystem or SQLite work on the game thread.
 
 ## Startup Integration
 
-`StartupStage` reads an immutable `SongRoots` snapshot, never `DTXPath`.
+Startup reads an immutable configured-root snapshot.
 
-Before cache/enumeration selection:
+- Preflight detects an obvious all-unavailable case.
+- Cache/enumeration decisions use the aligned root policy.
+- If enumeration produces no active roots, no import/publication occurs through
+  the normal path.
+- Startup then calls `PublishEmptyLibrary()` without database cleanup.
+- Title remains reachable and SQLite rows remain untouched.
 
-- Probe configured roots.
-- Pass available roots in configured order to `NeedsEnumerationAsync`, cache
-  hierarchy construction, or enumeration.
-- Log unavailable roots once.
-
-When no root is available on clean startup, publish an empty active hierarchy
-and empty active-root snapshot through a dedicated SongManager operation that
-does not import, stale-clean, or delete database rows. Startup completes and
-Title remains reachable.
+If at least one root is active, startup uses the normal cache/enumeration path
+and publishes the resulting versioned snapshot.
 
 ## Runtime Consumer Audit
 
-Slice 1 must grep and classify every production `DTXPath` read. No runtime
-consumer may silently remain first-root-only.
+Slice 1b must grep every production `DTXPath` read and classify it. No runtime
+consumer remains silently first-root-only.
 
-Known consumers:
+Known production consumers:
 
-- `StartupStage`: configured `SongRoots` snapshot.
-- `ConfigStage`: replace the read-only item.
-- `SongSelectionStage` / `PreviewImagePanel`: active-root fallback snapshot.
-- E2E fixtures and runtime helpers that provide production configuration.
+- Startup configuration.
+- Config display.
+- Song Select preview fallback.
+- E2E/runtime fixture setup.
 
-A source-level architecture test or explicit allowlist must fail if a new
-runtime `Config.DTXPath` read is introduced outside serialization/migration
-compatibility code.
+Add a source architecture test or explicit allowlist that permits `DTXPath` only
+inside compatibility serialization/migration code.
 
-### Preview resolution
+## Preview Resolution
 
-The normalized absolute `SongChart.FilePath` is authoritative. For legacy nodes
-with relative directories, replace `PreviewImagePanel.SongsRootPath` with an
-immutable ordered active-root snapshot such as `ActiveSongRootPaths`, trying
-each active root in order.
-
-Configured roots must not be used for this fallback because failed reload leaves
-the previous active hierarchy authoritative. Root N greater than zero must
-resolve correctly.
-
-`SongManager` exposes a copied current-search-path snapshot for Song Select
-activation and refresh.
+The normalized absolute chart path remains authoritative. For legacy nodes with
+relative directories, `PreviewImagePanel` receives the active-root snapshot and
+tries roots in order. It never uses newly configured roots when an old
+hierarchy remains active.
 
 ## Active Song Select Publication Handling
 
-A reload can commit and publish after Config deactivates. A player may reach an
-already-active Song Select stage before that terminal publication. Today Song
-Select copies `SongManager.RootSongs` during initialization and does not observe
-later publication, so merely proving that the stale list does not crash is
-insufficient.
+Publication while Song Select is deactivated needs no extra mechanism because
+normal activation rebuilds its list. The additional contract applies only while
+Song Select is already active.
 
-HPA-191 requires an update-thread refresh contract:
+On activation, subscribe to `SongLibraryPublished`; on deactivation, unsubscribe.
+The handler only records the newest pending version.
 
-- Song Select subscribes on activation and unsubscribes on deactivation to a
-  library-published notification. The existing `EnumerationCompleted` event may
-  be used if its post-publication contract is made explicit; otherwise add a
-  dedicated `SongLibraryPublished` event carrying a monotonically increasing
-  publication version and active-root snapshot.
-- The event handler never mutates UI collections. It records a pending version
-  or enqueues a refresh request guarded by the stage activation version.
-- `OnUpdate` snapshots `RootSongs` and active roots and replaces the displayed
-  root list on the game thread.
-- If the current navigation path still exists, restore it by stable path or
-  database identity. Otherwise reset to the root.
-- Preserve the selected chart by stable chart/database identity when possible;
-  otherwise select the first valid item.
-- Stop previews and clear status/history panels when the selected item no longer
-  exists.
-- Rebuild active All Songs, Bookmarks, Recent, filter, breadcrumb, preview-root,
-  and empty-state data from one publication version so the UI never mixes old
-  and new snapshots.
-- Stale or deactivated-stage notifications are ignored.
+On the update thread:
 
-Integration coverage must publish a replacement library while Song Select is
-active, including while inside a box and while Bookmarks or Recent is selected,
-and verify safe deterministic reconciliation rather than stale display or
-background-thread mutation.
+1. Fetch one `SongLibrarySnapshot`.
+2. Ignore stale versions.
+3. Replace the local root list and active-root fallback snapshot.
+4. Restore navigation by stable folder path/database identity when possible;
+   otherwise return to root.
+5. Restore selected chart by stable chart/database identity when possible;
+   otherwise choose the first valid item.
+6. Stop preview and clear status/history when the old selection disappeared.
+7. Rebuild All Songs, filters, Bookmarks, Recent, breadcrumb, preview roots, and
+   empty-state data from the same publication version.
+8. Never mutate UI collections from the publication callback thread.
+
+Multiple fast publications collapse to the newest version.
+
+All direct `RootSongs` consumers, including filter projection and bookmark
+reconciliation, now iterate copied snapshots. Tests publish concurrently while
+those operations enumerate.
 
 ## Active Views and Retained Data
 
-Removed/unavailable rows stay in SQLite, but active views do not surface them
-after a successful publication excludes their root:
-
-- All Songs uses the active hierarchy.
-- Bookmarks and Recent filter database-backed rows to active roots.
-- If reload fails, old active roots and their entries remain visible.
-- After successful removal, off-root entries are hidden but retained.
-- Successful re-add makes them visible with user data intact.
+- All Songs uses the active published hierarchy.
+- Bookmarks and Recent filter database-backed results to active roots.
+- A failed reload leaves old active entries visible.
+- Successful removal hides off-root entries but retains rows.
+- Successful re-add restores them with user data.
 
 ## Empty Library UX
 
 Song Select distinguishes:
 
-- No active roots and no configured root currently available: **No song folders
-  are currently available. Open Config to reconnect or change them.**
-- At least one active root but no supported charts: **No songs were found in the
-  active song folders.**
+- no active/available roots: **No song folders are currently available. Open
+  Config to reconnect or change them.**
+- active roots with no supported charts: **No songs were found in the active
+  song folders.**
 
-Exact wording may be localized later; the conditions remain distinct.
-
-## SongManager and Database Interaction
-
-No database migration is required.
-
-HPA-192 contracts remain authoritative:
-
-- Enumeration/persistence receive an ordered root array.
-- Root aliases are defensively deduplicated through `SongRootPolicy`.
-- Cleanup affects only roots supplied to a successful import.
-- Off-root charts and songs are retained.
-- User-owned scores, bookmarks, timestamps, ranks, combos, and history are
-  preserved.
-- Publication follows transaction commit.
-
-HPA-191 prevents textual overlap before import. The importer does not resolve
-physical aliases.
-
-Multiple roots remain flattened into the current root-level hierarchy. Equal
-display titles are allowed; identity remains path/database based.
-
-## Logging and User Feedback
+## Logging
 
 Structured logs include:
 
-- `DTXPath` migration and indexed-root parsing warnings.
-- Deliberate suppression of custom-root directory creation.
-- Old/new normalized root snapshots after commit.
-- Availability diagnostics.
-- Picker selected/cancelled outcomes at debug level and failures at warning.
-- Config operation-slot busy decisions and lease handoff failures.
-- Reload start, success, cancellation, pre-commit failure, and post-commit
-  partial failure.
-- Song Select publication-version refresh and reconciliation outcome.
+- legacy migration and indexed parsing warnings;
+- deliberate suppression of custom-root creation;
+- root-policy mode and dropped duplicates/overlaps;
+- preflight warnings and authoritative batch root failures;
+- operation lease acquisition/release failures;
+- reload/NX import terminal outcomes;
+- publication versions; and
+- Song Select reconciliation outcomes.
 
-Do not add per-file success logs beyond HPA-192 progress.
-
-User-facing examples:
-
-- `Reloading songs: 48 / 100 charts`
-- `Loaded 2 folders, 100 charts; 1 folder unavailable`
-- `Folders saved; no configured folder is currently available`
-- `Song library is busy importing NX scores`
-- `Reload failed; previous song list retained`
-- `Songs were updated but the list could not refresh; restart required`
+Do not add per-file success logs beyond existing HPA-192 progress.
 
 ## Testing Strategy
 
-### Configuration tests
+### Slice 1a configuration tests
 
-- Default config has one managed root and matching `DTXPath`.
-- Indexed roots round-trip in order and rewrite densely.
-- Legacy `DTXPath` migrates and persists immediately.
-- Known legacy `Songs` default migrates to `DTXFiles`.
-- Indexed entries take precedence.
-- Gaps, malformed indexes, duplicate indexes, and blanks behave as specified.
-- Root comparer is ignore-case on Windows/macOS and ordinal on Linux.
-- Chart canonical comparer remains ordinal.
-- Parent/child overlap is rejected symmetrically.
-- Physical aliases are documented but unresolved.
-- Custom missing roots are not created.
-- The managed default is created when restored.
-- Tests explicitly prove removal of the current unconditional custom-root
-  `EnsureDirectorySafe` behavior.
-- Persistence failure restores prior state and emits no event.
-- Successful update emits immutable old/new snapshots once.
-- Persistence statuses are distinct.
-- Downgrade mirror behavior is documented and serialization remains stable.
+- default/mirror behavior;
+- indexed round-trip and dense rewrite;
+- section-agnostic parsing remains unchanged;
+- second LoadConfig clears roots before parse;
+- legacy migration;
+- malformed/duplicate indexes;
+- missing custom paths are never created;
+- managed default creation;
+- atomic persistence rollback;
+- deferred-save marker clears only for the matching path; and
+- immutable event snapshots.
 
-### SongManager root-policy tests
+### Slice 1b root and SongManager tests
 
-- `SetCurrentSearchPaths` directly deduplicates case aliases under
-  `SongRootPolicy` and preserves first occurrence/order.
-- Its copied snapshot cannot be externally mutated.
-- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and
-  `NeedsEnumerationAsync` receive the aligned deduplicated roots.
-- Fresh enumeration and cache hierarchy behavior agree on root identity.
-- Linux case-distinct roots remain distinct.
+- both comparer modes run on every platform through the injected seam;
+- first-occurrence/order deduplication;
+- ignore-case and ordinal overlap matrices;
+- macOS-style case-differing parent/child rejection;
+- no use of `Path.GetRelativePath` for overlap policy;
+- SetCurrentSearchPaths empty input clears active roots;
+- PublishEmptyLibrary installs one coherent empty version;
+- RootSongs returns a stable copied snapshot;
+- filter projection remains safe during concurrent publication;
+- bookmark reconciliation remains safe during concurrent publication;
+- roots and active paths share one version;
+- startup cache/database callers use the same policy;
+- importer short-circuits before persistence/publication when batch active roots
+  are empty; and
+- authoritative unavailable counts come from root-failure batch errors.
 
-### Config and panel tests
+### Slice 2 UI/picker tests
 
-- System exposes **Song Folders**.
-- Singular/plural summaries are correct.
-- Panel uses an isolated draft.
-- Add/remove/reorder/Apply/Cancel/Back are deterministic.
-- Async picker cancellation/failure does not mutate the draft.
-- Stale picker completion cannot update an inactive panel.
-- Structural errors block; availability warnings may be applied.
-- Last root cannot be removed without replacement.
-- Config's delegate is the only `SetSongRoots` caller.
-- Busy changed-root Apply does not persist.
-- Persistence failure releases the lease and starts no reload.
-- `Saved` precedes `Closed` after success.
-- Throws at each reservation-handoff point cannot orphan the lease.
-- Key panels still work through overlay polymorphism.
-- macOS permission/authorization failure maps to Failed, while normal picker
-  cancellation maps to Cancelled.
+- menu and singular/plural summaries;
+- isolated panel draft;
+- add/remove/reorder/apply/cancel/back;
+- structural errors vs availability warnings;
+- async picker cancellation/failure;
+- stale picker generation;
+- Windows STA boundary;
+- macOS cancellation vs authorization failure; and
+- persisted roots are consumed on restart.
 
-### Reload and lifecycle tests
+### Slice 3a operation/reload tests
 
-- Unchanged roots do not write, acquire, or scan.
-- Reorder-only change invokes one full import.
-- Successful Apply invokes importer once with available roots in order.
-- Unavailable roots do not block available ones.
-- No available roots skip import, retain hierarchy, and release the lease.
-- Apply is rejected without persistence during NX import.
-- NX import is rejected during reload.
-- Lower-level busy maps to user-visible Busy.
-- Leaving Config cancels and observes without blocking.
-- Stale continuations cannot write Config UI.
-- Pre-commit failure/cancellation preserves old hierarchy.
-- Post-commit cancellation cannot suppress publication.
-- Unexpected post-commit publication failure reports partial success.
+- unchanged Apply does not acquire/write/scan;
+- Busy Apply does not persist;
+- one full scan for reorder-only change;
+- lease release on validation/persistence/task-construction/continuation errors;
+- lower-level enumeration Busy mapping;
+- NoAvailableRoots retains old Config hierarchy;
+- batch root failures drive final warning counts;
+- pre-commit cancellation preserves old hierarchy;
+- post-commit cancellation cannot suppress publication;
+- NX import and reload cannot overlap;
+- NX import progress never writes Config UI from a worker;
+- deactivation cancellation is non-blocking; and
+- both task lifecycles dispose CTS and release lease exactly once.
 
-### Song Select publication tests
+### Slice 3b Song Select/integration tests
 
-- Publication while Song Select is active is processed only on the update
-  thread.
-- Root list, active roots, filters, Bookmarks, Recent, preview fallback, and
-  empty-state data use the same publication version.
-- Selection is restored by stable identity when retained.
-- Removed selection resets deterministically and stops preview/status state.
-- Publication while inside a removed box resets to root safely.
-- Publication during Bookmarks or Recent refreshes that tab against active roots.
-- Notifications after deactivation are ignored.
-- Multiple fast publications apply only the newest version.
-
-### Startup and integration tests
-
-- Startup uses `SongRoots`, not compatibility `DTXPath`.
-- Production `DTXPath` reads are absent outside compatibility allowlist.
-- Multiple roots appear in configured order.
-- Root aliases import once under the root comparer.
-- Distinct roots import each chart once.
-- Root N preview fallback uses active roots.
-- Removed-root songs disappear after successful reload but remain stored.
-- Bookmarks/Recent hide off-active entries and restore after re-add.
-- Missing removable root does not block another root.
-- No available roots publish an empty active library without cleanup.
-- Empty states are distinct.
-- Windows and macOS compile only their picker implementation.
-- Existing HPA-192 cancellation, retention, and performance tests stay green.
+- publication callback only records a version;
+- update-thread reconciliation uses one coherent snapshot;
+- concurrent filter iteration cannot observe collection mutation;
+- stable selection/navigation restoration;
+- removed selection stops preview and clears panels;
+- publication inside a removed box returns safely to root;
+- Bookmarks/Recent refresh against active roots;
+- multiple publications apply newest only;
+- notifications after deactivation are ignored;
+- root N preview fallback;
+- removed-root data remains stored and reappears after re-add;
+- empty states are distinct; and
+- Windows/macOS builds remain isolated to their picker implementation.
 
 ## Implementation Slices
 
-Slices are hard dependencies and land in order: **Slice 1 → Slice 2 → Slice
-3**. Each is scoped to at most three engineer days.
+The slices are hard dependencies and land in order.
 
-### Slice 1: Canonical multi-root configuration and consumer migration
+### Slice 1a: Configuration model and persistence
 
-- Add `SongRoots`, indexed INI format, mirror, migration, persistence result,
-  immutable event snapshots, and immediate persistence.
-- Replace unconditional custom-root directory creation with managed-default-only
-  creation and add behavior-removal tests.
-- Add internal `SongRootPolicy` with normalization, explicit comparer, overlap,
-  and availability probing.
-- Align all `SongManager` root deduplication with the policy.
-- Add direct `SetCurrentSearchPaths` and startup cache/database caller coverage.
-- Update startup to consume snapshots and publish empty active state when needed.
-- Audit all production `DTXPath` consumers and add an architecture allowlist
-  test.
-- Add active-root snapshot exposure and multi-root preview fallback.
-- Do not add Config editing UI or live reload.
+- Add `SongRoots`, indexed format, mirror, migration, and load clearing.
+- Add persistence result/event snapshots.
+- Remove custom-root auto-creation.
+- Preserve section-agnostic parsing.
+- Correct pending-save clearing.
+- Add focused config tests.
+
+### Slice 1b: Root policy, SongManager snapshots, and startup consumers
+
+- Add testable `SongRootPolicy`.
+- Add segment-wise overlap detection.
+- Align all SongManager root deduplication.
+- Replace live RootSongs view with copied/versioned snapshots.
+- Add empty publication and remove empty-path early-return behavior.
+- Add authoritative no-active-root enumeration result.
+- Update startup, preview fallback, and runtime consumer audit.
+- Add concurrency and startup/cache-path tests.
 
 ### Slice 2: Cross-platform SongFolderPanel
 
-Depends on Slice 1.
+- Add `IConfigOverlayPanel`.
+- Add asynchronous Windows/macOS/fake pickers.
+- Implement draft editing and Config-owned Apply delegate.
+- Use restart-required status until live reload lands.
+- Add panel and platform tests.
 
-- Add `IConfigOverlayPanel` and adapt key panels.
-- Add asynchronous Windows, macOS, and fake picker implementations.
-- Include macOS consent/authorization UX and result mapping.
-- Replace **DTX Folder** with **Song Folders** and implement draft editing.
-- Commit through Config's single delegate.
-- Show temporary restart-required status after `Updated`.
-- Verify startup consumes persisted roots on next launch.
-- Add panel, threading, privacy-failure, and platform-boundary tests.
+### Slice 3a: Config operation coordinator and live reload
 
-### Slice 3: Live reload and active-stage reconciliation
+- Add atomic scoped lease coordinator.
+- Implement single-method Apply ownership.
+- Add reload service and HPA-192 adaptation.
+- Migrate NX import fully onto the same lifecycle.
+- Add non-blocking cancellation/observation and progress marshalling.
+- Add operation/reload tests.
 
-Depends on Slices 1 and 2.
+### Slice 3b: Active Song Select reconciliation and retained views
 
-- Add `ISongLibraryReloadService`.
-- Add Config mutual exclusion and scoped lease handoff with throw-safe release.
-- Add progress, warnings, non-blocking retirement, commit-to-publish terminal
-  semantics, and failure feedback.
-- Add active-root filtering for Bookmarks/Recent and deliberate empty states.
-- Add update-thread Song Select reconciliation for out-of-band publication,
-  including stable selection/navigation restoration.
-- Verify successful publication, retained old hierarchy on pre-commit failure,
-  post-commit recovery, and removed-root data retention.
-- Add multi-root lifecycle integration tests and Windows/macOS builds.
+- Add publication subscription/version handling.
+- Reconcile hierarchy/navigation/selection on update thread.
+- Refresh filters, Bookmarks, Recent, previews, and empty states coherently.
+- Add concurrent-publication and retained-data integration tests.
+
+Each slice is intended to fit within three engineer days. If Slice 3b expands
+beyond that during planning, split retained-data tab refresh from core hierarchy
+reconciliation rather than broadening one task.
 
 ## Acceptance Criteria
 
-- Existing one-path configurations migrate without library loss.
-- Fresh install has one managed default root.
-- Config adds, removes, and reorders roots on Windows and macOS.
-- Ordered roots survive restart and startup reads them.
-- Root comparison is ignore-case on Windows/macOS and ordinal on Linux; chart
-  canonical identity remains ordinal.
-- `SetCurrentSearchPaths` and startup cache/database paths use the same policy
-  with direct tests.
-- Duplicate and textual parent/child roots cannot be applied.
-- Missing custom roots remain configured and are never auto-created.
-- Removal of the current custom-path `EnsureDirectorySafe` behavior is explicit
-  and tested.
-- Existing auto-created directories are not deleted.
-- The first-root downgrade mirror and its older-build recreation caveat are
-  documented.
-- Unchanged roots do not acquire or scan; any changed ordered list performs at
-  most one full scan.
-- Busy changed-root Apply does not persist.
-- Every available root scans in configured order.
-- NX import and reload cannot run concurrently.
-- Slot handoff is throw-safe and cannot orphan ownership.
-- One unavailable root does not block available roots.
-- Successful reload atomically replaces hierarchy and active roots.
-- Pre-commit failure/cancellation never exposes partial hierarchy.
-- Post-commit cancellation cannot suppress publication.
-- Config deactivation never blocks the game thread.
-- Song Select safely reconciles an out-of-band publication while active.
-- No available root during Apply retains the previous active hierarchy.
-- No available root during startup reaches Title with empty active state and
-  leaves SQLite untouched.
-- Preview fallback works under every active root.
-- Removing a root hides its songs, Bookmarks, and Recent entries while retaining
-  database data.
-- Re-adding restores retained state and active views.
-- Song Select distinguishes unavailable roots from available-but-empty roots.
-- `DTXPath` remains compatibility-only; runtime consumers use configured or
-  active snapshots as appropriate.
-- Physical-target deduplication remains explicitly outside scope.
-- No DTXCreator, parser, schema, or synthetic-root-navigation change is
-  included.
+- Legacy one-root configuration migrates without library loss.
+- Indexed roots persist in order and load repeatedly without accumulation.
+- INI parsing remains section-agnostic.
+- `DTXPath` remains a compatibility mirror only.
+- Missing custom roots are never auto-created.
+- Root comparison supports testable ignore-case and ordinal modes.
+- Duplicate and comparer-aware parent/child roots cannot be applied.
+- Physical-target deduplication remains out of scope.
+- RootSongs never exposes a live mutable-list wrapper.
+- Concurrent publication cannot break filter/bookmark enumeration.
+- Empty publication clears hierarchy and active roots in one version.
+- Startup and every SongManager root path use the same policy.
+- Changed root lists perform at most one full scan; unchanged lists perform none.
+- Config root-failure counts reflect what the enumeration batch actually saw.
+- A no-active-root batch never imports or publishes through normal reload.
+- Config retains the old hierarchy when no root is active.
+- Startup publishes a deliberate empty library without cleanup when no root is
+  active.
+- Busy Apply does not persist.
+- NX import and reload share one throw-safe lifecycle and cannot overlap.
+- Config deactivation never blocks the update thread.
+- Commit-to-publication is non-cancellable.
+- Active Song Select reconciles a new publication on the update thread.
+- Bookmarks/Recent show only active-root rows while retained rows remain stored.
+- Preview fallback works for every active root.
+- Re-adding a root restores retained user data.
+- No DTXCreator, parser, schema, or synthetic-root-navigation change is included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
 **Date:** 2026-08-01  
-**Status:** Draft for review
+**Status:** Revised draft for review
 
 ## Context
 
@@ -23,25 +23,28 @@ The lower-level song system is already substantially multi-root capable:
 
 HPA-191 therefore does not require a database schema change or another song
 import architecture. The work is to make the ordered root list a first-class
-configuration value, expose safe cross-platform editing in Config, and reload
-the active library without routing the game through boot-only startup state.
+configuration value, expose safe cross-platform editing in Config, audit every
+legacy `DTXPath` runtime consumer, and reload the active library without routing
+the game through boot-only startup state.
 
 ## Goals
 
-- Allow the player to add, remove, and reorder song-library roots from the
-  Config stage.
+- Allow the player to add, remove, and reorder song-library roots from Config.
 - Support one or more persisted roots while retaining compatibility with
   existing `DTXPath` configurations.
-- Apply valid changes immediately and perform one live library reload.
+- Apply valid changes immediately and perform at most one live library reload.
 - Preserve the currently published hierarchy until a replacement reload has
   completed successfully.
 - Preserve database records and user-owned data for roots removed from the
   active configuration or temporarily unavailable.
 - Support Windows and macOS folder selection without referencing platform UI
   frameworks from shared game code.
-- Reject configurations that would scan the same subtree more than once.
+- Reject configurations that would scan the same textual subtree more than
+  once under the selected root-comparison policy.
 - Keep startup behavior deterministic when some or all configured roots are
   unavailable.
+- Serialize Config-initiated song-library mutation operations so NX score import
+  and song-folder reload cannot write or rebuild the library concurrently.
 
 ## Non-goals
 
@@ -50,27 +53,34 @@ the active library without routing the game through boot-only startup state.
 - Song database schema changes.
 - Filesystem watchers or automatic reload when a removable drive is mounted.
 - Background rescans after every individual add, remove, or reorder action.
+- A database-only optimization for reorder-only changes; any changed ordered
+  root list performs one full enumeration/import in HPA-191.
 - Editing or creating song files from Config.
 - Synthetic top-level boxes for each configured root.
 - Merging same-named folders or songs across different roots.
 - Deleting retained database records for removed roots.
+- Resolving filesystem aliases to a physical target. Symlinks, junctions, bind
+  mounts, aliases, and case-sensitive macOS volumes can expose the same target
+  through distinct paths; realpath/inode-based deduplication is deferred.
 - General-purpose file-picker infrastructure beyond directory selection.
+- Replacing the macOS AppleScript adapter with a native `NSOpenPanel` helper.
 - Linux-specific picker integration; the configuration and reload contracts
   remain platform-neutral, but HPA-191 targets the existing Windows and macOS
   game projects.
 
 ## Chosen Approach
 
-Add an ordered `SongRoots` collection as the sole runtime source of truth.
-Retain `DTXPath` only as a serialized compatibility mirror of the first root.
-A dedicated Config overlay edits a working copy and commits it only when the
-player selects **Apply**. A platform-specific folder-picker service supplies new
-paths. After the configuration is atomically persisted, a focused song-library
-reload service invokes the existing HPA-192 enumeration/import path once.
+Add an ordered `SongRoots` collection as the sole configured-root source of
+truth. Retain `DTXPath` only as a serialized compatibility mirror of the first
+root. A dedicated Config overlay edits a working copy and commits it only when
+the player selects **Apply**. An asynchronous platform-specific folder-picker
+service supplies new paths. After configuration is atomically persisted, a
+focused song-library reload service invokes the existing HPA-192
+enumeration/import path once.
 
 The old hierarchy remains published until the complete replacement batch has
-committed and been published. A failed or cancelled reload therefore cannot
-leave Song Select displaying a partial library.
+committed and been published. A failed or cancelled pre-commit reload therefore
+cannot leave Song Select displaying a partial library.
 
 Three root states are distinguished throughout the design:
 
@@ -78,33 +88,37 @@ Three root states are distinguished throughout the design:
 - **Available roots:** configured roots that currently exist and pass a minimal
   access probe.
 - **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy. Active roots change only after a successful reload, or during a
-  clean startup that intentionally publishes an empty library.
+  hierarchy. Active roots change only after a successful publication, or during
+  a clean startup that intentionally publishes an empty active library.
 
-This distinction allows removable-drive paths to remain configured without
-pretending they are currently usable.
+Configured roots and active roots may temporarily differ. For example, a player
+can save new roots and then encounter a failed reload; Song Select must continue
+to use the old active-root snapshot until a later reload or startup succeeds.
 
 ## Alternatives Considered
 
 ### Save and require restart
 
 This is the smallest implementation, but it leaves the active library stale
-until the player restarts and gives weak feedback that the change succeeded.
-It is rejected because the existing bulk importer already provides an atomic
-publication boundary suitable for a live reload.
+until restart and gives weak feedback that the change succeeded. It is rejected
+for the final feature because the existing bulk importer provides an atomic
+publication boundary suitable for a live reload. Slice 2 temporarily uses this
+behavior until Slice 3 lands.
 
 ### Transition Config back through StartupStage
 
 This reuses the startup progress screen, but `StartupStage` owns boot-specific
 phase state, activation generations, timing summaries, and exactly-once startup
-telemetry. Re-entering it for a user-initiated configuration operation would
-couple unrelated lifecycles and make telemetry ambiguous. It is rejected.
+telemetry. Re-entering it for a user-initiated operation would couple unrelated
+lifecycles and make telemetry ambiguous. It is rejected.
 
-### Rescan after every list edit
+### Rebuild from SQLite for reorder-only changes
 
-This would repeatedly traverse and persist the same library while the player is
-still composing the desired configuration. It is rejected in favor of a draft
-list and one Apply operation.
+The database hierarchy builder could potentially republish roots in a different
+order without reparsing charts. HPA-191 deliberately does not add that branch.
+Apply is an explicit refresh operation, and one full scan also observes any
+filesystem changes made while the panel was open. A future measured
+optimization may special-case reorder-only changes.
 
 ### Store one delimited `SongRoots=` value
 
@@ -121,20 +135,24 @@ and hand editing. Indexed keys are easier to parse, order, diagnose, and migrate
 public List<string> SongRoots { get; } = new();
 ```
 
-The collection is initialized with `AppPaths.GetDefaultSongsPath()`.
+The property remains get-only. Load, reset, and successful update operations
+clear and refill the existing list rather than replacing the list reference.
+Consumers must never retain or mutate that live collection. Every UI, event,
+reload, and startup boundary receives an immutable copied snapshot.
 
 `DTXPath` remains available for source and downgrade compatibility, but is a
 mirror only:
 
 - After load, reset, or a successful root update, it equals the first canonical
   configured root.
-- Production startup, Config UI, reload, and active-root filtering must consume
-  `SongRoots`, never `DTXPath`.
+- Production startup, Config UI, reload, active-root filtering, previews, and
+  other runtime behavior consume `SongRoots` or the active-root snapshot, never
+  `DTXPath`.
 - Direct legacy mutation of `DTXPath` is not a supported way to change the
   runtime library.
 
 At least one configured root is always required. Availability is not required;
-a single configured path may point to a currently disconnected removable drive.
+a single configured path may point to a disconnected removable drive.
 
 ### Persisted format
 
@@ -153,22 +171,19 @@ Rules:
 2. Roots are loaded in ascending numeric order; gaps are allowed.
 3. Malformed suffixes, blank values, and negative indexes are ignored with a
    warning.
-4. Duplicate indexes use the last parsed value, matching normal INI overwrite
-   expectations, and emit a warning.
-5. Values may contain `=` because `ConfigManager` already splits lines on the
-   first `=` only.
+4. Duplicate indexes use the last parsed value and emit a warning.
+5. Values may contain `=` because `ConfigManager` splits on the first `=` only.
 6. Save rewrites indexes densely from zero.
 7. `DTXPath` is always written as the first root for downgrade compatibility.
-8. `SongRoot.*` entries are the authority whenever at least one structurally
-   valid entry exists.
-9. When no valid indexed entries exist, the loader migrates the legacy
-   `DTXPath` value into a one-element root list.
-10. When neither representation yields a usable path, the managed default root
-    is restored.
+8. `SongRoot.*` entries are authoritative whenever at least one structurally
+   valid indexed entry exists.
+9. When no valid indexed entry exists, load migrates legacy `DTXPath` into a
+   one-element list.
+10. When neither representation yields a valid path, load restores the managed
+    default root.
 
 A successful legacy migration is persisted immediately through the existing
-atomic temp-file replacement so the next launch no longer depends on fallback
-logic.
+atomic temp-file replacement.
 
 ### Legacy path migration
 
@@ -177,7 +192,12 @@ The existing migration from legacy `Songs` defaults to the current managed
 before that value becomes `SongRoots[0]`.
 
 Indexed custom roots are not remapped merely because their final segment is
-named `Songs`; only the known legacy default representations are migrated.
+named `Songs`; only known legacy default representations are migrated.
+
+Previous releases may already have created an empty custom directory while a
+removable or network path was unavailable. HPA-191 stops creating such paths,
+but it does not delete or move directories created by earlier versions. The
+migration is logged; filesystem cleanup is left to the user.
 
 ### Directory creation
 
@@ -186,13 +206,35 @@ is selected or restored as the fallback root.
 
 The game must not create arbitrary custom roots. A missing custom path may be a
 removable drive, network mount, renamed directory, or user error. Creating it
-would hide the problem and could produce unwanted directories on the wrong
+would hide the problem and could produce an unwanted directory on the wrong
 volume.
 
-## Path Identity and Validation
+## Root Path Identity and Validation
 
-All roots are resolved and compared through one shared policy used by config
-load, Config UI, and the setter.
+Root comparison is intentionally distinct from HPA-192 chart identity.
+`SongPathIdentity.CanonicalComparer` remains ordinal and continues to protect
+exact persisted chart identities. HPA-191 does not redefine it as
+platform-aware.
+
+### Shared root policy
+
+Add an internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. It is
+the only path used by Config load, Config UI, `SetSongRoots`, startup,
+`SongManager` defensive root deduplication, and availability probing.
+
+`SongRootPolicy.RootComparer` uses
+`SongPathIdentity.LegacyAliasComparer`:
+
+- Windows and macOS: ordinal ignore-case.
+- Linux and other platforms: ordinal case-sensitive.
+
+This is a deliberate user-facing root policy. On a case-sensitive macOS volume,
+paths that differ only by case are still treated as duplicate configured roots
+for HPA-191. Resolving actual filesystem case or targets is outside scope.
+
+`SongPathIdentity` remains internal. No public API exposure is required because
+`ConfigManager`, stages, `SongManager`, and `SongRootPolicy` live in the same
+assembly. Tests use the repository's existing internal-test access pattern.
 
 ### Canonicalization
 
@@ -201,13 +243,18 @@ For each non-blank input:
 1. Expand supported home-relative forms through `AppPaths`.
 2. Resolve relative legacy paths against the same app-data base used today.
 3. Convert to an absolute full path.
-4. Normalize separators and trailing separators through `SongPathIdentity`.
-5. Compare with `SongPathIdentity.CanonicalComparer`, preserving platform path
-   case behavior.
-6. Persist the canonical absolute value.
+4. Normalize separators and trailing separators through
+   `SongPathIdentity.Normalize`.
+5. Compare roots with `SongRootPolicy.RootComparer`.
+6. Persist the normalized absolute value.
 
 Root order is semantically meaningful. It controls traversal order and the
 ordering of root-level nodes in Song Select.
+
+`SongManager.SetCurrentSearchPaths`, enumeration batch root creation, and other
+defensive deduplication must use `SongRootPolicy.RootComparer`, not
+`SongPathIdentity.CanonicalComparer`, so direct callers cannot reintroduce root
+case aliases that Config rejects.
 
 ### Blocking structural errors
 
@@ -215,18 +262,20 @@ The following prevent Apply and leave the current configuration unchanged:
 
 - No configured roots.
 - Blank or syntactically invalid paths.
-- Canonically duplicate roots.
-- Overlapping roots where either path is an ancestor of the other.
+- Duplicate roots under `SongRootPolicy.RootComparer`.
+- Overlapping roots where either normalized path is an ancestor of the other.
 
-Overlapping roots are rejected because scanning both a parent and its child
-would discover the same charts twice. The policy performs a symmetric
-ancestor check after canonicalization; authored order does not make an overlap
-valid.
+Overlap checks use the same root comparer for path-segment equality. Authored
+order does not make an overlap valid.
 
 Hand-edited invalid configuration must not prevent startup. During load, roots
 are processed in numeric order and the first accepted root wins. Later duplicate
 or overlapping entries are dropped with warnings. If all entries are rejected,
 the managed default is restored.
+
+Symlink, junction, mount, and alias targets are not resolved. Two textually
+different non-overlapping paths that reach the same physical directory may both
+scan in v1.
 
 ### Availability warnings
 
@@ -252,19 +301,13 @@ scan; that failure follows the reload error contract below.
 Replace the read-only **DTX Folder** item with a navigation item named
 **Song Folders**.
 
-Its value summary is:
-
-- `1 folder` for one configured root.
-- `<n> folders` for multiple roots.
-
-The description states that the folders are scanned in the displayed order and
-that Apply reloads the song library once.
+Its value summary is `1 folder` or `<n> folders`. The description states that
+folders are scanned in displayed order and Apply reloads the library once.
 
 ### Overlay abstraction
 
-`ConfigStage` currently models its active overlay as `IKeyAssignPanel`, although
-the lifecycle and drawing contract is generally useful. Introduce
-`IConfigOverlayPanel` containing the common members:
+Introduce `IConfigOverlayPanel` containing the common members currently carried
+by `IKeyAssignPanel`:
 
 - `IsActive`
 - `Closed`
@@ -273,25 +316,42 @@ the lifecycle and drawing contract is generally useful. Introduce
 - `Update(...)`
 - `Draw(...)`
 
-`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving existing key-panel
-contracts. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
-targeted boundary correction required to host a non-key-assignment panel; it is
-not a broader Config UI refactor.
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving its existing
+`Saved`-before-`Closed` contract. `ConfigStage._activePanel` becomes
+`IConfigOverlayPanel`. This is a targeted boundary correction, not a broader UI
+refactor.
 
-### SongFolderPanel
+### SongFolderPanel ownership
 
 `SongFolderPanel` receives:
 
-- An immutable snapshot of configured roots.
+- An immutable configured-root snapshot.
 - `IFolderPickerService`.
 - The shared root validation policy.
+- A commit delegate owned by `ConfigStage`:
 
-It owns a private draft list. Opening, reordering, adding, removing, or
+```csharp
+Func<IReadOnlyList<string>, SongRootUpdateResult> commitRoots
+```
+
+The panel owns a private draft list. Opening, reordering, adding, removing, or
 cancelling does not mutate `ConfigData`.
 
-The panel displays the full selected path and a scrollable ordered list. Long
-paths may be visually ellipsized, but validation and persistence always use the
-complete value.
+On **Apply**:
+
+1. The panel validates its draft.
+2. The panel passes an immutable draft snapshot to the Config-owned delegate.
+3. The delegate is the only caller of `IConfigManager.SetSongRoots`.
+4. Validation or persistence failure is returned to the panel; the panel stays
+   open and shows the error.
+5. On `Updated` or `Unchanged`, the panel stores the immutable committed
+   snapshot, raises `Saved`, then raises `Closed`.
+6. `ConfigStage` reads the committed snapshot during `Saved`. It starts a reload
+   only for `Updated`; `Unchanged` closes without a scan.
+
+The panel never holds `IConfigManager` and never persists roots independently.
+This prevents double commits and keeps event ordering consistent with existing
+Config panels.
 
 Supported actions:
 
@@ -301,55 +361,53 @@ Supported actions:
 - **Apply** — validate and commit the complete draft.
 - **Cancel** — discard the draft and close.
 
-Input behavior follows existing Config conventions:
-
-- Up/Down move selection.
-- Left/Right change the selected action where applicable.
-- Activate executes the highlighted action.
-- Back behaves as Cancel.
-
-Structural errors are shown in the panel and keep it open. Availability warnings
-are shown beside affected roots but do not disable Apply.
-
-A folder-picker cancellation is a no-op. A picker failure displays an error and
-leaves the draft unchanged.
+Structural errors keep the panel open. Availability warnings appear beside
+roots but do not disable Apply. Picker cancellation is a no-op; picker failure
+leaves the draft unchanged and displays an error.
 
 ## Platform Folder Picker
 
-Shared code depends only on:
+Shared code depends on an asynchronous interface:
 
 ```csharp
 public interface IFolderPickerService
 {
-    FolderPickerResult PickFolder(string? initialDirectory);
+    Task<FolderPickerResult> PickFolderAsync(
+        string? initialDirectory,
+        CancellationToken cancellationToken);
 }
 ```
 
 The result distinguishes selected, cancelled, unavailable, and failed outcomes
 and carries an error message only for failure.
 
+While a picker is active, the panel displays a selecting state and ignores
+repeat Add actions. Picker completion is marshalled back to panel state only if
+the panel activation generation is still current.
+
 Platform composition selects the implementation:
 
-- **Windows:** use `System.Windows.Forms.FolderBrowserDialog`, already supported
-  by the Windows project target. The dialog starts from the selected root or the
-  managed default when possible.
-- **macOS:** invoke the native folder chooser through a small `osascript`
-  adapter using `choose folder`, returning its POSIX path. Process arguments are
-  passed without shell interpolation, cancellation is mapped to Cancelled, and
-  non-cancellation failures include stderr in structured logging.
+- **Windows:** `FolderBrowserDialog` is acceptable because the Windows project
+  already enables WinForms. The implementation owns the required STA thread or
+  platform dispatcher; shared game/update code does not assume its thread is
+  STA. The dialog starts from the selected root or managed default when valid.
+- **macOS:** invoke `osascript` with `choose folder`, a clear prompt, and a
+  default location when `initialDirectory` exists. Construct arguments through
+  `ProcessStartInfo.ArgumentList`, never shell interpolation. Await process exit
+  asynchronously, map user cancellation to `Cancelled`, terminate the process
+  on cancellation when safe, and map privacy/automation denial or other
+  non-cancellation failures to `Failed` with stderr in structured logs.
 
-The shared `DTXMania.Game` code must not reference WinForms, AppleScript process
-construction, or other platform UI types. Picker implementations and service
-registration live in platform-specific source files or projects.
-
-Headless tests inject a deterministic fake picker.
+The shared project must not reference WinForms, AppleScript process
+construction, or native picker types. Headless tests inject a deterministic fake
+picker. A future native `NSOpenPanel` helper may replace AppleScript without
+changing the shared interface.
 
 ## Commit and Persistence Flow
 
-Applying roots is an explicit user commit, so it requires stronger semantics
-than an ordinary deferred toggle edit.
+Applying roots is an explicit user commit and requires immediate persistence.
 
-`IConfigManager` gains a typed root update operation returning a result:
+`IConfigManager` gains:
 
 ```csharp
 SongRootUpdateResult SetSongRoots(
@@ -357,115 +415,249 @@ SongRootUpdateResult SetSongRoots(
     IReadOnlyList<string> roots);
 ```
 
+The result contract is:
+
+```csharp
+public enum SongRootUpdateStatus
+{
+    Updated,
+    Unchanged,
+    ValidationFailed,
+    PersistenceFailed
+}
+
+public sealed record SongRootUpdateResult(
+    SongRootUpdateStatus Status,
+    IReadOnlyList<string> CanonicalRoots,
+    IReadOnlyList<SongRootDiagnostic> Diagnostics)
+{
+    public bool IsSuccess =>
+        Status is SongRootUpdateStatus.Updated
+            or SongRootUpdateStatus.Unchanged;
+}
+```
+
+The implementation may adjust concrete type names but must preserve those four
+outcomes and immutable snapshots.
+
 The operation:
 
 1. Validates and canonicalizes the complete list.
-2. Captures the prior `SongRoots` and `DTXPath` values.
-3. Updates both in memory.
-4. Writes the complete config immediately through the existing atomic
-   temp-file replacement.
+2. Captures prior `SongRoots` and `DTXPath` snapshots.
+3. Clears/refills `SongRoots` and updates `DTXPath` in memory.
+4. Writes the complete config immediately through atomic temp-file replacement.
 5. Clears any pending deferred-save marker on success because all current
    settings were written.
-6. Restores the prior in-memory values if persistence fails.
+6. Restores prior in-memory values if persistence fails.
 7. Raises `SongRootsChanged` only after persistence succeeds.
-8. Is a no-op success when the canonical ordered list is unchanged.
+8. Returns `Unchanged` without a write or event when the canonical ordered list
+   is unchanged.
 
-Event subscribers are isolated using the same per-subscriber exception handling
-as existing config events. A subscriber failure does not undo an accepted and
-persisted configuration.
-
-If persistence fails, the panel remains open, the old configuration remains the
-truth, and no reload begins.
+`SongRootsChangedEventArgs` carries copied immutable old and new root snapshots.
+Subscriber exceptions are isolated using existing config-event behavior. A
+subscriber failure cannot undo accepted persisted configuration.
 
 ## Live Library Reload
 
 ### Boundary
 
-Introduce an `ISongLibraryReloadService` abstraction so `ConfigStage` does not
-own raw `SongManager` orchestration and tests do not need the singleton.
+Introduce `ISongLibraryReloadService` so `ConfigStage` does not own raw
+`SongManager` orchestration and tests do not need the singleton.
 
 The production implementation:
 
-- Resolves currently available roots from the persisted configured list.
-- Adapts `EnumerationProgress` to a Config status string.
-- Invokes `SongManager.EnumerateAndImportSongsAsync` once.
-- Returns the successful active-root set, aggregate counts, warnings, or a
-  terminal failure/cancellation result.
-- Allows only one in-flight reload.
+- Resolves available roots from the persisted configured snapshot.
+- Adapts `EnumerationProgress` to Config status.
+- Invokes `SongManager.EnumerateAndImportSongsAsync` exactly once for any
+  changed ordered list, including reorder-only changes.
+- Returns the successful active-root set, aggregate counts, skipped-root
+  warnings, busy, cancellation, partial post-commit failure, or terminal
+  pre-commit failure.
+- Allows one in-flight reload.
 
-It does not create another import path. The existing HPA-192 batch builder,
-bulk transaction, hierarchy finalization, and publication remain authoritative.
+It does not call `NeedsEnumerationAsync` and does not invent a cache or
+reorder-only path. HPA-192 remains the sole importer and publication authority.
 
 ### Apply sequence
 
-1. `SongFolderPanel` validates its draft.
-2. `ConfigManager.SetSongRoots` atomically persists the canonical list.
-3. The panel closes and Config displays a reload status.
-4. The reload service probes all configured roots.
-5. When at least one root is available, one enumeration/import starts with only
+1. `SongFolderPanel` validates and commits its draft.
+2. `ConfigManager.SetSongRoots` atomically persists the canonical ordered list.
+3. `Saved` fires before `Closed`; Config captures the committed snapshot.
+4. `Unchanged` closes with no reload.
+5. `Updated` acquires the Config song-operation slot and displays reload status.
+6. The reload service probes all configured roots.
+7. When at least one root is available, one enumeration/import starts with only
    those roots.
-6. The old hierarchy remains active while discovery and persistence run.
-7. On successful commit, `SongManager.PublishEnumeration` replaces the hierarchy
-   and current active-root snapshot atomically.
-8. Config reports loaded root, chart, logical-song, skipped-root, and error
-   counts.
+8. The old hierarchy remains active while discovery and persistence run.
+9. On successful commit, finalization and publication replace the hierarchy and
+   active-root snapshot atomically.
+10. Config reports folder, chart, unavailable-folder, and error counts. Logical
+    song counts remain structured-log detail rather than user-facing copy.
 
-Unavailable configured roots are omitted from that scan and listed as warnings.
-Their database records are retained because they are outside the active import
-roots.
+Unavailable configured roots are omitted from the scan and listed as warnings.
+Their database records remain outside active import cleanup.
 
-When no configured root is currently available, Config does not invoke the
-importer and does not clear the current hierarchy. The roots remain saved and
-Config reports that the current library was retained until a successful future
-reload or restart.
+When no configured root is available, Config skips the importer and retains the
+current active hierarchy. The roots remain saved and Config reports that the
+current library is retained until a later successful reload or restart.
 
-### Concurrency and lifecycle
+### Config operation mutual exclusion
 
-- A second Apply/reload request is rejected while one reload is in flight.
-- Song-folder editing may be reopened only after the prior reload terminates.
-- Leaving Config cancels the reload and observes its task.
-- The cancellation source is disposed only after the operation terminates,
-  preserving HPA-192's enumeration-slot and cancellation-winddown guarantees.
-- Config deactivation must not block indefinitely waiting for filesystem work.
-- The reload task may complete during a stage transition, but it must not write
-  into disposed Config graphics or panel state. Status publication is guarded
-  by an activation generation or equivalent lifetime token.
+`ConfigStage` owns one operation slot for Config-initiated song-library work:
 
-### Failure and cancellation
+```text
+None | NxScoreImport | SongFolderReload
+```
 
-If discovery, import, or publication fails:
+Both `StartNxScoreImport` and song-folder Apply must acquire this slot before
+starting work and release it only in their terminal continuation.
 
-- The newly persisted configured roots remain saved.
-- The previous active hierarchy and active-root snapshot remain published.
+Required behavior:
+
+- Apply while NX import is running is rejected with a clear status; roots are
+  not re-persisted and no reload starts.
+- NX import while reload is running is rejected with a clear status.
+- A second reload is rejected while reload is active.
+- Existing `SongManager` enumeration-slot rejection is converted to a `Busy`
+  reload result, never an unhandled `InvalidOperationException`.
+- Future Config features that mutate or rebuild the song library must use the
+  same slot.
+
+The operation slot prevents the current NX import and reload paths from racing
+on SQLite and hierarchy refresh. `SongManager` retains its own enumeration slot
+as the lower-level defensive boundary for non-Config callers.
+
+### Cancellation, commit, and publication
+
+The HPA-192 transaction commit through hierarchy publication is treated as a
+non-cancellable terminal section:
+
+- Cancellation is honored during probing, discovery, parsing, matching, and
+  persistence before the database commit.
+- Once the bulk import commits successfully, the caller must not perform another
+  cancellation check before `FinalizePendingNodes` and `PublishEnumeration`.
+- A cancellation request arriving after commit is ignored until publication
+  completes; the result is success, not cancellation.
+- This rule prevents the database from reflecting the new active-root cleanup
+  while the old hierarchy remains published solely because cancellation arrived
+  in the commit-to-publish gap.
+
+If an unexpected finalization or publication exception occurs after commit, the
+old hierarchy remains atomically intact, but the database may already reflect
+the new import. Report a distinct partial-success failure requiring restart;
+do not claim rollback. This is an exceptional recovery path, not normal
+cancellation behavior.
+
+### Config deactivation
+
+Leaving Config requests cancellation for whichever Config song operation owns
+the slot. Deactivation never synchronously waits for filesystem or SQLite work
+on the game/update thread.
+
+Use the same pattern as `StartupStage`:
+
+- Increment an activation generation.
+- Cancel the operation CTS.
+- Attach an execute-synchronously observation continuation.
+- Observe any fault and dispose the CTS only after task termination.
+- Suppress UI/status writes from stale generations.
+
+The game-wide `SongManager` operation may finish after Config deactivates. A
+post-commit reload still finalizes and publishes; only Config-specific visual
+feedback is suppressed.
+
+### Failure classes
+
+Before database commit, failure or cancellation means:
+
+- Persisted configured roots remain saved.
+- Database transaction rolls back.
+- Previous active hierarchy and active-root snapshot remain published.
 - No partial hierarchy is exposed.
-- The player sees a concise failure message explaining that the saved roots will
-  be retried on the next startup or Apply.
-- Detailed exceptions and failed-root diagnostics are logged.
+- Config reports that the saved roots will be retried on startup or Apply.
 
-If cancellation occurs before publication, the same old-hierarchy guarantee
-applies. If the HPA-192 operation has already committed and published before the
-cancellation is observed, that successful publication remains authoritative;
-the status must not claim that the library was rolled back.
+After database commit, cancellation no longer changes the success path. An
+unexpected post-commit publication failure uses the partial-success recovery
+message described above.
 
 ## Startup Integration
 
-`StartupStage` reads a snapshot of `Config.SongRoots`, never `DTXPath`.
+`StartupStage` reads an immutable snapshot of `Config.SongRoots`, never
+`DTXPath`.
 
-Before selecting the cache or enumeration path, startup performs the shared
-availability probe:
+Before cache/enumeration selection, startup performs the shared availability
+probe:
 
 - Available roots are passed to `NeedsEnumerationAsync`, cache hierarchy
   construction, and enumeration.
-- Unavailable roots are logged once with their diagnostics.
-- Root order remains the configured order.
+- Unavailable roots are logged once with diagnostics.
+- Root order remains configured order.
 
-When no configured root is available during a clean startup, startup completes
-successfully with an empty active hierarchy and an empty active-root snapshot.
-It does not delete or stale-clean any database records. The title screen remains
-reachable, and the player can enter Config to repair the paths.
+When no configured root is available during clean startup, startup publishes an
+empty active hierarchy and empty active-root snapshot through a dedicated
+`SongManager` operation that does not import, stale-clean, or delete database
+records. Startup completes and Title remains reachable.
 
-A later successful startup or Apply restores songs from the retained database or
-re-enumerates the returned roots according to the normal load-path decision.
+A later startup or Apply restores songs from retained data or enumeration using
+the normal load decision.
+
+## Runtime Consumer Audit
+
+Slice 1 must grep every production `DTXPath` read and classify it. No runtime
+consumer may silently remain first-root-only.
+
+Known consumers include:
+
+- `StartupStage`: switch to configured `SongRoots` snapshot.
+- `ConfigStage`: replace the read-only DTX Folder item.
+- `SongSelectionStage` / `PreviewImagePanel`: remove the single
+  `SongsRootPath` fallback.
+- Any E2E fixture or runtime helper that supplies the production configuration.
+
+### Preview resolution
+
+The selected chart's normalized absolute `SongChart.FilePath` remains the first
+and authoritative source for its directory.
+
+For legacy nodes whose directory is still relative,
+`PreviewImagePanel.SongsRootPath` becomes an immutable ordered active-root
+snapshot, for example `ActiveSongRootPaths`. The panel tries each active root in
+order. It must not use configured roots because a failed reload can leave the
+old hierarchy and old active roots authoritative.
+
+`SongManager` exposes a copied read-only current-search-path snapshot for
+SongSelection activation and refresh. A preview under root N greater than zero
+must resolve without falling back to root zero.
+
+## Active Views and Retained Data
+
+Removed or unavailable-root rows remain in SQLite, but active Song Select views
+must not surface them after a successful reload excludes that root.
+
+Product rule:
+
+- All Songs uses the published active hierarchy.
+- Bookmarks and Recent filter database-backed results to the current active-root
+  snapshot.
+- If a reload fails and the previous hierarchy stays active, the previous roots'
+  Bookmarks and Recent entries remain visible because those roots are still
+  active.
+- After a successful removal reload, off-root Bookmarks and Recent entries are
+  hidden but retained.
+- Re-adding and successfully publishing the root makes retained entries visible
+  again with their user-owned data intact.
+
+## Empty Library UX
+
+Song Select must show a deliberate empty state rather than a blank list:
+
+- Configured roots exist but none are active/available: **No song folders are
+  currently available. Open Config to reconnect or change them.**
+- At least one active root exists but contains no supported charts: **No songs
+  were found in the active song folders.**
+
+Exact copy may be localized later, but the two conditions remain distinct and
+are covered by logic tests.
 
 ## SongManager and Database Interaction
 
@@ -474,44 +666,44 @@ No database migration is required.
 The existing HPA-192 contracts remain in force:
 
 - Enumeration and persistence receive an ordered root array.
-- Exact duplicate roots are defensively deduplicated again in `SongManager`.
-- Cleanup affects only roots successfully supplied to the import.
+- Root aliases are defensively deduplicated with `SongRootPolicy.RootComparer`.
+- Cleanup affects only roots supplied to the successful import.
 - Charts and songs outside those roots are retained.
-- Bookmarks, all score-speed variants, play counts, recent-play timestamps,
-  ranks, full-combo state, and performance history remain user-owned data.
-- The replacement hierarchy is published only after the transaction commits.
+- Bookmarks, score-speed variants, play counts, recent timestamps, ranks,
+  full-combo state, and performance history remain user-owned.
+- The replacement hierarchy is published only after transaction commit.
 
-HPA-191 prevents overlapping configured roots before they reach `SongManager`.
-The importer is not responsible for inferring which overlapping root the player
-intended.
+HPA-191 prevents textual parent/child overlaps before they reach `SongManager`.
+The importer is not responsible for resolving physical aliases or choosing
+which overlapping root the player intended.
 
 Multiple roots remain flattened into the existing root-level hierarchy in
-configured order. Two roots may legitimately produce boxes or songs with equal
-display titles; identity remains path/database based and the nodes are not
-merged. Adding synthetic per-root containers would change navigation semantics
-and is outside this issue.
+configured order. Equal display titles are allowed; identity remains path and
+database based, and nodes are not merged.
 
 ## Logging and User Feedback
 
 Structured logs include:
 
-- Config migration from `DTXPath` to indexed roots.
+- Migration from `DTXPath` to indexed roots.
 - Dropped malformed, duplicate, or overlapping hand-edited entries.
-- Selected and cancelled folder-picker outcomes at debug level.
-- Picker failures at warning level.
-- Canonical old and new root lists after a successful commit.
+- Canonical old/new root lists after commit.
 - Availability warnings by configured root.
-- Reload start, success, cancellation, and failure with aggregate counts.
+- Picker selected/cancelled outcomes at debug level and failures at warning.
+- Config operation-slot busy decisions.
+- Reload start, success, cancellation, pre-commit failure, and post-commit
+  partial failure with aggregate counts.
 
-Normal logs must not emit per-file success messages beyond the progress behavior
-already owned by HPA-192.
+Normal logs must not emit new per-file success messages beyond HPA-192 progress.
 
-Config displays one concise status line for the current operation, for example:
+Config user-facing examples:
 
 - `Reloading songs: 48 / 100 charts`
 - `Loaded 2 folders, 100 charts; 1 folder unavailable`
 - `Folders saved; no configured folder is currently available`
+- `Song library is busy importing NX scores`
 - `Reload failed; previous song list retained`
+- `Songs were updated but the list could not refresh; restart required`
 
 ## Testing Strategy
 
@@ -519,113 +711,147 @@ Config displays one concise status line for the current operation, for example:
 
 - Default config contains exactly the managed default root and mirrors it to
   `DTXPath`.
-- Indexed roots round-trip in order and are rewritten densely.
+- Indexed roots round-trip in order and rewrite densely.
 - Legacy `DTXPath` migrates to one indexed root and persists immediately.
 - Legacy default `Songs` migration still resolves to `DTXFiles`.
 - Indexed entries take precedence over `DTXPath`.
-- Gaps, malformed indexes, duplicate indexes, and blank values are handled as
+- Gaps, malformed indexes, duplicate indexes, and blank values behave as
   specified.
-- Canonical duplicates are rejected by the setter and dropped safely on load.
+- Root duplicates use `SongRootPolicy.RootComparer`: ignore-case on Windows and
+  macOS, ordinal on Linux.
+- `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
 - Parent/child overlaps are rejected symmetrically.
-- Root comparison follows platform path semantics.
+- Symlink/junction aliases are documented but not resolved.
 - Missing custom roots are not created.
-- The managed default root is created when restored as fallback.
-- Failed config persistence restores the prior in-memory roots and emits no
-  change event.
-- A successful update raises `SongRootsChanged` once after persistence.
+- Managed default root is created when restored.
+- Persistence failure restores old roots and emits no event.
+- Successful update raises one event with immutable snapshots.
+- `Unchanged`, `ValidationFailed`, and `PersistenceFailed` results are distinct.
 
 ### Config and panel tests
 
-- The System category exposes **Song Folders** instead of a read-only path.
-- The count summary uses singular and plural forms.
-- Panel activation starts from an isolated draft.
-- Add, remove, reorder, Apply, Cancel, and Back behavior are deterministic.
-- Picker cancellation and failure do not mutate the draft.
-- Structural errors keep the panel open.
-- Missing paths appear as warnings and may be applied.
-- The last configured root cannot be removed without adding another.
-- Apply does not start a reload when persistence fails.
-- Active overlay polymorphism continues to support existing key panels.
+- System exposes **Song Folders** instead of a read-only path.
+- Singular/plural count summaries are correct.
+- Panel starts from an isolated draft.
+- Add, remove, reorder, Apply, Cancel, and Back are deterministic.
+- Async picker cancellation/failure does not mutate the draft.
+- Stale picker completion cannot update a reactivated/disposed panel.
+- Structural errors keep the panel open; availability warnings may be applied.
+- Last configured root cannot be removed without adding another.
+- Config's commit delegate is the only `SetSongRoots` caller.
+- `Saved` fires before `Closed` after successful commit.
+- Persistence failure keeps the panel open and starts no reload.
+- Active overlay polymorphism continues supporting existing key panels.
 
-### Reload-service tests
+### Operation and reload tests
 
-- One successful Apply triggers exactly one importer call with roots in order.
-- Unavailable roots are skipped without preventing available roots from loading.
-- No available roots skip import and retain the existing hierarchy.
-- Concurrent reload is rejected.
-- Success publishes the new hierarchy and active roots.
-- Failure and pre-publication cancellation preserve the previous hierarchy.
-- Leaving Config cancels and safely observes the operation.
-- Post-publication cancellation is reported as success, not rollback.
+- Unchanged ordered roots perform no write and no scan.
+- Reorder-only changed roots perform exactly one full importer call.
+- One successful Apply invokes importer once with available roots in order.
+- Unavailable roots are skipped without blocking available roots.
+- No available roots skip import and retain existing hierarchy.
+- Apply is rejected while NX import runs.
+- NX import is rejected while reload runs.
+- Lower-level enumeration busy is mapped to a user-visible Busy result.
+- Leaving Config cancels and asynchronously observes the active operation.
+- Stale generation continuations cannot write Config UI state.
+- Pre-commit failure/cancellation preserves old hierarchy.
+- Cancellation after commit cannot suppress publication and reports success.
+- Unexpected post-commit publication failure reports partial success/restart.
 
-### Startup and integration tests
+### Startup and runtime integration tests
 
-- Startup consumes `SongRoots`, not the compatibility `DTXPath` value.
-- Multiple available roots appear in configured order.
+- Startup consumes `SongRoots`, not compatibility `DTXPath`.
+- Every production `DTXPath` consumer is removed or explicitly compatibility-only.
+- Multiple roots appear in configured order.
+- Root aliases are imported once under the selected root comparer.
 - Charts under distinct roots are imported once each.
-- Removed-root songs disappear from the active hierarchy after successful
-  reload but remain in SQLite with scores and bookmarks intact.
-- Re-adding the root restores retained user-owned state.
-- A missing removable-drive root does not block another root.
-- No available roots produce an empty active library without database cleanup.
-- Windows and macOS projects compile with only their own picker implementation.
-- Existing HPA-192 enumeration, cancellation, score-retention, and performance
-  tests remain green.
+- Root N preview fallback resolves using active roots, not configured root zero.
+- Removed-root songs disappear from active hierarchy after success but remain in
+  SQLite with scores/bookmarks intact.
+- Bookmarks and Recent hide off-active-root rows and restore them after re-add.
+- Missing removable root does not block another root.
+- No available roots publish an empty active library without database cleanup.
+- Distinct Song Select empty states are selected correctly.
+- Windows and macOS compile with only their picker implementation.
+- Existing HPA-192 cancellation, retention, and performance tests remain green.
 
 ## Implementation Slices
 
-Each slice is intended to fit within three engineer days and be executable by a
-junior code agent with repository-wide access.
+The slices are hard dependencies and land in order: **Slice 1 → Slice 2 →
+Slice 3**. Each is intended to fit within three engineer days.
 
-### Slice 1: Canonical multi-root configuration
+### Slice 1: Canonical multi-root configuration and consumer migration
 
-- Add `SongRoots`, the indexed INI format, compatibility mirror, migration, and
-  immediate persistence behavior.
-- Add shared canonicalization, overlap validation, and availability probing.
-- Update `IConfigManager`, `ConfigManager`, `ConfigData`, and startup root
-  consumption.
-- Add configuration and startup unit tests.
-- Do not add Config UI or live reload in this slice.
+- Add `SongRoots`, indexed INI format, compatibility mirror, migration, result
+  contract, immutable event snapshots, and immediate persistence.
+- Add internal `SongRootPolicy` with the explicit root comparer, overlap
+  validation, normalization, and availability probing.
+- Align `SongManager` defensive root deduplication with the root policy.
+- Update startup to consume root snapshots and publish an empty active library
+  when no root is available.
+- Audit and migrate all production `DTXPath` consumers, including active-root
+  preview fallback and active-root snapshot exposure.
+- Add configuration, startup, preview, and consumer-audit tests.
+- Do not add Config editing UI or live reload.
 
 ### Slice 2: Cross-platform SongFolderPanel
 
-- Add `IConfigOverlayPanel` and adapt the existing key-panel interface.
-- Add `IFolderPickerService` with Windows, macOS, and fake implementations.
-- Replace **DTX Folder** with **Song Folders** and implement the draft editing
-  panel.
-- Commit through `SetSongRoots`, but show a temporary `restart required` status
-  until Slice 3 supplies live reload.
-- Add panel and platform-boundary tests.
+Depends on Slice 1.
+
+- Add `IConfigOverlayPanel` and adapt key-panel interface.
+- Add asynchronous `IFolderPickerService` with Windows, macOS, and fake
+  implementations.
+- Replace **DTX Folder** with **Song Folders** and implement draft editing.
+- Commit through Config's single commit delegate and `SetSongRoots`.
+- Show temporary `restart required` status after `Updated` until Slice 3.
+- Verify the persisted roots are consumed by Startup on the next launch.
+- Add panel, picker-threading, and platform-boundary tests.
 
 ### Slice 3: Live reload and retained-data integration
 
-- Add `ISongLibraryReloadService` and Config lifecycle coordination.
-- Add progress, unavailable-root summaries, cancellation, and failure feedback.
-- Verify successful publication, old-hierarchy retention, and removed-root data
-  retention.
+Depends on Slices 1 and 2.
+
+- Add `ISongLibraryReloadService`.
+- Add Config operation mutual exclusion shared by NX import and reload.
+- Add progress, unavailable-root summaries, non-blocking cancellation
+  observation, commit-to-publish terminal semantics, and failure feedback.
+- Add active-root filtering for Bookmarks/Recent and deliberate empty-state UX.
+- Verify successful publication, old-hierarchy retention, post-commit recovery,
+  and removed-root data retention.
 - Add multi-root integration tests and Windows/macOS build validation.
 
 ## Acceptance Criteria
 
-- Existing one-path `DTXPath` configurations migrate without losing the library.
+- Existing one-path `DTXPath` configurations migrate without library loss.
 - A fresh install has one managed default song root.
 - Config allows adding, removing, and reordering roots on Windows and macOS.
-- The ordered root list survives restart.
-- Duplicate and parent/child-overlapping roots cannot be applied.
+- Ordered roots survive restart and are read by startup after Slice 2.
+- Root duplicate comparison is explicitly ignore-case on Windows/macOS and
+  ordinal on Linux; chart canonical identity remains ordinal.
+- Duplicate and textual parent/child-overlapping roots cannot be applied.
 - Missing custom roots remain configured and are never created automatically.
-- Applying a changed list performs at most one live scan.
+- Previously auto-created custom directories are not deleted by migration.
+- Unchanged roots do not scan; any changed ordered list performs at most one full
+  scan, including reorder-only changes.
 - Every available root is scanned in configured order.
+- NX import and song reload cannot run concurrently from Config.
+- Busy lower-level enumeration is reported without an unhandled exception.
 - One unavailable root does not prevent available roots from loading.
-- A successful reload replaces the active hierarchy atomically.
-- A failed or cancelled pre-publication reload never exposes a partial hierarchy.
-- When no root is available during Apply, the previous active hierarchy remains
-  visible and the saved configuration is retried later.
-- When no root is available during startup, the game reaches Title with an empty
-  active library and leaves the database untouched.
-- Removing a root removes its songs from active views after a successful reload
-  but preserves their bookmarks, scores, variants, and performance history.
-- Re-adding a root restores retained user data.
-- `DTXPath` remains a compatibility mirror only; runtime code consumes
-  `SongRoots`.
+- A successful reload replaces active hierarchy atomically.
+- Pre-commit failure or cancellation never exposes a partial hierarchy.
+- Cancellation after commit cannot suppress hierarchy publication.
+- Config deactivation never blocks the game thread waiting for reload/import.
+- No available root during Apply retains the previous active hierarchy.
+- No available root during startup reaches Title with an empty active library
+  and leaves SQLite untouched.
+- Preview fallback under any active root resolves correctly.
+- Removing a root hides its songs, Bookmarks, and Recent entries after successful
+  reload while preserving their database records and user-owned data.
+- Re-adding a root restores retained user data and active views.
+- Song Select distinguishes unavailable folders from available-but-empty roots.
+- `DTXPath` remains a compatibility mirror only; every runtime consumer uses
+  configured or active root snapshots as appropriate.
+- Symlink/junction/physical-target deduplication is explicitly outside scope.
 - No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
   included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -2,160 +2,154 @@
 
 **Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
 **Date:** 2026-08-01  
-**Status:** Revised draft for review
+**Status:** Revised after second-pass design review
 
 ## Context
 
-DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath` and
-writes it as `DTXPath=` in `Config.ini`. `ConfigStage` displays that value as a
-read-only **DTX Folder** item. During startup, `StartupStage` wraps the value in
-a one-element string array before passing it into the song-loading pipeline.
+DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath`,
+writes it as `DTXPath=` in `Config.ini`, displays it as a read-only **DTX
+Folder** item in `ConfigStage`, and wraps it in a one-element array during
+startup.
 
 The lower-level song system is already substantially multi-root capable:
 
-- `SongManager` accepts arrays of search roots.
+- `SongManager` accepts ordered arrays of search roots.
 - Enumeration normalizes and deduplicates roots.
 - Root traversal order is preserved in the published hierarchy.
-- HPA-192 bulk import and cleanup are scoped to active roots.
-- Database rows outside active roots are retained, protecting scores,
-  bookmarks, performance history, and other user-owned state when a library is
-  temporarily removed or unavailable.
+- HPA-192 bulk import and stale cleanup are scoped to the active roots supplied
+  to a completed import.
+- Rows outside active roots are retained, protecting bookmarks, score variants,
+  play history, ranks, full-combo state, and performance history when a library
+  is removed or unavailable.
 
-HPA-191 therefore does not require a database schema change or another song
-import architecture. The work is to make the ordered root list a first-class
-configuration value, expose safe cross-platform editing in Config, audit every
-legacy `DTXPath` runtime consumer, and reload the active library without routing
-the game through boot-only startup state.
+HPA-191 therefore does not introduce another importer or a database schema
+migration. It makes the ordered root list a first-class configuration value,
+adds safe Config editing and platform folder selection, migrates every runtime
+consumer away from the single-root compatibility property, and performs one
+atomic live reload without routing the game through boot-only `StartupStage`
+state.
 
 ## Goals
 
-- Allow the player to add, remove, and reorder song-library roots from Config.
-- Support one or more persisted roots while retaining compatibility with
-  existing `DTXPath` configurations.
-- Apply valid changes immediately and perform at most one live library reload.
-- Preserve the currently published hierarchy until a replacement reload has
-  completed successfully.
-- Preserve database records and user-owned data for roots removed from the
-  active configuration or temporarily unavailable.
-- Support Windows and macOS folder selection without referencing platform UI
-  frameworks from shared game code.
-- Reject configurations that would scan the same textual subtree more than
-  once under the selected root-comparison policy.
+- Allow players to add, remove, and reorder song-library roots from Config.
+- Persist one or more ordered roots while migrating existing `DTXPath`
+  configurations without library loss.
+- Apply valid changes immediately and perform at most one live reload.
+- Preserve the currently published hierarchy until a replacement library has
+  committed and published successfully.
+- Preserve database rows and user-owned state for removed or temporarily
+  unavailable roots.
+- Support Windows and macOS folder selection without platform UI dependencies
+  in shared game code.
+- Reject textual duplicate or parent/child root combinations that would scan the
+  same subtree more than once under the selected root-comparison policy.
 - Keep startup deterministic when some or all configured roots are unavailable.
-- Serialize Config-initiated song-library mutation operations so NX score import
-  and song-folder reload cannot write or rebuild the library concurrently.
+- Serialize Config-initiated library mutation operations so NX score import and
+  song-folder reload cannot race.
+- Keep an already-active Song Select stage coherent when a reload publishes
+  after Config has deactivated.
 
 ## Non-goals
 
 - DTXCreator changes.
-- Changes to chart parsing, `set.def`, or `box.def` semantics.
+- Chart parser, `set.def`, or `box.def` semantic changes.
 - Song database schema changes.
-- Filesystem watchers or automatic reload when a removable drive is mounted.
-- Background rescans after every individual add, remove, or reorder action.
-- A database-only optimization for reorder-only changes; any changed ordered
-  root list performs one full enumeration/import in HPA-191.
-- Editing or creating song files from Config.
+- Filesystem watchers or automatic reload when removable media mounts.
+- Rescanning after each individual draft edit.
+- A database-only reorder fast path. Any changed ordered root list performs one
+  full enumeration/import in HPA-191.
+- Editing or creating chart files from Config.
 - Synthetic top-level boxes for each configured root.
-- Merging same-named folders or songs across different roots.
-- Deleting retained database records for removed roots.
-- Resolving filesystem aliases to a physical target. Symlinks, junctions, bind
-  mounts, aliases, and case-sensitive macOS volumes can expose the same target
-  through distinct paths; realpath/inode-based deduplication is deferred.
-- General-purpose file-picker infrastructure beyond directory selection.
+- Merging same-named folders or songs across roots.
+- Deleting retained records for removed roots.
+- Resolving filesystem aliases to physical targets. Symlinks, junctions, bind
+  mounts, aliases, and case-sensitive macOS volumes may expose one target through
+  distinct paths; realpath/inode-based deduplication is deferred.
+- General-purpose file-picker infrastructure beyond folder selection.
 - Replacing the macOS AppleScript adapter with a native `NSOpenPanel` helper.
-- Linux-specific picker integration; the configuration and reload contracts
+- Linux-specific picker integration. The configuration and reload contracts
   remain platform-neutral, but HPA-191 targets the existing Windows and macOS
-  game projects.
+  projects.
 
 ## Chosen Approach
 
 Add an ordered `SongRoots` collection as the sole configured-root source of
-truth. Retain `DTXPath` only as a serialized compatibility mirror of the first
-root. A dedicated Config overlay edits a working copy and commits it only when
-the player selects **Apply**. An asynchronous platform-specific folder-picker
-service supplies new paths. After configuration is atomically persisted, a
-focused song-library reload service invokes the existing HPA-192
-enumeration/import path once.
+truth. Keep `DTXPath` only as a serialized compatibility mirror of the first
+root. A Config overlay edits a private draft and commits through one
+Config-owned delegate. An asynchronous platform picker supplies new paths.
+After the changed list is persisted atomically, a focused reload service invokes
+the existing HPA-192 enumeration/import path once.
 
-The old hierarchy remains published until the complete replacement batch has
-committed and been published. A failed or cancelled pre-commit reload therefore
-cannot leave Song Select displaying a partial library.
+The old hierarchy remains active until the complete replacement batch commits,
+finalizes, and publishes. Failure or cancellation before commit cannot expose a
+partial list.
 
-Three root states are distinguished throughout the design:
+The design distinguishes three root states:
 
-- **Configured roots:** the ordered canonical paths persisted in `Config.ini`.
-- **Available roots:** configured roots that currently exist and pass a minimal
+- **Configured roots:** ordered normalized paths persisted in `Config.ini`.
+- **Available roots:** configured roots that currently exist and pass a shallow
   access probe.
 - **Active roots:** roots represented by the currently published `SongManager`
-  hierarchy. Active roots change only after successful publication, or during a
-  clean startup that intentionally publishes an empty active library.
+  hierarchy.
 
-Configured roots and active roots may temporarily differ. For example, a player
-can save new roots and then encounter a failed reload; Song Select must continue
-to use the old active-root snapshot until a later reload or startup succeeds.
+Configured and active roots may differ after a failed reload. Runtime surfaces
+that represent the published library must use the active-root snapshot, not the
+new configured list.
 
 ## Alternatives Considered
 
 ### Save and require restart
 
-This is the smallest implementation, but it leaves the active library stale
-until restart and gives weak feedback that the change succeeded. It is rejected
-for the final feature because the existing bulk importer provides an atomic
-publication boundary suitable for a live reload. Slice 2 temporarily uses this
-behavior until Slice 3 lands.
+This is the smallest change but leaves the active library stale and provides
+weak confirmation. It is rejected for the completed feature. Slice 2 uses a
+temporary restart-required state until Slice 3 lands.
 
-### Transition Config back through StartupStage
+### Transition Config through StartupStage
 
-This reuses the startup progress screen, but `StartupStage` owns boot-specific
-phase state, activation generations, timing summaries, and exactly-once startup
-telemetry. Re-entering it for a user-initiated operation would couple unrelated
-lifecycles and make telemetry ambiguous. It is rejected.
+`StartupStage` owns boot phases, activation generations, timing summaries, and
+exactly-once startup telemetry. Re-entering it for a user operation would couple
+unrelated lifecycles and make telemetry ambiguous. It is rejected.
 
 ### Rebuild from SQLite for reorder-only changes
 
-The database hierarchy builder could potentially republish roots in a different
-order without reparsing charts. HPA-191 deliberately does not add that branch.
-Apply is an explicit refresh operation, and one full scan also observes any
-filesystem changes made while the panel was open. A future measured
-optimization may special-case reorder-only changes.
+The hierarchy builder could potentially republish roots in a new order without
+parsing charts. HPA-191 deliberately does not add that branch. Apply is an
+explicit refresh and one full scan also observes filesystem changes made while
+the panel was open. A future measured optimization may specialize reorder-only
+changes.
 
-### Store one delimited `SongRoots=` value
+### Store one delimited value
 
-A delimiter would conflict with legal path characters and complicate escaping
-and hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
+A delimiter conflicts with legal path characters and complicates escaping and
+hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
 
 ## Configuration Contract
 
 ### Runtime model
 
-`ConfigData` gains an ordered mutable collection:
+`ConfigData` gains:
 
 ```csharp
 public List<string> SongRoots { get; } = new();
 ```
 
-The property remains get-only. Load, reset, and successful update operations
-clear and refill the existing list rather than replacing the list reference.
-Consumers must never retain or mutate that live collection. Every UI, event,
-reload, and startup boundary receives an immutable copied snapshot.
+The property remains get-only. Load, reset, and successful updates clear and
+refill the existing collection instead of replacing its reference. Consumers
+must never retain or mutate the live list. Startup, UI, events, and reload
+boundaries receive copied immutable snapshots.
 
-`DTXPath` remains available for source and downgrade compatibility, but is a
-mirror only:
+`DTXPath` remains for source and downgrade compatibility only:
 
-- After load, reset, or a successful root update, it equals the first canonical
+- After load, reset, or a successful update, it equals the first normalized
   configured root.
-- Production startup, Config UI, reload, active-root filtering, previews, and
-  other runtime behavior consume `SongRoots` or the active-root snapshot, never
-  `DTXPath`.
-- Direct legacy mutation of `DTXPath` is not a supported way to change the
-  runtime library.
+- Startup, Config, reload, active views, previews, and all other runtime behavior
+  consume configured or active root snapshots instead.
+- Direct mutation of `DTXPath` is not a supported runtime update mechanism.
 
-At least one configured root is always required. Availability is not required;
-a single configured path may point to a disconnected removable drive.
+At least one configured root is required. Availability is not required; the
+only root may be a disconnected removable or network location.
 
 ### Persisted format
-
-`Config.ini` stores roots in explicit order:
 
 ```ini
 [System]
@@ -166,60 +160,73 @@ SongRoot.1=D:\Community Charts
 
 Rules:
 
-1. `SongRoot.<index>` uses a non-negative decimal integer index.
-2. Roots are loaded in ascending numeric order; gaps are allowed.
-3. Malformed suffixes, blank values, and negative indexes are ignored with a
+1. `SongRoot.<index>` uses a non-negative decimal integer.
+2. Entries load in ascending numeric order; gaps are allowed.
+3. Malformed suffixes, negative indexes, and blank values are ignored with a
    warning.
 4. Duplicate indexes use the last parsed value and emit a warning.
-5. Values may contain `=` because `ConfigManager` splits on the first `=` only.
+5. Values may contain `=` because parsing splits on the first `=` only.
 6. Save rewrites indexes densely from zero.
-7. `DTXPath` is always written as the first root for downgrade compatibility.
-8. `SongRoot.*` entries are authoritative whenever at least one structurally
-   valid indexed entry exists.
-9. When no valid indexed entry exists, load migrates legacy `DTXPath` into a
-   one-element list.
-10. When neither representation yields a valid path, load restores the managed
-    default root.
+7. `DTXPath` mirrors the first root.
+8. At least one structurally valid indexed entry makes `SongRoot.*`
+   authoritative.
+9. With no valid indexed entry, load migrates legacy `DTXPath` into a one-root
+   list.
+10. If neither representation yields a valid path, load restores the managed
+    default.
 
-A successful legacy migration is persisted immediately through the existing
+A successful legacy migration is immediately persisted through the existing
 atomic temp-file replacement.
+
+### Downgrade compatibility caveat
+
+The `DTXPath` mirror is best-effort compatibility, not a guarantee that older
+build behavior is safe. If the first root is an unavailable removable or
+network path and the user runs a pre-HPA-191 build, that older build may execute
+its unconditional directory-creation behavior and create an empty directory at
+that path. HPA-191 cannot prevent behavior after a downgrade; ordering a stable
+local root first reduces that risk.
 
 ### Legacy path migration
 
-The existing migration from legacy `Songs` defaults to the current managed
-`DTXFiles` location is retained. It applies to the fallback `DTXPath` value
-before that value becomes `SongRoots[0]`.
+The existing known-default migration from `Songs` to the managed `DTXFiles`
+location remains. It applies to the fallback legacy value before it becomes
+`SongRoots[0]`. Indexed custom roots are not remapped merely because their final
+segment is named `Songs`.
 
-Indexed custom roots are not remapped merely because their final segment is
-named `Songs`; only known legacy default representations are migrated.
+Previous builds may already have created empty custom directories while a
+removable or network root was unavailable. HPA-191 does not delete or move such
+folders.
 
-Previous releases may already have created an empty custom directory while a
-removable or network path was unavailable. HPA-191 stops creating such paths,
-but it does not delete or move directories created by earlier versions. The
-migration is logged; filesystem cleanup is left to the user.
+### Deliberate removal of custom-root auto-creation
 
-### Directory creation
+Today `NormalizeConfigPaths` unconditionally calls
+`EnsureDirectorySafe(Config.DTXPath)`, creating every configured custom path at
+load. Slice 1 deliberately removes that behavior.
 
-The game may create the managed default `AppPaths.GetDefaultSongsPath()` when it
-is selected or restored as the fallback root.
+After HPA-191:
 
-The game must not create arbitrary custom roots. A missing custom path may be a
-removable drive, network mount, renamed directory, or user error. Creating it
-would hide the problem and could produce an unwanted directory on the wrong
-volume.
+- The game may create only `AppPaths.GetDefaultSongsPath()` when the managed
+  default is selected or restored as fallback.
+- Missing custom roots are retained as unavailable configuration values.
+- No load, migration, Apply, startup, or availability probe creates a custom
+  directory.
+- Existing directories created by older versions are left untouched.
+
+This is an intentional product behavior change, not merely an implementation
+detail of the multi-root format.
 
 ## Root Path Identity and Validation
 
-Root comparison is intentionally distinct from HPA-192 chart identity.
-`SongPathIdentity.CanonicalComparer` remains ordinal and continues to protect
-exact persisted chart identities. HPA-191 does not redefine it as
-platform-aware.
+Root identity is intentionally separate from HPA-192 chart identity.
+`SongPathIdentity.CanonicalComparer` remains ordinal for exact persisted chart
+identity.
 
 ### Shared root policy
 
-Add an internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. It is
-the only path used by Config load, Config UI, `SetSongRoots`, startup,
-`SongManager` defensive root deduplication, and availability probing.
+Add internal `SongRootPolicy` in the shared `DTXMania.Game` assembly. Config
+load, Config UI, `SetSongRoots`, startup, defensive `SongManager` root
+deduplication, overlap checks, and availability probing all use this policy.
 
 `SongRootPolicy.RootComparer` uses
 `SongPathIdentity.LegacyAliasComparer`:
@@ -227,86 +234,95 @@ the only path used by Config load, Config UI, `SetSongRoots`, startup,
 - Windows and macOS: ordinal ignore-case.
 - Linux and other platforms: ordinal case-sensitive.
 
-This is a deliberate user-facing root policy. On a case-sensitive macOS volume,
-paths that differ only by case are still treated as duplicate configured roots
-for HPA-191. Resolving actual filesystem case or targets is outside scope.
+On a case-sensitive macOS volume, case-only root variants are still treated as
+duplicates for HPA-191. Physical-case and real-target discovery are out of
+scope.
 
-`SongPathIdentity` remains internal. No public API exposure is required because
-`ConfigManager`, stages, `SongManager`, and `SongRootPolicy` live in the same
-assembly. Tests use the repository's existing internal-test access pattern.
+`SongPathIdentity` remains internal. No public exposure is necessary because the
+policy and consumers live in the shared assembly; tests use the repository's
+internal-test access pattern.
 
 ### Canonicalization
 
 For each non-blank input:
 
 1. Expand supported home-relative forms through `AppPaths`.
-2. Resolve relative legacy paths against the same app-data base used today.
+2. Resolve legacy relative paths against the existing app-data base.
 3. Convert to an absolute full path.
-4. Normalize separators and trailing separators through
+4. Normalize separators and trailing separators with
    `SongPathIdentity.Normalize`.
 5. Compare roots with `SongRootPolicy.RootComparer`.
 6. Persist the normalized absolute value.
 
-Root order is semantically meaningful. It controls traversal order and the
-ordering of root-level nodes in Song Select.
+Root order controls traversal and root-level presentation order.
 
-`SongManager.SetCurrentSearchPaths`, enumeration batch root creation, and other
-defensive deduplication must use `SongRootPolicy.RootComparer`, not
-`SongPathIdentity.CanonicalComparer`, so direct callers cannot reintroduce root
-case aliases that Config rejects.
+### Defensive SongManager alignment
+
+`SongManager.SetCurrentSearchPaths`, enumeration-batch root creation, and every
+other defensive root deduplication point must use
+`SongRootPolicy.RootComparer`, not the ordinal chart comparer. Direct callers
+must not reintroduce aliases that Config rejects.
+
+This is a deliberate behavior change for all `SetCurrentSearchPaths` callers,
+including startup cache/database paths such as `LoadScoreCacheAsync`,
+`BuildSongListFromDatabasePublicAsync`, and `NeedsEnumerationAsync`. On Windows
+and macOS, roots differing only by case will now collapse to one root in those
+paths as well as during fresh enumeration.
+
+Slice 1 must add focused coverage for `SetCurrentSearchPaths` behavior and its
+snapshot, plus caller-path tests for cache load, database hierarchy rebuild, and
+enumeration decisions. The comparer change must not rely only on Config-panel
+integration tests.
 
 ### Blocking structural errors
 
-The following prevent Apply and leave the current configuration unchanged:
+Apply is blocked by:
 
-- No configured roots.
+- No roots.
 - Blank or syntactically invalid paths.
-- Duplicate roots under `SongRootPolicy.RootComparer`.
-- Overlapping roots where either normalized path is an ancestor of the other.
+- Duplicates under `SongRootPolicy.RootComparer`.
+- Parent/child overlap in either direction after normalization.
 
-Overlap checks use the same root comparer for path-segment equality. Authored
-order does not make an overlap valid.
+Overlap segment comparison uses the same root comparer. Authored order does not
+make overlap valid.
 
-Hand-edited invalid configuration must not prevent startup. During load, roots
-are processed in numeric order and the first accepted root wins. Later duplicate
-or overlapping entries are dropped with warnings. If all entries are rejected,
-the managed default is restored.
+Hand-edited invalid configuration must not prevent startup. Load processes
+entries in numeric order; the first accepted root wins and later duplicate or
+overlapping entries are dropped with warnings. If all are rejected, the managed
+default is restored.
 
 Symlink, junction, mount, and alias targets are not resolved. Two textually
-different non-overlapping paths that reach the same physical directory may both
+different non-overlapping paths reaching the same physical directory may both
 scan in v1.
 
 ### Availability warnings
 
-Missing and inaccessible paths are warnings, not structural errors. They remain
-configured so removable or network libraries can return later.
+Missing and inaccessible roots are warnings, not structural failures. They stay
+configured so removable and network libraries can return later.
 
-A minimal availability probe must:
+The shallow probe:
 
-- Check that the directory exists.
-- Attempt to begin a shallow directory enumeration to detect obvious access
-  failures without recursively scanning charts.
-- Catch path, I/O, and authorization errors and return a diagnostic instead of
-  throwing.
+- Checks directory existence.
+- Attempts to begin a shallow directory enumeration.
+- Catches path, I/O, and authorization failures and returns a diagnostic.
+- Never recursively scans charts and never creates directories.
 
-Only roots passing this probe are supplied to a live reload or normal startup
-load. A path may still fail later because availability can change during a
-scan; that failure follows the reload error contract below.
+Only available roots are supplied to startup or live reload. A root may still
+fail during scanning if availability changes; that follows the reload failure
+contract.
 
 ## Config User Experience
 
 ### System menu entry
 
-Replace the read-only **DTX Folder** item with a navigation item named
-**Song Folders**.
-
-Its value summary is `1 folder` or `<n> folders`. The description states that
-folders are scanned in displayed order and Apply reloads the library once.
+Replace **DTX Folder** with a navigation item named **Song Folders**. Its value
+is `1 folder` or `<n> folders`. The description says folders are scanned in the
+displayed order and Apply reloads once.
 
 ### Overlay abstraction
 
-Introduce `IConfigOverlayPanel` containing the common members currently carried
-by `IKeyAssignPanel`:
+Introduce `IConfigOverlayPanel` with the common lifecycle currently carried by
+`IKeyAssignPanel`:
 
 - `IsActive`
 - `Closed`
@@ -315,10 +331,9 @@ by `IKeyAssignPanel`:
 - `Update(...)`
 - `Draw(...)`
 
-`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving its existing
-`Saved`-before-`Closed` contract. `ConfigStage._activePanel` becomes
-`IConfigOverlayPanel`. This is a targeted boundary correction, not a broader UI
-refactor.
+`IKeyAssignPanel` inherits it and keeps the existing `Saved`-before-`Closed`
+contract. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
+targeted boundary correction, not a broad UI rewrite.
 
 ### SongFolderPanel ownership
 
@@ -326,44 +341,33 @@ refactor.
 
 - An immutable configured-root snapshot.
 - `IFolderPickerService`.
-- The shared root validation policy.
-- A commit delegate owned by `ConfigStage`:
+- The shared validation policy.
+- A Config-owned commit delegate:
 
 ```csharp
 Func<IReadOnlyList<string>, SongFolderCommitResult> commitRoots
 ```
 
-The panel owns a private draft list. Opening, reordering, adding, removing, or
-cancelling does not mutate `ConfigData`.
+The panel owns a private draft. Add, remove, reorder, Back, and Cancel never
+mutate configuration.
 
-The Config-owned delegate is the only commit owner. For a draft snapshot it:
+The delegate is the only commit owner:
 
-1. Canonicalizes and compares against the current configured snapshot.
-2. Returns `Unchanged` without acquiring an operation slot or writing.
-3. For a changed list, attempts to reserve the Config operation slot as
-   `SongFolderReload` **before** calling `SetSongRoots`.
-4. Returns `Busy` without persisting when NX import or another reload owns the
+1. Canonicalize and compare the draft with the current configured snapshot.
+2. Return `Unchanged` without acquiring a slot or writing.
+3. For a changed list, reserve the Config operation slot as
+   `SongFolderReload` before persistence.
+4. Return `Busy` without persisting if NX import or another reload owns the
    slot.
-5. Calls `IConfigManager.SetSongRoots` only after the slot is reserved.
-6. Releases the slot immediately when validation or persistence fails.
-7. Retains the reserved slot on `Updated` so the `Saved` handler can start the
-   matching reload without a race.
+5. Call `SetSongRoots` only while holding the reservation.
+6. Release the slot immediately on validation or persistence failure.
+7. Retain the reservation on `Updated` for handoff to the reload task.
 
-On **Apply**, the panel passes an immutable draft snapshot to that delegate.
-Validation, persistence, or busy failure keeps the panel open and displays the
-returned diagnostic. On `Updated` or `Unchanged`, the panel stores the immutable
-committed snapshot, raises `Saved`, then raises `Closed`.
+On Apply, failure or `Busy` keeps the panel open with a diagnostic. On `Updated`
+or `Unchanged`, the panel stores an immutable committed snapshot, raises
+`Saved`, then `Closed`.
 
-`ConfigStage` reads the committed snapshot during `Saved`:
-
-- `Unchanged`: no operation slot is held and no reload starts.
-- `Updated`: the reload starts using the already-reserved slot. The handler must
-  either attach the reload task or release the slot before returning; it must
-  not leave a reserved slot orphaned if task construction fails.
-
-The panel never holds `IConfigManager` and never persists roots independently.
-
-The panel-level result distinguishes orchestration from persistence:
+The panel never holds `IConfigManager` and never persists independently.
 
 ```csharp
 public enum SongFolderCommitStatus
@@ -383,19 +387,19 @@ public sealed record SongFolderCommitResult(
 
 Supported actions:
 
-- **Add Folder** — invoke the platform picker and append a unique selection.
-- **Remove** — remove the selected root when at least one draft root remains.
-- **Move Up** / **Move Down** — change scan and display order.
-- **Apply** — validate and commit the complete draft.
-- **Cancel** — discard the draft and close.
+- **Add Folder**
+- **Remove** while one draft root remains
+- **Move Up** / **Move Down**
+- **Apply**
+- **Cancel**
 
-Structural errors keep the panel open. Availability warnings appear beside
-roots but do not disable Apply. Picker cancellation is a no-op; picker failure
-leaves the draft unchanged and displays an error.
+Structural errors keep the panel open. Availability warnings do not disable
+Apply. Picker cancellation is a no-op; picker failure leaves the draft
+unchanged.
 
 ## Platform Folder Picker
 
-Shared code depends on an asynchronous interface:
+Shared code uses:
 
 ```csharp
 public interface IFolderPickerService
@@ -406,30 +410,34 @@ public interface IFolderPickerService
 }
 ```
 
-The result distinguishes selected, cancelled, unavailable, and failed outcomes
-and carries an error message only for failure.
+The result distinguishes Selected, Cancelled, Unavailable, and Failed. While a
+picker is active, repeat Add actions are ignored. Completion updates panel state
+only when its activation generation remains current.
 
-While a picker is active, the panel displays a selecting state and ignores
-repeat Add actions. Picker completion is marshalled back to panel state only if
-the panel activation generation is still current.
+### Windows
 
-Platform composition selects the implementation:
+`FolderBrowserDialog` is acceptable because the Windows project already enables
+WinForms. The platform implementation owns STA dispatch; shared update code does
+not assume it runs on an STA thread. The dialog starts from the selected root or
+managed default when valid.
 
-- **Windows:** `FolderBrowserDialog` is acceptable because the Windows project
-  already enables WinForms. The implementation owns the required STA thread or
-  platform dispatcher; shared game/update code does not assume its thread is
-  STA. The dialog starts from the selected root or managed default when valid.
-- **macOS:** invoke `osascript` with `choose folder`, a clear prompt, and a
-  default location when `initialDirectory` exists. Construct arguments through
-  `ProcessStartInfo.ArgumentList`, never shell interpolation. Await process exit
-  asynchronously, map user cancellation to `Cancelled`, terminate the process
-  on cancellation when safe, and map privacy/automation denial or other
-  non-cancellation failures to `Failed` with stderr in structured logs.
+### macOS
 
-The shared project must not reference WinForms, AppleScript process
-construction, or native picker types. Headless tests inject a deterministic fake
-picker. A future native `NSOpenPanel` helper may replace AppleScript without
-changing the shared interface.
+Invoke `osascript` using Standard Additions `choose folder`, with a clear prompt
+and `default location` when the initial directory exists. Build arguments with
+`ProcessStartInfo.ArgumentList`, never shell interpolation. Await exit
+asynchronously, distinguish the standard user-cancel error, terminate on
+cancellation when safe, and log stderr for non-cancellation failures.
+
+The first invocation may display macOS system consent or privacy UI depending on
+the host process and selected location. The product must not promise a specific
+System Settings pane. Cancellation remains a normal `Cancelled` result;
+permission or authorization denial is `Failed` with a concise user message and
+structured diagnostic.
+
+Shared code must not reference WinForms, AppleScript construction, or native
+picker types. Headless tests inject a deterministic fake. A future
+`NSOpenPanel` helper may replace the adapter without changing the interface.
 
 ## Config Persistence API
 
@@ -440,8 +448,6 @@ SongRootUpdateResult SetSongRoots(
     string configFilePath,
     IReadOnlyList<string> roots);
 ```
-
-This persistence-level result remains independent of Config's `Busy` status:
 
 ```csharp
 public enum SongRootUpdateStatus
@@ -463,270 +469,265 @@ public sealed record SongRootUpdateResult(
 }
 ```
 
-The implementation may adjust concrete type names but must preserve those four
-persistence outcomes and immutable snapshots.
-
-The operation:
+The persistence operation:
 
 1. Validates and canonicalizes the complete list.
 2. Captures prior `SongRoots` and `DTXPath` snapshots.
-3. Clears/refills `SongRoots` and updates `DTXPath` in memory.
-4. Writes the complete config immediately through atomic temp-file replacement.
-5. Clears any pending deferred-save marker on success because all current
-   settings were written.
+3. Clears/refills `SongRoots` and updates the mirror in memory.
+4. Writes the complete config through atomic temp-file replacement.
+5. Clears the deferred-save marker on success because all settings were written.
 6. Restores prior in-memory values if persistence fails.
 7. Raises `SongRootsChanged` only after persistence succeeds.
-8. Returns `Unchanged` without a write or event when the canonical ordered list
-   is unchanged.
+8. Returns `Unchanged` without write or event for an equal ordered list.
 
-`SongRootsChangedEventArgs` carries copied immutable old and new root snapshots.
-Subscriber exceptions are isolated using existing config-event behavior. A
-subscriber failure cannot undo accepted persisted configuration.
+Event args carry copied immutable old/new snapshots. Subscriber exceptions are
+isolated and cannot roll back accepted configuration.
 
 ## Live Library Reload
 
 ### Boundary
 
-Introduce `ISongLibraryReloadService` so `ConfigStage` does not own raw
-`SongManager` orchestration and tests do not need the singleton.
+Introduce `ISongLibraryReloadService` so `ConfigStage` does not directly own raw
+singleton orchestration.
 
-The production implementation:
+The production service:
 
-- Resolves available roots from the persisted configured snapshot.
+- Probes the persisted configured snapshot.
 - Adapts `EnumerationProgress` to Config status.
-- Invokes `SongManager.EnumerateAndImportSongsAsync` exactly once for any
-  changed ordered list, including reorder-only changes.
-- Returns the successful active-root set, aggregate counts, skipped-root
-  warnings, busy, cancellation, partial post-commit failure, or terminal
-  pre-commit failure.
+- Calls `SongManager.EnumerateAndImportSongsAsync` exactly once for every changed
+  ordered list, including reorder-only changes.
+- Returns active roots, aggregate counts, unavailable warnings, Busy,
+  cancellation, pre-commit failure, or post-commit partial failure.
 - Allows one in-flight reload.
 
-It does not call `NeedsEnumerationAsync` and does not invent a cache or
-reorder-only path. HPA-192 remains the sole importer and publication authority.
+It does not call `NeedsEnumerationAsync` or create another cache/reorder path.
 
 ### Apply sequence
 
-1. The panel validates its draft locally.
-2. Config's commit delegate detects `Unchanged` or reserves the
-   `SongFolderReload` operation slot for a changed list.
-3. A busy slot returns `Busy`; roots are not persisted and the panel stays open.
-4. With the slot reserved, `ConfigManager.SetSongRoots` atomically persists the
-   canonical ordered list.
-5. Validation/persistence failure releases the slot and keeps the panel open.
-6. `Updated` stores the committed snapshot and raises `Saved` before `Closed`.
-7. Config's `Saved` handler starts reload using the existing slot reservation.
-8. The reload service probes all configured roots.
-9. When at least one root is available, one enumeration/import starts with only
-   those roots.
-10. The old hierarchy remains active while discovery and persistence run.
-11. On successful commit, finalization and publication replace the hierarchy and
-    active-root snapshot atomically.
-12. Config reports folder, chart, unavailable-folder, and error counts. Logical
-    song counts remain structured-log detail rather than user-facing copy.
+1. Panel validates the draft locally.
+2. Config's delegate returns `Unchanged` or reserves `SongFolderReload`.
+3. A busy slot returns `Busy`; no persistence occurs.
+4. With the slot reserved, `SetSongRoots` persists the canonical list.
+5. Failure releases the slot and keeps the panel open.
+6. `Updated` raises `Saved` before `Closed`.
+7. The `Saved` handler starts reload using the reservation.
+8. Reload probes configured roots.
+9. With at least one available root, it starts one enumeration/import.
+10. The previous hierarchy stays active during discovery and persistence.
+11. Commit, finalization, and publication replace hierarchy and active roots.
+12. Config reports folder, chart, unavailable-folder, and error counts.
 
-Unavailable configured roots are omitted from the scan and listed as warnings.
-Their database records remain outside active import cleanup.
-
-When no configured root is available, Config skips the importer, retains the
-current active hierarchy, reports the warning, and releases the operation slot.
+If no root is available, import is skipped, the previous hierarchy is retained,
+a warning is shown, and the operation slot is released.
 
 ### Config operation mutual exclusion
 
-`ConfigStage` owns one operation slot for Config-initiated song-library work:
+`ConfigStage` owns:
 
 ```text
 None | NxScoreImport | SongFolderReload
 ```
 
-Both `StartNxScoreImport` and changed-root Apply must reserve this slot before
-performing persistence or database work and release it only in their terminal
-continuation.
+NX import and changed-root Apply acquire the same slot. Apply while NX import is
+active returns `Busy` without persistence. NX import while reload is active is
+rejected. A second reload is rejected. Lower-level
+`InvalidOperationException` from an occupied SongManager enumeration slot is
+mapped to a user-visible Busy result.
 
-Required behavior:
+### Throw-safe reservation handoff
 
-- Apply while NX import is running returns `Busy`; roots are not persisted and
-  no reload starts.
-- NX import while reload is running is rejected with a clear status.
-- A second reload is rejected while reload is active.
-- Existing `SongManager` enumeration-slot rejection is converted to a `Busy`
-  reload result, never an unhandled `InvalidOperationException`.
-- Future Config features that mutate or rebuild the song library must use the
-  same slot.
+The reservation-to-task handoff is a strict implementation invariant. Acquiring
+the slot, persisting, raising `Saved`, constructing the reload task, and
+transferring release ownership must use `try/finally` or an equivalent scoped
+lease.
 
-The operation slot prevents the current NX import and reload paths from racing
-on SQLite and hierarchy refresh. `SongManager` retains its own enumeration slot
-as the lower-level defensive boundary for non-Config callers.
+Required ownership rule:
+
+- Before the reload task is attached, synchronous code owns the lease and must
+  release it in `finally` on every exit or exception.
+- Only after the terminal continuation is attached may release ownership move
+  to that continuation.
+- Task-construction, event-subscriber, or continuation-registration failure
+  cannot orphan the slot.
+- The terminal continuation releases exactly once.
+
+A dedicated test injects a throw at each handoff point and verifies the next
+operation can acquire the slot.
 
 ### Cancellation, commit, and publication
 
-The HPA-192 transaction commit through hierarchy publication is treated as a
-non-cancellable terminal section:
+Database commit through hierarchy publication is non-cancellable:
 
 - Cancellation is honored during probing, discovery, parsing, matching, and
-  persistence before database commit.
-- Once bulk import commits successfully, the caller must not perform another
-  cancellation check before `FinalizePendingNodes` and `PublishEnumeration`.
-- A cancellation request arriving after commit is ignored until publication
-  completes; the result is success, not cancellation.
-- This prevents the database from reflecting new active-root cleanup while the
-  old hierarchy remains solely because cancellation arrived in the
-  commit-to-publish gap.
+  persistence before commit.
+- After commit succeeds, no cancellation check occurs before
+  `FinalizePendingNodes` and `PublishEnumeration`.
+- A request arriving after commit is ignored until publication completes and is
+  reported as success.
 
-If an unexpected finalization or publication exception occurs after commit, the
-old hierarchy remains atomically intact, but the database may already reflect
-the new import. Report a distinct partial-success failure requiring restart;
-do not claim rollback.
+This prevents the database from reflecting new active-root cleanup while the
+old hierarchy remains solely because cancellation arrived in the commit-to-
+publish gap.
+
+An unexpected finalization/publication exception after commit reports a distinct
+partial-success/restart-required outcome. It must not claim rollback.
 
 ### Config deactivation
 
-Leaving Config requests cancellation for whichever Config song operation owns
-the slot. Deactivation never synchronously waits for filesystem or SQLite work
-on the game/update thread.
+Leaving Config requests cancellation but never blocks the update thread waiting
+for filesystem or SQLite work.
 
-Use the same pattern as `StartupStage`:
+Use the `StartupStage` retirement pattern:
 
 - Increment an activation generation.
 - Cancel the operation CTS.
 - Attach an execute-synchronously observation continuation.
-- Observe any fault and dispose the CTS only after task termination.
-- Release the Config operation slot in that terminal continuation.
-- Suppress UI/status writes from stale generations.
+- Observe faults and dispose the CTS only after termination.
+- Release the operation lease in the terminal continuation.
+- Suppress Config UI/status writes from stale generations.
 
-The game-wide `SongManager` operation may finish after Config deactivates. A
-post-commit reload still finalizes and publishes; only Config-specific visual
-feedback is suppressed.
-
-### Failure classes
-
-Before database commit, failure or cancellation means:
-
-- Persisted configured roots remain saved when persistence had already
-  succeeded.
-- Database transaction rolls back.
-- Previous active hierarchy and active-root snapshot remain published.
-- No partial hierarchy is exposed.
-- Config reports that saved roots will be retried on startup or Apply.
-
-After database commit, cancellation no longer changes the success path. An
-unexpected post-commit publication failure uses the partial-success recovery
-message described above.
+A post-commit reload may finish and publish after Config deactivates.
 
 ## Startup Integration
 
-`StartupStage` reads an immutable snapshot of `Config.SongRoots`, never
-`DTXPath`.
+`StartupStage` reads an immutable `SongRoots` snapshot, never `DTXPath`.
 
-Before cache/enumeration selection, startup performs the shared availability
-probe:
+Before cache/enumeration selection:
 
-- Available roots are passed to `NeedsEnumerationAsync`, cache hierarchy
-  construction, and enumeration.
-- Unavailable roots are logged once with diagnostics.
-- Root order remains configured order.
+- Probe configured roots.
+- Pass available roots in configured order to `NeedsEnumerationAsync`, cache
+  hierarchy construction, or enumeration.
+- Log unavailable roots once.
 
-When no configured root is available during clean startup, startup publishes an
-empty active hierarchy and empty active-root snapshot through a dedicated
-`SongManager` operation that does not import, stale-clean, or delete database
-records. Startup completes and Title remains reachable.
-
-A later startup or Apply restores songs from retained data or enumeration using
-the normal load decision.
+When no root is available on clean startup, publish an empty active hierarchy
+and empty active-root snapshot through a dedicated SongManager operation that
+does not import, stale-clean, or delete database rows. Startup completes and
+Title remains reachable.
 
 ## Runtime Consumer Audit
 
-Slice 1 must grep every production `DTXPath` read and classify it. No runtime
+Slice 1 must grep and classify every production `DTXPath` read. No runtime
 consumer may silently remain first-root-only.
 
-Known consumers include:
+Known consumers:
 
-- `StartupStage`: switch to configured `SongRoots` snapshot.
-- `ConfigStage`: replace the read-only DTX Folder item.
-- `SongSelectionStage` / `PreviewImagePanel`: remove the single
-  `SongsRootPath` fallback.
-- Any E2E fixture or runtime helper that supplies production configuration.
+- `StartupStage`: configured `SongRoots` snapshot.
+- `ConfigStage`: replace the read-only item.
+- `SongSelectionStage` / `PreviewImagePanel`: active-root fallback snapshot.
+- E2E fixtures and runtime helpers that provide production configuration.
+
+A source-level architecture test or explicit allowlist must fail if a new
+runtime `Config.DTXPath` read is introduced outside serialization/migration
+compatibility code.
 
 ### Preview resolution
 
-The selected chart's normalized absolute `SongChart.FilePath` remains the first
-and authoritative source for its directory.
+The normalized absolute `SongChart.FilePath` is authoritative. For legacy nodes
+with relative directories, replace `PreviewImagePanel.SongsRootPath` with an
+immutable ordered active-root snapshot such as `ActiveSongRootPaths`, trying
+each active root in order.
 
-For legacy nodes whose directory is still relative,
-`PreviewImagePanel.SongsRootPath` becomes an immutable ordered active-root
-snapshot, for example `ActiveSongRootPaths`. The panel tries each active root in
-order. It must not use configured roots because a failed reload can leave the
-old hierarchy and old active roots authoritative.
+Configured roots must not be used for this fallback because failed reload leaves
+the previous active hierarchy authoritative. Root N greater than zero must
+resolve correctly.
 
-`SongManager` exposes a copied read-only current-search-path snapshot for
-SongSelection activation and refresh. A preview under root N greater than zero
-must resolve without falling back to root zero.
+`SongManager` exposes a copied current-search-path snapshot for Song Select
+activation and refresh.
+
+## Active Song Select Publication Handling
+
+A reload can commit and publish after Config deactivates. A player may reach an
+already-active Song Select stage before that terminal publication. Today Song
+Select copies `SongManager.RootSongs` during initialization and does not observe
+later publication, so merely proving that the stale list does not crash is
+insufficient.
+
+HPA-191 requires an update-thread refresh contract:
+
+- Song Select subscribes on activation and unsubscribes on deactivation to a
+  library-published notification. The existing `EnumerationCompleted` event may
+  be used if its post-publication contract is made explicit; otherwise add a
+  dedicated `SongLibraryPublished` event carrying a monotonically increasing
+  publication version and active-root snapshot.
+- The event handler never mutates UI collections. It records a pending version
+  or enqueues a refresh request guarded by the stage activation version.
+- `OnUpdate` snapshots `RootSongs` and active roots and replaces the displayed
+  root list on the game thread.
+- If the current navigation path still exists, restore it by stable path or
+  database identity. Otherwise reset to the root.
+- Preserve the selected chart by stable chart/database identity when possible;
+  otherwise select the first valid item.
+- Stop previews and clear status/history panels when the selected item no longer
+  exists.
+- Rebuild active All Songs, Bookmarks, Recent, filter, breadcrumb, preview-root,
+  and empty-state data from one publication version so the UI never mixes old
+  and new snapshots.
+- Stale or deactivated-stage notifications are ignored.
+
+Integration coverage must publish a replacement library while Song Select is
+active, including while inside a box and while Bookmarks or Recent is selected,
+and verify safe deterministic reconciliation rather than stale display or
+background-thread mutation.
 
 ## Active Views and Retained Data
 
-Removed or unavailable-root rows remain in SQLite, but active Song Select views
-must not surface them after a successful reload excludes that root.
+Removed/unavailable rows stay in SQLite, but active views do not surface them
+after a successful publication excludes their root:
 
-Product rule:
-
-- All Songs uses the published active hierarchy.
-- Bookmarks and Recent filter database-backed results to the current active-root
-  snapshot.
-- If reload fails and the previous hierarchy stays active, previous roots'
-  Bookmarks and Recent entries remain visible because those roots remain active.
-- After successful removal reload, off-root Bookmarks and Recent entries are
-  hidden but retained.
-- Re-adding and successfully publishing the root makes retained entries visible
-  again with user-owned data intact.
+- All Songs uses the active hierarchy.
+- Bookmarks and Recent filter database-backed rows to active roots.
+- If reload fails, old active roots and their entries remain visible.
+- After successful removal, off-root entries are hidden but retained.
+- Successful re-add makes them visible with user data intact.
 
 ## Empty Library UX
 
-Song Select must show a deliberate empty state rather than a blank list:
+Song Select distinguishes:
 
-- No active roots and no configured root is currently available: **No song
-  folders are currently available. Open Config to reconnect or change them.**
-- At least one active root exists but contains no supported charts: **No songs
-  were found in the active song folders.**
+- No active roots and no configured root currently available: **No song folders
+  are currently available. Open Config to reconnect or change them.**
+- At least one active root but no supported charts: **No songs were found in the
+  active song folders.**
 
-Exact copy may be localized later, but the two conditions remain distinct and
-are covered by logic tests.
+Exact wording may be localized later; the conditions remain distinct.
 
 ## SongManager and Database Interaction
 
 No database migration is required.
 
-The existing HPA-192 contracts remain in force:
+HPA-192 contracts remain authoritative:
 
-- Enumeration and persistence receive an ordered root array.
-- Root aliases are defensively deduplicated with `SongRootPolicy.RootComparer`.
-- Cleanup affects only roots supplied to the successful import.
-- Charts and songs outside those roots are retained.
-- Bookmarks, score-speed variants, play counts, recent timestamps, ranks,
-  full-combo state, and performance history remain user-owned.
-- Replacement hierarchy is published only after transaction commit.
+- Enumeration/persistence receive an ordered root array.
+- Root aliases are defensively deduplicated through `SongRootPolicy`.
+- Cleanup affects only roots supplied to a successful import.
+- Off-root charts and songs are retained.
+- User-owned scores, bookmarks, timestamps, ranks, combos, and history are
+  preserved.
+- Publication follows transaction commit.
 
-HPA-191 prevents textual parent/child overlaps before they reach `SongManager`.
-The importer is not responsible for resolving physical aliases or choosing
-which overlapping root the player intended.
+HPA-191 prevents textual overlap before import. The importer does not resolve
+physical aliases.
 
-Multiple roots remain flattened into the existing root-level hierarchy in
-configured order. Equal display titles are allowed; identity remains path and
-database based, and nodes are not merged.
+Multiple roots remain flattened into the current root-level hierarchy. Equal
+display titles are allowed; identity remains path/database based.
 
 ## Logging and User Feedback
 
 Structured logs include:
 
-- Migration from `DTXPath` to indexed roots.
-- Dropped malformed, duplicate, or overlapping hand-edited entries.
-- Canonical old/new root lists after commit.
-- Availability warnings by configured root.
+- `DTXPath` migration and indexed-root parsing warnings.
+- Deliberate suppression of custom-root directory creation.
+- Old/new normalized root snapshots after commit.
+- Availability diagnostics.
 - Picker selected/cancelled outcomes at debug level and failures at warning.
-- Config operation-slot busy decisions.
+- Config operation-slot busy decisions and lease handoff failures.
 - Reload start, success, cancellation, pre-commit failure, and post-commit
-  partial failure with aggregate counts.
+  partial failure.
+- Song Select publication-version refresh and reconciliation outcome.
 
-Normal logs must not emit new per-file success messages beyond HPA-192 progress.
+Do not add per-file success logs beyond HPA-192 progress.
 
-Config user-facing examples:
+User-facing examples:
 
 - `Reloading songs: 48 / 100 charts`
 - `Loaded 2 folders, 100 charts; 1 folder unavailable`
@@ -737,155 +738,189 @@ Config user-facing examples:
 
 ## Testing Strategy
 
-### Configuration unit tests
+### Configuration tests
 
-- Default config contains exactly managed default root and mirrors `DTXPath`.
+- Default config has one managed root and matching `DTXPath`.
 - Indexed roots round-trip in order and rewrite densely.
-- Legacy `DTXPath` migrates to one indexed root and persists immediately.
-- Legacy default `Songs` migration still resolves to `DTXFiles`.
-- Indexed entries take precedence over `DTXPath`.
-- Gaps, malformed indexes, duplicate indexes, and blank values behave as
-  specified.
-- Root duplicates use `SongRootPolicy.RootComparer`: ignore-case on Windows and
-  macOS, ordinal on Linux.
-- `SongPathIdentity.CanonicalComparer` remains ordinal for chart identity.
-- Parent/child overlaps are rejected symmetrically.
-- Symlink/junction aliases are documented but not resolved.
-- Missing custom roots are not created.
-- Managed default root is created when restored.
-- Persistence failure restores old roots and emits no event.
-- Successful update raises one event with immutable snapshots.
-- Persistence result statuses are distinct.
+- Legacy `DTXPath` migrates and persists immediately.
+- Known legacy `Songs` default migrates to `DTXFiles`.
+- Indexed entries take precedence.
+- Gaps, malformed indexes, duplicate indexes, and blanks behave as specified.
+- Root comparer is ignore-case on Windows/macOS and ordinal on Linux.
+- Chart canonical comparer remains ordinal.
+- Parent/child overlap is rejected symmetrically.
+- Physical aliases are documented but unresolved.
+- Custom missing roots are not created.
+- The managed default is created when restored.
+- Tests explicitly prove removal of the current unconditional custom-root
+  `EnsureDirectorySafe` behavior.
+- Persistence failure restores prior state and emits no event.
+- Successful update emits immutable old/new snapshots once.
+- Persistence statuses are distinct.
+- Downgrade mirror behavior is documented and serialization remains stable.
+
+### SongManager root-policy tests
+
+- `SetCurrentSearchPaths` directly deduplicates case aliases under
+  `SongRootPolicy` and preserves first occurrence/order.
+- Its copied snapshot cannot be externally mutated.
+- `LoadScoreCacheAsync`, `BuildSongListFromDatabasePublicAsync`, and
+  `NeedsEnumerationAsync` receive the aligned deduplicated roots.
+- Fresh enumeration and cache hierarchy behavior agree on root identity.
+- Linux case-distinct roots remain distinct.
 
 ### Config and panel tests
 
-- System exposes **Song Folders** instead of a read-only path.
-- Singular/plural count summaries are correct.
-- Panel starts from an isolated draft.
-- Add, remove, reorder, Apply, Cancel, and Back are deterministic.
+- System exposes **Song Folders**.
+- Singular/plural summaries are correct.
+- Panel uses an isolated draft.
+- Add/remove/reorder/Apply/Cancel/Back are deterministic.
 - Async picker cancellation/failure does not mutate the draft.
-- Stale picker completion cannot update a reactivated/disposed panel.
-- Structural errors keep panel open; availability warnings may be applied.
-- Last configured root cannot be removed without adding another.
+- Stale picker completion cannot update an inactive panel.
+- Structural errors block; availability warnings may be applied.
+- Last root cannot be removed without replacement.
 - Config's delegate is the only `SetSongRoots` caller.
 - Busy changed-root Apply does not persist.
-- Persistence failure releases the reserved slot, keeps panel open, and starts
-  no reload.
-- `Saved` fires before `Closed` after successful commit.
-- Updated `Saved` handler cannot orphan the reserved slot.
-- Active overlay polymorphism continues supporting key panels.
+- Persistence failure releases the lease and starts no reload.
+- `Saved` precedes `Closed` after success.
+- Throws at each reservation-handoff point cannot orphan the lease.
+- Key panels still work through overlay polymorphism.
+- macOS permission/authorization failure maps to Failed, while normal picker
+  cancellation maps to Cancelled.
 
-### Operation and reload tests
+### Reload and lifecycle tests
 
-- Unchanged ordered roots perform no write, slot acquisition, or scan.
-- Reorder-only changed roots perform exactly one full importer call.
+- Unchanged roots do not write, acquire, or scan.
+- Reorder-only change invokes one full import.
 - Successful Apply invokes importer once with available roots in order.
-- Unavailable roots are skipped without blocking available roots.
-- No available roots skip import, retain hierarchy, and release the slot.
-- Apply is rejected without persistence while NX import runs.
-- NX import is rejected while reload runs.
-- Lower-level enumeration busy maps to a user-visible Busy result.
-- Leaving Config cancels and asynchronously observes active operation.
-- Stale generation continuations cannot write Config UI state.
+- Unavailable roots do not block available ones.
+- No available roots skip import, retain hierarchy, and release the lease.
+- Apply is rejected without persistence during NX import.
+- NX import is rejected during reload.
+- Lower-level busy maps to user-visible Busy.
+- Leaving Config cancels and observes without blocking.
+- Stale continuations cannot write Config UI.
 - Pre-commit failure/cancellation preserves old hierarchy.
-- Cancellation after commit cannot suppress publication and reports success.
-- Unexpected post-commit publication failure reports partial success/restart.
+- Post-commit cancellation cannot suppress publication.
+- Unexpected post-commit publication failure reports partial success.
 
-### Startup and runtime integration tests
+### Song Select publication tests
 
-- Startup consumes `SongRoots`, not compatibility `DTXPath`.
-- Every production `DTXPath` consumer is removed or compatibility-only.
+- Publication while Song Select is active is processed only on the update
+  thread.
+- Root list, active roots, filters, Bookmarks, Recent, preview fallback, and
+  empty-state data use the same publication version.
+- Selection is restored by stable identity when retained.
+- Removed selection resets deterministically and stops preview/status state.
+- Publication while inside a removed box resets to root safely.
+- Publication during Bookmarks or Recent refreshes that tab against active roots.
+- Notifications after deactivation are ignored.
+- Multiple fast publications apply only the newest version.
+
+### Startup and integration tests
+
+- Startup uses `SongRoots`, not compatibility `DTXPath`.
+- Production `DTXPath` reads are absent outside compatibility allowlist.
 - Multiple roots appear in configured order.
-- Root aliases are imported once under selected root comparer.
-- Charts under distinct roots are imported once each.
-- Root N preview fallback uses active roots, not configured root zero.
-- Removed-root songs disappear from active hierarchy after success but remain in
-  SQLite with scores/bookmarks intact.
-- Bookmarks and Recent hide off-active-root rows and restore them after re-add.
+- Root aliases import once under the root comparer.
+- Distinct roots import each chart once.
+- Root N preview fallback uses active roots.
+- Removed-root songs disappear after successful reload but remain stored.
+- Bookmarks/Recent hide off-active entries and restore after re-add.
 - Missing removable root does not block another root.
-- No available roots publish empty active library without database cleanup.
-- Distinct Song Select empty states are selected correctly.
-- Windows and macOS compile with only their picker implementation.
-- Existing HPA-192 cancellation, retention, and performance tests remain green.
+- No available roots publish an empty active library without cleanup.
+- Empty states are distinct.
+- Windows and macOS compile only their picker implementation.
+- Existing HPA-192 cancellation, retention, and performance tests stay green.
 
 ## Implementation Slices
 
-The slices are hard dependencies and land in order: **Slice 1 → Slice 2 →
-Slice 3**. Each is intended to fit within three engineer days.
+Slices are hard dependencies and land in order: **Slice 1 → Slice 2 → Slice
+3**. Each is scoped to at most three engineer days.
 
 ### Slice 1: Canonical multi-root configuration and consumer migration
 
-- Add `SongRoots`, indexed INI format, compatibility mirror, migration,
-  persistence result, immutable event snapshots, and immediate persistence.
-- Add internal `SongRootPolicy` with explicit root comparer, overlap validation,
-  normalization, and availability probing.
-- Align `SongManager` defensive root deduplication with root policy.
-- Update startup to consume snapshots and publish empty active library when no
-  root is available.
-- Audit and migrate all production `DTXPath` consumers, including active-root
-  preview fallback and active-root snapshot exposure.
-- Add configuration, startup, preview, and consumer-audit tests.
+- Add `SongRoots`, indexed INI format, mirror, migration, persistence result,
+  immutable event snapshots, and immediate persistence.
+- Replace unconditional custom-root directory creation with managed-default-only
+  creation and add behavior-removal tests.
+- Add internal `SongRootPolicy` with normalization, explicit comparer, overlap,
+  and availability probing.
+- Align all `SongManager` root deduplication with the policy.
+- Add direct `SetCurrentSearchPaths` and startup cache/database caller coverage.
+- Update startup to consume snapshots and publish empty active state when needed.
+- Audit all production `DTXPath` consumers and add an architecture allowlist
+  test.
+- Add active-root snapshot exposure and multi-root preview fallback.
 - Do not add Config editing UI or live reload.
 
 ### Slice 2: Cross-platform SongFolderPanel
 
 Depends on Slice 1.
 
-- Add `IConfigOverlayPanel` and adapt key-panel interface.
-- Add asynchronous `IFolderPickerService` with Windows, macOS, and fake
-  implementations.
+- Add `IConfigOverlayPanel` and adapt key panels.
+- Add asynchronous Windows, macOS, and fake picker implementations.
+- Include macOS consent/authorization UX and result mapping.
 - Replace **DTX Folder** with **Song Folders** and implement draft editing.
-- Commit through Config's single commit delegate and `SetSongRoots`.
-- Show temporary `restart required` status after `Updated` until Slice 3.
-- Verify persisted roots are consumed by Startup on next launch.
-- Add panel, picker-threading, and platform-boundary tests.
+- Commit through Config's single delegate.
+- Show temporary restart-required status after `Updated`.
+- Verify startup consumes persisted roots on next launch.
+- Add panel, threading, privacy-failure, and platform-boundary tests.
 
-### Slice 3: Live reload and retained-data integration
+### Slice 3: Live reload and active-stage reconciliation
 
 Depends on Slices 1 and 2.
 
 - Add `ISongLibraryReloadService`.
-- Add Config operation mutual exclusion shared by NX import and reload, with
-  reservation before changed-root persistence.
-- Add progress, unavailable-root summaries, non-blocking cancellation
-  observation, commit-to-publish terminal semantics, and failure feedback.
-- Add active-root filtering for Bookmarks/Recent and deliberate empty-state UX.
-- Verify successful publication, old-hierarchy retention, post-commit recovery,
-  and removed-root data retention.
-- Add multi-root integration tests and Windows/macOS build validation.
+- Add Config mutual exclusion and scoped lease handoff with throw-safe release.
+- Add progress, warnings, non-blocking retirement, commit-to-publish terminal
+  semantics, and failure feedback.
+- Add active-root filtering for Bookmarks/Recent and deliberate empty states.
+- Add update-thread Song Select reconciliation for out-of-band publication,
+  including stable selection/navigation restoration.
+- Verify successful publication, retained old hierarchy on pre-commit failure,
+  post-commit recovery, and removed-root data retention.
+- Add multi-root lifecycle integration tests and Windows/macOS builds.
 
 ## Acceptance Criteria
 
-- Existing one-path `DTXPath` configurations migrate without library loss.
-- Fresh install has one managed default song root.
-- Config allows adding, removing, and reordering roots on Windows and macOS.
-- Ordered roots survive restart and are read by startup after Slice 2.
-- Root duplicate comparison is ignore-case on Windows/macOS and ordinal on
-  Linux; chart canonical identity remains ordinal.
-- Duplicate and textual parent/child-overlapping roots cannot be applied.
-- Missing custom roots remain configured and are never created automatically.
-- Previously auto-created custom directories are not deleted by migration.
-- Unchanged roots do not acquire slot or scan; any changed ordered list performs
-  at most one full scan, including reorder-only changes.
-- Busy changed-root Apply does not persist the draft.
-- Every available root is scanned in configured order.
-- NX import and song reload cannot run concurrently from Config.
-- Busy lower-level enumeration is reported without an unhandled exception.
-- One unavailable root does not prevent available roots from loading.
-- Successful reload replaces active hierarchy atomically.
-- Pre-commit failure or cancellation never exposes partial hierarchy.
-- Cancellation after commit cannot suppress hierarchy publication.
-- Config deactivation never blocks game thread waiting for reload/import.
-- No available root during Apply retains previous active hierarchy.
-- No available root during startup reaches Title with empty active library and
+- Existing one-path configurations migrate without library loss.
+- Fresh install has one managed default root.
+- Config adds, removes, and reorders roots on Windows and macOS.
+- Ordered roots survive restart and startup reads them.
+- Root comparison is ignore-case on Windows/macOS and ordinal on Linux; chart
+  canonical identity remains ordinal.
+- `SetCurrentSearchPaths` and startup cache/database paths use the same policy
+  with direct tests.
+- Duplicate and textual parent/child roots cannot be applied.
+- Missing custom roots remain configured and are never auto-created.
+- Removal of the current custom-path `EnsureDirectorySafe` behavior is explicit
+  and tested.
+- Existing auto-created directories are not deleted.
+- The first-root downgrade mirror and its older-build recreation caveat are
+  documented.
+- Unchanged roots do not acquire or scan; any changed ordered list performs at
+  most one full scan.
+- Busy changed-root Apply does not persist.
+- Every available root scans in configured order.
+- NX import and reload cannot run concurrently.
+- Slot handoff is throw-safe and cannot orphan ownership.
+- One unavailable root does not block available roots.
+- Successful reload atomically replaces hierarchy and active roots.
+- Pre-commit failure/cancellation never exposes partial hierarchy.
+- Post-commit cancellation cannot suppress publication.
+- Config deactivation never blocks the game thread.
+- Song Select safely reconciles an out-of-band publication while active.
+- No available root during Apply retains the previous active hierarchy.
+- No available root during startup reaches Title with empty active state and
   leaves SQLite untouched.
-- Preview fallback under any active root resolves correctly.
-- Removing a root hides songs, Bookmarks, and Recent after successful reload
-  while preserving database records and user-owned data.
-- Re-adding a root restores retained user data and active views.
-- Song Select distinguishes unavailable folders from available-but-empty roots.
-- `DTXPath` remains compatibility mirror only; every runtime consumer uses
-  configured or active snapshots as appropriate.
-- Symlink/junction/physical-target deduplication is outside scope.
-- No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
+- Preview fallback works under every active root.
+- Removing a root hides its songs, Bookmarks, and Recent entries while retaining
+  database data.
+- Re-adding restores retained state and active views.
+- Song Select distinguishes unavailable roots from available-but-empty roots.
+- `DTXPath` remains compatibility-only; runtime consumers use configured or
+  active snapshots as appropriate.
+- Physical-target deduplication remains explicitly outside scope.
+- No DTXCreator, parser, schema, or synthetic-root-navigation change is
   included.

--- a/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
+++ b/docs/superpowers/specs/2026-08-01-hpa-191-song-folders-design.md
@@ -1,0 +1,631 @@
+# HPA-191 Configurable Multiple Song Folders Design
+
+**Issue:** [HPA-191](https://linear.app/cwchanap/issue/HPA-191/allow-change-song-folders)  
+**Date:** 2026-08-01  
+**Status:** Draft for review
+
+## Context
+
+DTXManiaCX currently persists one song-library path in `ConfigData.DTXPath` and
+writes it as `DTXPath=` in `Config.ini`. `ConfigStage` displays that value as a
+read-only **DTX Folder** item. During startup, `StartupStage` wraps the value in
+a one-element string array before passing it into the song-loading pipeline.
+
+The lower-level song system is already substantially multi-root capable:
+
+- `SongManager` accepts arrays of search roots.
+- Enumeration normalizes and deduplicates roots.
+- Root traversal order is preserved in the published hierarchy.
+- HPA-192 bulk import and cleanup are scoped to active roots.
+- Database rows outside active roots are retained, protecting scores,
+  bookmarks, performance history, and other user-owned state when a library is
+  temporarily removed or unavailable.
+
+HPA-191 therefore does not require a database schema change or another song
+import architecture. The work is to make the ordered root list a first-class
+configuration value, expose safe cross-platform editing in Config, and reload
+the active library without routing the game through boot-only startup state.
+
+## Goals
+
+- Allow the player to add, remove, and reorder song-library roots from the
+  Config stage.
+- Support one or more persisted roots while retaining compatibility with
+  existing `DTXPath` configurations.
+- Apply valid changes immediately and perform one live library reload.
+- Preserve the currently published hierarchy until a replacement reload has
+  completed successfully.
+- Preserve database records and user-owned data for roots removed from the
+  active configuration or temporarily unavailable.
+- Support Windows and macOS folder selection without referencing platform UI
+  frameworks from shared game code.
+- Reject configurations that would scan the same subtree more than once.
+- Keep startup behavior deterministic when some or all configured roots are
+  unavailable.
+
+## Non-goals
+
+- DTXCreator changes.
+- Changes to chart parsing, `set.def`, or `box.def` semantics.
+- Song database schema changes.
+- Filesystem watchers or automatic reload when a removable drive is mounted.
+- Background rescans after every individual add, remove, or reorder action.
+- Editing or creating song files from Config.
+- Synthetic top-level boxes for each configured root.
+- Merging same-named folders or songs across different roots.
+- Deleting retained database records for removed roots.
+- General-purpose file-picker infrastructure beyond directory selection.
+- Linux-specific picker integration; the configuration and reload contracts
+  remain platform-neutral, but HPA-191 targets the existing Windows and macOS
+  game projects.
+
+## Chosen Approach
+
+Add an ordered `SongRoots` collection as the sole runtime source of truth.
+Retain `DTXPath` only as a serialized compatibility mirror of the first root.
+A dedicated Config overlay edits a working copy and commits it only when the
+player selects **Apply**. A platform-specific folder-picker service supplies new
+paths. After the configuration is atomically persisted, a focused song-library
+reload service invokes the existing HPA-192 enumeration/import path once.
+
+The old hierarchy remains published until the complete replacement batch has
+committed and been published. A failed or cancelled reload therefore cannot
+leave Song Select displaying a partial library.
+
+Three root states are distinguished throughout the design:
+
+- **Configured roots:** the ordered canonical paths persisted in `Config.ini`.
+- **Available roots:** configured roots that currently exist and pass a minimal
+  access probe.
+- **Active roots:** roots represented by the currently published `SongManager`
+  hierarchy. Active roots change only after a successful reload, or during a
+  clean startup that intentionally publishes an empty library.
+
+This distinction allows removable-drive paths to remain configured without
+pretending they are currently usable.
+
+## Alternatives Considered
+
+### Save and require restart
+
+This is the smallest implementation, but it leaves the active library stale
+until the player restarts and gives weak feedback that the change succeeded.
+It is rejected because the existing bulk importer already provides an atomic
+publication boundary suitable for a live reload.
+
+### Transition Config back through StartupStage
+
+This reuses the startup progress screen, but `StartupStage` owns boot-specific
+phase state, activation generations, timing summaries, and exactly-once startup
+telemetry. Re-entering it for a user-initiated configuration operation would
+couple unrelated lifecycles and make telemetry ambiguous. It is rejected.
+
+### Rescan after every list edit
+
+This would repeatedly traverse and persist the same library while the player is
+still composing the desired configuration. It is rejected in favor of a draft
+list and one Apply operation.
+
+### Store one delimited `SongRoots=` value
+
+A delimiter would conflict with legal path characters and complicate escaping
+and hand editing. Indexed keys are easier to parse, order, diagnose, and migrate.
+
+## Configuration Contract
+
+### Runtime model
+
+`ConfigData` gains an ordered mutable collection:
+
+```csharp
+public List<string> SongRoots { get; } = new();
+```
+
+The collection is initialized with `AppPaths.GetDefaultSongsPath()`.
+
+`DTXPath` remains available for source and downgrade compatibility, but is a
+mirror only:
+
+- After load, reset, or a successful root update, it equals the first canonical
+  configured root.
+- Production startup, Config UI, reload, and active-root filtering must consume
+  `SongRoots`, never `DTXPath`.
+- Direct legacy mutation of `DTXPath` is not a supported way to change the
+  runtime library.
+
+At least one configured root is always required. Availability is not required;
+a single configured path may point to a currently disconnected removable drive.
+
+### Persisted format
+
+`Config.ini` stores roots in explicit order:
+
+```ini
+[System]
+DTXPath=C:\DTX\Main
+SongRoot.0=C:\DTX\Main
+SongRoot.1=D:\Community Charts
+```
+
+Rules:
+
+1. `SongRoot.<index>` uses a non-negative decimal integer index.
+2. Roots are loaded in ascending numeric order; gaps are allowed.
+3. Malformed suffixes, blank values, and negative indexes are ignored with a
+   warning.
+4. Duplicate indexes use the last parsed value, matching normal INI overwrite
+   expectations, and emit a warning.
+5. Values may contain `=` because `ConfigManager` already splits lines on the
+   first `=` only.
+6. Save rewrites indexes densely from zero.
+7. `DTXPath` is always written as the first root for downgrade compatibility.
+8. `SongRoot.*` entries are the authority whenever at least one structurally
+   valid entry exists.
+9. When no valid indexed entries exist, the loader migrates the legacy
+   `DTXPath` value into a one-element root list.
+10. When neither representation yields a usable path, the managed default root
+    is restored.
+
+A successful legacy migration is persisted immediately through the existing
+atomic temp-file replacement so the next launch no longer depends on fallback
+logic.
+
+### Legacy path migration
+
+The existing migration from legacy `Songs` defaults to the current managed
+`DTXFiles` location is retained. It applies to the fallback `DTXPath` value
+before that value becomes `SongRoots[0]`.
+
+Indexed custom roots are not remapped merely because their final segment is
+named `Songs`; only the known legacy default representations are migrated.
+
+### Directory creation
+
+The game may create the managed default `AppPaths.GetDefaultSongsPath()` when it
+is selected or restored as the fallback root.
+
+The game must not create arbitrary custom roots. A missing custom path may be a
+removable drive, network mount, renamed directory, or user error. Creating it
+would hide the problem and could produce unwanted directories on the wrong
+volume.
+
+## Path Identity and Validation
+
+All roots are resolved and compared through one shared policy used by config
+load, Config UI, and the setter.
+
+### Canonicalization
+
+For each non-blank input:
+
+1. Expand supported home-relative forms through `AppPaths`.
+2. Resolve relative legacy paths against the same app-data base used today.
+3. Convert to an absolute full path.
+4. Normalize separators and trailing separators through `SongPathIdentity`.
+5. Compare with `SongPathIdentity.CanonicalComparer`, preserving platform path
+   case behavior.
+6. Persist the canonical absolute value.
+
+Root order is semantically meaningful. It controls traversal order and the
+ordering of root-level nodes in Song Select.
+
+### Blocking structural errors
+
+The following prevent Apply and leave the current configuration unchanged:
+
+- No configured roots.
+- Blank or syntactically invalid paths.
+- Canonically duplicate roots.
+- Overlapping roots where either path is an ancestor of the other.
+
+Overlapping roots are rejected because scanning both a parent and its child
+would discover the same charts twice. The policy performs a symmetric
+ancestor check after canonicalization; authored order does not make an overlap
+valid.
+
+Hand-edited invalid configuration must not prevent startup. During load, roots
+are processed in numeric order and the first accepted root wins. Later duplicate
+or overlapping entries are dropped with warnings. If all entries are rejected,
+the managed default is restored.
+
+### Availability warnings
+
+Missing and inaccessible paths are warnings, not structural errors. They remain
+configured so removable or network libraries can return later.
+
+A minimal availability probe must:
+
+- Check that the directory exists.
+- Attempt to begin a shallow directory enumeration to detect obvious access
+  failures without recursively scanning charts.
+- Catch path, I/O, and authorization errors and return a diagnostic instead of
+  throwing.
+
+Only roots passing this probe are supplied to a live reload or normal startup
+load. A path may still fail later because availability can change during a
+scan; that failure follows the reload error contract below.
+
+## Config User Experience
+
+### System menu entry
+
+Replace the read-only **DTX Folder** item with a navigation item named
+**Song Folders**.
+
+Its value summary is:
+
+- `1 folder` for one configured root.
+- `<n> folders` for multiple roots.
+
+The description states that the folders are scanned in the displayed order and
+that Apply reloads the song library once.
+
+### Overlay abstraction
+
+`ConfigStage` currently models its active overlay as `IKeyAssignPanel`, although
+the lifecycle and drawing contract is generally useful. Introduce
+`IConfigOverlayPanel` containing the common members:
+
+- `IsActive`
+- `Closed`
+- `Saved`
+- `Activate()` / `Deactivate()`
+- `Update(...)`
+- `Draw(...)`
+
+`IKeyAssignPanel` inherits `IConfigOverlayPanel`, preserving existing key-panel
+contracts. `ConfigStage._activePanel` becomes `IConfigOverlayPanel`. This is a
+targeted boundary correction required to host a non-key-assignment panel; it is
+not a broader Config UI refactor.
+
+### SongFolderPanel
+
+`SongFolderPanel` receives:
+
+- An immutable snapshot of configured roots.
+- `IFolderPickerService`.
+- The shared root validation policy.
+
+It owns a private draft list. Opening, reordering, adding, removing, or
+cancelling does not mutate `ConfigData`.
+
+The panel displays the full selected path and a scrollable ordered list. Long
+paths may be visually ellipsized, but validation and persistence always use the
+complete value.
+
+Supported actions:
+
+- **Add Folder** — invoke the platform picker and append a unique selection.
+- **Remove** — remove the selected root when at least one draft root remains.
+- **Move Up** / **Move Down** — change scan and display order.
+- **Apply** — validate and commit the complete draft.
+- **Cancel** — discard the draft and close.
+
+Input behavior follows existing Config conventions:
+
+- Up/Down move selection.
+- Left/Right change the selected action where applicable.
+- Activate executes the highlighted action.
+- Back behaves as Cancel.
+
+Structural errors are shown in the panel and keep it open. Availability warnings
+are shown beside affected roots but do not disable Apply.
+
+A folder-picker cancellation is a no-op. A picker failure displays an error and
+leaves the draft unchanged.
+
+## Platform Folder Picker
+
+Shared code depends only on:
+
+```csharp
+public interface IFolderPickerService
+{
+    FolderPickerResult PickFolder(string? initialDirectory);
+}
+```
+
+The result distinguishes selected, cancelled, unavailable, and failed outcomes
+and carries an error message only for failure.
+
+Platform composition selects the implementation:
+
+- **Windows:** use `System.Windows.Forms.FolderBrowserDialog`, already supported
+  by the Windows project target. The dialog starts from the selected root or the
+  managed default when possible.
+- **macOS:** invoke the native folder chooser through a small `osascript`
+  adapter using `choose folder`, returning its POSIX path. Process arguments are
+  passed without shell interpolation, cancellation is mapped to Cancelled, and
+  non-cancellation failures include stderr in structured logging.
+
+The shared `DTXMania.Game` code must not reference WinForms, AppleScript process
+construction, or other platform UI types. Picker implementations and service
+registration live in platform-specific source files or projects.
+
+Headless tests inject a deterministic fake picker.
+
+## Commit and Persistence Flow
+
+Applying roots is an explicit user commit, so it requires stronger semantics
+than an ordinary deferred toggle edit.
+
+`IConfigManager` gains a typed root update operation returning a result:
+
+```csharp
+SongRootUpdateResult SetSongRoots(
+    string configFilePath,
+    IReadOnlyList<string> roots);
+```
+
+The operation:
+
+1. Validates and canonicalizes the complete list.
+2. Captures the prior `SongRoots` and `DTXPath` values.
+3. Updates both in memory.
+4. Writes the complete config immediately through the existing atomic
+   temp-file replacement.
+5. Clears any pending deferred-save marker on success because all current
+   settings were written.
+6. Restores the prior in-memory values if persistence fails.
+7. Raises `SongRootsChanged` only after persistence succeeds.
+8. Is a no-op success when the canonical ordered list is unchanged.
+
+Event subscribers are isolated using the same per-subscriber exception handling
+as existing config events. A subscriber failure does not undo an accepted and
+persisted configuration.
+
+If persistence fails, the panel remains open, the old configuration remains the
+truth, and no reload begins.
+
+## Live Library Reload
+
+### Boundary
+
+Introduce an `ISongLibraryReloadService` abstraction so `ConfigStage` does not
+own raw `SongManager` orchestration and tests do not need the singleton.
+
+The production implementation:
+
+- Resolves currently available roots from the persisted configured list.
+- Adapts `EnumerationProgress` to a Config status string.
+- Invokes `SongManager.EnumerateAndImportSongsAsync` once.
+- Returns the successful active-root set, aggregate counts, warnings, or a
+  terminal failure/cancellation result.
+- Allows only one in-flight reload.
+
+It does not create another import path. The existing HPA-192 batch builder,
+bulk transaction, hierarchy finalization, and publication remain authoritative.
+
+### Apply sequence
+
+1. `SongFolderPanel` validates its draft.
+2. `ConfigManager.SetSongRoots` atomically persists the canonical list.
+3. The panel closes and Config displays a reload status.
+4. The reload service probes all configured roots.
+5. When at least one root is available, one enumeration/import starts with only
+   those roots.
+6. The old hierarchy remains active while discovery and persistence run.
+7. On successful commit, `SongManager.PublishEnumeration` replaces the hierarchy
+   and current active-root snapshot atomically.
+8. Config reports loaded root, chart, logical-song, skipped-root, and error
+   counts.
+
+Unavailable configured roots are omitted from that scan and listed as warnings.
+Their database records are retained because they are outside the active import
+roots.
+
+When no configured root is currently available, Config does not invoke the
+importer and does not clear the current hierarchy. The roots remain saved and
+Config reports that the current library was retained until a successful future
+reload or restart.
+
+### Concurrency and lifecycle
+
+- A second Apply/reload request is rejected while one reload is in flight.
+- Song-folder editing may be reopened only after the prior reload terminates.
+- Leaving Config cancels the reload and observes its task.
+- The cancellation source is disposed only after the operation terminates,
+  preserving HPA-192's enumeration-slot and cancellation-winddown guarantees.
+- Config deactivation must not block indefinitely waiting for filesystem work.
+- The reload task may complete during a stage transition, but it must not write
+  into disposed Config graphics or panel state. Status publication is guarded
+  by an activation generation or equivalent lifetime token.
+
+### Failure and cancellation
+
+If discovery, import, or publication fails:
+
+- The newly persisted configured roots remain saved.
+- The previous active hierarchy and active-root snapshot remain published.
+- No partial hierarchy is exposed.
+- The player sees a concise failure message explaining that the saved roots will
+  be retried on the next startup or Apply.
+- Detailed exceptions and failed-root diagnostics are logged.
+
+If cancellation occurs before publication, the same old-hierarchy guarantee
+applies. If the HPA-192 operation has already committed and published before the
+cancellation is observed, that successful publication remains authoritative;
+the status must not claim that the library was rolled back.
+
+## Startup Integration
+
+`StartupStage` reads a snapshot of `Config.SongRoots`, never `DTXPath`.
+
+Before selecting the cache or enumeration path, startup performs the shared
+availability probe:
+
+- Available roots are passed to `NeedsEnumerationAsync`, cache hierarchy
+  construction, and enumeration.
+- Unavailable roots are logged once with their diagnostics.
+- Root order remains the configured order.
+
+When no configured root is available during a clean startup, startup completes
+successfully with an empty active hierarchy and an empty active-root snapshot.
+It does not delete or stale-clean any database records. The title screen remains
+reachable, and the player can enter Config to repair the paths.
+
+A later successful startup or Apply restores songs from the retained database or
+re-enumerates the returned roots according to the normal load-path decision.
+
+## SongManager and Database Interaction
+
+No database migration is required.
+
+The existing HPA-192 contracts remain in force:
+
+- Enumeration and persistence receive an ordered root array.
+- Exact duplicate roots are defensively deduplicated again in `SongManager`.
+- Cleanup affects only roots successfully supplied to the import.
+- Charts and songs outside those roots are retained.
+- Bookmarks, all score-speed variants, play counts, recent-play timestamps,
+  ranks, full-combo state, and performance history remain user-owned data.
+- The replacement hierarchy is published only after the transaction commits.
+
+HPA-191 prevents overlapping configured roots before they reach `SongManager`.
+The importer is not responsible for inferring which overlapping root the player
+intended.
+
+Multiple roots remain flattened into the existing root-level hierarchy in
+configured order. Two roots may legitimately produce boxes or songs with equal
+display titles; identity remains path/database based and the nodes are not
+merged. Adding synthetic per-root containers would change navigation semantics
+and is outside this issue.
+
+## Logging and User Feedback
+
+Structured logs include:
+
+- Config migration from `DTXPath` to indexed roots.
+- Dropped malformed, duplicate, or overlapping hand-edited entries.
+- Selected and cancelled folder-picker outcomes at debug level.
+- Picker failures at warning level.
+- Canonical old and new root lists after a successful commit.
+- Availability warnings by configured root.
+- Reload start, success, cancellation, and failure with aggregate counts.
+
+Normal logs must not emit per-file success messages beyond the progress behavior
+already owned by HPA-192.
+
+Config displays one concise status line for the current operation, for example:
+
+- `Reloading songs: 48 / 100 charts`
+- `Loaded 2 folders, 100 charts; 1 folder unavailable`
+- `Folders saved; no configured folder is currently available`
+- `Reload failed; previous song list retained`
+
+## Testing Strategy
+
+### Configuration unit tests
+
+- Default config contains exactly the managed default root and mirrors it to
+  `DTXPath`.
+- Indexed roots round-trip in order and are rewritten densely.
+- Legacy `DTXPath` migrates to one indexed root and persists immediately.
+- Legacy default `Songs` migration still resolves to `DTXFiles`.
+- Indexed entries take precedence over `DTXPath`.
+- Gaps, malformed indexes, duplicate indexes, and blank values are handled as
+  specified.
+- Canonical duplicates are rejected by the setter and dropped safely on load.
+- Parent/child overlaps are rejected symmetrically.
+- Root comparison follows platform path semantics.
+- Missing custom roots are not created.
+- The managed default root is created when restored as fallback.
+- Failed config persistence restores the prior in-memory roots and emits no
+  change event.
+- A successful update raises `SongRootsChanged` once after persistence.
+
+### Config and panel tests
+
+- The System category exposes **Song Folders** instead of a read-only path.
+- The count summary uses singular and plural forms.
+- Panel activation starts from an isolated draft.
+- Add, remove, reorder, Apply, Cancel, and Back behavior are deterministic.
+- Picker cancellation and failure do not mutate the draft.
+- Structural errors keep the panel open.
+- Missing paths appear as warnings and may be applied.
+- The last configured root cannot be removed without adding another.
+- Apply does not start a reload when persistence fails.
+- Active overlay polymorphism continues to support existing key panels.
+
+### Reload-service tests
+
+- One successful Apply triggers exactly one importer call with roots in order.
+- Unavailable roots are skipped without preventing available roots from loading.
+- No available roots skip import and retain the existing hierarchy.
+- Concurrent reload is rejected.
+- Success publishes the new hierarchy and active roots.
+- Failure and pre-publication cancellation preserve the previous hierarchy.
+- Leaving Config cancels and safely observes the operation.
+- Post-publication cancellation is reported as success, not rollback.
+
+### Startup and integration tests
+
+- Startup consumes `SongRoots`, not the compatibility `DTXPath` value.
+- Multiple available roots appear in configured order.
+- Charts under distinct roots are imported once each.
+- Removed-root songs disappear from the active hierarchy after successful
+  reload but remain in SQLite with scores and bookmarks intact.
+- Re-adding the root restores retained user-owned state.
+- A missing removable-drive root does not block another root.
+- No available roots produce an empty active library without database cleanup.
+- Windows and macOS projects compile with only their own picker implementation.
+- Existing HPA-192 enumeration, cancellation, score-retention, and performance
+  tests remain green.
+
+## Implementation Slices
+
+Each slice is intended to fit within three engineer days and be executable by a
+junior code agent with repository-wide access.
+
+### Slice 1: Canonical multi-root configuration
+
+- Add `SongRoots`, the indexed INI format, compatibility mirror, migration, and
+  immediate persistence behavior.
+- Add shared canonicalization, overlap validation, and availability probing.
+- Update `IConfigManager`, `ConfigManager`, `ConfigData`, and startup root
+  consumption.
+- Add configuration and startup unit tests.
+- Do not add Config UI or live reload in this slice.
+
+### Slice 2: Cross-platform SongFolderPanel
+
+- Add `IConfigOverlayPanel` and adapt the existing key-panel interface.
+- Add `IFolderPickerService` with Windows, macOS, and fake implementations.
+- Replace **DTX Folder** with **Song Folders** and implement the draft editing
+  panel.
+- Commit through `SetSongRoots`, but show a temporary `restart required` status
+  until Slice 3 supplies live reload.
+- Add panel and platform-boundary tests.
+
+### Slice 3: Live reload and retained-data integration
+
+- Add `ISongLibraryReloadService` and Config lifecycle coordination.
+- Add progress, unavailable-root summaries, cancellation, and failure feedback.
+- Verify successful publication, old-hierarchy retention, and removed-root data
+  retention.
+- Add multi-root integration tests and Windows/macOS build validation.
+
+## Acceptance Criteria
+
+- Existing one-path `DTXPath` configurations migrate without losing the library.
+- A fresh install has one managed default song root.
+- Config allows adding, removing, and reordering roots on Windows and macOS.
+- The ordered root list survives restart.
+- Duplicate and parent/child-overlapping roots cannot be applied.
+- Missing custom roots remain configured and are never created automatically.
+- Applying a changed list performs at most one live scan.
+- Every available root is scanned in configured order.
+- One unavailable root does not prevent available roots from loading.
+- A successful reload replaces the active hierarchy atomically.
+- A failed or cancelled pre-publication reload never exposes a partial hierarchy.
+- When no root is available during Apply, the previous active hierarchy remains
+  visible and the saved configuration is retried later.
+- When no root is available during startup, the game reaches Title with an empty
+  active library and leaves the database untouched.
+- Removing a root removes its songs from active views after a successful reload
+  but preserves their bookmarks, scores, variants, and performance history.
+- Re-adding a root restores retained user data.
+- `DTXPath` remains a compatibility mirror only; runtime code consumes
+  `SongRoots`.
+- No DTXCreator, parser, song schema, or synthetic-root-navigation changes are
+  included.


### PR DESCRIPTION
## Summary

- Add ordered, persisted song-folder configuration with legacy `DTXPath` compatibility.
- Add platform folder pickers, validation, Apply/Revert behavior, and serialized live reload coordination.
- Publish coherent versioned song-library snapshots and reconcile Song Select navigation, selection, tabs, bookmarks, recent songs, and previews safely across reloads.
- Harden dispatcher cancellation/fault handling and update-thread lifecycle cleanup.

## Validation

- Full Release suite: 7,571 passed, 0 failed.
- Task-focused gates: Task 1B 224/224, Task 2 195/195, Task 3A 80/80, Task 3B 204/204.
- macOS Release build: 0 warnings, 0 errors.
- Windows Release build: 130 existing warnings, 0 errors.
- `DTXPath` compatibility audit limited to intended `ConfigManager` migration/compatibility paths.

## Notes

This PR targets `main`. Native macOS/Windows picker interaction and the full graphical smoke matrix remain outstanding manual release checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage multiple ordered song folders from the configuration screen.
  * Add, remove, reorder, validate, and apply folders with live library reloads and progress feedback.
  * Select folders using native pickers on Windows and macOS.
  * Song selection now reflects library updates and supports empty-library states.
* **Bug Fixes**
  * Improved handling of unavailable, duplicate, overlapping, and invalid folders.
  * Preserved existing selections and previews when possible during library updates.
  * Improved cancellation, concurrency, stale-update, and failed-reload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->