### PR TITLE
docs: finalize HPA-519 design and HPA-529 implementation plan

### DIFF
--- a/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
@@ -585,6 +585,8 @@ Required tests:
 9. Discovery never reads or exposes the free-form emergency exception body.
 10. Unwritable capture returns `Report = null` and a safe `FailureCode` without throwing.
 
+Define `CrashStoreFixture` as a private test helper in `CrashReportStoreTests.cs`; it owns a temporary directory, fake `TimeProvider`, injectable archive writer, deterministic report IDs, and cleanup.
+
 Example retention test:
 
 ```csharp
@@ -1027,7 +1029,7 @@ public void PublishConfigurationContext_ShouldUseOnlyApprovedConcreteFields()
     };
     config.KeyBindings["Snare"] = 1;
 
-    BaseGameCrashContext.PublishConfiguration(diagnostics, config);
+    CrashContextPublisher.PublishConfiguration(diagnostics, config);
 
     var snapshot = diagnostics.Contexts.Single(CrashContextKind.Configuration);
     Assert.Equal(1920, snapshot.Fields["ScreenWidth"]);
@@ -1037,7 +1039,7 @@ public void PublishConfigurationContext_ShouldUseOnlyApprovedConcreteFields()
 }
 ```
 
-Use `CrashContextPublisher.PublishConfiguration` as the concrete helper name; keep it internal and deterministic.
+Use `CrashContextPublisher.PublishConfiguration` as the concrete helper; keep the class internal and deterministic.
 
 - [ ] **Step 2: Write failing stage and input tests**
 
@@ -1241,6 +1243,7 @@ git commit -m "feat: capture cached game crash context"
 
 **Files:**
 - Test: `DTXMania.Test/CrashReporting/CrashReportIntegrationTests.cs`
+- Test helper (inside the same file): `TemporaryAppDataRoot` and `CrashReportTestReader`
 - Modify as needed: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs`
 - Modify as needed: `DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs`
 
@@ -1249,6 +1252,8 @@ git commit -m "feat: capture cached game crash context"
 - Produces: deterministic integration proof using `DTXMANIA_APPDATA_ROOT` and fake `IGameApplication`.
 
 - [ ] **Step 1: Write the pre-graphics integration test**
+
+Inside `CrashReportIntegrationTests.cs`, define `TemporaryAppDataRoot` as a disposable temporary-directory helper and `CrashReportTestReader.ReadAllText(string path)` to concatenate the approved ZIP entries or read the emergency text file. These helpers must not live in production code.
 
 ```csharp
 [Fact]
@@ -1260,7 +1265,7 @@ public void Run_WhenFactoryThrowsBeforeGameConstruction_ShouldWriteOneSanitizedR
     try
     {
         Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", appData.Path);
-        using var runtime = CrashReportRuntime.CreateBestEffort(
+        var runtime = CrashReportRuntime.CreateBestEffort(
             StartupTimingTrace.Disabled,
             TextWriter.Null);
 
@@ -1571,16 +1576,20 @@ Assert the same conditions.
 For ZIP:
 
 ```bash
-unzip -p "<actual-report-path>" report.json
-unzip -p "<actual-report-path>" exception.txt
-unzip -p "<actual-report-path>" logs.ndjson
-unzip -p "<actual-report-path>" breadcrumbs.json
+report_path="$(find "$DTXMANIA_APPDATA_ROOT/CrashReports" -maxdepth 1 -type f -name 'crash-*.zip' | head -n 1)"
+test -n "$report_path"
+unzip -p "$report_path" report.json
+unzip -p "$report_path" exception.txt
+unzip -p "$report_path" logs.ndjson
+unzip -p "$report_path" breadcrumbs.json
 ```
 
 For emergency text:
 
 ```bash
-sed -n '1,80p' "<actual-report-path>"
+report_path="$(find "$DTXMANIA_APPDATA_ROOT/CrashReports" -maxdepth 1 -type f -name 'crash-*.txt' | head -n 1)"
+test -n "$report_path"
+sed -n '1,80p' "$report_path"
 ```
 
 Confirm:

--- a/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
@@ -2,6 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+**Status:** Ready for implementation after PR review.  
 **Goal:** Add process-boundary managed crash capture that preserves console logging, writes privacy-safe local ZIP or emergency-text reports, keeps the newest five reports, and proves `Update`/`Draw` exceptions reach the executable boundary on WindowsDX and DesktopGL.
 
 **Architecture:** `CrashReportRuntime` is created at process entry and owns the shared `ILoggerFactory`, bounded crash buffers, cached context, sanitizer, and report store. `Game1` receives only an `IGameCrashDiagnostics` facade; fatal capture occurs in an explicit entry-point lifecycle before guarded game disposal. The crash path reads immutable copies of already-cached state and performs no network, database, graphics, device-enumeration, shell, or cross-thread work.

--- a/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
@@ -22,6 +22,8 @@
 - WindowsDX callback propagation must run automatically in the existing Windows E2E job.
 - DesktopGL callback propagation must be verified manually on Apple Silicon and recorded with exact commands, commit/build identity, OS/runtime information, and observed results.
 - Production code must not expose a crash-injection switch in Release builds. The E2E injection hook must be compiled only under `DEBUG`.
+- Implement the tasks in order. Do not start Task 5 until Task 4's process ownership tests pass; do not start Task 7 until Tasks 1–6 pass on both unit-test projects.
+- Keep each task as a separate reviewable commit. Correct a defect in the task that introduced its contract rather than hiding it in a later integration-only commit.
 - The canonical design and normative amendments are:
   - `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design.md`
   - `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md`

--- a/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
@@ -336,24 +336,13 @@ public void UnknownRenderedMessage_ShouldBeOmitted()
 }
 
 [Fact]
-public void UnknownStringProperty_ShouldBeRedacted()
+public void UnknownStringValue_ShouldBeRedactedByCentralPolicy()
 {
-    using var provider = new CrashLogBufferProvider(
-        CrashLogFieldPolicy.Default,
-        TimeProvider.System,
-        capacity: 8);
-    using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
-    var logger = factory.CreateLogger("test");
+    var normalized = CrashLogFieldPolicy.Default.NormalizeProperty(
+        propertyName: "Status",
+        value: "Secret Song");
 
-    logger.LogInformation(
-        new EventId(5101, "StageTransitionRequested"),
-        "Stage transition to {TargetStage} for {SongTitle}",
-        StageType.Title,
-        "Secret Song");
-
-    var record = Assert.Single(provider.Snapshot());
-    Assert.Equal(StageType.Title, record.Properties["TargetStage"]);
-    Assert.Equal("[REDACTED]", record.Properties["SongTitle"]);
+    Assert.Equal("[REDACTED]", normalized);
 }
 ```
 
@@ -521,6 +510,20 @@ internal sealed record CrashReportWriteResult(
     bool UsedEmergencyFallback,
     string? FailureCode);
 
+internal sealed record CrashReportDocument(
+    CrashReportSummary Summary,
+    Exception Exception,
+    IReadOnlyList<CrashLogRecord> Logs,
+    IReadOnlyList<CrashBreadcrumb> Breadcrumbs,
+    IReadOnlyList<CrashContextSnapshot> Context,
+    IReadOnlyList<string> SensitivePaths);
+
+internal interface ICrashReportArtifactWriter
+{
+    void WriteZip(Stream destination, CrashReportDocument document);
+    void WriteEmergencyText(Stream destination, CrashReportDocument document);
+}
+
 internal sealed class CrashReportStore
 {
     CrashReportWriteResult Capture(CrashCaptureData data);
@@ -577,7 +580,7 @@ Required tests:
 1. ZIP contains exactly `report.json`, `exception.txt`, `logs.ndjson`, `breadcrumbs.json`, and `README.txt`.
 2. `report.json` has schema version `1` and format-neutral summary fields.
 3. ZIP is first written with a `.tmp` name and finalized in the same directory.
-4. A throwing ZIP writer produces one emergency `.txt`.
+4. A throwing `ICrashReportArtifactWriter.WriteZip` produces one emergency `.txt` through `WriteEmergencyText`.
 5. Emergency text starts with a versioned allowlisted header and can be discovered as `CrashReportFormat.EmergencyText`.
 6. Corrupt emergency header falls back to filename ID/time and `Unknown` fields.
 7. Six mixed ZIP/text reports retain exactly five newest reports.
@@ -585,7 +588,7 @@ Required tests:
 9. Discovery never reads or exposes the free-form emergency exception body.
 10. Unwritable capture returns `Report = null` and a safe `FailureCode` without throwing.
 
-Define `CrashStoreFixture` as a private test helper in `CrashReportStoreTests.cs`; it owns a temporary directory, fake `TimeProvider`, injectable archive writer, deterministic report IDs, and cleanup.
+Define `CrashStoreFixture` as a private test helper in `CrashReportStoreTests.cs`; it owns a temporary directory, fake `TimeProvider`, fake `ICrashReportArtifactWriter`, deterministic report IDs, and cleanup.
 
 Example retention test:
 
@@ -599,7 +602,7 @@ public void Capture_SixMixedReports_ShouldRetainNewestFiveAcrossFormats()
     for (var index = 0; index < 6; index++)
     {
         fixture.Clock.Advance(TimeSpan.FromSeconds(1));
-        fixture.ArchiveWriter.FailZip = index % 2 == 1;
+        fixture.ArtifactWriter.FailZip = index % 2 == 1;
         Assert.NotNull(store.Capture(fixture.CreateCapture(index)).Report);
     }
 
@@ -639,7 +642,9 @@ Do not attempt to infer whether an arbitrary phrase is a song title. Omission is
 
 - [ ] **Step 5: Implement versioned ZIP serialization**
 
-`CrashReportArchiveWriter.WriteZip` writes:
+`CrashReportArchiveWriter` implements `ICrashReportArtifactWriter`.
+
+`WriteZip` writes:
 - `report.json` — schema `1`, report ID, UTC timestamp, assembly informational version with assembly-version fallback, OS/runtime/architecture, summary, context statuses, included entries, truncation flags;
 - `exception.txt` — exception type, omitted/sanitized message field, sanitized stack, bounded inner chain;
 - `logs.ndjson` — newest records that fit both 500-entry and 512-KB limits;
@@ -648,17 +653,17 @@ Do not attempt to infer whether an arbitrary phrase is a song title. Omission is
 
 Use deterministic UTF-8 without BOM and `JsonSerializerOptions.WriteIndented = true` only for `report.json` and `breadcrumbs.json`.
 
-`WriteEmergencyText` starts with this machine-readable header:
+`WriteEmergencyText` starts with this grammar; angle-bracket terms below are values supplied from `CrashReportDocument.Summary`, not unresolved implementation fields:
 
 ```text
 DTXMANIACX-CRASH-REPORT 1
-ReportId: <id>
-CapturedAtUtc: <round-trip UTC>
-BuildId: <sanitized build>
-OperatingSystem: <sanitized OS>
-ProcessArchitecture: <architecture>
-StageOrMilestone: <sanitized value or Unknown>
-ExceptionType: <type>
+ReportId: <report-id-value>
+CapturedAtUtc: <round-trip-utc-value>
+BuildId: <sanitized-build-value>
+OperatingSystem: <sanitized-os-value>
+ProcessArchitecture: <architecture-value>
+StageOrMilestone: <sanitized-value-or-Unknown>
+ExceptionType: <exception-type-value>
 ---
 ```
 
@@ -671,7 +676,7 @@ Construction:
 ```csharp
 internal CrashReportStore(
     string rootPath,
-    CrashReportArchiveWriter writer,
+    ICrashReportArtifactWriter writer,
     TimeProvider timeProvider,
     TextWriter errorWriter)
 ```
@@ -860,9 +865,9 @@ public static CrashReportRuntime CreateBestEffort(
 ```
 
 The production method must:
-1. create the console logger factory first;
-2. attempt to add crash components without creating the report directory;
-3. on expected setup failure, dispose the partially built factory and create a fresh console-only factory;
+1. construct crash components that perform no report-directory I/O;
+2. create one logger factory with `AddConsole()` and, when enabled, `AddProvider(crashLogBufferProvider)`;
+3. on an expected crash-component or provider setup failure, dispose the partial factory if one exists and create one fresh console-only factory;
 4. write one sanitized `crash_reporting_disabled code=<fixed-code>` line to `errorWriter ?? Console.Error`;
 5. return a disabled runtime.
 
@@ -898,7 +903,7 @@ internal BaseGame(
     _logger = _loggerFactory.CreateLogger<BaseGame>();
 }
 
-public sealed class Game1 : BaseGame, IGameApplication
+public class Game1 : BaseGame, IGameApplication
 {
     internal Game1(
         StartupTimingTrace startupTimingTrace,
@@ -909,7 +914,7 @@ public sealed class Game1 : BaseGame, IGameApplication
 }
 ```
 
-Adapt the actual existing `Game1` declaration without sealing it if tests subclass it. Remove production parameterless constructors. Do not add a constructor that creates its own logger factory.
+Remove production parameterless constructors. Do not add a constructor that creates its own logger factory.
 
 Remove `_loggerFactory.Dispose()` from `BaseGame.DisposeManagedResources()`.
 
@@ -923,9 +928,13 @@ Do not expose the full runtime, store, or context registry through `IStageGame`.
 
 - [ ] **Step 6: Implement explicit entry-point lifecycle**
 
-`Program.cs` becomes conceptually:
+`Program.cs` becomes:
 
 ```csharp
+using DTXMania.Game;
+using DTXMania.Game.Lib.Diagnostics.CrashReporting;
+using DTXMania.Game.Lib.Stage;
+
 var startupTrace = StartupTimingTrace.StartProcess();
 var crashRuntime = CrashReportRuntime.CreateBestEffort(startupTrace, Console.Error);
 
@@ -1162,7 +1171,15 @@ Record:
 
 Never include shared-data values or song identity.
 
-Update `BaseGame.CreateLoadContentServices()` to pass the process-owned sinks.
+Update `BaseGame.CreateLoadContentServices()` to create the manager as:
+
+```csharp
+new StageManager(
+    this,
+    _loggerFactory.CreateLogger<StageManager>(),
+    _gameCrashDiagnostics.Breadcrumbs,
+    _gameCrashDiagnostics.Contexts)
+```
 
 - [ ] **Step 8: Add count-only MIDI context**
 
@@ -1244,8 +1261,7 @@ git commit -m "feat: capture cached game crash context"
 **Files:**
 - Test: `DTXMania.Test/CrashReporting/CrashReportIntegrationTests.cs`
 - Test helper (inside the same file): `TemporaryAppDataRoot` and `CrashReportTestReader`
-- Modify as needed: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs`
-- Modify as needed: `DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs`
+- No production file change is expected; a production correction belongs in the task that introduced the defective contract and must retain that task's focused regression test.
 
 **Interfaces:**
 - Consumes: all prior production components.
@@ -1333,10 +1349,7 @@ Expected: both suites pass.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add \
-  DTXMania.Test/CrashReporting/CrashReportIntegrationTests.cs \
-  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs \
-  DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs
+git add DTXMania.Test/CrashReporting/CrashReportIntegrationTests.cs
 git commit -m "test: verify crash report integration"
 ```
 
@@ -1415,17 +1428,19 @@ Call the hook:
 
 - [ ] **Step 3: Write Windows crash smoke tests**
 
-For both `update` and `draw`:
-1. build an isolated fixture with `E2EFixtureBuilder`;
-2. start the Windows game project with the debug-only environment override;
-3. wait for non-zero exit;
-4. assert exactly one completed report under `<fixture.AppDataRoot>/CrashReports`;
-5. assert no `.tmp`;
-6. open the ZIP or text summary and assert exception type is `InvalidOperationException`;
-7. assert the controlled crash appears once as the primary exception;
-8. assert stdout/stderr and report files are copied to `fixture.ArtifactRoot` on failure.
+Add a private `ReadCrashSummary(string reportPath)` helper to `CrashReportingSmokeTests.cs`. It must open `report.json` from ZIP or parse only the emergency header before `---` and return a `CrashReportSummary`. Do not reference internal production parser types from the E2E assembly.
 
-Example test shape:
+For both `update` and `draw`, the test must:
+1. build an isolated fixture with `E2EFixtureBuilder`;
+2. start the Windows game project with `DTXMANIA_E2E_CRASH_INJECTION` set to the theory value;
+3. await `WaitForExitAsync` and assert a non-zero exit code;
+4. enumerate `<fixture.AppDataRoot>/CrashReports` and assert exactly one completed `.zip` or `.txt`;
+5. assert no `.tmp` exists;
+6. call `ReadCrashSummary` and assert `ExceptionType == "InvalidOperationException"`;
+7. inspect `exception.txt` or the emergency body and assert `DTXMANIA_E2E_CONTROLLED_CRASH` appears exactly once;
+8. copy stdout, stderr, and report files to `fixture.ArtifactRoot` in the test's `finally` block.
+
+Use this concrete test skeleton:
 
 ```csharp
 [Theory(Timeout = 180_000)]
@@ -1434,10 +1449,62 @@ Example test shape:
 public async Task ControlledCallbackCrash_ShouldReachProgramBoundaryExactlyOnce(
     string injectionPoint)
 {
-    // Build fixture, start process with environment override, await exit,
-    // inspect one completed report, and assert no duplicate.
+    var repoRoot = FindRepoRoot();
+    var runRoot = Path.Combine(
+        Path.GetTempPath(),
+        "dtx-crash-e2e-" + Guid.NewGuid().ToString("N"));
+    var fixture = E2EFixtureBuilder.Build(
+        runRoot,
+        repoRoot,
+        GetAvailablePort());
+    await using var process = new GameProcessDriver();
+
+    try
+    {
+        process.Start(
+            repoRoot,
+            "DTXMania.Game/DTXMania.Game.Windows.csproj",
+            fixture,
+            environmentOverrides: new Dictionary<string, string?>
+            {
+                ["DTXMANIA_E2E_CRASH_INJECTION"] = injectionPoint
+            });
+
+        var exitCode = await process.WaitForExitAsync(
+            TimeSpan.FromSeconds(120),
+            CancellationToken.None);
+        Assert.NotEqual(0, exitCode);
+
+        var reportRoot = Path.Combine(fixture.AppDataRoot, "CrashReports");
+        var reports = Directory.EnumerateFiles(reportRoot, "crash-*")
+            .Where(path => Path.GetExtension(path) is ".zip" or ".txt")
+            .ToArray();
+        var reportPath = Assert.Single(reports);
+        Assert.Empty(Directory.EnumerateFiles(reportRoot, "*.tmp"));
+
+        var summary = ReadCrashSummary(reportPath);
+        Assert.Equal("InvalidOperationException", summary.ExceptionType);
+        Assert.Equal(
+            1,
+            ReadPrimaryExceptionText(reportPath)
+                .Split("DTXMANIA_E2E_CONTROLLED_CRASH")
+                .Length - 1);
+    }
+    finally
+    {
+        await E2EArtifactWriter.WriteTextAsync(
+            fixture,
+            $"crash-{injectionPoint}-stdout.log",
+            process.StandardOutput);
+        await E2EArtifactWriter.WriteTextAsync(
+            fixture,
+            $"crash-{injectionPoint}-stderr.log",
+            process.StandardError);
+    }
 }
 ```
+
+Use the existing overloads from `E2EFixtureBuilder`; adjust only the fixture builder arguments needed by the current signature, not the test behavior above.
 
 - [ ] **Step 4: Run E2E support tests**
 
@@ -1566,10 +1633,18 @@ Assert:
 Repeat Step 2 with a fresh root and:
 
 ```bash
+run_root="$(mktemp -d /tmp/dtx-hpa529-draw.XXXXXX)"
+export DTXMANIA_APPDATA_ROOT="$run_root"
 export DTXMANIA_E2E_CRASH_INJECTION="draw"
+set +e
+dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+exit_code=$?
+set -e
+test "$exit_code" -ne 0
+find "$run_root/CrashReports" -maxdepth 1 -type f -name 'crash-*' -print
 ```
 
-Assert the same conditions.
+Assert the same conditions as the update run.
 
 - [ ] **Step 4: Inspect privacy-sensitive output**
 

--- a/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
@@ -1,0 +1,1668 @@
+# HPA-529 Managed Crash Report Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add process-boundary managed crash capture that preserves console logging, writes privacy-safe local ZIP or emergency-text reports, keeps the newest five reports, and proves `Update`/`Draw` exceptions reach the executable boundary on WindowsDX and DesktopGL.
+
+**Architecture:** `CrashReportRuntime` is created at process entry and owns the shared `ILoggerFactory`, bounded crash buffers, cached context, sanitizer, and report store. `Game1` receives only an `IGameCrashDiagnostics` facade; fatal capture occurs in an explicit entry-point lifecycle before guarded game disposal. The crash path reads immutable copies of already-cached state and performs no network, database, graphics, device-enumeration, shell, or cross-thread work.
+
+**Tech Stack:** .NET 8, C# 12, MonoGame 3.8 WindowsDX/DesktopGL, `Microsoft.Extensions.Logging`, `System.Text.Json`, `System.IO.Compression`, xUnit, Moq, existing `DTXMania.E2E` process harness.
+
+## Global Constraints
+
+- Scope is limited to managed fatal exceptions that reach the executable process boundary during game construction, startup, `Update`, `Draw`, or `Game.Run()`.
+- Do not add `AppDomain.UnhandledException`, `FirstChanceException`, or `TaskScheduler.UnobservedTaskException` handlers.
+- Do not add automatic upload, telemetry, screenshots, native dumps, hang detection, or GitHub integration.
+- A recoverable crash-report bootstrap failure must preserve fully functional console logging; only crash buffering, capture, cached context, and inbox behavior degrade to no-ops.
+- `CrashReportRuntime` is the sole owner and disposer of the shared `ILoggerFactory`; `BaseGame` must neither create nor dispose it.
+- Replace `using var game` in `Program.cs` with explicit capture-before-dispose lifecycle code. Disposal failure is secondary and cannot replace the original exception.
+- Fatal capture must use cached state only: no device enumeration, filesystem scan beyond report persistence, SQLite access, network access, graphics calls, shell launching, cross-thread dispatch, or blocking waits.
+- Sanitize before persistence. Unknown dynamic strings, arbitrary rendered log messages, complete configuration objects, secrets, paths, usernames, song/chart identity, hardware IDs, binding names, and MIDI note identities must not reach disk.
+- Keep one latest-five quota across completed ZIP and emergency-text reports inside `CrashReportStore`.
+- WindowsDX callback propagation must run automatically in the existing Windows E2E job.
+- DesktopGL callback propagation must be verified manually on Apple Silicon and recorded with exact commands, commit/build identity, OS/runtime information, and observed results.
+- Production code must not expose a crash-injection switch in Release builds. The E2E injection hook must be compiled only under `DEBUG`.
+- The canonical design and normative amendments are:
+  - `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design.md`
+  - `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md`
+
+---
+
+## File Structure
+
+### New production files
+
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs` — public game-facing interfaces, enums, report summaries, and no-op singleton implementations.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs` — process-lifetime composition, enabled/console-only bootstrap, fatal snapshot capture, and logger ownership.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashLogFieldPolicy.cs` — centralized event/template/property allowlist and scalar normalization.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashLogBufferProvider.cs` — bounded thread-safe `ILoggerProvider` and immutable snapshot API.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashBreadcrumbBuffer.cs` — bounded semantic breadcrumb sink and immutable snapshot API.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashContextSnapshotStore.cs` — atomically replaced cached context sections and sensitive-path registry.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSanitizer.cs` — path/secret/source-location redaction and conservative exception-message policy.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportArchiveWriter.cs` — versioned ZIP entries and versioned emergency-text header/body serialization.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs` — lazy directory creation, atomic finalization, discovery, stale-temp cleanup, fallback, and unified retention.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs` — injectable executable lifecycle seam that preserves the original fatal exception.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashContextPublisher.cs` — deterministic mapping from existing config/graphics/input/stage state into allowlisted cached context.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/DebugCrashInjection.cs` — `DEBUG`-only `Update`/`Draw` injection hook used by real-process E2E verification.
+
+### Modified production files
+
+- `DTXMania.Game/Program.cs`
+- `DTXMania.Game/Game1.cs`
+- `DTXMania.Game/Lib/Utilities/AppPaths.cs`
+- `DTXMania.Game/Lib/Stage/IStageGame.cs`
+- `DTXMania.Game/Lib/Stage/StageManager.cs`
+- `DTXMania.Game/Lib/Input/Midi/MidiInputSource.cs`
+- `DTXMania.Game/Lib/Input/ModularInputManager.cs`
+
+### New test files
+
+- `DTXMania.Test/CrashReporting/CrashReportContractsTests.cs`
+- `DTXMania.Test/CrashReporting/CrashLogBufferProviderTests.cs`
+- `DTXMania.Test/CrashReporting/CrashBreadcrumbBufferTests.cs`
+- `DTXMania.Test/CrashReporting/CrashContextSnapshotStoreTests.cs`
+- `DTXMania.Test/CrashReporting/CrashReportSanitizerTests.cs`
+- `DTXMania.Test/CrashReporting/CrashReportStoreTests.cs`
+- `DTXMania.Test/CrashReporting/CrashReportRuntimeTests.cs`
+- `DTXMania.Test/CrashReporting/GameEntryPointTests.cs`
+- `DTXMania.E2E/CrashReportingSmokeTests.cs`
+
+### Modified test and CI files
+
+- `DTXMania.Test/Utilities/AppPathsTests.cs`
+- `DTXMania.Test/BaseGameTests.cs`
+- `DTXMania.Test/Stage/StageManagerTransitionTests.cs`
+- `DTXMania.Test/Input/Midi/MidiInputSourceTests.cs`
+- `DTXMania.Test/Input/ModularInputManagerTests.cs`
+- `DTXMania.E2E/Process/GameProcessDriver.cs`
+- `.github/workflows/build-and-test.yml` only if an explicit crash-smoke filter step is needed; prefer the existing `Category=E2E` step when the new tests fit its runtime budget.
+
+### Verification evidence
+
+- `docs/verification/hpa-529-macos-crash-propagation.md` — actual Apple Silicon/DesktopGL `Update` and `Draw` verification evidence, written only after the commands have been executed.
+
+---
+
+### Task 1: Define stable crash-report contracts and the app-data path
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs`
+- Modify: `DTXMania.Game/Lib/Utilities/AppPaths.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportContractsTests.cs`
+- Test: `DTXMania.Test/Utilities/AppPathsTests.cs`
+
+**Interfaces:**
+- Produces:
+  - `CrashReportFormat`
+  - `CrashContextKind`
+  - `CrashContextStatus`
+  - `CrashReportSummary`
+  - `CrashContextSnapshot`
+  - `CrashBreadcrumb`
+  - `ICrashBreadcrumbSink`
+  - `ICrashContextSink`
+  - `ICrashSensitiveDataSink`
+  - `ICrashReportInbox`
+  - `IGameCrashDiagnostics`
+  - no-op singleton implementations used by console-only mode and isolated tests
+  - `AppPaths.GetCrashReportsRoot()`
+
+- [ ] **Step 1: Write failing contract and path tests**
+
+Create tests that lock the exact public shapes and path behavior:
+
+```csharp
+[Fact]
+public void GetCrashReportsRoot_ShouldUseAppDataCrashReportsDirectory()
+{
+    var previous = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+    var root = Path.Combine(Path.GetTempPath(), "dtx-crash-root-" + Guid.NewGuid().ToString("N"));
+
+    try
+    {
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", root);
+
+        Assert.Equal(
+            Path.Combine(Path.GetFullPath(root), "CrashReports"),
+            AppPaths.GetCrashReportsRoot());
+    }
+    finally
+    {
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", previous);
+    }
+}
+
+[Fact]
+public void EmptyInbox_ShouldReturnNoReportsAndRejectMutationsWithoutThrowing()
+{
+    var inbox = EmptyCrashReportInbox.Instance;
+
+    Assert.Empty(inbox.GetReports());
+    Assert.False(inbox.TryAcknowledge("missing", out var acknowledgeError));
+    Assert.Equal("report_not_found", acknowledgeError);
+    Assert.False(inbox.TryDelete("missing", out var deleteError));
+    Assert.Equal("report_not_found", deleteError);
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify failure**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~AppPathsTests|FullyQualifiedName~CrashReportContractsTests"
+```
+
+Expected: compile failure because the crash-report contracts and `GetCrashReportsRoot()` do not exist.
+
+- [ ] **Step 3: Implement the exact contract model**
+
+Use one focused contract file with these signatures:
+
+```csharp
+namespace DTXMania.Game.Lib.Diagnostics.CrashReporting;
+
+public enum CrashReportFormat
+{
+    ZipBundle,
+    EmergencyText
+}
+
+public enum CrashContextKind
+{
+    Process,
+    Application,
+    Startup,
+    Configuration,
+    Stage,
+    Graphics,
+    Audio,
+    Input
+}
+
+public enum CrashContextStatus
+{
+    Available,
+    NotInitialized,
+    Unavailable,
+    CollectionFailed
+}
+
+public sealed record CrashReportSummary(
+    string ReportId,
+    DateTimeOffset CapturedAtUtc,
+    string BuildId,
+    string OperatingSystem,
+    string ProcessArchitecture,
+    string StageOrMilestone,
+    string ExceptionType,
+    CrashReportFormat Format,
+    string FileName);
+
+public sealed record CrashContextSnapshot(
+    CrashContextKind Kind,
+    CrashContextStatus Status,
+    IReadOnlyDictionary<string, object?> Fields,
+    string? FailureCode = null);
+
+public sealed record CrashBreadcrumb(
+    DateTimeOffset TimestampUtc,
+    string EventName,
+    IReadOnlyDictionary<string, object?> Properties);
+
+public interface ICrashBreadcrumbSink
+{
+    void Record(string eventName, IReadOnlyDictionary<string, object?>? properties = null);
+}
+
+public interface ICrashContextSink
+{
+    void SetSnapshot(CrashContextSnapshot snapshot);
+}
+
+public interface ICrashSensitiveDataSink
+{
+    void RegisterPath(string? path);
+}
+
+public interface ICrashReportInbox
+{
+    IReadOnlyList<CrashReportSummary> GetReports();
+    bool TryAcknowledge(string reportId, out string? errorCode);
+    bool TryDelete(string reportId, out string? errorCode);
+}
+
+public interface IGameCrashDiagnostics
+{
+    ILoggerFactory LoggerFactory { get; }
+    ICrashBreadcrumbSink Breadcrumbs { get; }
+    ICrashContextSink Contexts { get; }
+    ICrashSensitiveDataSink SensitiveData { get; }
+    ICrashReportInbox Inbox { get; }
+}
+```
+
+Add internal or public sealed no-op singletons for each sink and `EmptyCrashReportInbox`. They must not allocate per call and must never throw.
+
+- [ ] **Step 4: Add the crash-report root**
+
+In `AppPaths` add:
+
+```csharp
+public static string GetCrashReportsRoot()
+{
+    return Path.GetFullPath(Path.Combine(GetAppDataRoot(), "CrashReports"));
+}
+```
+
+Do not create the directory here. Directory creation remains lazy inside `CrashReportStore`.
+
+- [ ] **Step 5: Run Windows and macOS-compatible unit tests**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~AppPathsTests|FullyQualifiedName~CrashReportContractsTests"
+```
+
+On macOS also run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~AppPathsTests|FullyQualifiedName~CrashReportContractsTests"
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs \
+  DTXMania.Game/Lib/Utilities/AppPaths.cs \
+  DTXMania.Test/CrashReporting/CrashReportContractsTests.cs \
+  DTXMania.Test/Utilities/AppPathsTests.cs
+git commit -m "feat: define crash report contracts"
+```
+
+---
+
+### Task 2: Implement centralized privacy policy and bounded in-memory diagnostics
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashLogFieldPolicy.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashLogBufferProvider.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashBreadcrumbBuffer.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashContextSnapshotStore.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashLogBufferProviderTests.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashBreadcrumbBufferTests.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashContextSnapshotStoreTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1 contracts.
+- Produces:
+  - `CrashLogFieldPolicy.Default`
+  - internal immutable `CrashLogRecord`
+  - `CrashLogBufferProvider.Snapshot()`
+  - `CrashBreadcrumbBuffer.Snapshot()`
+  - `CrashContextSnapshotStore.Snapshot()`
+  - `CrashContextSnapshotStore.SensitivePathSnapshot()`
+
+- [ ] **Step 1: Write failing log-policy tests**
+
+Cover the security-critical behavior:
+
+```csharp
+[Fact]
+public void UnknownRenderedMessage_ShouldBeOmitted()
+{
+    using var provider = new CrashLogBufferProvider(
+        CrashLogFieldPolicy.Default,
+        TimeProvider.System,
+        capacity: 8);
+    using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+    var logger = factory.CreateLogger("test");
+
+    logger.LogInformation($"Loaded song Secret Song Name");
+
+    var record = Assert.Single(provider.Snapshot());
+    Assert.Equal("[UNCLASSIFIED MESSAGE OMITTED]", record.MessageTemplate);
+    Assert.Empty(record.Properties);
+}
+
+[Fact]
+public void UnknownStringProperty_ShouldBeRedacted()
+{
+    using var provider = new CrashLogBufferProvider(
+        CrashLogFieldPolicy.Default,
+        TimeProvider.System,
+        capacity: 8);
+    using var factory = LoggerFactory.Create(builder => builder.AddProvider(provider));
+    var logger = factory.CreateLogger("test");
+
+    logger.LogInformation(
+        new EventId(5101, "StageTransitionRequested"),
+        "Stage transition to {TargetStage} for {SongTitle}",
+        StageType.Title,
+        "Secret Song");
+
+    var record = Assert.Single(provider.Snapshot());
+    Assert.Equal(StageType.Title, record.Properties["TargetStage"]);
+    Assert.Equal("[REDACTED]", record.Properties["SongTitle"]);
+}
+```
+
+Also test:
+- capacity drops oldest records;
+- snapshot is an immutable copy;
+- numeric, Boolean, enum, and `DateTimeOffset` values normalize deterministically;
+- event/template mismatch results in an omitted template;
+- exception type may be retained but exception message is not stored by the logger buffer.
+
+- [ ] **Step 2: Write failing breadcrumb and context tests**
+
+```csharp
+[Fact]
+public void BreadcrumbSnapshot_ShouldCopyMutableBuffer()
+{
+    var buffer = new CrashBreadcrumbBuffer(TimeProvider.System, capacity: 2);
+
+    buffer.Record("stage_transition_requested",
+        new Dictionary<string, object?> { ["TargetStage"] = StageType.Title });
+    var snapshot = buffer.Snapshot();
+    buffer.Record("stage_transition_completed",
+        new Dictionary<string, object?> { ["TargetStage"] = StageType.Title });
+
+    Assert.Single(snapshot);
+    Assert.Equal("stage_transition_requested", snapshot[0].EventName);
+}
+
+[Fact]
+public void ContextStore_ShouldReplaceOneSectionAtomically()
+{
+    var store = new CrashContextSnapshotStore();
+
+    store.SetSnapshot(new CrashContextSnapshot(
+        CrashContextKind.Stage,
+        CrashContextStatus.Available,
+        new Dictionary<string, object?> { ["Stage"] = StageType.Startup }));
+    store.SetSnapshot(new CrashContextSnapshot(
+        CrashContextKind.Stage,
+        CrashContextStatus.Available,
+        new Dictionary<string, object?> { ["Stage"] = StageType.Title }));
+
+    var stage = Assert.Single(store.Snapshot(), item => item.Kind == CrashContextKind.Stage);
+    Assert.Equal(StageType.Title, stage.Fields["Stage"]);
+}
+```
+
+Also test duplicate sensitive paths are normalized and deduplicated with `AppPaths.SkinPathComparer`.
+
+- [ ] **Step 3: Run the focused tests and verify failure**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~CrashLogBufferProviderTests|FullyQualifiedName~CrashBreadcrumbBufferTests|FullyQualifiedName~CrashContextSnapshotStoreTests"
+```
+
+Expected: compile failure because the buffers and policy do not exist.
+
+- [ ] **Step 4: Implement `CrashLogFieldPolicy`**
+
+Define one immutable policy. Do not let individual logger call sites decide privacy.
+
+The default policy must:
+- allow only named `EventId` values registered in one dictionary;
+- preserve the registered message template, not `formatter(state, exception)`;
+- read `{OriginalFormat}` from structured logger state;
+- retain only these property names initially:
+
+```text
+Stage
+PreviousStage
+TargetStage
+Milestone
+Width
+Height
+Fullscreen
+VSync
+MidiDeviceCount
+Enabled
+Count
+Status
+```
+
+- allow `bool`, integral numeric types, floating-point numeric types, enums, `DateTime`, `DateTimeOffset`, and `Guid`;
+- convert unknown strings to `[REDACTED]`;
+- convert unsupported objects to `[REDACTED]`;
+- limit normalized text to 128 characters;
+- represent unknown templates as `[UNCLASSIFIED MESSAGE OMITTED]`.
+
+Use IDs `5100`–`5199` for crash-safe lifecycle events so they do not collide with ordinary event ID `0`.
+
+- [ ] **Step 5: Implement the bounded log provider**
+
+Use a lock-protected circular queue or `Queue<T>` with fixed capacity. `ILogger.Log` must:
+1. extract `{OriginalFormat}` without rendering the message;
+2. classify the event/template through `CrashLogFieldPolicy`;
+3. copy only normalized allowed properties;
+4. retain exception type and sanitized stack later, but not exception message;
+5. append one immutable record and evict the oldest record when full.
+
+Do not serialize JSON or allocate ZIP data on the log hot path.
+
+- [ ] **Step 6: Implement breadcrumb and context stores**
+
+`CrashBreadcrumbBuffer` uses the same scalar normalization policy but accepts only stable event names declared in a `HashSet<string>`. Unknown event names are recorded as `unknown_event` without caller properties.
+
+`CrashContextSnapshotStore`:
+- stores one immutable snapshot per `CrashContextKind`;
+- replaces sections under a lock;
+- returns copied arrays from `Snapshot()`;
+- implements `ICrashSensitiveDataSink`;
+- normalizes registered paths with `Path.GetFullPath` inside a narrow exception filter;
+- never throws from `RegisterPath`.
+
+- [ ] **Step 7: Run focused tests**
+
+Run the Task 2 filter from Step 3.
+
+Expected: all focused tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashLogFieldPolicy.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashLogBufferProvider.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashBreadcrumbBuffer.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashContextSnapshotStore.cs \
+  DTXMania.Test/CrashReporting/CrashLogBufferProviderTests.cs \
+  DTXMania.Test/CrashReporting/CrashBreadcrumbBufferTests.cs \
+  DTXMania.Test/CrashReporting/CrashContextSnapshotStoreTests.cs
+git commit -m "feat: buffer crash-safe diagnostics"
+```
+
+---
+
+### Task 3: Implement sanitization, report serialization, atomic storage, fallback, and retention
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSanitizer.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportArchiveWriter.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportSanitizerTests.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportStoreTests.cs`
+
+**Interfaces:**
+- Consumes:
+  - `CrashReportSummary`
+  - immutable log, breadcrumb, context, and sensitive-path snapshots from Tasks 1–2
+- Produces:
+
+```csharp
+internal sealed record CrashCaptureData(
+    Exception Exception,
+    IReadOnlyList<CrashLogRecord> Logs,
+    IReadOnlyList<CrashBreadcrumb> Breadcrumbs,
+    IReadOnlyList<CrashContextSnapshot> Context,
+    IReadOnlyList<string> SensitivePaths);
+
+internal sealed record CrashReportWriteResult(
+    CrashReportSummary? Report,
+    bool UsedEmergencyFallback,
+    string? FailureCode);
+
+internal sealed class CrashReportStore
+{
+    CrashReportWriteResult Capture(CrashCaptureData data);
+    IReadOnlyList<CrashReportSummary> DiscoverCompletedReports();
+    void Cleanup();
+}
+```
+
+- [ ] **Step 1: Write failing sanitizer tests**
+
+Use deliberately sensitive values:
+
+```csharp
+[Fact]
+public void SanitizeStackTrace_ShouldRemoveHomeAndSourcePaths()
+{
+    var home = Path.Combine(Path.GetTempPath(), "Users", "alice");
+    var sanitizer = new CrashReportSanitizer(
+        [home, Path.Combine(home, "Library", "Application Support", "DTXManiaCX")]);
+
+    var input =
+        $"at Example.Run() in {Path.Combine(home, "src", "Game.cs")}:line 42";
+
+    var result = sanitizer.SanitizeStackTrace(input);
+
+    Assert.DoesNotContain("alice", result, StringComparison.OrdinalIgnoreCase);
+    Assert.DoesNotContain("Game.cs", result, StringComparison.OrdinalIgnoreCase);
+    Assert.Contains("[SOURCE]", result);
+}
+
+[Fact]
+public void SanitizeExceptionMessage_ShouldOmitArbitraryContent()
+{
+    var sanitizer = new CrashReportSanitizer([]);
+
+    Assert.Equal(
+        "[EXCEPTION MESSAGE OMITTED]",
+        sanitizer.SanitizeExceptionMessage("Failed to load Secret Song Name"));
+}
+```
+
+Also test:
+- API-key-like values;
+- URI query strings;
+- registered song and skin roots;
+- Windows and Unix absolute paths;
+- username segments;
+- nested inner exceptions;
+- sanitizer failure returns `[REDACTED]`, never original input.
+
+- [ ] **Step 2: Write failing store tests for the complete contract**
+
+Required tests:
+1. ZIP contains exactly `report.json`, `exception.txt`, `logs.ndjson`, `breadcrumbs.json`, and `README.txt`.
+2. `report.json` has schema version `1` and format-neutral summary fields.
+3. ZIP is first written with a `.tmp` name and finalized in the same directory.
+4. A throwing ZIP writer produces one emergency `.txt`.
+5. Emergency text starts with a versioned allowlisted header and can be discovered as `CrashReportFormat.EmergencyText`.
+6. Corrupt emergency header falls back to filename ID/time and `Unknown` fields.
+7. Six mixed ZIP/text reports retain exactly five newest reports.
+8. Stale `.tmp` files older than 24 hours are deleted; newer temporary files are ignored, not treated as completed reports.
+9. Discovery never reads or exposes the free-form emergency exception body.
+10. Unwritable capture returns `Report = null` and a safe `FailureCode` without throwing.
+
+Example retention test:
+
+```csharp
+[Fact]
+public void Capture_SixMixedReports_ShouldRetainNewestFiveAcrossFormats()
+{
+    using var fixture = CrashStoreFixture.Create();
+    var store = fixture.CreateStore();
+
+    for (var index = 0; index < 6; index++)
+    {
+        fixture.Clock.Advance(TimeSpan.FromSeconds(1));
+        fixture.ArchiveWriter.FailZip = index % 2 == 1;
+        Assert.NotNull(store.Capture(fixture.CreateCapture(index)).Report);
+    }
+
+    var reports = store.DiscoverCompletedReports();
+
+    Assert.Equal(5, reports.Count);
+    Assert.DoesNotContain(reports, report => report.ReportId == fixture.ReportId(0));
+}
+```
+
+- [ ] **Step 3: Run tests and verify failure**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~CrashReportSanitizerTests|FullyQualifiedName~CrashReportStoreTests"
+```
+
+Expected: compile failure because sanitizer, writer, and store do not exist.
+
+- [ ] **Step 4: Implement conservative sanitization**
+
+`CrashReportSanitizer` must:
+- precompute normalized sensitive path prefixes;
+- replace registered prefixes with `[PATH]`;
+- strip source file portions from stack frames while retaining type/method and line number;
+- remove URI query strings;
+- replace absolute paths not already registered with `[PATH]`;
+- replace likely username/home segments with `[USER]`;
+- omit arbitrary exception messages by default as `[EXCEPTION MESSAGE OMITTED]`;
+- permit only fixed crash-subsystem-generated failure codes and labels;
+- bound every output field.
+
+Do not attempt to infer whether an arbitrary phrase is a song title. Omission is the safe default.
+
+- [ ] **Step 5: Implement versioned ZIP serialization**
+
+`CrashReportArchiveWriter.WriteZip` writes:
+- `report.json` — schema `1`, report ID, UTC timestamp, assembly informational version with assembly-version fallback, OS/runtime/architecture, summary, context statuses, included entries, truncation flags;
+- `exception.txt` — exception type, omitted/sanitized message field, sanitized stack, bounded inner chain;
+- `logs.ndjson` — newest records that fit both 500-entry and 512-KB limits;
+- `breadcrumbs.json` — newest 100 breadcrumbs;
+- `README.txt` — local-only generation, no automatic upload, inspect before attaching.
+
+Use deterministic UTF-8 without BOM and `JsonSerializerOptions.WriteIndented = true` only for `report.json` and `breadcrumbs.json`.
+
+`WriteEmergencyText` starts with this machine-readable header:
+
+```text
+DTXMANIACX-CRASH-REPORT 1
+ReportId: <id>
+CapturedAtUtc: <round-trip UTC>
+BuildId: <sanitized build>
+OperatingSystem: <sanitized OS>
+ProcessArchitecture: <architecture>
+StageOrMilestone: <sanitized value or Unknown>
+ExceptionType: <type>
+---
+```
+
+The body after `---` is human-readable sanitized emergency content and is never parsed by title-screen code.
+
+- [ ] **Step 6: Implement `CrashReportStore`**
+
+Construction:
+
+```csharp
+internal CrashReportStore(
+    string rootPath,
+    CrashReportArchiveWriter writer,
+    TimeProvider timeProvider,
+    TextWriter errorWriter)
+```
+
+Capture flow:
+1. generate `crash-yyyyMMdd-HHmmssZ-<6 lowercase hex>.zip`;
+2. lazily create the root;
+3. write `.<report-id>.tmp` in the same directory;
+4. flush/close;
+5. `File.Move(temp, final, overwrite: false)`;
+6. if ZIP writing/finalization fails, delete temp best-effort and repeat with `.txt`;
+7. enforce combined retention;
+8. return a summary or a fixed failure code.
+
+Narrowly catch expected I/O/path exceptions. Do not catch `OutOfMemoryException`, `StackOverflowException`, or `AccessViolationException`.
+
+Discovery:
+- parse `report.json` from ZIP without extracting;
+- parse only the emergency header before `---`;
+- sort newest first by captured timestamp, then filename ordinal;
+- never include `.tmp`.
+
+- [ ] **Step 7: Run focused tests and both test project builds**
+
+Run the Task 3 filter, then:
+
+```bash
+dotnet build DTXMania.Test/DTXMania.Test.csproj --configuration Debug
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug
+```
+
+Expected: focused tests pass and both test projects compile.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSanitizer.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportArchiveWriter.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs \
+  DTXMania.Test/CrashReporting/CrashReportSanitizerTests.cs \
+  DTXMania.Test/CrashReporting/CrashReportStoreTests.cs
+git commit -m "feat: persist sanitized crash reports"
+```
+
+---
+
+### Task 4: Compose the process runtime and replace implicit game disposal
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs`
+- Modify: `DTXMania.Game/Program.cs`
+- Modify: `DTXMania.Game/Game1.cs`
+- Modify: `DTXMania.Game/Lib/Stage/IStageGame.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportRuntimeTests.cs`
+- Test: `DTXMania.Test/CrashReporting/GameEntryPointTests.cs`
+- Test: `DTXMania.Test/BaseGameTests.cs`
+- Test: `DTXMania.Test/Stage/IStageGameContractTests.cs`
+
+**Interfaces:**
+- Consumes: Tasks 1–3.
+- Produces:
+  - `CrashReportRuntime.CreateBestEffort(StartupTimingTrace, TextWriter)`
+  - `CrashReportRuntime.GameDiagnostics`
+  - `CrashReportRuntime.CaptureFatal(Exception)`
+  - `CrashReportRuntime.RecordSecondaryFailure(string, Exception)`
+  - `IGameApplication`
+  - `ICrashRuntimeLifetime`
+  - `GameEntryPoint.Run(Func<IGameApplication>, ICrashRuntimeLifetime, TextWriter)`
+  - production constructors:
+    - `Game1(StartupTimingTrace, IGameCrashDiagnostics)`
+    - `BaseGame(StartupTimingTrace, IGameCrashDiagnostics)`
+
+- [ ] **Step 1: Write runtime-degradation tests**
+
+```csharp
+[Fact]
+public void CreateBestEffort_WhenStoreFactoryFails_ShouldPreserveConsoleLogger()
+{
+    using var errorWriter = new StringWriter();
+    using var runtime = CrashReportRuntime.CreateBestEffort(
+        StartupTimingTrace.Disabled,
+        errorWriter,
+        storeFactory: () => throw new UnauthorizedAccessException("denied"));
+
+    var logger = runtime.GameDiagnostics.LoggerFactory.CreateLogger("probe");
+    var exception = Record.Exception(() => logger.LogInformation("console survives"));
+
+    Assert.Null(exception);
+    Assert.False(runtime.IsCaptureEnabled);
+    Assert.Same(EmptyCrashReportInbox.Instance, runtime.GameDiagnostics.Inbox);
+    Assert.Contains("crash_reporting_disabled", errorWriter.ToString());
+}
+```
+
+Also test:
+- enabled runtime installs both console and crash providers;
+- `CaptureFatal` never throws when store capture fails;
+- runtime owns/disposes factory exactly once;
+- disabled mode does not allocate report files;
+- `OutOfMemoryException` from the injected store factory is not swallowed.
+
+Use an internal test overload for dependency injection; keep the production overload small.
+
+- [ ] **Step 2: Write lifecycle tests before changing `Program.cs`**
+
+Define:
+
+```csharp
+internal interface IGameApplication : IDisposable
+{
+    void Run();
+}
+
+internal interface ICrashRuntimeLifetime : IDisposable
+{
+    void CaptureFatal(Exception exception);
+    void RecordSecondaryFailure(string failureCode, Exception exception);
+}
+```
+
+Test the exact ordering with fakes:
+
+```csharp
+[Fact]
+public void Run_WhenGameThrows_ShouldCaptureBeforeDisposeAndPreserveOriginalFailure()
+{
+    var calls = new List<string>();
+    var game = new FakeGameApplication(
+        run: () => { calls.Add("run"); throw new InvalidOperationException("fatal"); },
+        dispose: () => calls.Add("dispose"));
+    var runtime = new FakeCrashRuntime(
+        capture: _ => calls.Add("capture"),
+        dispose: () => calls.Add("runtime_dispose"));
+
+    var exitCode = GameEntryPoint.Run(
+        () => game,
+        runtime,
+        TextWriter.Null);
+
+    Assert.Equal(1, exitCode);
+    Assert.Equal(
+        ["run", "capture", "dispose", "runtime_dispose"],
+        calls);
+}
+```
+
+Add tests where:
+- game construction throws;
+- capture reports an internal failure;
+- game disposal throws;
+- runtime disposal throws;
+- normal run returns `0`;
+- the original exception type is passed to `CaptureFatal`;
+- a secondary disposal failure is reported without replacing the original.
+
+- [ ] **Step 3: Run tests and verify failure**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~CrashReportRuntimeTests|FullyQualifiedName~GameEntryPointTests|FullyQualifiedName~BaseGameTests.LoggerFactory"
+```
+
+Expected: compile failure because runtime/lifecycle types and injected constructors do not exist.
+
+- [ ] **Step 4: Implement enabled and console-only runtime composition**
+
+`CrashReportRuntime` owns:
+- one `ILoggerFactory`;
+- optional `CrashLogBufferProvider`;
+- optional `CrashBreadcrumbBuffer`;
+- optional `CrashContextSnapshotStore`;
+- optional `CrashReportStore`;
+- one immutable `IGameCrashDiagnostics` facade.
+
+Production bootstrap:
+
+```csharp
+public static CrashReportRuntime CreateBestEffort(
+    StartupTimingTrace startupTrace,
+    TextWriter? errorWriter = null)
+```
+
+The production method must:
+1. create the console logger factory first;
+2. attempt to add crash components without creating the report directory;
+3. on expected setup failure, dispose the partially built factory and create a fresh console-only factory;
+4. write one sanitized `crash_reporting_disabled code=<fixed-code>` line to `errorWriter ?? Console.Error`;
+5. return a disabled runtime.
+
+Use a narrow expected-exception filter. Do not use `catch (Exception)` for bootstrap degradation.
+
+`CaptureFatal`:
+- takes immutable copies of logs, breadcrumbs, contexts, and sensitive paths;
+- delegates to `CrashReportStore.Capture`;
+- catches only expected report I/O/serialization failures;
+- writes a fixed sanitized stderr failure line;
+- never rethrows a report failure over the game failure.
+
+- [ ] **Step 5: Replace game construction and ownership**
+
+Change production constructors to:
+
+```csharp
+internal BaseGame(
+    StartupTimingTrace startupTimingTrace,
+    IGameCrashDiagnostics crashDiagnostics)
+{
+    _startupTimingTrace =
+        startupTimingTrace ?? throw new ArgumentNullException(nameof(startupTimingTrace));
+    _gameCrashDiagnostics =
+        crashDiagnostics ?? throw new ArgumentNullException(nameof(crashDiagnostics));
+
+    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    _graphicsDeviceManager = new GraphicsDeviceManager(this);
+    Content.RootDirectory = "Content";
+    IsMouseVisible = true;
+
+    _loggerFactory = _gameCrashDiagnostics.LoggerFactory;
+    _logger = _loggerFactory.CreateLogger<BaseGame>();
+}
+
+public sealed class Game1 : BaseGame, IGameApplication
+{
+    internal Game1(
+        StartupTimingTrace startupTimingTrace,
+        IGameCrashDiagnostics crashDiagnostics)
+        : base(startupTimingTrace, crashDiagnostics)
+    {
+    }
+}
+```
+
+Adapt the actual existing `Game1` declaration without sealing it if tests subclass it. Remove production parameterless constructors. Do not add a constructor that creates its own logger factory.
+
+Remove `_loggerFactory.Dispose()` from `BaseGame.DisposeManagedResources()`.
+
+Expose only this additional stage-facing property through `IStageGame`:
+
+```csharp
+ICrashReportInbox CrashReportInbox { get; }
+```
+
+Do not expose the full runtime, store, or context registry through `IStageGame`.
+
+- [ ] **Step 6: Implement explicit entry-point lifecycle**
+
+`Program.cs` becomes conceptually:
+
+```csharp
+var startupTrace = StartupTimingTrace.StartProcess();
+var crashRuntime = CrashReportRuntime.CreateBestEffort(startupTrace, Console.Error);
+
+return GameEntryPoint.Run(
+    () => new Game1(startupTrace, crashRuntime.GameDiagnostics),
+    crashRuntime,
+    Console.Error);
+```
+
+`GameEntryPoint.Run` uses an explicit nullable game variable. It captures inside `catch` before entering guarded disposal. `finally` disposes the game and runtime independently. Do not use `using var`.
+
+- [ ] **Step 7: Update constructor and disposal tests**
+
+Update `BaseGameTests` helpers to inject a `TestGameCrashDiagnostics` or console-only diagnostics facade rather than setting `_loggerFactory` after construction where real construction is exercised.
+
+Keep `ReflectionHelpers.CreateUninitialized<T>()` for tests that intentionally bypass the MonoGame constructor.
+
+Add an assertion to disposal tests:
+
+```csharp
+loggerFactory.Verify(factory => factory.Dispose(), Times.Never);
+```
+
+when using a mock factory owned by the test runtime.
+
+- [ ] **Step 8: Run focused and full unit tests**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~CrashReportRuntimeTests|FullyQualifiedName~GameEntryPointTests|FullyQualifiedName~BaseGameTests|FullyQualifiedName~IStageGameContractTests"
+```
+
+Then:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --configuration Debug
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs \
+  DTXMania.Game/Program.cs \
+  DTXMania.Game/Game1.cs \
+  DTXMania.Game/Lib/Stage/IStageGame.cs \
+  DTXMania.Test/CrashReporting/CrashReportRuntimeTests.cs \
+  DTXMania.Test/CrashReporting/GameEntryPointTests.cs \
+  DTXMania.Test/BaseGameTests.cs \
+  DTXMania.Test/Stage/IStageGameContractTests.cs
+git commit -m "feat: capture fatal game exceptions"
+```
+
+---
+
+### Task 5: Publish cached game context and semantic breadcrumbs
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashContextPublisher.cs`
+- Modify: `DTXMania.Game/Game1.cs`
+- Modify: `DTXMania.Game/Lib/Stage/StageManager.cs`
+- Modify: `DTXMania.Game/Lib/Input/Midi/MidiInputSource.cs`
+- Modify: `DTXMania.Game/Lib/Input/ModularInputManager.cs`
+- Test: `DTXMania.Test/BaseGameTests.cs`
+- Test: `DTXMania.Test/Stage/StageManagerTransitionTests.cs`
+- Test: `DTXMania.Test/Input/Midi/MidiInputSourceTests.cs`
+- Test: `DTXMania.Test/Input/ModularInputManagerTests.cs`
+
+**Interfaces:**
+- Consumes: `IGameCrashDiagnostics` and sinks from Tasks 1–4.
+- Produces cached sections for process/application/startup/configuration/stage/graphics/audio/input and stable breadcrumb events.
+
+- [ ] **Step 1: Write failing context tests**
+
+Lock the initial configuration mapping:
+
+```csharp
+[Fact]
+public void PublishConfigurationContext_ShouldUseOnlyApprovedConcreteFields()
+{
+    var diagnostics = new RecordingGameCrashDiagnostics();
+    var config = new ConfigData
+    {
+        ScreenWidth = 1920,
+        ScreenHeight = 1080,
+        FullScreen = true,
+        VSyncWait = false,
+        BufferSizeMs = 80,
+        AutoPlay = true,
+        NoFail = true,
+        EnableGameApi = true,
+        GameApiKey = "must-not-appear",
+        DTXPath = @"C:\Secret\Songs",
+        SkinPath = @"C:\Secret\Skin"
+    };
+    config.KeyBindings["Snare"] = 1;
+
+    BaseGameCrashContext.PublishConfiguration(diagnostics, config);
+
+    var snapshot = diagnostics.Contexts.Single(CrashContextKind.Configuration);
+    Assert.Equal(1920, snapshot.Fields["ScreenWidth"]);
+    Assert.Equal(1, snapshot.Fields["KeyBindingCount"]);
+    Assert.DoesNotContain(snapshot.Fields, field => field.Key.Contains("Key", StringComparison.Ordinal) && field.Value?.ToString() == "must-not-appear");
+    Assert.DoesNotContain(snapshot.Fields.Values, value => value?.ToString()?.Contains("Secret", StringComparison.Ordinal) == true);
+}
+```
+
+Use `CrashContextPublisher.PublishConfiguration` as the concrete helper name; keep it internal and deterministic.
+
+- [ ] **Step 2: Write failing stage and input tests**
+
+Stage manager tests must verify exact stable events:
+
+```csharp
+[Fact]
+public void ChangeStage_ShouldRecordRequestedAndCompletedBreadcrumbs()
+{
+    var breadcrumbs = new RecordingBreadcrumbSink();
+    var contexts = new RecordingContextSink();
+    var manager = new StageManager(
+        CreateStageGame(),
+        NullLogger<StageManager>.Instance,
+        breadcrumbs,
+        contexts);
+
+    manager.ChangeStage(StageType.Title);
+
+    Assert.Contains(breadcrumbs.Events,
+        item => item.EventName == "stage_transition_requested");
+    Assert.Contains(breadcrumbs.Events,
+        item => item.EventName == "stage_transition_completed");
+    Assert.Equal(
+        StageType.Title,
+        contexts.Single(CrashContextKind.Stage).Fields["Stage"]);
+}
+```
+
+Input tests:
+- `MidiInputSource.DeviceCount` is count-only and thread-safe;
+- `ModularInputManager.ConnectedMidiDeviceCount` returns zero before devices and current count after refresh;
+- no device names or stable IDs appear in context/breadcrumb properties.
+
+- [ ] **Step 3: Run focused tests and verify failure**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~BaseGameTests|FullyQualifiedName~StageManagerTransitionTests|FullyQualifiedName~MidiInputSourceTests|FullyQualifiedName~ModularInputManagerTests"
+```
+
+Expected: focused new tests fail because instrumentation is absent.
+
+- [ ] **Step 4: Publish process and application context at runtime creation**
+
+In `CrashReportRuntime` seed:
+- runtime framework description;
+- OS description;
+- process architecture;
+- process start UTC;
+- application informational version with assembly-version fallback.
+
+Use fixed field names registered in `CrashLogFieldPolicy`. Do not include command-line arguments or environment variables.
+
+- [ ] **Step 5: Publish startup and configuration snapshots from `BaseGame`**
+
+At existing lifecycle points:
+- after config load: publish approved config fields and register `DTXPath`, `SkinPath`, app-data root, config path, database path, playback cache root, and crash root only as sensitive prefixes;
+- after `InputManager` construction: set input section;
+- after graphics initialization: set graphics section;
+- in `ReportStartupActivated`, `ReportStartupFrameRendered`, and `ReportStartupSummaryAndTitleRequested`: update a fixed `Milestone` value;
+- when no global audio-device abstraction exists: publish `CrashContextStatus.Unavailable` for `Audio` with fixed `FailureCode = "audio_device_summary_unavailable"`; do not perform active discovery.
+
+The configuration section may contain only:
+- `ScreenWidth`
+- `ScreenHeight`
+- `FullScreen`
+- `VSyncWait`
+- `BufferSizeMs`
+- `AutoPlay`
+- `NoFail`
+- `EnableGameApi`
+- `KeyBindingCount`
+- `SystemKeyBindingCount`
+- `UnboundDrumLaneCount`
+- `UnboundDrumButtonCount`
+- `MidiVelocityThresholdCount`
+
+- [ ] **Step 6: Instrument graphics events**
+
+Publish count/enum-only graphics values:
+- width;
+- height;
+- fullscreen;
+- VSync;
+- back-buffer format enum;
+- depth-stencil format enum;
+- MSAA count;
+- device availability.
+
+Record fixed breadcrumbs:
+- `graphics_device_lost`
+- `graphics_device_reset`
+- `graphics_settings_changed`
+
+Do not use `GraphicsSettings.ToString()` because it creates an uncontrolled rendered string.
+
+- [ ] **Step 7: Instrument stage transitions centrally**
+
+Extend the current constructor without breaking logger-only tests:
+
+```csharp
+public StageManager(
+    IStageGame game,
+    ILogger<StageManager>? logger = null,
+    ICrashBreadcrumbSink? breadcrumbs = null,
+    ICrashContextSink? contexts = null)
+```
+
+Default missing sinks to no-op singletons.
+
+Record:
+- `stage_transition_requested` after transition validation and before start;
+- `stage_transition_completed` after successful activation;
+- stage context after activation;
+- `stage_transition_rejected` only with fixed reason enum/string from a closed set.
+
+Never include shared-data values or song identity.
+
+Update `BaseGame.CreateLoadContentServices()` to pass the process-owned sinks.
+
+- [ ] **Step 8: Add count-only MIDI context**
+
+Add:
+
+```csharp
+public int DeviceCount
+{
+    get
+    {
+        lock (_sync)
+            return _devices.Count;
+    }
+}
+```
+
+to `MidiInputSource`, and:
+
+```csharp
+public int ConnectedMidiDeviceCount => _midiInputSource?.DeviceCount ?? 0;
+```
+
+to `ModularInputManager`.
+
+In `BaseGame.Update`, after `InputManager.Update`, compare the current count with a cached previous count. Only on change:
+- update the input context with `MidiDeviceCount`;
+- record `midi_device_count_changed` with the count.
+
+Do not call `RefreshDevices`, `DeviceNames`, or the MIDI backend from crash capture.
+
+- [ ] **Step 9: Register crash-safe event IDs**
+
+Where recent logs add value, use fixed IDs from `5100`–`5199` and templates registered in `CrashLogFieldPolicy`, for example:
+
+```csharp
+private static readonly EventId StageTransitionRequestedEvent =
+    new(5110, "StageTransitionRequested");
+
+_logger.LogDebug(
+    StageTransitionRequestedEvent,
+    "Stage transition requested: {PreviousStage} -> {TargetStage}",
+    previousStageType ?? StageType.Startup,
+    stageType);
+```
+
+Do not convert every existing log call. Unregistered logs remain category/level/timestamp records with omitted messages.
+
+- [ ] **Step 10: Run focused and full unit tests**
+
+Run the Step 3 filter, then both platform unit suites:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --configuration Debug
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashContextPublisher.cs \
+  DTXMania.Game/Game1.cs \
+  DTXMania.Game/Lib/Stage/StageManager.cs \
+  DTXMania.Game/Lib/Input/Midi/MidiInputSource.cs \
+  DTXMania.Game/Lib/Input/ModularInputManager.cs \
+  DTXMania.Test/BaseGameTests.cs \
+  DTXMania.Test/Stage/StageManagerTransitionTests.cs \
+  DTXMania.Test/Input/Midi/MidiInputSourceTests.cs \
+  DTXMania.Test/Input/ModularInputManagerTests.cs
+git commit -m "feat: capture cached game crash context"
+```
+
+---
+
+### Task 6: Prove end-to-end local capture, privacy, and fallback without MonoGame graphics
+
+**Files:**
+- Test: `DTXMania.Test/CrashReporting/CrashReportIntegrationTests.cs`
+- Modify as needed: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs`
+- Modify as needed: `DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs`
+
+**Interfaces:**
+- Consumes: all prior production components.
+- Produces: deterministic integration proof using `DTXMANIA_APPDATA_ROOT` and fake `IGameApplication`.
+
+- [ ] **Step 1: Write the pre-graphics integration test**
+
+```csharp
+[Fact]
+public void Run_WhenFactoryThrowsBeforeGameConstruction_ShouldWriteOneSanitizedReport()
+{
+    using var appData = new TemporaryAppDataRoot();
+    var previous = Environment.GetEnvironmentVariable("DTXMANIA_APPDATA_ROOT");
+
+    try
+    {
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", appData.Path);
+        using var runtime = CrashReportRuntime.CreateBestEffort(
+            StartupTimingTrace.Disabled,
+            TextWriter.Null);
+
+        var exitCode = GameEntryPoint.Run(
+            () => throw new InvalidOperationException(
+                $"song={Path.Combine(appData.Path, "Secret Song.dtx")}"),
+            runtime,
+            TextWriter.Null);
+
+        Assert.Equal(1, exitCode);
+        var report = Assert.Single(
+            Directory.EnumerateFiles(AppPaths.GetCrashReportsRoot(), "crash-*"));
+        var allText = CrashReportTestReader.ReadAllText(report);
+        Assert.DoesNotContain("Secret Song", allText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(appData.Path, allText, StringComparison.OrdinalIgnoreCase);
+    }
+    finally
+    {
+        Environment.SetEnvironmentVariable("DTXMANIA_APPDATA_ROOT", previous);
+    }
+}
+```
+
+- [ ] **Step 2: Add integration tests for failure isolation**
+
+Add tests for:
+- one context snapshot marked `CollectionFailed` does not block the report;
+- archive writer failure creates discoverable emergency text;
+- both ZIP and text discovery expose `CrashReportSummary`;
+- runtime bootstrap factory failure leaves game runner and console logger functional;
+- game disposal failure does not change exit code or report’s primary exception type;
+- six captures through `CrashReportRuntime` retain exactly five;
+- no `.tmp` remains after successful or fallback capture;
+- report text contains none of:
+  - `GameApiKey`;
+  - test username;
+  - DTX/skin paths;
+  - song title;
+  - MIDI stable ID;
+  - arbitrary rendered log string.
+
+- [ ] **Step 3: Run integration tests and inspect one generated artifact**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~CrashReportIntegrationTests"
+```
+
+Keep one test artifact under the test result directory only when a test fails. Successful tests clean temporary app-data roots.
+
+Expected: all integration tests pass.
+
+- [ ] **Step 4: Run both unit suites**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --configuration Debug
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug
+```
+
+Expected: both suites pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  DTXMania.Test/CrashReporting/CrashReportIntegrationTests.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/GameEntryPoint.cs
+git commit -m "test: verify crash report integration"
+```
+
+---
+
+### Task 7: Add WindowsDX real-process `Update` and `Draw` crash verification
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/DebugCrashInjection.cs`
+- Modify: `DTXMania.Game/Game1.cs`
+- Modify: `DTXMania.E2E/Process/GameProcessDriver.cs`
+- Create: `DTXMania.E2E/CrashReportingSmokeTests.cs`
+- Modify: `.github/workflows/build-and-test.yml` only if required to isolate timeout/artifacts.
+
+**Interfaces:**
+- Consumes: process boundary and store from Tasks 1–6.
+- Produces:
+  - `DEBUG`-only `DTXMANIA_E2E_CRASH_INJECTION=update|draw`
+  - `GameProcessDriver.Start(..., IReadOnlyDictionary<string,string?>? environmentOverrides)`
+  - `GameProcessDriver.WaitForExitAsync(...)`
+  - Windows CI proof for both callback paths.
+
+- [ ] **Step 1: Write E2E support tests for process environment overrides**
+
+Extend `GameProcessDriver` with:
+
+```csharp
+public void Start(
+    string repoRoot,
+    string gameProjectPath,
+    E2EFixture fixture,
+    bool enableSimulatedMidi = false,
+    IReadOnlyDictionary<string, string?>? environmentOverrides = null)
+```
+
+Rules:
+- `null` value removes an inherited variable;
+- non-null value sets it;
+- reserved fixture variables may not be overridden:
+  - `DTXMANIA_APPDATA_ROOT`
+  - `DTXMANIA_LAUNCH_TOKEN`.
+
+Add:
+
+```csharp
+public async Task<int> WaitForExitAsync(
+    TimeSpan timeout,
+    CancellationToken cancellationToken)
+```
+
+that waits, drains redirected output, and returns the exit code.
+
+Write `Category=E2E-Support` tests before implementation.
+
+- [ ] **Step 2: Implement a `DEBUG`-only injection hook**
+
+`DebugCrashInjection.cs` must be entirely wrapped in:
+
+```csharp
+#if DEBUG
+...
+#endif
+```
+
+It reads `DTXMANIA_E2E_CRASH_INJECTION` once, accepts only `update` or `draw`, and throws one fixed exception exactly once from the matching callback:
+
+```csharp
+throw new InvalidOperationException("DTXMANIA_E2E_CONTROLLED_CRASH");
+```
+
+Do not include song/config/path values. Release compilation must contain no reference to the environment variable or controlled exception text.
+
+Call the hook:
+- at the beginning of `BaseGame.Update` after the process has entered MonoGame update execution;
+- at the beginning of `BaseGame.Draw` before graphics-dependent work.
+
+- [ ] **Step 3: Write Windows crash smoke tests**
+
+For both `update` and `draw`:
+1. build an isolated fixture with `E2EFixtureBuilder`;
+2. start the Windows game project with the debug-only environment override;
+3. wait for non-zero exit;
+4. assert exactly one completed report under `<fixture.AppDataRoot>/CrashReports`;
+5. assert no `.tmp`;
+6. open the ZIP or text summary and assert exception type is `InvalidOperationException`;
+7. assert the controlled crash appears once as the primary exception;
+8. assert stdout/stderr and report files are copied to `fixture.ArtifactRoot` on failure.
+
+Example test shape:
+
+```csharp
+[Theory(Timeout = 180_000)]
+[InlineData("update")]
+[InlineData("draw")]
+public async Task ControlledCallbackCrash_ShouldReachProgramBoundaryExactlyOnce(
+    string injectionPoint)
+{
+    // Build fixture, start process with environment override, await exit,
+    // inspect one completed report, and assert no duplicate.
+}
+```
+
+- [ ] **Step 4: Run E2E support tests**
+
+On Windows:
+
+```powershell
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj `
+  --configuration Debug `
+  --filter "Category=E2E-Support"
+```
+
+Expected: support tests pass.
+
+- [ ] **Step 5: Run crash smoke tests locally on Windows**
+
+```powershell
+$env:ALSOFT_DRIVERS = "null"
+$env:DTXMANIA_E2E_GAME_PROJECT = "DTXMania.Game/DTXMania.Game.Windows.csproj"
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj `
+  --configuration Debug `
+  --filter "FullyQualifiedName~CrashReportingSmokeTests"
+```
+
+Expected: update and draw cases pass.
+
+- [ ] **Step 6: Verify Release excludes the injection hook**
+
+Build Release:
+
+```powershell
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj --configuration Release
+```
+
+Inspect the source-generated build output or use `strings`/PowerShell binary search on the built game assembly and assert it does not contain:
+
+```text
+DTXMANIA_E2E_CRASH_INJECTION
+DTXMANIA_E2E_CONTROLLED_CRASH
+```
+
+Record the command and result in the implementation PR.
+
+- [ ] **Step 7: Keep CI execution explicit**
+
+The existing workflow already runs `Category=E2E` on Windows. If the two crash tests keep the total job within its current budget, no workflow edit is needed.
+
+If isolation is required, add a named step after gameplay smoke:
+
+```yaml
+- name: Run crash reporting E2E
+  env:
+    ALSOFT_DRIVERS: 'null'
+    DTXMANIA_E2E_GAME_PROJECT: DTXMania.Game/DTXMania.Game.Windows.csproj
+    DTXMANIA_E2E_ARTIFACT_ROOT: TestResults/e2e-crash
+  run: dotnet test DTXMania.E2E/DTXMania.E2E.csproj --configuration Debug --verbosity normal --logger trx --results-directory ./TestResults/e2e-crash --filter "FullyQualifiedName~CrashReportingSmokeTests"
+```
+
+When adding this step, exclude `CrashReportingSmokeTests` from the existing broad E2E step to avoid duplicate execution.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Diagnostics/CrashReporting/DebugCrashInjection.cs \
+  DTXMania.Game/Game1.cs \
+  DTXMania.E2E/Process/GameProcessDriver.cs \
+  DTXMania.E2E/CrashReportingSmokeTests.cs \
+  .github/workflows/build-and-test.yml
+git commit -m "test: verify Windows crash propagation"
+```
+
+If the workflow file did not change, omit it from `git add`.
+
+---
+
+### Task 8: Record DesktopGL evidence and run final acceptance gates
+
+**Files:**
+- Create after executing the checks: `docs/verification/hpa-529-macos-crash-propagation.md`
+- Modify only for defects discovered by verification: files from Tasks 1–7
+
+**Interfaces:**
+- Consumes: complete HPA-529 implementation.
+- Produces: recorded Apple Silicon evidence and final acceptance evidence.
+
+- [ ] **Step 1: Build the real macOS game in Debug and Release**
+
+On Apple Silicon:
+
+```bash
+git rev-parse HEAD
+sw_vers
+uname -m
+dotnet --info
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Release
+```
+
+Expected:
+- architecture reports `arm64`;
+- both builds succeed;
+- Release assembly does not contain the debug injection variable or controlled exception text.
+
+- [ ] **Step 2: Verify DesktopGL `Update` propagation**
+
+```bash
+run_root="$(mktemp -d /tmp/dtx-hpa529-update.XXXXXX)"
+export DTXMANIA_APPDATA_ROOT="$run_root"
+export DTXMANIA_E2E_CRASH_INJECTION="update"
+set +e
+dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+exit_code=$?
+set -e
+test "$exit_code" -ne 0
+find "$run_root/CrashReports" -maxdepth 1 -type f -name 'crash-*' -print
+```
+
+Assert:
+- non-zero exit;
+- exactly one completed `.zip` or `.txt`;
+- zero `.tmp`;
+- summary exception type is `InvalidOperationException`.
+
+- [ ] **Step 3: Verify DesktopGL `Draw` propagation**
+
+Repeat Step 2 with a fresh root and:
+
+```bash
+export DTXMANIA_E2E_CRASH_INJECTION="draw"
+```
+
+Assert the same conditions.
+
+- [ ] **Step 4: Inspect privacy-sensitive output**
+
+For ZIP:
+
+```bash
+unzip -p "<actual-report-path>" report.json
+unzip -p "<actual-report-path>" exception.txt
+unzip -p "<actual-report-path>" logs.ndjson
+unzip -p "<actual-report-path>" breadcrumbs.json
+```
+
+For emergency text:
+
+```bash
+sed -n '1,80p' "<actual-report-path>"
+```
+
+Confirm:
+- no home path;
+- no app-data path;
+- no song/skin path;
+- no API key;
+- no username;
+- no arbitrary rendered log content;
+- report ID/time/build/OS/architecture/stage-or-milestone/exception type are present.
+
+- [ ] **Step 5: Write the verification note with actual output**
+
+Create `docs/verification/hpa-529-macos-crash-propagation.md` containing:
+- commit SHA from `git rev-parse HEAD`;
+- `sw_vers`, `uname -m`, and relevant `dotnet --info` lines;
+- exact commands run;
+- actual exit codes;
+- actual generated report filenames and formats;
+- update result;
+- draw result;
+- Release injection-string absence result;
+- privacy inspection result.
+
+Do not write placeholders. Copy the observed values from the commands.
+
+- [ ] **Step 6: Run final unit and build gates**
+
+On macOS:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Release
+```
+
+On Windows or CI:
+
+```powershell
+dotnet test DTXMania.Test/DTXMania.Test.csproj --configuration Debug
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj --configuration Debug --filter "Category=E2E-Support"
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj --configuration Debug --filter "FullyQualifiedName~CrashReportingSmokeTests"
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj --configuration Release
+```
+
+Expected: zero failed tests and both Release builds succeed.
+
+- [ ] **Step 7: Perform a final report-schema and retention audit**
+
+Using an isolated `DTXMANIA_APPDATA_ROOT`, generate six reports with at least one emergency fallback through an integration test hook. Confirm:
+- exactly five completed reports remain;
+- ZIP and text share one ordering;
+- no temporary files remain;
+- every report is discoverable as a `CrashReportSummary`;
+- report failure never prevents ordinary console logging.
+
+- [ ] **Step 8: Commit verification evidence**
+
+```bash
+git add docs/verification/hpa-529-macos-crash-propagation.md
+git commit -m "docs: record macOS crash propagation"
+```
+
+---
+
+## Final Self-Review Checklist
+
+Before marking HPA-529 complete, verify every item with fresh command output:
+
+- [ ] Production has no parameterless `Game1` or `BaseGame` constructor that self-creates diagnostics.
+- [ ] `CrashReportRuntime` owns and disposes the shared logger factory exactly once.
+- [ ] Disabled crash capture still emits ordinary console logs.
+- [ ] `Program.cs` contains explicit capture-before-dispose lifecycle code and no `using var game`.
+- [ ] Fatal capture uses immutable copies of cached state only.
+- [ ] Context capture performs no device enumeration, SQLite access, network access, shell launch, graphics call, or cross-thread wait.
+- [ ] Unknown logs and dynamic strings are omitted or redacted before persistence.
+- [ ] The full `ConfigData` object is never serialized.
+- [ ] ZIP schema contains exactly the five approved entries.
+- [ ] Emergency text has a parseable allowlisted header and a free-form body that UI code never parses.
+- [ ] One latest-five quota covers ZIP and emergency text.
+- [ ] WindowsDX `Update` and `Draw` propagation passes in automated E2E.
+- [ ] DesktopGL `Update` and `Draw` propagation has recorded Apple Silicon evidence.
+- [ ] Release builds contain no debug crash-injection variable or controlled exception string.
+- [ ] Windows and macOS unit suites pass.
+- [ ] Windows and macOS Release builds succeed.
+- [ ] HPA-530 can consume `CrashReportSummary` and `ICrashReportInbox` without parsing report files or implementing retention.

--- a/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
+++ b/docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md
@@ -23,7 +23,8 @@
 - WindowsDX callback propagation must run automatically in the existing Windows E2E job.
 - DesktopGL callback propagation must be verified manually on Apple Silicon and recorded with exact commands, commit/build identity, OS/runtime information, and observed results.
 - Production code must not expose a crash-injection switch in Release builds. The E2E injection hook must be compiled only under `DEBUG`.
-- Implement the tasks in order. Do not start Task 5 until Task 4's process ownership tests pass; do not start Task 7 until Tasks 1–6 pass on both unit-test projects.
+- Implement Tasks 1–8 strictly in order. Do not parallelize tasks that modify `Game1.cs`, `CrashReportRuntime.cs`, or the report contracts.
+- Do not start Task 5 until Task 4's process ownership tests pass; do not start Task 7 until Tasks 1–6 pass on both unit-test projects.
 - Keep each task as a separate reviewable commit. Correct a defect in the task that introduced its contract rather than hiding it in a later integration-only commit.
 - The canonical design and normative amendments are:
   - `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design.md`

--- a/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md
+++ b/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md
@@ -1,0 +1,70 @@
+# HPA-519 Managed Crash Reporting — Design Review Notes
+
+**Date:** 2026-08-02  
+**Status:** Draft review companion  
+**Canonical design:** [`2026-08-02-hpa-519-managed-crash-report-design.md`](./2026-08-02-hpa-519-managed-crash-report-design.md)  
+**Linear:** HPA-519, with implementation children HPA-529 and HPA-530
+
+## Purpose
+
+This document provides a compact review checklist for the approved HPA-519 managed crash-reporting design. It does not replace or override the canonical specification. Product decisions, architecture, report schema, privacy rules, failure handling, and acceptance criteria remain authoritative in the canonical design.
+
+## Non-negotiable design invariants
+
+1. **No automatic upload.** Crash artifacts are written locally. The player must explicitly open GitHub, inspect the report, and attach the ZIP manually.
+2. **Process-boundary scope.** The first implementation captures only managed fatal exceptions that reach the executable entry point during game construction, startup, or `Game.Run()`.
+3. **Crash-path isolation.** Fatal capture performs no network access, database queries, device enumeration, graphics work, shell launch, cross-thread dispatch, or asynchronous fire-and-forget work.
+4. **Sanitize before persistence.** Secrets, user paths, usernames, song/chart identity, stable hardware identifiers, arbitrary rendered messages, and non-allowlisted configuration values never reach disk.
+5. **Cached context only.** Context providers expose bounded immutable snapshots prepared during normal operation. A failed provider cannot prevent the core exception report from being written.
+6. **Bounded storage.** Reports use atomic finalization, emergency text fallback, stale-temporary cleanup, and latest-five retention.
+7. **Non-blocking recovery UX.** The title screen starts normally. Pending reports appear through one optional notification and a user-invoked review panel.
+8. **Acknowledged is not submitted.** Opening GitHub, opening the folder, or dismissing the notification may acknowledge a report, but CX never claims an issue was created.
+
+## Reviewer focus
+
+### Architecture
+
+- `CrashReportRuntime` is created before `Game1` and owns process-lifetime logging and crash-report services.
+- `BaseGame` consumes the shared logger factory without owning or prematurely disposing it.
+- `TitleStage` receives only `ICrashReportInbox`; ZIP creation, sanitization, retention, and shell operations remain outside the stage.
+- No static service locator or broad global exception-handler behavior is introduced.
+
+### Privacy and report format
+
+- The ZIP contract remains versioned and machine-readable: `report.json`, `exception.txt`, `logs.ndjson`, `breadcrumbs.json`, and `README.txt`.
+- Logs preserve safe templates, event metadata, and allowlisted scalar properties rather than arbitrary rendered strings.
+- Configuration capture is allowlist-only; the full `ConfigData` object is never serialized.
+- GitHub issue URLs contain only report ID, build identity, OS/architecture, stage or initialization milestone, exception type, and attachment instructions.
+
+### Resilience
+
+- Each optional report section can fail independently.
+- ZIP failure attempts a minimal sanitized emergency report.
+- Report persistence failure does not trigger retry loops or obscure the original fatal exception.
+- Inbox-state corruption is non-fatal and causes discovered reports to become unacknowledged again.
+
+### User experience
+
+- The notification never steals focus or blocks normal title-menu navigation.
+- The review panel contains safe summary metadata only and does not render raw logs or stack traces.
+- Delete requires confirmation.
+- Browser or folder-launch failures remain visible, retryable, and unacknowledged.
+
+## Delivery order
+
+1. **HPA-529 — Process-boundary capture and sanitized local bundles**
+   - Establish the runtime, logging/breadcrumb buffers, cached context, bundle contract, sanitization, retention, fallback, and tests.
+2. **HPA-530 — Title-screen inbox and GitHub handoff**
+   - Consume the stable report-store contract and add notification, review actions, inbox state, launch behavior, and UI tests.
+
+HPA-530 remains blocked by HPA-529. Native dumps, arbitrary-thread fatal handlers, hang detection, screenshots, automatic telemetry, and managed upload remain future work.
+
+## Approval gate
+
+The design is ready for implementation planning when reviewers confirm:
+
+- the process-boundary scope is explicit;
+- privacy rules are enforceable through allowlists and tests;
+- no fatal-path dependency can block report persistence;
+- the two implementation tickets have stable boundaries;
+- the title-screen UX remains optional and non-blocking.

--- a/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md
+++ b/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md
@@ -20,6 +20,7 @@ The canonical design remains authoritative for product scope, architecture, repo
 - `StageManager` already centralizes stage-transition logging and is the correct breadcrumb insertion point.
 - `ConfigData` contains `GameApiKey`, but does not contain a concrete `InputMode` property.
 - No existing reusable browser/directory launcher exists in `DTXMania.Game`.
+- `DTXMania.E2E` targets `net8.0-windows7.0`; the gameplay process harness runs in the Windows CI job, while macOS CI runs the macOS unit-test project rather than gameplay E2E.
 
 ## Non-negotiable design invariants
 
@@ -31,64 +32,99 @@ The canonical design remains authoritative for product scope, architecture, repo
 6. **Bounded storage.** Reports use atomic finalization, emergency-text fallback, stale-temporary cleanup, and one shared latest-five limit across all completed report formats.
 7. **Non-blocking recovery UX.** The title screen starts normally. Pending reports appear through one optional notification and a user-invoked review panel.
 8. **Acknowledged is not submitted.** Opening GitHub, opening the folder, or dismissing the notification may acknowledge a report, but CX never claims an issue was created.
+9. **Logging survives diagnostic degradation.** Losing crash persistence must never disable the existing console logging path.
 
 ## Required HPA-529 implementation gates
 
-### 1. Transfer logger-factory ownership completely
+### 1. Transfer logger-factory ownership completely and define the constructor contract
 
 `CrashReportRuntime` becomes the sole process-lifetime owner of the shared `ILoggerFactory`.
 
+The target production composition contract is:
+
+```text
+Program
+  ├─ StartupTimingTrace.StartProcess()
+  ├─ CrashReportRuntime.TryCreate(...)
+  └─ new Game1(startupTrace, crashRuntime.GameDiagnostics)
+
+Game1(StartupTimingTrace, IGameCrashDiagnostics)
+  └─ BaseGame(StartupTimingTrace, IGameCrashDiagnostics)
+```
+
+`IGameCrashDiagnostics` is a narrow game-facing facade, not a service locator. It exposes only the dependencies consumed during normal game operation:
+
+- `ILoggerFactory`;
+- breadcrumb sink;
+- cached-context registration/update surface;
+- `ICrashReportInbox`.
+
+The complete crash runtime, report store, capture operation, and lifetime controls are not exposed through `IStageGame` or to stages.
+
 Implementation review must verify all of the following:
 
-- `BaseGame` receives the shared factory instead of creating its own.
+- `BaseGame` receives the shared factory through `IGameCrashDiagnostics` instead of creating its own.
 - `_loggerFactory.Dispose()` is removed from `BaseGame.DisposeManagedResources()`.
 - `BaseGame` does not dispose any provider owned by `CrashReportRuntime`.
 - `CrashReportRuntime` disposes the factory exactly once after fatal capture and game cleanup have completed.
+- Production `BaseGame()` and `Game1()` constructors that self-create diagnostics are removed; there is no fallback constructor with dual ownership.
+- Tests inject an explicit enabled or console-only diagnostics facade. Tests that intentionally bypass construction may continue using the existing uninitialized-object seam.
 - Constructor and shutdown tests detect premature disposal and double disposal.
 
 This is an explicit migration requirement, not merely a documentation preference.
 
-### 2. Verify MonoGame exception propagation on both targets
+### 2. Verify MonoGame exception propagation with achievable platform evidence
 
 The process-boundary design depends on exceptions thrown from MonoGame callbacks reaching the `Program` catch boundary.
 
-Before HPA-529 is considered complete, verify on both supported backends:
-
-- Windows x64 / MonoGame WindowsDX;
-- macOS arm64 / MonoGame DesktopGL.
-
-For each target, inject controlled exceptions from both `Update` and `Draw` and confirm:
+For both `Update` and `Draw`, verify that:
 
 - the exception reaches the executable process boundary exactly once;
 - one completed crash report is written;
 - the original exception remains the primary failure;
 - no framework-level handler silently consumes the exception.
 
-The internal application-runner seam covers pre-game and orchestration tests, but does not replace this backend-specific verification. If either backend consumes callback exceptions, implementation must stop and revise the capture boundary rather than silently declaring HPA-529 complete.
+Verification delivery is platform-specific:
 
-### 3. Degrade safely when crash-runtime bootstrap fails
+- **Windows x64 / WindowsDX:** add or extend the existing Windows gameplay E2E harness so the check runs automatically in CI.
+- **macOS arm64 / DesktopGL:** perform a manual local verification on Apple Silicon using the real game process. Record the exact commands, app build identifier, OS/runtime details, and observed result in the implementation PR or a checked-in verification note.
+
+The current repository has no cross-platform gameplay E2E harness for macOS. HPA-529 does not expand into an E2E infrastructure migration. A reusable macOS CI gameplay harness may be tracked separately. The internal application-runner seam covers pre-game and orchestration tests, but does not replace either real-backend check.
+
+If either backend consumes callback exceptions, implementation must stop and revise the capture boundary rather than silently declaring HPA-529 complete.
+
+### 3. Degrade safely when crash-runtime bootstrap fails without losing console logs
 
 Crash reporting is diagnostic infrastructure and must not prevent the game from launching because of a recoverable setup failure.
 
-Use an explicit best-effort bootstrap contract, such as `CrashReportRuntime.TryCreate(...)`, that can return a disabled/no-op runtime when expected environment or setup failures occur. Requirements:
+Use an explicit best-effort bootstrap contract, such as `CrashReportRuntime.TryCreate(...)`, that returns either:
 
+- an enabled runtime with console logging plus the bounded crash provider; or
+- a disabled runtime whose `IGameCrashDiagnostics` still owns a fully functional console `ILoggerFactory`, while crash persistence, crash buffering, breadcrumbs/context capture, and inbox behavior degrade to safe no-ops.
+
+Requirements:
+
+- an unwritable crash directory or failed report-store setup must not silence ordinary game logs;
 - path resolution, directory permission, report-store setup, or provider-initialization failures emit a minimal sanitized message to standard error;
 - the game continues without crash capture when the failure is recoverable;
 - report-directory creation remains lazy where practical so read-only startup does not fail unnecessarily;
-- the disabled runtime still provides safe no-op logger/inbox dependencies required by composition;
+- the disabled runtime still provides safe composition dependencies, including the console logger factory and empty inbox;
 - catastrophic runtime failures such as `OutOfMemoryException`, `StackOverflowException`, or `AccessViolationException` are not broadly swallowed under the graceful-degradation rule.
 
-### 4. Define capture and game-disposal ordering
+This bootstrap rule applies before a game crash occurs. It does not conflict with fatal-capture behavior: once the game has already failed, inability to create or write the report emits a last-resort sanitized stderr message and process termination still follows from the original game exception.
 
-The review claim that `using var` necessarily leaves `Game1` undisposed is not correct; disposal behavior depends on the generated scope and catch/finally placement. The actual risk is ambiguous ordering and a disposal exception masking the original crash.
+### 4. Replace compiler-generated `using` disposal with an explicit entry-point lifecycle
 
-The entry-point lifecycle must therefore be explicit:
+The review claim that `using var` necessarily leaves `Game1` undisposed is not correct. However, compiler-generated disposal cannot express the required capture-before-dispose ordering or safely prevent a disposal exception from masking the original crash.
+
+`Program.cs` must therefore replace the existing `using var game` with an explicit nullable game variable and explicit `try`/`catch`/`finally` lifecycle:
 
 1. retain the original exception;
 2. synchronously capture the crash from cached context **before** game disposal mutates or releases that context;
 3. perform guarded best-effort `Game1.Dispose()` afterward;
 4. record or write a sanitized secondary disposal failure without replacing the original exception;
-5. dispose `CrashReportRuntime` last.
+5. dispose `CrashReportRuntime` last;
+6. return a non-zero exit code for the original fatal exception.
 
 Crash capture must succeed without requiring successful `Game1` disposal. Open SQLite, graphics, audio, or other game resources must not block writing to the separate crash-report directory.
 
@@ -100,7 +136,7 @@ Required composition order:
 
 1. create the startup trace at process entry;
 2. create the crash runtime and optionally register a read-only/cached startup-milestone context source;
-3. construct `Game1` with the same startup trace.
+3. construct `Game1` with the same startup trace and the injected diagnostics facade.
 
 The crash runtime may observe cached milestone data but does not own or replace startup timing.
 
@@ -142,6 +178,30 @@ The log and breadcrumb buffers are bounded, thread-safe, and mutable during norm
 
 No design wording should imply that the live buffers themselves are immutable.
 
+### 9. Keep report retention unified inside `CrashReportStore`
+
+Retention belongs to HPA-529 and the storage boundary, not the title-screen ticket.
+
+The latest-five limit counts completed `.zip` and emergency `.txt` reports together, ordered by authoritative capture metadata with a deterministic filename/timestamp fallback. ZIP and text reports do not receive separate quotas. `ICrashReportInbox` consumes the retained set and never implements its own retention policy.
+
+### 10. Give emergency-text reports a discoverable summary contract
+
+Emergency `.txt` fallback reports must participate in discovery and the next-launch inbox even though they do not contain `report.json`.
+
+The emergency writer must prepend a small, versioned, allowlisted header that `CrashReportStore` can parse without reading arbitrary exception text. Initial header fields are:
+
+- format/schema version;
+- report ID;
+- UTC capture timestamp;
+- application/build identifier;
+- OS and architecture;
+- stage or initialization milestone when cached;
+- exception type.
+
+After the header separator, the file may contain the sanitized human-readable emergency report. If the header is missing or corrupt, discovery falls back to the report ID/timestamp encoded in the filename and exposes `Unknown` for unavailable summary fields.
+
+`CrashReportStore` returns one format-neutral `CrashReportSummary` model for ZIP and emergency-text reports. The UI never parses report files directly.
+
 ## Required HPA-530 implementation gates
 
 ### 1. Specify cross-platform launcher behavior
@@ -149,48 +209,63 @@ No design wording should imply that the live buffers themselves are immutable.
 `IExternalLauncher` remains a narrow abstraction, with platform implementations that avoid command-shell string construction:
 
 - **Windows:** use `Process.Start` with `ProcessStartInfo.UseShellExecute = true` for the URI or directory path.
-- **macOS:** execute `/usr/bin/open` with the URI or path supplied through `ArgumentList`.
+- **macOS:** execute `/usr/bin/open` with arguments supplied through `ArgumentList`; add `--` as a separate argument before the validated URI or directory target so a leading-hyphen target cannot be interpreted as an option.
 
 Requirements:
 
 - never invoke `cmd /c`, `sh -c`, or concatenate user-controlled values into a shell command;
 - validate that GitHub URIs use HTTPS and the expected repository host/path;
 - accept only the internally resolved crash-report directory for folder opening;
+- verify the `/usr/bin/open -- <target>` invocation on the supported macOS release during HPA-530 platform smoke testing;
 - treat non-zero exit, process-start failure, or unsupported platform as a retryable UI error;
 - acknowledge a report only after the launcher reports successful process start.
 
-### 2. Keep report retention unified
+### 2. Define emergency-report inbox and review behavior
 
-The latest-five limit counts completed `.zip` and emergency `.txt` reports together, ordered by authoritative capture metadata with a deterministic filename/timestamp fallback. ZIP and text reports do not receive separate quotas.
+Completed ZIP and emergency-text reports both:
+
+- appear in the unacknowledged notification count;
+- participate in Previous/Next navigation;
+- can be acknowledged, dismissed, and deleted;
+- can open the crash-report folder;
+- can open a prefilled GitHub issue using their format-neutral `CrashReportSummary`.
+
+For a ZIP report, the panel renders the safe summary produced from `report.json`. For an emergency-text report, it renders the parsed allowlisted header and an **Emergency fallback report** label. Missing values display as `Unknown`; the panel never reads or displays the free-form exception body.
+
+The attachment instruction must name the actual retained file type: attach the `.zip` bundle for normal reports or the `.txt` fallback for emergency reports.
 
 ## Reviewer focus
 
 ### Architecture
 
 - `CrashReportRuntime` is available before `Game1` and owns process-lifetime logging and crash-report services.
+- A disabled crash runtime preserves fully functional console logging.
 - `BaseGame` no longer creates or disposes the shared logger factory.
+- The explicit constructor contract prevents dual diagnostics ownership.
 - Fatal capture occurs before guarded game disposal and preserves the original exception.
-- `TitleStage` receives only `ICrashReportInbox`; ZIP creation, sanitization, retention, and shell operations remain outside the stage.
+- `TitleStage` receives only `ICrashReportInbox`; report parsing, sanitization, retention, and shell operations remain outside the stage.
 - No static service locator or broad global exception-handler behavior is introduced.
 
 ### Privacy and report format
 
 - The ZIP contract remains versioned and machine-readable: `report.json`, `exception.txt`, `logs.ndjson`, `breadcrumbs.json`, and `README.txt`.
+- Emergency text has a minimal versioned allowlisted summary header.
 - Logs preserve safe templates, event metadata, and centrally allowlisted scalar properties rather than arbitrary rendered strings.
 - Configuration capture uses only the concrete field mapping defined above; the full `ConfigData` object is never serialized.
 - GitHub issue URLs contain only report ID, build identity, OS/architecture, stage or initialization milestone, exception type, and attachment instructions.
 
 ### Resilience
 
-- Expected crash-runtime bootstrap failures degrade to a disabled runtime without blocking game startup.
+- Expected crash-runtime bootstrap failures degrade to console-only diagnostics without blocking game startup.
 - Each optional report section can fail independently.
-- ZIP failure attempts a minimal sanitized emergency report.
+- ZIP failure attempts a minimal sanitized emergency report that remains discoverable by the inbox.
 - Report persistence failure does not trigger retry loops or obscure the original fatal exception.
 - Inbox-state corruption is non-fatal and causes discovered reports to become unacknowledged again.
 
 ### User experience
 
 - The notification never steals focus or blocks normal title-menu navigation.
+- ZIP and emergency-text reports have a consistent review and action flow.
 - The review panel contains safe summary metadata only and does not render raw logs or stack traces.
 - Delete requires confirmation.
 - Browser or folder-launch failures remain visible, retryable, and unacknowledged.
@@ -198,23 +273,26 @@ The latest-five limit counts completed `.zip` and emergency `.txt` reports toget
 ## Delivery order
 
 1. **HPA-529 — Process-boundary capture and sanitized local bundles**
-   - Establish runtime bootstrap/degradation, explicit logger ownership, process/backend verification, capture/disposal ordering, safe-log policy, cached context, bundle contract, sanitization, retention, fallback, and tests.
+   - Establish runtime bootstrap/degradation, explicit constructor and logger ownership, Windows automated and macOS manual backend verification, capture/disposal ordering, safe-log policy, cached context, ZIP/emergency summary contracts, sanitization, unified retention, fallback, and tests.
 2. **HPA-530 — Title-screen inbox and GitHub handoff**
-   - Consume the stable report-store contract and add notification, review actions, inbox state, exact platform launch behavior, and UI tests.
+   - Consume the stable format-neutral report summary and retained set; add notification, review actions, inbox state, exact platform launch behavior, emergency-report UX, and UI tests.
 
-HPA-530 remains blocked by HPA-529. Native dumps, arbitrary-thread fatal handlers, hang detection, screenshots, automatic telemetry, and managed upload remain future work.
+HPA-530 remains blocked by HPA-529. Native dumps, arbitrary-thread fatal handlers, hang detection, screenshots, automatic telemetry, managed upload, and a reusable macOS gameplay E2E CI harness remain future work.
 
 ## Approval gate
 
 The design is ready for implementation planning when reviewers confirm:
 
-- logger ownership and disposal migration are explicit;
-- callback-exception propagation is verified on both MonoGame backends;
+- logger ownership and the injected constructor contract are explicit;
+- disabled crash capture preserves console logging;
+- Windows callback propagation is automated and macOS propagation has recorded real-backend evidence;
 - crash-runtime bootstrap can degrade safely for recoverable failures;
-- capture-before-dispose ordering preserves the original exception;
+- explicit capture-before-dispose ordering preserves the original exception;
 - startup-timing ownership is unambiguous;
 - privacy rules are centralized, concrete, and enforceable through tests;
-- completed report retention is unified across formats;
-- cross-platform launcher behavior is explicit and avoids shell injection;
+- completed report retention is unified inside the storage ticket;
+- emergency text has a complete inbox path;
+- cross-platform launcher behavior is explicit and avoids option/shell injection;
+- the canonical design links to this normative addendum;
 - the two implementation tickets have stable boundaries;
 - the title-screen UX remains optional and non-blocking.

--- a/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md
+++ b/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md
@@ -1,13 +1,25 @@
-# HPA-519 Managed Crash Reporting — Design Review Notes
+# HPA-519 Managed Crash Reporting — Design Review Amendments
 
 **Date:** 2026-08-02  
-**Status:** Draft review companion  
+**Status:** Normative review addendum  
 **Canonical design:** [`2026-08-02-hpa-519-managed-crash-report-design.md`](./2026-08-02-hpa-519-managed-crash-report-design.md)  
 **Linear:** HPA-519, with implementation children HPA-529 and HPA-530
 
 ## Purpose
 
-This document provides a compact review checklist for the approved HPA-519 managed crash-reporting design. It does not replace or override the canonical specification. Product decisions, architecture, report schema, privacy rules, failure handling, and acceptance criteria remain authoritative in the canonical design.
+This document records implementation constraints discovered while reviewing the approved HPA-519 managed crash-reporting design against the current DTXManiaCX codebase.
+
+The canonical design remains authoritative for product scope, architecture, report schema, privacy policy, failure handling, and UX. The clarifications and verification gates below are **required amendments** where the canonical design was ambiguous or did not name an existing implementation trap.
+
+## Validated codebase findings
+
+- `Program.cs` currently constructs `Game1`, starts `StartupTimingTrace`, and calls `Run()` directly without a process-level exception boundary.
+- `BaseGame` currently creates the shared console-only `ILoggerFactory`.
+- `BaseGame.DisposeManagedResources()` currently calls `_loggerFactory.Dispose()`.
+- `AppPaths` owns the application-data-root policy and the `DTXMANIA_APPDATA_ROOT` test override.
+- `StageManager` already centralizes stage-transition logging and is the correct breadcrumb insertion point.
+- `ConfigData` contains `GameApiKey`, but does not contain a concrete `InputMode` property.
+- No existing reusable browser/directory launcher exists in `DTXMania.Game`.
 
 ## Non-negotiable design invariants
 
@@ -15,29 +27,162 @@ This document provides a compact review checklist for the approved HPA-519 manag
 2. **Process-boundary scope.** The first implementation captures only managed fatal exceptions that reach the executable entry point during game construction, startup, or `Game.Run()`.
 3. **Crash-path isolation.** Fatal capture performs no network access, database queries, device enumeration, graphics work, shell launch, cross-thread dispatch, or asynchronous fire-and-forget work.
 4. **Sanitize before persistence.** Secrets, user paths, usernames, song/chart identity, stable hardware identifiers, arbitrary rendered messages, and non-allowlisted configuration values never reach disk.
-5. **Cached context only.** Context providers expose bounded immutable snapshots prepared during normal operation. A failed provider cannot prevent the core exception report from being written.
-6. **Bounded storage.** Reports use atomic finalization, emergency text fallback, stale-temporary cleanup, and latest-five retention.
+5. **Cached context only.** Context providers expose bounded snapshots prepared during normal operation. A failed provider cannot prevent the core exception report from being written.
+6. **Bounded storage.** Reports use atomic finalization, emergency-text fallback, stale-temporary cleanup, and one shared latest-five limit across all completed report formats.
 7. **Non-blocking recovery UX.** The title screen starts normally. Pending reports appear through one optional notification and a user-invoked review panel.
 8. **Acknowledged is not submitted.** Opening GitHub, opening the folder, or dismissing the notification may acknowledge a report, but CX never claims an issue was created.
+
+## Required HPA-529 implementation gates
+
+### 1. Transfer logger-factory ownership completely
+
+`CrashReportRuntime` becomes the sole process-lifetime owner of the shared `ILoggerFactory`.
+
+Implementation review must verify all of the following:
+
+- `BaseGame` receives the shared factory instead of creating its own.
+- `_loggerFactory.Dispose()` is removed from `BaseGame.DisposeManagedResources()`.
+- `BaseGame` does not dispose any provider owned by `CrashReportRuntime`.
+- `CrashReportRuntime` disposes the factory exactly once after fatal capture and game cleanup have completed.
+- Constructor and shutdown tests detect premature disposal and double disposal.
+
+This is an explicit migration requirement, not merely a documentation preference.
+
+### 2. Verify MonoGame exception propagation on both targets
+
+The process-boundary design depends on exceptions thrown from MonoGame callbacks reaching the `Program` catch boundary.
+
+Before HPA-529 is considered complete, verify on both supported backends:
+
+- Windows x64 / MonoGame WindowsDX;
+- macOS arm64 / MonoGame DesktopGL.
+
+For each target, inject controlled exceptions from both `Update` and `Draw` and confirm:
+
+- the exception reaches the executable process boundary exactly once;
+- one completed crash report is written;
+- the original exception remains the primary failure;
+- no framework-level handler silently consumes the exception.
+
+The internal application-runner seam covers pre-game and orchestration tests, but does not replace this backend-specific verification. If either backend consumes callback exceptions, implementation must stop and revise the capture boundary rather than silently declaring HPA-529 complete.
+
+### 3. Degrade safely when crash-runtime bootstrap fails
+
+Crash reporting is diagnostic infrastructure and must not prevent the game from launching because of a recoverable setup failure.
+
+Use an explicit best-effort bootstrap contract, such as `CrashReportRuntime.TryCreate(...)`, that can return a disabled/no-op runtime when expected environment or setup failures occur. Requirements:
+
+- path resolution, directory permission, report-store setup, or provider-initialization failures emit a minimal sanitized message to standard error;
+- the game continues without crash capture when the failure is recoverable;
+- report-directory creation remains lazy where practical so read-only startup does not fail unnecessarily;
+- the disabled runtime still provides safe no-op logger/inbox dependencies required by composition;
+- catastrophic runtime failures such as `OutOfMemoryException`, `StackOverflowException`, or `AccessViolationException` are not broadly swallowed under the graceful-degradation rule.
+
+### 4. Define capture and game-disposal ordering
+
+The review claim that `using var` necessarily leaves `Game1` undisposed is not correct; disposal behavior depends on the generated scope and catch/finally placement. The actual risk is ambiguous ordering and a disposal exception masking the original crash.
+
+The entry-point lifecycle must therefore be explicit:
+
+1. retain the original exception;
+2. synchronously capture the crash from cached context **before** game disposal mutates or releases that context;
+3. perform guarded best-effort `Game1.Dispose()` afterward;
+4. record or write a sanitized secondary disposal failure without replacing the original exception;
+5. dispose `CrashReportRuntime` last.
+
+Crash capture must succeed without requiring successful `Game1` disposal. Open SQLite, graphics, audio, or other game resources must not block writing to the separate crash-report directory.
+
+### 5. Reconcile `StartupTimingTrace` ownership
+
+`StartupTimingTrace` remains responsible for startup-performance measurement; `CrashReportRuntime` remains responsible for crash diagnostics. They must not become competing process singletons.
+
+Required composition order:
+
+1. create the startup trace at process entry;
+2. create the crash runtime and optionally register a read-only/cached startup-milestone context source;
+3. construct `Game1` with the same startup trace.
+
+The crash runtime may observe cached milestone data but does not own or replace startup timing.
+
+### 6. Centralize the safe-log property policy
+
+The allowlist for structured log properties must live in one immutable, unit-tested policy component, for example `CrashLogFieldPolicy`.
+
+The policy defines:
+
+- allowed property names;
+- permitted scalar types;
+- maximum serialized lengths;
+- replacement behavior for unknown strings and unstructured messages;
+- any field-specific normalization.
+
+Individual logging call sites must not make ad-hoc privacy decisions. Unknown dynamic strings remain `[REDACTED]`, and unsafe unstructured messages remain omitted.
+
+### 7. Pin configuration capture to concrete fields
+
+The first configuration snapshot must map directly to existing `ConfigData` members:
+
+- `ScreenWidth`;
+- `ScreenHeight`;
+- `FullScreen`;
+- `VSyncWait`;
+- `BufferSizeMs`;
+- `AutoPlay`;
+- `NoFail`;
+- `EnableGameApi`;
+- counts only for `KeyBindings`, `SystemKeyBindings`, `UnboundDrumLanes`, `UnboundDrumButtons`, and `MidiVelocityThresholds`.
+
+Do not capture `GameApiKey`, paths, binding names, MIDI note identities, or complete dictionaries/sets.
+
+The earlier phrase **selected input mode** is removed from the initial configuration allowlist because `ConfigData` has no such field. A future input context provider may expose a stable non-identifying enum if one is introduced explicitly.
+
+### 8. Clarify buffer and snapshot semantics
+
+The log and breadcrumb buffers are bounded, thread-safe, and mutable during normal operation. Fatal capture takes an immutable copy/snapshot. Context-provider snapshots are immutable cached values replaced atomically during normal operation.
+
+No design wording should imply that the live buffers themselves are immutable.
+
+## Required HPA-530 implementation gates
+
+### 1. Specify cross-platform launcher behavior
+
+`IExternalLauncher` remains a narrow abstraction, with platform implementations that avoid command-shell string construction:
+
+- **Windows:** use `Process.Start` with `ProcessStartInfo.UseShellExecute = true` for the URI or directory path.
+- **macOS:** execute `/usr/bin/open` with the URI or path supplied through `ArgumentList`.
+
+Requirements:
+
+- never invoke `cmd /c`, `sh -c`, or concatenate user-controlled values into a shell command;
+- validate that GitHub URIs use HTTPS and the expected repository host/path;
+- accept only the internally resolved crash-report directory for folder opening;
+- treat non-zero exit, process-start failure, or unsupported platform as a retryable UI error;
+- acknowledge a report only after the launcher reports successful process start.
+
+### 2. Keep report retention unified
+
+The latest-five limit counts completed `.zip` and emergency `.txt` reports together, ordered by authoritative capture metadata with a deterministic filename/timestamp fallback. ZIP and text reports do not receive separate quotas.
 
 ## Reviewer focus
 
 ### Architecture
 
-- `CrashReportRuntime` is created before `Game1` and owns process-lifetime logging and crash-report services.
-- `BaseGame` consumes the shared logger factory without owning or prematurely disposing it.
+- `CrashReportRuntime` is available before `Game1` and owns process-lifetime logging and crash-report services.
+- `BaseGame` no longer creates or disposes the shared logger factory.
+- Fatal capture occurs before guarded game disposal and preserves the original exception.
 - `TitleStage` receives only `ICrashReportInbox`; ZIP creation, sanitization, retention, and shell operations remain outside the stage.
 - No static service locator or broad global exception-handler behavior is introduced.
 
 ### Privacy and report format
 
 - The ZIP contract remains versioned and machine-readable: `report.json`, `exception.txt`, `logs.ndjson`, `breadcrumbs.json`, and `README.txt`.
-- Logs preserve safe templates, event metadata, and allowlisted scalar properties rather than arbitrary rendered strings.
-- Configuration capture is allowlist-only; the full `ConfigData` object is never serialized.
+- Logs preserve safe templates, event metadata, and centrally allowlisted scalar properties rather than arbitrary rendered strings.
+- Configuration capture uses only the concrete field mapping defined above; the full `ConfigData` object is never serialized.
 - GitHub issue URLs contain only report ID, build identity, OS/architecture, stage or initialization milestone, exception type, and attachment instructions.
 
 ### Resilience
 
+- Expected crash-runtime bootstrap failures degrade to a disabled runtime without blocking game startup.
 - Each optional report section can fail independently.
 - ZIP failure attempts a minimal sanitized emergency report.
 - Report persistence failure does not trigger retry loops or obscure the original fatal exception.
@@ -53,9 +198,9 @@ This document provides a compact review checklist for the approved HPA-519 manag
 ## Delivery order
 
 1. **HPA-529 — Process-boundary capture and sanitized local bundles**
-   - Establish the runtime, logging/breadcrumb buffers, cached context, bundle contract, sanitization, retention, fallback, and tests.
+   - Establish runtime bootstrap/degradation, explicit logger ownership, process/backend verification, capture/disposal ordering, safe-log policy, cached context, bundle contract, sanitization, retention, fallback, and tests.
 2. **HPA-530 — Title-screen inbox and GitHub handoff**
-   - Consume the stable report-store contract and add notification, review actions, inbox state, launch behavior, and UI tests.
+   - Consume the stable report-store contract and add notification, review actions, inbox state, exact platform launch behavior, and UI tests.
 
 HPA-530 remains blocked by HPA-529. Native dumps, arbitrary-thread fatal handlers, hang detection, screenshots, automatic telemetry, and managed upload remain future work.
 
@@ -63,8 +208,13 @@ HPA-530 remains blocked by HPA-529. Native dumps, arbitrary-thread fatal handler
 
 The design is ready for implementation planning when reviewers confirm:
 
-- the process-boundary scope is explicit;
-- privacy rules are enforceable through allowlists and tests;
-- no fatal-path dependency can block report persistence;
+- logger ownership and disposal migration are explicit;
+- callback-exception propagation is verified on both MonoGame backends;
+- crash-runtime bootstrap can degrade safely for recoverable failures;
+- capture-before-dispose ordering preserves the original exception;
+- startup-timing ownership is unambiguous;
+- privacy rules are centralized, concrete, and enforceable through tests;
+- completed report retention is unified across formats;
+- cross-platform launcher behavior is explicit and avoids shell injection;
 - the two implementation tickets have stable boundaries;
 - the title-screen UX remains optional and non-blocking.

--- a/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design.md
+++ b/docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-08-02  
 **Status:** Approved  
+**Amended by:** [`2026-08-02-hpa-519-managed-crash-report-design-review.md`](./2026-08-02-hpa-519-managed-crash-report-design-review.md) — normative implementation constraints.  
 **Linear:** HPA-519 — Crash report  
 **Scope:** Capture managed fatal exceptions observed at the executable process boundary, retain a small sanitized diagnostic bundle, and offer a non-blocking GitHub issue handoff on the next launch.
 


### PR DESCRIPTION
## Summary

- retain the approved HPA-519 managed crash-reporting design
- add normative implementation amendments from three codebase review passes
- add an executable, TDD-oriented implementation plan for HPA-529
- align the HPA-529 and HPA-530 Linear tickets with stable ownership and delivery boundaries

## Documents

- Canonical design: `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design.md`
- Normative amendments: `docs/superpowers/specs/2026-08-02-hpa-519-managed-crash-report-design-review.md`
- HPA-529 implementation plan: `docs/superpowers/plans/2026-08-02-hpa-529-managed-crash-report-foundation.md`

## Implementation sequence

The HPA-529 plan is split into eight strictly ordered, independently reviewable tasks:

1. Crash-report contracts and app-data path
2. Central privacy policy and bounded log/breadcrumb/context buffers
3. Sanitized ZIP/emergency-text persistence and unified retention
4. Process runtime composition, injected ownership, and explicit capture-before-dispose lifecycle
5. Cached game context and semantic breadcrumbs
6. Headless integration coverage for privacy, fallback, and failure isolation
7. Automated WindowsDX `Update`/`Draw` crash propagation E2E
8. Recorded Apple Silicon/DesktopGL verification and final acceptance gates

Each task starts with failing tests, names exact files and interfaces, supplies focused commands, and ends with a separate reviewable commit.

## Critical execution gates

- disabled crash capture must preserve normal console logging
- `CrashReportRuntime` solely owns the shared `ILoggerFactory`
- production constructors must inject `IGameCrashDiagnostics`; no self-created fallback ownership
- fatal capture must occur before guarded game disposal
- crash capture reads cached state only and performs no network, database, device enumeration, graphics, shell, or cross-thread work
- sanitization happens before persistence
- ZIP and emergency-text reports share one latest-five quota inside `CrashReportStore`
- WindowsDX callback propagation is automated in the existing Windows E2E path
- DesktopGL callback propagation is manually verified on Apple Silicon with recorded evidence
- the debug crash-injection hook must be absent from Release builds

## Developer impact

Documentation only. This PR does not change runtime behavior, application code, tests, or build configuration. Implementation should begin from updated `main` after this documentation PR is reviewed and merged.

## Validation

- re-fetched the finalized implementation-plan header from the PR branch
- self-reviewed the full plan for placeholders, interface mismatches, ownership ambiguity, task ordering, and verification feasibility
- verified the plan contains eight ordered tasks, explicit red/green commands, per-task commits, and a final acceptance checklist
- verified the existing macOS CI path does not provide gameplay-process E2E, so the plan records real Apple Silicon verification instead of claiming automated coverage
- no build or test run was applicable because the PR remains documentation-only

## Linear

- Parent: https://linear.app/cwchanap/issue/HPA-519/add-managed-crash-reports-and-next-launch-github-handoff
- Foundation: https://linear.app/cwchanap/issue/HPA-529/add-process-boundary-crash-capture-and-sanitized-local-bundles
- Inbox/UI: https://linear.app/cwchanap/issue/HPA-530/add-title-screen-crash-inbox-and-github-issue-handoff