### PR TITLE
docs: plan HPA-520 connected HDMI device status

### DIFF
--- a/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
+++ b/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
@@ -2,21 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Show the currently connected drum device names on the Drum Mapping page using the existing MIDI device lifecycle and hot-plug scan.
+**Goal:** Show the currently connected drum-device names on the Drum Mapping page using the existing MIDI lifecycle and hot-plug scan.
 
-**Architecture:** Add one read-only device-name property to `ModularInputManager`, then format and draw that snapshot from `DrumConfigStage` on every frame. Keep `MidiInputSource` as the sole owner of enumeration and hot-plug state; add no new timer, event bus, device selector, or Windows-specific discovery path.
+**Architecture:** Add one read-only UI snapshot to `ModularInputManager`, then format and draw that snapshot from `DrumConfigStage` on every frame. Keep `MidiInputSource` as the sole owner of enumeration and hot-plug state; keep crash diagnostics on device count only.
 
 **Tech Stack:** .NET 8, C#, MonoGame, xUnit, existing DryWetMIDI-backed input subsystem.
 
 ## Global Constraints
 
-- User-facing copy says `HDMI device`; internal APIs remain named `MIDI`.
+- User-facing copy keeps the requested `HDMI device` label; internal APIs remain named `MIDI`.
+- Exact no-device copy: `HDMI device: None detected (keyboard still works)`.
 - Reuse `MidiInputSource.DeviceNames`; do not enumerate devices from the stage.
 - Reuse the existing three-second hot-plug scan; do not add another refresh mechanism.
+- Device names are UI-only. Telemetry, breadcrumbs, and crash context continue using count only.
 - The status is informational and must not block keyboard or MIDI capture.
 - Do not change drum bindings, velocity thresholds, popup state, or input routing.
-- The Windows-only pad-selection crash is out of scope. Capture its managed crash report and stop if it occurs during verification.
-- Add no new production files or dependencies.
+- The Windows-only pad-selection crash is out of scope. Retain its managed crash report and stop if it occurs.
+- Add no new production files, dependencies, timers, event buses, device selectors, or rescan controls.
 
 ---
 
@@ -25,15 +27,16 @@
 **Modify:**
 
 - `DTXMania.Game/Lib/Input/ModularInputManager.cs`
-  - Exposes a read-only snapshot of currently connected MIDI device display names.
+  - Exposes connected MIDI display names for UI use.
+  - Clarifies that the existing count property is the diagnostics boundary.
 - `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
   - Formats and draws the user-facing HDMI device status line.
 - `DTXMania.Test/Input/ModularInputManagerTests.cs`
-  - Verifies empty, sorted, and refreshed device-name snapshots.
+  - Verifies empty, sorted, and refreshed name snapshots.
 - `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`
-  - Verifies exact disconnected, singular, and plural status copy.
+  - Verifies exact no-device, singular, and plural copy.
 
-No file split is needed. Each production change is a small addition to the existing owner of that responsibility.
+No file split is needed. Each production edit belongs to the existing owner of that responsibility.
 
 ---
 
@@ -46,10 +49,11 @@ No file split is needed. Each production change is a small addition to the exist
 **Interfaces:**
 - Consumes: `MidiInputSource.DeviceNames : IReadOnlyList<string>`
 - Produces: `ModularInputManager.ConnectedMidiDeviceNames : IReadOnlyList<string>`
+- Preserves: `ModularInputManager.ConnectedMidiDeviceCount : int` as the telemetry/crash-context value
 
 - [ ] **Step 1: Add the no-device failing test**
 
-Add this test near `ConnectedMidiDeviceCount_ShouldBeZeroBeforeDevicesAndRefreshToCurrentCount`:
+Add near `ConnectedMidiDeviceCount_ShouldBeZeroBeforeDevicesAndRefreshToCurrentCount`:
 
 ```csharp
 [Fact]
@@ -101,9 +105,9 @@ public void ConnectedMidiDeviceNames_AfterRefresh_ReturnsUpdatedSnapshot()
 }
 ```
 
-- [ ] **Step 4: Run the focused tests and verify they fail**
+- [ ] **Step 4: Run the focused tests and verify failure**
 
-Mac:
+macOS:
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
@@ -119,14 +123,29 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj `
 
 Expected: compilation fails because `ConnectedMidiDeviceNames` does not exist.
 
-- [ ] **Step 5: Add the minimal pass-through property**
+- [ ] **Step 5: Update the count-property contract**
 
-Place this property next to `ConnectedMidiDeviceCount`:
+Replace the existing `ConnectedMidiDeviceCount` XML documentation with:
 
 ```csharp
 /// <summary>
-/// Gets a read-only snapshot of connected MIDI device display names.
-/// Returns an empty snapshot when no MIDI source or device is available.
+/// Gets the current number of connected MIDI devices for telemetry and crash context.
+/// Display names are available separately through ConnectedMidiDeviceNames and must
+/// not be added to crash diagnostics.
+/// </summary>
+public int ConnectedMidiDeviceCount => _midiInputSource?.DeviceCount ?? 0;
+```
+
+Do not change any `Game1` or `CrashContextPublisher.PublishInput` call sites.
+
+- [ ] **Step 6: Add the minimal UI snapshot property**
+
+Place next to `ConnectedMidiDeviceCount`:
+
+```csharp
+/// <summary>
+/// Gets a read-only snapshot of connected MIDI device display names for UI use.
+/// Device names must not be added to telemetry or crash context.
 /// </summary>
 public IReadOnlyList<string> ConnectedMidiDeviceNames =>
     _midiInputSource?.DeviceNames ?? Array.Empty<string>();
@@ -134,13 +153,13 @@ public IReadOnlyList<string> ConnectedMidiDeviceNames =>
 
 Do not call `RefreshDevices()` from this getter. `MidiInputSource.DeviceNames` already returns a new sorted list under its lock.
 
-- [ ] **Step 6: Run the focused tests and verify they pass**
+- [ ] **Step 7: Run the focused tests and verify success**
 
 Run the same focused command for the current platform.
 
 Expected: all `ModularInputManagerTests` pass.
 
-- [ ] **Step 7: Review the boundary**
+- [ ] **Step 8: Review the boundary**
 
 Confirm:
 
@@ -148,8 +167,9 @@ Confirm:
 - No stable IDs are exposed.
 - No mutable internal collection is returned.
 - Reading the property has no side effects.
+- `CrashContextPublisher.PublishInput` still receives only `ConnectedMidiDeviceCount`.
 
-- [ ] **Step 8: Commit Task 1**
+- [ ] **Step 9: Commit Task 1**
 
 ```bash
 git add \
@@ -168,15 +188,17 @@ git commit -m "feat: expose connected midi device names"
 
 **Interfaces:**
 - Consumes: `ModularInputManager.ConnectedMidiDeviceNames : IReadOnlyList<string>`
-- Produces: `DrumConfigStage.FormatHdmiDeviceStatus(IReadOnlyList<string>) : string`
+- Produces: private `DrumConfigStage.FormatHdmiDeviceStatus(IReadOnlyList<string>) : string`
 
-- [ ] **Step 1: Add the disconnected formatter test**
+The formatter remains private to match the existing private-static helper pattern in `DrumConfigStageTests`. Do not widen production visibility solely for testing.
 
-Use the direct private-static reflection pattern already used in `DrumConfigStageTests`:
+- [ ] **Step 1: Add the no-device formatter test**
+
+Use the direct private-static reflection pattern already present in this test file:
 
 ```csharp
 [Fact]
-public void FormatHdmiDeviceStatus_NoDevices_ShowsNotConnected()
+public void FormatHdmiDeviceStatus_NoDevices_ShowsKeyboardFallback()
 {
     var method = typeof(DrumConfigStage).GetMethod(
         "FormatHdmiDeviceStatus",
@@ -187,7 +209,9 @@ public void FormatHdmiDeviceStatus_NoDevices_ShowsNotConnected()
         null,
         new object[] { Array.Empty<string>() })!;
 
-    Assert.Equal("HDMI device: Not connected", status);
+    Assert.Equal(
+        "HDMI device: None detected (keyboard still works)",
+        status);
 }
 ```
 
@@ -231,9 +255,9 @@ public void FormatHdmiDeviceStatus_MultipleDevices_ShowsCountAndNames()
 }
 ```
 
-- [ ] **Step 4: Run the formatter tests and verify they fail**
+- [ ] **Step 4: Run the formatter tests and verify failure**
 
-Mac:
+macOS:
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
@@ -247,17 +271,17 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj `
   --filter "FullyQualifiedName~DrumConfigStageTests"
 ```
 
-Expected: the formatter tests fail because `FormatHdmiDeviceStatus` does not exist.
+Expected: formatter tests fail because `FormatHdmiDeviceStatus` does not exist.
 
 - [ ] **Step 5: Implement the pure formatter**
 
-Add this method near the existing stage geometry and formatting helpers:
+Add near the existing stage geometry helpers:
 
 ```csharp
 private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
 {
     if (deviceNames == null || deviceNames.Count == 0)
-        return "HDMI device: Not connected";
+        return "HDMI device: None detected (keyboard still works)";
 
     if (deviceNames.Count == 1)
         return $"HDMI device: {deviceNames[0]}";
@@ -292,9 +316,9 @@ if (_font != null)
 }
 ```
 
-Keep the read inside `OnDraw`. Do not add a stage field or populate names in `OnActivate`.
+Keep the read inside `OnDraw`. Do not add a stage cache, event subscription, hit rectangle, or focusable control.
 
-- [ ] **Step 7: Run the focused stage tests and verify they pass**
+- [ ] **Step 7: Run the focused stage tests and verify success**
 
 Run the same focused command for the current platform.
 
@@ -302,16 +326,16 @@ Expected: all `DrumConfigStageTests` pass.
 
 - [ ] **Step 8: Verify interaction remains unchanged by inspection**
 
-Confirm the change does not modify:
+Confirm the diff does not modify:
 
 - `OnUpdate`.
 - `OpenPopup`.
 - `ProcessPopupCapture`.
 - `ApplyCapture`.
-- MIDI threshold adjustment.
-- Focus, hover, or reset geometry.
+- MIDI-threshold adjustment.
+- Focus, hover, popup, or reset geometry.
 
-The new line must have no hit rectangle or input handling.
+No automated draw-path test is required. `OnDraw` is excluded from coverage, the wiring is a small adjacent read-format-draw block, and Windows hardware verification is the integration gate.
 
 - [ ] **Step 9: Commit Task 2**
 
@@ -334,7 +358,7 @@ git commit -m "feat: show connected drum device in mapping page"
 - Consumes: completed Tasks 1 and 2.
 - Produces: verified connected/disconnected behavior and a retained crash report if the separate crash reproduces.
 
-- [ ] **Step 1: Run both focused suites together on macOS**
+- [ ] **Step 1: Run both focused suites on macOS**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
@@ -343,7 +367,7 @@ dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
 
 Expected: PASS with no hardware dependency.
 
-- [ ] **Step 2: Run both focused suites together on Windows**
+- [ ] **Step 2: Run both focused suites on Windows**
 
 ```powershell
 dotnet test DTXMania.Test/DTXMania.Test.csproj `
@@ -352,47 +376,62 @@ dotnet test DTXMania.Test/DTXMania.Test.csproj `
 
 Expected: PASS.
 
-- [ ] **Step 3: Run normal repository-required gates**
+- [ ] **Step 3: Run the exact repository-wide macOS gates**
 
-Run the build and test commands required by the repository for both supported platforms. Do not weaken or skip existing CI filters.
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
 
-Expected: all required gates pass.
+Expected: both commands pass.
 
-- [ ] **Step 4: Verify disconnected Windows behavior**
+- [ ] **Step 4: Run the exact repository-wide Windows gates**
+
+```powershell
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj
+dotnet test DTXMania.Test/DTXMania.Test.csproj
+```
+
+Expected: both commands pass.
+
+No gameplay E2E addition is required for this informational text-only feature.
+
+- [ ] **Step 5: Verify disconnected Windows behavior**
 
 With the physical drum device disconnected:
 
 1. Start the Windows game.
 2. Open Config → Drum Mapping.
-3. Confirm the page shows `HDMI device: Not connected`.
+3. Confirm the exact text `HDMI device: None detected (keyboard still works)`.
 4. Open a drum-lane capture popup.
 5. Confirm keyboard capture still works.
 
-- [ ] **Step 5: Verify connection while the page remains open**
+- [ ] **Step 6: Verify connection while the page remains open**
 
-1. Connect the physical drum device without restarting the game.
-2. Wait up to `GameConstants.Input.DeviceScanIntervalMs` plus one rendered frame.
-3. Confirm the device name appears.
-4. Confirm no page reopen is required.
+1. Return to the Drum Mapping page if needed.
+2. Connect the physical drum device without restarting the game.
+3. Wait up to `GameConstants.Input.DeviceScanIntervalMs` plus one rendered frame.
+4. Confirm the device name appears.
+5. Confirm no page reopen is required.
 
-If the device does not appear, inspect `ConnectedMidiDeviceNames`. If it remains empty, stop and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
+If the name remains absent, inspect `ConnectedMidiDeviceNames`. If it is empty, stop and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
 
-- [ ] **Step 6: Verify MIDI capture remains unchanged**
+- [ ] **Step 7: Verify MIDI capture remains unchanged**
 
 1. Select a drum lane.
 2. Hit one pad on the connected device.
 3. Confirm the existing `MIDI.<note>` binding is captured.
 4. Confirm existing velocity-threshold controls behave unchanged.
 
-- [ ] **Step 7: Verify disconnect while the page remains open**
+- [ ] **Step 8: Verify disconnect while the page remains open**
 
 1. Disconnect the physical device.
 2. Wait for the existing hot-plug interval.
-3. Confirm the status returns to `HDMI device: Not connected`.
+3. Confirm the exact no-device text returns.
 4. Confirm the stage remains responsive.
 5. Confirm keyboard capture still works.
 
-- [ ] **Step 8: Apply the Windows crash stop condition**
+- [ ] **Step 9: Apply the Windows crash stop condition**
 
 If selecting a pad crashes:
 
@@ -402,7 +441,7 @@ If selecting a pad crashes:
 4. Create or update the separate Windows crash issue.
 5. Do not add a broad `try/catch` to `DrumConfigStage` or the input update loop.
 
-- [ ] **Step 9: Review the final implementation diff**
+- [ ] **Step 10: Review the final diff**
 
 ```bash
 git diff main...HEAD -- \
@@ -412,35 +451,18 @@ git diff main...HEAD -- \
   DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
 ```
 
-Confirm the production diff contains only:
-
-- One read-only input property.
-- One pure formatter.
-- One status-line draw call.
-- Focused tests.
-
-- [ ] **Step 10: Prepare the implementation PR summary**
-
-The implementation PR body must state:
-
-- Connected names come from the existing MIDI backend.
-- The page updates through the existing hot-plug scan.
-- No input behavior or device lifecycle changed.
-- Windows hardware verification results.
-- The separate crash status, without claiming it was fixed.
+Confirm there are no changes to diagnostics payloads, input routing, popup behavior, bindings, thresholds, or unrelated files.
 
 ---
 
-## Final Acceptance Checklist
+## Completion Checklist
 
-- [ ] No-device state shows `HDMI device: Not connected`.
-- [ ] One device shows its display name.
-- [ ] Multiple devices show count and names.
-- [ ] Device changes appear without reopening the page.
-- [ ] Keyboard assignment remains available while disconnected.
-- [ ] MIDI capture and velocity thresholds remain unchanged.
-- [ ] Mac focused tests pass.
-- [ ] Windows focused tests pass.
-- [ ] Repository-required gates pass.
-- [ ] Actual Windows hardware verification is recorded.
-- [ ] Any Windows crash is deferred with its managed crash report.
+- [ ] Exact no-device copy is implemented and tested.
+- [ ] Count XML documentation clearly identifies the telemetry/crash-context boundary.
+- [ ] Names remain UI-only.
+- [ ] Empty, sorted, and refreshed snapshots are tested.
+- [ ] Singular and plural status formatting is tested.
+- [ ] Focused macOS and Windows tests pass.
+- [ ] Full macOS and Windows build/test commands pass.
+- [ ] Real Windows connect, disconnect, keyboard fallback, and MIDI capture are verified.
+- [ ] Any Windows crash or absent backend name is moved to a separate investigation.

--- a/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
+++ b/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
@@ -2,23 +2,26 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Show the currently connected drum-device names on the Drum Mapping page using the existing MIDI lifecycle and hot-plug scan.
+**Goal:** Show the currently connected drum-device status on the Drum Mapping page using the existing MIDI lifecycle, bounded text layout, and platform-appropriate verification.
 
-**Architecture:** Add one read-only UI snapshot to `ModularInputManager`, then format and draw that snapshot from `DrumConfigStage` on every frame. Keep `MidiInputSource` as the sole owner of enumeration and hot-plug state; keep crash diagnostics on device count only.
+**Architecture:** Add one read-only device-name property to `ModularInputManager`, then format and draw a compact snapshot from `DrumConfigStage` on every frame. Keep `MidiInputSource` as the sole owner of enumeration and hot-plug state; reuse `TextHelper.TruncateToWidth`; add no new timer, event bus, device selector, or Windows-specific discovery path.
 
 **Tech Stack:** .NET 8, C#, MonoGame, xUnit, existing DryWetMIDI-backed input subsystem.
 
 ## Global Constraints
 
-- User-facing copy keeps the requested `HDMI device` label; internal APIs remain named `MIDI`.
+- User-facing copy deliberately says `HDMI device`; internal APIs remain named `MIDI`.
 - Exact no-device copy: `HDMI device: None detected (keyboard still works)`.
+- Multiple-device copy: `HDMI devices (N): <first name>, +<N-1> more`.
 - Reuse `MidiInputSource.DeviceNames`; do not enumerate devices from the stage.
 - Reuse the existing three-second hot-plug scan; do not add another refresh mechanism.
-- Device names are UI-only. Telemetry, breadcrumbs, and crash context continue using count only.
+- Reuse `TextHelper.TruncateToWidth`; do not create another truncation helper.
+- Draw the status below the Reset control and bound it to the virtual viewport.
+- Device names are UI-only; telemetry and crash context continue using count only.
 - The status is informational and must not block keyboard or MIDI capture.
 - Do not change drum bindings, velocity thresholds, popup state, or input routing.
-- The Windows-only pad-selection crash is out of scope. Retain its managed crash report and stop if it occurs.
-- Add no new production files, dependencies, timers, event buses, device selectors, or rescan controls.
+- The Windows-only pad-selection crash is out of scope. Capture its managed crash report and stop if it occurs during verification.
+- Add no new production files or dependencies.
 
 ---
 
@@ -27,16 +30,17 @@
 **Modify:**
 
 - `DTXMania.Game/Lib/Input/ModularInputManager.cs`
-  - Exposes connected MIDI display names for UI use.
-  - Clarifies that the existing count property is the diagnostics boundary.
+  - Expose a read-only snapshot of connected MIDI device display names.
+  - Clarify the count-only telemetry/crash-context contract.
 - `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
-  - Formats and draws the user-facing HDMI device status line.
+  - Format compact HDMI-device copy.
+  - Draw it below Reset and truncate it to the virtual viewport width.
 - `DTXMania.Test/Input/ModularInputManagerTests.cs`
-  - Verifies empty, sorted, and refreshed name snapshots.
+  - Verify empty, sorted, and refreshed snapshots.
 - `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`
-  - Verifies exact no-device, singular, and plural copy.
+  - Verify exact zero, singular, and compact plural copy.
 
-No file split is needed. Each production edit belongs to the existing owner of that responsibility.
+No file split is needed. Each change stays with the existing owner of that responsibility.
 
 ---
 
@@ -49,7 +53,7 @@ No file split is needed. Each production edit belongs to the existing owner of t
 **Interfaces:**
 - Consumes: `MidiInputSource.DeviceNames : IReadOnlyList<string>`
 - Produces: `ModularInputManager.ConnectedMidiDeviceNames : IReadOnlyList<string>`
-- Preserves: `ModularInputManager.ConnectedMidiDeviceCount : int` as the telemetry/crash-context value
+- Preserves: `ModularInputManager.ConnectedMidiDeviceCount : int` as the telemetry/crash-context boundary
 
 - [ ] **Step 1: Add the no-device failing test**
 
@@ -105,27 +109,18 @@ public void ConnectedMidiDeviceNames_AfterRefresh_ReturnsUpdatedSnapshot()
 }
 ```
 
-- [ ] **Step 4: Run the focused tests and verify failure**
-
-macOS:
+- [ ] **Step 4: Run the focused macOS test class and verify failure**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
   --filter "FullyQualifiedName~ModularInputManagerTests"
 ```
 
-Windows:
-
-```powershell
-dotnet test DTXMania.Test/DTXMania.Test.csproj `
-  --filter "FullyQualifiedName~ModularInputManagerTests"
-```
-
 Expected: compilation fails because `ConnectedMidiDeviceNames` does not exist.
 
-- [ ] **Step 5: Update the count-property contract**
+- [ ] **Step 5: Add the pass-through property and clarify the count contract**
 
-Replace the existing `ConnectedMidiDeviceCount` XML documentation with:
+Place next to the existing MIDI availability/count properties:
 
 ```csharp
 /// <summary>
@@ -134,15 +129,7 @@ Replace the existing `ConnectedMidiDeviceCount` XML documentation with:
 /// not be added to crash diagnostics.
 /// </summary>
 public int ConnectedMidiDeviceCount => _midiInputSource?.DeviceCount ?? 0;
-```
 
-Do not change any `Game1` or `CrashContextPublisher.PublishInput` call sites.
-
-- [ ] **Step 6: Add the minimal UI snapshot property**
-
-Place next to `ConnectedMidiDeviceCount`:
-
-```csharp
 /// <summary>
 /// Gets a read-only snapshot of connected MIDI device display names for UI use.
 /// Device names must not be added to telemetry or crash context.
@@ -151,25 +138,29 @@ public IReadOnlyList<string> ConnectedMidiDeviceNames =>
     _midiInputSource?.DeviceNames ?? Array.Empty<string>();
 ```
 
-Do not call `RefreshDevices()` from this getter. `MidiInputSource.DeviceNames` already returns a new sorted list under its lock.
+Do not call `RefreshDevices()` from either getter. `MidiInputSource.DeviceNames` already returns a new sorted list under its lock.
 
-- [ ] **Step 7: Run the focused tests and verify success**
+- [ ] **Step 6: Run the focused macOS test class and verify success**
 
-Run the same focused command for the current platform.
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~ModularInputManagerTests"
+```
 
-Expected: all `ModularInputManagerTests` pass.
+Expected: PASS.
 
-- [ ] **Step 8: Review the boundary**
+- [ ] **Step 7: Review the boundary**
 
 Confirm:
 
-- No `IMidiInputDevice` instances leave the input subsystem.
-- No stable IDs are exposed.
+- No `IMidiInputDevice` instance leaves the input subsystem.
+- No stable ID is exposed.
 - No mutable internal collection is returned.
 - Reading the property has no side effects.
-- `CrashContextPublisher.PublishInput` still receives only `ConnectedMidiDeviceCount`.
+- `Game1`, `CrashContextPublisher`, breadcrumbs, and crash-field policy are unchanged.
+- The per-frame snapshot allocation is accepted; do not add a stale stage cache without performance evidence.
 
-- [ ] **Step 9: Commit Task 1**
+- [ ] **Step 8: Commit Task 1**
 
 ```bash
 git add \
@@ -180,7 +171,7 @@ git commit -m "feat: expose connected midi device names"
 
 ---
 
-### Task 2: Format and Render HDMI Device Status
+### Task 2: Format and Render a Bounded HDMI Device Status
 
 **Files:**
 - Modify: `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
@@ -188,13 +179,12 @@ git commit -m "feat: expose connected midi device names"
 
 **Interfaces:**
 - Consumes: `ModularInputManager.ConnectedMidiDeviceNames : IReadOnlyList<string>`
-- Produces: private `DrumConfigStage.FormatHdmiDeviceStatus(IReadOnlyList<string>) : string`
+- Consumes: `TextHelper.TruncateToWidth(string, float, IFont) : string`
+- Produces: `DrumConfigStage.FormatHdmiDeviceStatus(IReadOnlyList<string>) : string`
 
-The formatter remains private to match the existing private-static helper pattern in `DrumConfigStageTests`. Do not widen production visibility solely for testing.
+- [ ] **Step 1: Add the exact no-device formatter test**
 
-- [ ] **Step 1: Add the no-device formatter test**
-
-Use the direct private-static reflection pattern already present in this test file:
+Use the direct private-static reflection pattern already used by `GetResetButtonRect` tests:
 
 ```csharp
 [Fact]
@@ -234,11 +224,11 @@ public void FormatHdmiDeviceStatus_OneDevice_ShowsDeviceName()
 }
 ```
 
-- [ ] **Step 3: Add the multiple-device formatter test**
+- [ ] **Step 3: Add the compact multiple-device formatter test**
 
 ```csharp
 [Fact]
-public void FormatHdmiDeviceStatus_MultipleDevices_ShowsCountAndNames()
+public void FormatHdmiDeviceStatus_MultipleDevices_PreservesFirstAndSummarizesRest()
 {
     var method = typeof(DrumConfigStage).GetMethod(
         "FormatHdmiDeviceStatus",
@@ -247,27 +237,18 @@ public void FormatHdmiDeviceStatus_MultipleDevices_ShowsCountAndNames()
 
     var status = (string)method!.Invoke(
         null,
-        new object[] { new[] { "Alpha Kit", "Zeta Kit" } })!;
+        new object[] { new[] { "Alpha Kit", "Beta Kit", "Zeta Kit" } })!;
 
     Assert.Equal(
-        "HDMI devices (2): Alpha Kit, Zeta Kit",
+        "HDMI devices (3): Alpha Kit, +2 more",
         status);
 }
 ```
 
-- [ ] **Step 4: Run the formatter tests and verify failure**
-
-macOS:
+- [ ] **Step 4: Run the focused stage test class and verify failure**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
-  --filter "FullyQualifiedName~DrumConfigStageTests"
-```
-
-Windows:
-
-```powershell
-dotnet test DTXMania.Test/DTXMania.Test.csproj `
   --filter "FullyQualifiedName~DrumConfigStageTests"
 ```
 
@@ -275,7 +256,7 @@ Expected: formatter tests fail because `FormatHdmiDeviceStatus` does not exist.
 
 - [ ] **Step 5: Implement the pure formatter**
 
-Add near the existing stage geometry helpers:
+Add near existing stage geometry helpers:
 
 ```csharp
 private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
@@ -286,15 +267,15 @@ private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
     if (deviceNames.Count == 1)
         return $"HDMI device: {deviceNames[0]}";
 
-    return $"HDMI devices ({deviceNames.Count}): {string.Join(", ", deviceNames)}";
+    return $"HDMI devices ({deviceNames.Count}): {deviceNames[0]}, +{deviceNames.Count - 1} more";
 }
 ```
 
-Do not add normalization, truncation, or filtering in this task.
+Do not re-sort in the stage. The source snapshot already supplies its existing ordinal order.
 
-- [ ] **Step 6: Draw the live device status**
+- [ ] **Step 6: Draw below Reset and truncate to the virtual viewport**
 
-In `OnDraw`, replace the existing single-line `_font` condition with:
+In `OnDraw`, keep the heading and add the status in the same `_font != null` block:
 
 ```csharp
 if (_font != null)
@@ -308,21 +289,35 @@ if (_font != null)
     var connectedDeviceNames =
         _input?.ModularInputManager.ConnectedMidiDeviceNames
         ?? Array.Empty<string>();
+    var deviceStatus = FormatHdmiDeviceStatus(connectedDeviceNames);
+    var visibleDeviceStatus = TextHelper.TruncateToWidth(
+        deviceStatus,
+        vw - 40,
+        _font);
+
     _font.DrawString(
         _spriteBatch,
-        FormatHdmiDeviceStatus(connectedDeviceNames),
-        new Vector2(20, 40),
+        visibleDeviceStatus,
+        new Vector2(20, 48),
         DarkText);
 }
 ```
 
-Keep the read inside `OnDraw`. Do not add a stage cache, event subscription, hit rectangle, or focusable control.
+Rationale:
 
-- [ ] **Step 7: Run the focused stage tests and verify success**
+- The Reset control ends at virtual `y = 42`; `y = 48` leaves a visible gap.
+- `vw - 40` preserves a 20-pixel margin on both sides.
+- `TextHelper.TruncateToWidth` protects against a single unusually long device name.
+- Do not add a stage cache, new truncation helper, event subscription, hit rectangle, or focusable control.
 
-Run the same focused command for the current platform.
+- [ ] **Step 7: Run the focused stage test class and verify success**
 
-Expected: all `DrumConfigStageTests` pass.
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~DrumConfigStageTests"
+```
+
+Expected: PASS.
 
 - [ ] **Step 8: Verify interaction remains unchanged by inspection**
 
@@ -333,9 +328,9 @@ Confirm the diff does not modify:
 - `ProcessPopupCapture`.
 - `ApplyCapture`.
 - MIDI-threshold adjustment.
-- Focus, hover, popup, or reset geometry.
+- Focus, hover, popup, or Reset geometry.
 
-No automated draw-path test is required. `OnDraw` is excluded from coverage, the wiring is a small adjacent read-format-draw block, and Windows hardware verification is the integration gate.
+No automated draw-path or screenshot test is required. The formatter is unit-tested, width bounding reuses the existing tested helper, and visual wiring receives a local smoke check.
 
 - [ ] **Step 9: Commit Task 2**
 
@@ -348,35 +343,68 @@ git commit -m "feat: show connected drum device in mapping page"
 
 ---
 
-### Task 3: Cross-Platform Regression and Windows Hardware Verification
+### Task 3: Local macOS Visual Smoke
+
+**Files:**
+- No planned code changes.
+
+**Interfaces:**
+- Consumes: completed Tasks 1 and 2.
+- Produces: visual evidence that the no-device line is positioned correctly without hardware.
+
+- [ ] **Step 1: Run the macOS game with no MIDI device**
+
+```bash
+dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+- [ ] **Step 2: Navigate to the Drum Mapping page**
+
+Use the normal UI or the existing Game API/MCP navigation tools:
+
+1. Open Config.
+2. Open Drum Mapping.
+3. Leave MIDI hardware disconnected.
+
+- [ ] **Step 3: Capture a screenshot**
+
+Use the Game API/MCP screenshot path when available; otherwise use the OS screenshot tool.
+
+Confirm:
+
+- The exact text is `HDMI device: None detected (keyboard still works)`.
+- The status line is below and clear of Reset.
+- The status line does not clip at the right edge.
+- The heading and drum-kit content remain readable.
+
+Do not invent a runtime device-name injection seam for this task. The current Game API injects input events, not device discovery names. Compact plural copy is covered by the formatter test, and long-name width bounding is delegated to the existing tested `TextHelper`.
+
+- [ ] **Step 4: Record the visual result in the implementation PR**
+
+Add the screenshot or a concise verification note to the implementation PR description. Do not commit generated screenshot artifacts unless repository convention requires it.
+
+---
+
+### Task 4: Regression, CI, and Windows Hardware Verification
 
 **Files:**
 - No planned code changes.
 - Do not fix the Windows-only crash in this branch.
 
 **Interfaces:**
-- Consumes: completed Tasks 1 and 2.
-- Produces: verified connected/disconnected behavior and a retained crash report if the separate crash reproduces.
+- Consumes: completed Tasks 1–3.
+- Produces: green local macOS tests, green PR CI, and Windows hardware verification.
 
-- [ ] **Step 1: Run both focused suites on macOS**
+- [ ] **Step 1: Run the combined focused macOS suites**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
   --filter "FullyQualifiedName~ModularInputManagerTests|FullyQualifiedName~DrumConfigStageTests"
 ```
 
-Expected: PASS with no hardware dependency.
-
-- [ ] **Step 2: Run both focused suites on Windows**
-
-```powershell
-dotnet test DTXMania.Test/DTXMania.Test.csproj `
-  --filter "FullyQualifiedName~ModularInputManagerTests|FullyQualifiedName~DrumConfigStageTests"
-```
-
 Expected: PASS.
 
-- [ ] **Step 3: Run the exact repository-wide macOS gates**
+- [ ] **Step 2: Run the full local macOS gates**
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -385,45 +413,45 @@ dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
 
 Expected: both commands pass.
 
-- [ ] **Step 4: Run the exact repository-wide Windows gates**
+- [ ] **Step 3: Push and confirm the PR checks**
 
-```powershell
-dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj
-dotnet test DTXMania.Test/DTXMania.Test.csproj
-```
+Confirm at minimum:
 
-Expected: both commands pass.
+- `build-and-test-windows` is green.
+- `build-and-test-macos` is green.
+- Existing required checks remain green.
 
-No gameplay E2E addition is required for this informational text-only feature.
+Do not require a macOS-only implementation environment to run the Windows full suite locally. The Windows CI job is the authoritative automated Windows gate.
 
-- [ ] **Step 5: Verify disconnected Windows behavior**
+- [ ] **Step 4: Verify disconnected Windows behavior**
 
 With the physical drum device disconnected:
 
 1. Start the Windows game.
 2. Open Config → Drum Mapping.
-3. Confirm the exact text `HDMI device: None detected (keyboard still works)`.
+3. Confirm `HDMI device: None detected (keyboard still works)`.
 4. Open a drum-lane capture popup.
 5. Confirm keyboard capture still works.
 
-- [ ] **Step 6: Verify connection while the page remains open**
+- [ ] **Step 5: Verify connection while the page remains open**
 
-1. Return to the Drum Mapping page if needed.
+1. Return to Drum Mapping if needed.
 2. Connect the physical drum device without restarting the game.
 3. Wait up to `GameConstants.Input.DeviceScanIntervalMs` plus one rendered frame.
-4. Confirm the device name appears.
+4. Confirm its device name appears.
 5. Confirm no page reopen is required.
+6. If multiple ports appear, confirm the first name and `+N more` summary.
 
-If the name remains absent, inspect `ConnectedMidiDeviceNames`. If it is empty, stop and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
+If the name remains absent, inspect `ConnectedMidiDeviceNames`. If empty, stop and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
 
-- [ ] **Step 7: Verify MIDI capture remains unchanged**
+- [ ] **Step 6: Verify MIDI capture remains unchanged**
 
 1. Select a drum lane.
 2. Hit one pad on the connected device.
 3. Confirm the existing `MIDI.<note>` binding is captured.
 4. Confirm existing velocity-threshold controls behave unchanged.
 
-- [ ] **Step 8: Verify disconnect while the page remains open**
+- [ ] **Step 7: Verify disconnect while the page remains open**
 
 1. Disconnect the physical device.
 2. Wait for the existing hot-plug interval.
@@ -431,7 +459,7 @@ If the name remains absent, inspect `ConnectedMidiDeviceNames`. If it is empty, 
 4. Confirm the stage remains responsive.
 5. Confirm keyboard capture still works.
 
-- [ ] **Step 9: Apply the Windows crash stop condition**
+- [ ] **Step 8: Apply the Windows crash stop condition**
 
 If selecting a pad crashes:
 
@@ -441,7 +469,7 @@ If selecting a pad crashes:
 4. Create or update the separate Windows crash issue.
 5. Do not add a broad `try/catch` to `DrumConfigStage` or the input update loop.
 
-- [ ] **Step 10: Review the final diff**
+- [ ] **Step 9: Review the final diff**
 
 ```bash
 git diff main...HEAD -- \
@@ -458,11 +486,15 @@ Confirm there are no changes to diagnostics payloads, input routing, popup behav
 ## Completion Checklist
 
 - [ ] Exact no-device copy is implemented and tested.
+- [ ] Compact plural copy preserves the first device name and summarizes the rest.
+- [ ] Status is drawn below Reset at `(20, 48)`.
+- [ ] Status width is bounded with `TextHelper.TruncateToWidth`.
 - [ ] Count XML documentation clearly identifies the telemetry/crash-context boundary.
 - [ ] Names remain UI-only.
 - [ ] Empty, sorted, and refreshed snapshots are tested.
 - [ ] Singular and plural status formatting is tested.
-- [ ] Focused macOS and Windows tests pass.
-- [ ] Full macOS and Windows build/test commands pass.
+- [ ] Focused and full macOS gates pass locally.
+- [ ] Required PR checks, including Windows build/test CI, are green.
+- [ ] macOS no-device screenshot confirms basic layout.
 - [ ] Real Windows connect, disconnect, keyboard fallback, and MIDI capture are verified.
 - [ ] Any Windows crash or absent backend name is moved to a separate investigation.

--- a/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
+++ b/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
@@ -25,7 +25,7 @@
 **Modify:**
 
 - `DTXMania.Game/Lib/Input/ModularInputManager.cs`
-  - Exposes an immutable/read-only snapshot of currently connected MIDI device display names.
+  - Exposes a read-only snapshot of currently connected MIDI device display names.
 - `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
   - Formats and draws the user-facing HDMI device status line.
 - `DTXMania.Test/Input/ModularInputManagerTests.cs`
@@ -49,7 +49,7 @@ No file split is needed. Each production change is a small addition to the exist
 
 - [ ] **Step 1: Add the no-device failing test**
 
-Add this test near the existing `ConnectedMidiDeviceCount_ShouldBeZeroBeforeDevicesAndRefreshToCurrentCount` test:
+Add this test near `ConnectedMidiDeviceCount_ShouldBeZeroBeforeDevicesAndRefreshToCurrentCount`:
 
 ```csharp
 [Fact]
@@ -121,7 +121,7 @@ Expected: compilation fails because `ConnectedMidiDeviceNames` does not exist.
 
 - [ ] **Step 5: Add the minimal pass-through property**
 
-In `ModularInputManager`, place the property next to `ConnectedMidiDeviceCount`:
+Place this property next to `ConnectedMidiDeviceCount`:
 
 ```csharp
 /// <summary>
@@ -142,7 +142,7 @@ Expected: all `ModularInputManagerTests` pass.
 
 - [ ] **Step 7: Review the boundary**
 
-Confirm the implementation exposes only names:
+Confirm:
 
 - No `IMidiInputDevice` instances leave the input subsystem.
 - No stable IDs are exposed.
@@ -172,32 +172,24 @@ git commit -m "feat: expose connected midi device names"
 
 - [ ] **Step 1: Add the disconnected formatter test**
 
-Add this test to `DrumConfigStageTests`:
+Use the direct private-static reflection pattern already used in `DrumConfigStageTests`:
 
 ```csharp
 [Fact]
 public void FormatHdmiDeviceStatus_NoDevices_ShowsNotConnected()
 {
-    var status = ReflectionHelpers.InvokePrivateStaticMethod<string>(
-        typeof(DrumConfigStage),
+    var method = typeof(DrumConfigStage).GetMethod(
         "FormatHdmiDeviceStatus",
-        Array.Empty<string>());
+        BindingFlags.NonPublic | BindingFlags.Static);
+    Assert.NotNull(method);
+
+    var status = (string)method!.Invoke(
+        null,
+        new object[] { Array.Empty<string>() })!;
 
     Assert.Equal("HDMI device: Not connected", status);
 }
 ```
-
-If `ReflectionHelpers` does not expose `InvokePrivateStaticMethod<T>`, use the established direct reflection pattern already present in the test file:
-
-```csharp
-var method = typeof(DrumConfigStage).GetMethod(
-    "FormatHdmiDeviceStatus",
-    BindingFlags.NonPublic | BindingFlags.Static);
-Assert.NotNull(method);
-var status = (string)method!.Invoke(null, new object[] { Array.Empty<string>() })!;
-```
-
-Use one pattern consistently for all three formatter tests.
 
 - [ ] **Step 2: Add the single-device formatter test**
 
@@ -259,7 +251,7 @@ Expected: the formatter tests fail because `FormatHdmiDeviceStatus` does not exi
 
 - [ ] **Step 5: Implement the pure formatter**
 
-Add this private static method near the other stage geometry/formatting helpers:
+Add this method near the existing stage geometry and formatting helpers:
 
 ```csharp
 private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
@@ -274,11 +266,11 @@ private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
 }
 ```
 
-The null guard is a cheap defensive boundary for reflection tests and future callers. Do not add normalization, truncation, or filtering unless the existing font/rendering path requires it during manual verification.
+Do not add normalization, truncation, or filtering in this task.
 
 - [ ] **Step 6: Draw the live device status**
 
-In `OnDraw`, immediately after drawing the existing `DRUM MAPPING` heading, read and render the current snapshot:
+In `OnDraw`, replace the existing single-line `_font` condition with:
 
 ```csharp
 if (_font != null)
@@ -300,7 +292,7 @@ if (_font != null)
 }
 ```
 
-Keep the read inside `OnDraw`. Do not add a stage field for the names and do not populate names in `OnActivate`.
+Keep the read inside `OnDraw`. Do not add a stage field or populate names in `OnActivate`.
 
 - [ ] **Step 7: Run the focused stage tests and verify they pass**
 
@@ -317,7 +309,7 @@ Confirm the change does not modify:
 - `ProcessPopupCapture`.
 - `ApplyCapture`.
 - MIDI threshold adjustment.
-- focus, hover, or reset geometry.
+- Focus, hover, or reset geometry.
 
 The new line must have no hit rectangle or input handling.
 
@@ -335,7 +327,7 @@ git commit -m "feat: show connected drum device in mapping page"
 ### Task 3: Cross-Platform Regression and Windows Hardware Verification
 
 **Files:**
-- Modify only if verification finds a documentation or test expectation mismatch.
+- No planned code changes.
 - Do not fix the Windows-only crash in this branch.
 
 **Interfaces:**
@@ -378,13 +370,12 @@ With the physical drum device disconnected:
 
 - [ ] **Step 5: Verify connection while the page remains open**
 
-1. Return to the Drum Mapping page if needed.
-2. Connect the physical drum device without restarting the game.
-3. Wait up to the existing `GameConstants.Input.DeviceScanIntervalMs` interval plus one rendered frame.
-4. Confirm the device name appears.
-5. Confirm no page reopen is required.
+1. Connect the physical drum device without restarting the game.
+2. Wait up to `GameConstants.Input.DeviceScanIntervalMs` plus one rendered frame.
+3. Confirm the device name appears.
+4. Confirm no page reopen is required.
 
-If the device does not appear, inspect `ConnectedMidiDeviceNames`. If it remains empty, stop this implementation and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
+If the device does not appear, inspect `ConnectedMidiDeviceNames`. If it remains empty, stop and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
 
 - [ ] **Step 6: Verify MIDI capture remains unchanged**
 
@@ -403,7 +394,7 @@ If the device does not appear, inspect `ConnectedMidiDeviceNames`. If it remains
 
 - [ ] **Step 8: Apply the Windows crash stop condition**
 
-If selecting a pad crashes at any point:
+If selecting a pad crashes:
 
 1. Retain the generated managed crash report.
 2. Record the exact reproduction sequence and Windows/device details.
@@ -411,7 +402,7 @@ If selecting a pad crashes at any point:
 4. Create or update the separate Windows crash issue.
 5. Do not add a broad `try/catch` to `DrumConfigStage` or the input update loop.
 
-- [ ] **Step 9: Review the final diff**
+- [ ] **Step 9: Review the final implementation diff**
 
 ```bash
 git diff main...HEAD -- \
@@ -421,7 +412,7 @@ git diff main...HEAD -- \
   DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
 ```
 
-Confirm the final production diff contains only:
+Confirm the production diff contains only:
 
 - One read-only input property.
 - One pure formatter.
@@ -430,11 +421,11 @@ Confirm the final production diff contains only:
 
 - [ ] **Step 10: Prepare the implementation PR summary**
 
-Use a PR body that states:
+The implementation PR body must state:
 
-- Connected device names are surfaced from the existing MIDI backend.
-- The Drum Mapping page updates through the existing hot-plug scan.
-- No input behavior or device lifecycle was changed.
+- Connected names come from the existing MIDI backend.
+- The page updates through the existing hot-plug scan.
+- No input behavior or device lifecycle changed.
 - Windows hardware verification results.
 - The separate crash status, without claiming it was fixed.
 

--- a/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
+++ b/docs/superpowers/plans/2026-08-06-hpa-520-hdmi-device-status.md
@@ -1,0 +1,455 @@
+# HPA-520 HDMI Device Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the currently connected drum device names on the Drum Mapping page using the existing MIDI device lifecycle and hot-plug scan.
+
+**Architecture:** Add one read-only device-name property to `ModularInputManager`, then format and draw that snapshot from `DrumConfigStage` on every frame. Keep `MidiInputSource` as the sole owner of enumeration and hot-plug state; add no new timer, event bus, device selector, or Windows-specific discovery path.
+
+**Tech Stack:** .NET 8, C#, MonoGame, xUnit, existing DryWetMIDI-backed input subsystem.
+
+## Global Constraints
+
+- User-facing copy says `HDMI device`; internal APIs remain named `MIDI`.
+- Reuse `MidiInputSource.DeviceNames`; do not enumerate devices from the stage.
+- Reuse the existing three-second hot-plug scan; do not add another refresh mechanism.
+- The status is informational and must not block keyboard or MIDI capture.
+- Do not change drum bindings, velocity thresholds, popup state, or input routing.
+- The Windows-only pad-selection crash is out of scope. Capture its managed crash report and stop if it occurs during verification.
+- Add no new production files or dependencies.
+
+---
+
+## File Structure
+
+**Modify:**
+
+- `DTXMania.Game/Lib/Input/ModularInputManager.cs`
+  - Exposes an immutable/read-only snapshot of currently connected MIDI device display names.
+- `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
+  - Formats and draws the user-facing HDMI device status line.
+- `DTXMania.Test/Input/ModularInputManagerTests.cs`
+  - Verifies empty, sorted, and refreshed device-name snapshots.
+- `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`
+  - Verifies exact disconnected, singular, and plural status copy.
+
+No file split is needed. Each production change is a small addition to the existing owner of that responsibility.
+
+---
+
+### Task 1: Expose Connected MIDI Device Names
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Input/ModularInputManager.cs`
+- Test: `DTXMania.Test/Input/ModularInputManagerTests.cs`
+
+**Interfaces:**
+- Consumes: `MidiInputSource.DeviceNames : IReadOnlyList<string>`
+- Produces: `ModularInputManager.ConnectedMidiDeviceNames : IReadOnlyList<string>`
+
+- [ ] **Step 1: Add the no-device failing test**
+
+Add this test near the existing `ConnectedMidiDeviceCount_ShouldBeZeroBeforeDevicesAndRefreshToCurrentCount` test:
+
+```csharp
+[Fact]
+public void ConnectedMidiDeviceNames_NoDevices_ReturnsEmpty()
+{
+    Assert.Empty(_inputManager.ConnectedMidiDeviceNames);
+}
+```
+
+- [ ] **Step 2: Add the sorted-names failing test**
+
+```csharp
+[Fact]
+public void ConnectedMidiDeviceNames_WithDevices_ReturnsSortedNames()
+{
+    _midiBackend.SetDevices(
+        new TestMidiInputDevice("midi-b", "Zeta Kit"),
+        new TestMidiInputDevice("midi-a", "Alpha Kit"));
+
+    _inputManager.Update(GameConstants.Input.DeviceScanIntervalMs / 1000.0);
+
+    Assert.Equal(
+        new[] { "Alpha Kit", "Zeta Kit" },
+        _inputManager.ConnectedMidiDeviceNames);
+}
+```
+
+- [ ] **Step 3: Add the refresh failing test**
+
+```csharp
+[Fact]
+public void ConnectedMidiDeviceNames_AfterRefresh_ReturnsUpdatedSnapshot()
+{
+    _midiBackend.SetDevices(
+        new TestMidiInputDevice("midi-a", "First Kit"));
+    _inputManager.Update(GameConstants.Input.DeviceScanIntervalMs / 1000.0);
+
+    Assert.Equal(
+        new[] { "First Kit" },
+        _inputManager.ConnectedMidiDeviceNames);
+
+    _midiBackend.SetDevices(
+        new TestMidiInputDevice("midi-b", "Replacement Kit"));
+    _inputManager.Update(GameConstants.Input.DeviceScanIntervalMs / 1000.0);
+
+    Assert.Equal(
+        new[] { "Replacement Kit" },
+        _inputManager.ConnectedMidiDeviceNames);
+}
+```
+
+- [ ] **Step 4: Run the focused tests and verify they fail**
+
+Mac:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~ModularInputManagerTests"
+```
+
+Windows:
+
+```powershell
+dotnet test DTXMania.Test/DTXMania.Test.csproj `
+  --filter "FullyQualifiedName~ModularInputManagerTests"
+```
+
+Expected: compilation fails because `ConnectedMidiDeviceNames` does not exist.
+
+- [ ] **Step 5: Add the minimal pass-through property**
+
+In `ModularInputManager`, place the property next to `ConnectedMidiDeviceCount`:
+
+```csharp
+/// <summary>
+/// Gets a read-only snapshot of connected MIDI device display names.
+/// Returns an empty snapshot when no MIDI source or device is available.
+/// </summary>
+public IReadOnlyList<string> ConnectedMidiDeviceNames =>
+    _midiInputSource?.DeviceNames ?? Array.Empty<string>();
+```
+
+Do not call `RefreshDevices()` from this getter. `MidiInputSource.DeviceNames` already returns a new sorted list under its lock.
+
+- [ ] **Step 6: Run the focused tests and verify they pass**
+
+Run the same focused command for the current platform.
+
+Expected: all `ModularInputManagerTests` pass.
+
+- [ ] **Step 7: Review the boundary**
+
+Confirm the implementation exposes only names:
+
+- No `IMidiInputDevice` instances leave the input subsystem.
+- No stable IDs are exposed.
+- No mutable internal collection is returned.
+- Reading the property has no side effects.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Input/ModularInputManager.cs \
+  DTXMania.Test/Input/ModularInputManagerTests.cs
+git commit -m "feat: expose connected midi device names"
+```
+
+---
+
+### Task 2: Format and Render HDMI Device Status
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
+- Test: `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`
+
+**Interfaces:**
+- Consumes: `ModularInputManager.ConnectedMidiDeviceNames : IReadOnlyList<string>`
+- Produces: `DrumConfigStage.FormatHdmiDeviceStatus(IReadOnlyList<string>) : string`
+
+- [ ] **Step 1: Add the disconnected formatter test**
+
+Add this test to `DrumConfigStageTests`:
+
+```csharp
+[Fact]
+public void FormatHdmiDeviceStatus_NoDevices_ShowsNotConnected()
+{
+    var status = ReflectionHelpers.InvokePrivateStaticMethod<string>(
+        typeof(DrumConfigStage),
+        "FormatHdmiDeviceStatus",
+        Array.Empty<string>());
+
+    Assert.Equal("HDMI device: Not connected", status);
+}
+```
+
+If `ReflectionHelpers` does not expose `InvokePrivateStaticMethod<T>`, use the established direct reflection pattern already present in the test file:
+
+```csharp
+var method = typeof(DrumConfigStage).GetMethod(
+    "FormatHdmiDeviceStatus",
+    BindingFlags.NonPublic | BindingFlags.Static);
+Assert.NotNull(method);
+var status = (string)method!.Invoke(null, new object[] { Array.Empty<string>() })!;
+```
+
+Use one pattern consistently for all three formatter tests.
+
+- [ ] **Step 2: Add the single-device formatter test**
+
+```csharp
+[Fact]
+public void FormatHdmiDeviceStatus_OneDevice_ShowsDeviceName()
+{
+    var method = typeof(DrumConfigStage).GetMethod(
+        "FormatHdmiDeviceStatus",
+        BindingFlags.NonPublic | BindingFlags.Static);
+    Assert.NotNull(method);
+
+    var status = (string)method!.Invoke(
+        null,
+        new object[] { new[] { "Roland TD-17" } })!;
+
+    Assert.Equal("HDMI device: Roland TD-17", status);
+}
+```
+
+- [ ] **Step 3: Add the multiple-device formatter test**
+
+```csharp
+[Fact]
+public void FormatHdmiDeviceStatus_MultipleDevices_ShowsCountAndNames()
+{
+    var method = typeof(DrumConfigStage).GetMethod(
+        "FormatHdmiDeviceStatus",
+        BindingFlags.NonPublic | BindingFlags.Static);
+    Assert.NotNull(method);
+
+    var status = (string)method!.Invoke(
+        null,
+        new object[] { new[] { "Alpha Kit", "Zeta Kit" } })!;
+
+    Assert.Equal(
+        "HDMI devices (2): Alpha Kit, Zeta Kit",
+        status);
+}
+```
+
+- [ ] **Step 4: Run the formatter tests and verify they fail**
+
+Mac:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~DrumConfigStageTests"
+```
+
+Windows:
+
+```powershell
+dotnet test DTXMania.Test/DTXMania.Test.csproj `
+  --filter "FullyQualifiedName~DrumConfigStageTests"
+```
+
+Expected: the formatter tests fail because `FormatHdmiDeviceStatus` does not exist.
+
+- [ ] **Step 5: Implement the pure formatter**
+
+Add this private static method near the other stage geometry/formatting helpers:
+
+```csharp
+private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
+{
+    if (deviceNames == null || deviceNames.Count == 0)
+        return "HDMI device: Not connected";
+
+    if (deviceNames.Count == 1)
+        return $"HDMI device: {deviceNames[0]}";
+
+    return $"HDMI devices ({deviceNames.Count}): {string.Join(", ", deviceNames)}";
+}
+```
+
+The null guard is a cheap defensive boundary for reflection tests and future callers. Do not add normalization, truncation, or filtering unless the existing font/rendering path requires it during manual verification.
+
+- [ ] **Step 6: Draw the live device status**
+
+In `OnDraw`, immediately after drawing the existing `DRUM MAPPING` heading, read and render the current snapshot:
+
+```csharp
+if (_font != null)
+{
+    _font.DrawString(
+        _spriteBatch,
+        "DRUM MAPPING  -  click a piece, then hit your input.  Back: save & exit",
+        new Vector2(20, 16),
+        DarkText);
+
+    var connectedDeviceNames =
+        _input?.ModularInputManager.ConnectedMidiDeviceNames
+        ?? Array.Empty<string>();
+    _font.DrawString(
+        _spriteBatch,
+        FormatHdmiDeviceStatus(connectedDeviceNames),
+        new Vector2(20, 40),
+        DarkText);
+}
+```
+
+Keep the read inside `OnDraw`. Do not add a stage field for the names and do not populate names in `OnActivate`.
+
+- [ ] **Step 7: Run the focused stage tests and verify they pass**
+
+Run the same focused command for the current platform.
+
+Expected: all `DrumConfigStageTests` pass.
+
+- [ ] **Step 8: Verify interaction remains unchanged by inspection**
+
+Confirm the change does not modify:
+
+- `OnUpdate`.
+- `OpenPopup`.
+- `ProcessPopupCapture`.
+- `ApplyCapture`.
+- MIDI threshold adjustment.
+- focus, hover, or reset geometry.
+
+The new line must have no hit rectangle or input handling.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add \
+  DTXMania.Game/Lib/Stage/DrumConfigStage.cs \
+  DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
+git commit -m "feat: show connected drum device in mapping page"
+```
+
+---
+
+### Task 3: Cross-Platform Regression and Windows Hardware Verification
+
+**Files:**
+- Modify only if verification finds a documentation or test expectation mismatch.
+- Do not fix the Windows-only crash in this branch.
+
+**Interfaces:**
+- Consumes: completed Tasks 1 and 2.
+- Produces: verified connected/disconnected behavior and a retained crash report if the separate crash reproduces.
+
+- [ ] **Step 1: Run both focused suites together on macOS**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~ModularInputManagerTests|FullyQualifiedName~DrumConfigStageTests"
+```
+
+Expected: PASS with no hardware dependency.
+
+- [ ] **Step 2: Run both focused suites together on Windows**
+
+```powershell
+dotnet test DTXMania.Test/DTXMania.Test.csproj `
+  --filter "FullyQualifiedName~ModularInputManagerTests|FullyQualifiedName~DrumConfigStageTests"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run normal repository-required gates**
+
+Run the build and test commands required by the repository for both supported platforms. Do not weaken or skip existing CI filters.
+
+Expected: all required gates pass.
+
+- [ ] **Step 4: Verify disconnected Windows behavior**
+
+With the physical drum device disconnected:
+
+1. Start the Windows game.
+2. Open Config → Drum Mapping.
+3. Confirm the page shows `HDMI device: Not connected`.
+4. Open a drum-lane capture popup.
+5. Confirm keyboard capture still works.
+
+- [ ] **Step 5: Verify connection while the page remains open**
+
+1. Return to the Drum Mapping page if needed.
+2. Connect the physical drum device without restarting the game.
+3. Wait up to the existing `GameConstants.Input.DeviceScanIntervalMs` interval plus one rendered frame.
+4. Confirm the device name appears.
+5. Confirm no page reopen is required.
+
+If the device does not appear, inspect `ConnectedMidiDeviceNames`. If it remains empty, stop this implementation and create a separate Windows device-discovery investigation. Do not add a second discovery API here.
+
+- [ ] **Step 6: Verify MIDI capture remains unchanged**
+
+1. Select a drum lane.
+2. Hit one pad on the connected device.
+3. Confirm the existing `MIDI.<note>` binding is captured.
+4. Confirm existing velocity-threshold controls behave unchanged.
+
+- [ ] **Step 7: Verify disconnect while the page remains open**
+
+1. Disconnect the physical device.
+2. Wait for the existing hot-plug interval.
+3. Confirm the status returns to `HDMI device: Not connected`.
+4. Confirm the stage remains responsive.
+5. Confirm keyboard capture still works.
+
+- [ ] **Step 8: Apply the Windows crash stop condition**
+
+If selecting a pad crashes at any point:
+
+1. Retain the generated managed crash report.
+2. Record the exact reproduction sequence and Windows/device details.
+3. Stop work on this branch.
+4. Create or update the separate Windows crash issue.
+5. Do not add a broad `try/catch` to `DrumConfigStage` or the input update loop.
+
+- [ ] **Step 9: Review the final diff**
+
+```bash
+git diff main...HEAD -- \
+  DTXMania.Game/Lib/Input/ModularInputManager.cs \
+  DTXMania.Game/Lib/Stage/DrumConfigStage.cs \
+  DTXMania.Test/Input/ModularInputManagerTests.cs \
+  DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
+```
+
+Confirm the final production diff contains only:
+
+- One read-only input property.
+- One pure formatter.
+- One status-line draw call.
+- Focused tests.
+
+- [ ] **Step 10: Prepare the implementation PR summary**
+
+Use a PR body that states:
+
+- Connected device names are surfaced from the existing MIDI backend.
+- The Drum Mapping page updates through the existing hot-plug scan.
+- No input behavior or device lifecycle was changed.
+- Windows hardware verification results.
+- The separate crash status, without claiming it was fixed.
+
+---
+
+## Final Acceptance Checklist
+
+- [ ] No-device state shows `HDMI device: Not connected`.
+- [ ] One device shows its display name.
+- [ ] Multiple devices show count and names.
+- [ ] Device changes appear without reopening the page.
+- [ ] Keyboard assignment remains available while disconnected.
+- [ ] MIDI capture and velocity thresholds remain unchanged.
+- [ ] Mac focused tests pass.
+- [ ] Windows focused tests pass.
+- [ ] Repository-required gates pass.
+- [ ] Actual Windows hardware verification is recorded.
+- [ ] Any Windows crash is deferred with its managed crash report.

--- a/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
+++ b/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
@@ -8,57 +8,61 @@
 
 Show the currently connected drum device on the existing Drum Mapping page so the player can confirm that the expected hardware is visible before assigning pads.
 
-This is a small visibility feature. It does not change device discovery, input routing, bindings, velocity thresholds, or the capture popup workflow.
+This is a small visibility feature. It does not change device discovery, input routing, bindings, velocity thresholds, diagnostics, or the capture-popup workflow.
 
-## Terminology and Implementation Assumption
+## Product Copy Decision
 
-The requested user-facing term is **HDMI device**. DTXManiaCX does not currently have an HDMI input abstraction. The connected drum hardware already enters the application through the existing MIDI device backend and is exposed by `MidiInputSource.DeviceNames`.
+The requested user-facing label is **HDMI device**. DTXManiaCX does not have an HDMI input abstraction; the connected drum hardware is enumerated by the existing MIDI backend and exposed through `MidiInputSource.DeviceNames`.
 
-Therefore:
+The label is retained as an explicit product requirement, but the disconnected copy must not imply that the whole assignment screen is unusable. The exact copy is:
 
-- User-facing copy uses **HDMI device** as requested.
-- Internal APIs and types remain named **MIDI**.
-- HPA-520 surfaces the device names already reported by `MidiInputSource`.
-- If the real Windows hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops. Device discovery must then be investigated separately instead of adding a second Windows-specific discovery path to this ticket.
+| Device count | Text |
+| --- | --- |
+| 0 | `HDMI device: None detected (keyboard still works)` |
+| 1 | `HDMI device: <device name>` |
+| 2+ | `HDMI devices (N): <name 1>, <name 2>, ...` |
+
+Internal APIs and types remain named **MIDI**. If the real Windows drum hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops and device discovery moves to a separate Windows investigation. This ticket must not add a second discovery path.
 
 ## Goals
 
-1. Show a clear disconnected state when no drum device is detected.
+1. Show a clear no-device state without suggesting that keyboard assignment is disabled.
 2. Show the connected device name when one device is detected.
 3. Show device count and names when multiple devices are detected.
 4. Reflect connect and disconnect changes while the page remains open.
-5. Preserve keyboard assignment and all existing drum binding behavior.
+5. Preserve keyboard assignment and all existing drum-binding behavior.
 6. Keep the implementation small and reuse the existing device lifecycle.
 
 ## Non-Goals
 
 - Debugging or fixing the Windows-only pad-selection crash.
-- Adding a new device enumeration backend.
+- Adding a new device-enumeration backend.
 - Adding a manual rescan button.
-- Persisting a preferred device.
+- Persisting or selecting a preferred device.
 - Device-specific bindings.
 - Adding a standalone device settings screen.
 - Redesigning the Drum Mapping page.
-- Changing MIDI capture, velocity thresholds, or hot-plug timing.
+- Changing MIDI capture, velocity thresholds, hot-plug timing, or crash diagnostics.
 
 ## Existing Architecture
 
 `MidiInputSource` owns MIDI device enumeration and lifecycle. It already:
 
 - Tracks active devices.
-- Returns connected names through a locked `DeviceNames` snapshot.
+- Returns connected display names through a locked, sorted `DeviceNames` snapshot.
 - Handles zero devices without failure.
 - Refreshes devices through `RefreshDevices()`.
 
-`ModularInputManager` owns the registered input sources. It already:
+`ModularInputManager` owns registered input sources. It already:
 
 - Exposes `MidiAvailable`.
 - Exposes `ConnectedMidiDeviceCount`.
-- Calls the existing device refresh path every three seconds through the hot-plug scan.
+- Calls the existing device-refresh path every three seconds through the hot-plug scan.
+- Uses device names in local diagnostics output, but publishes only device count to crash context.
 
 `DrumConfigStage` owns the Drum Mapping page and renders the page title, drum kit, reset control, and capture popup.
 
-The missing seam is a read-only device-name snapshot at the `ModularInputManager` boundary.
+The only missing seam is a read-only device-name snapshot at the `ModularInputManager` boundary for UI use.
 
 ## Chosen Design
 
@@ -67,6 +71,10 @@ The missing seam is a read-only device-name snapshot at the `ModularInputManager
 Add a read-only property to `ModularInputManager`:
 
 ```csharp
+/// <summary>
+/// Gets a read-only snapshot of connected MIDI device display names for UI use.
+/// Device names must not be added to telemetry or crash context.
+/// </summary>
 public IReadOnlyList<string> ConnectedMidiDeviceNames =>
     _midiInputSource?.DeviceNames ?? Array.Empty<string>();
 ```
@@ -77,10 +85,26 @@ The property delegates to the existing source snapshot. It must not:
 - Return device objects or stable identifiers.
 - Expose mutable internal collections.
 - Cache names independently of `MidiInputSource`.
+- Feed device names into telemetry, breadcrumbs, or crash reports.
 
 `MidiInputSource.DeviceNames` already returns a new sorted list while holding its synchronization lock, so the stage receives a safe snapshot.
 
-### 2. Format Status Text in the Stage
+### 2. Clarify the Existing Count Contract
+
+Update the XML documentation for `ConnectedMidiDeviceCount` so the two APIs are not contradictory:
+
+```csharp
+/// <summary>
+/// Gets the current number of connected MIDI devices for telemetry and crash context.
+/// Display names are available separately through ConnectedMidiDeviceNames and must
+/// not be added to crash diagnostics.
+/// </summary>
+public int ConnectedMidiDeviceCount => _midiInputSource?.DeviceCount ?? 0;
+```
+
+`Game1` and `CrashContextPublisher.PublishInput` continue using count only. No diagnostic schema changes are part of HPA-520.
+
+### 3. Format Status Text in the Stage
 
 Add a private static formatter to `DrumConfigStage`:
 
@@ -88,17 +112,11 @@ Add a private static formatter to `DrumConfigStage`:
 private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
 ```
 
-Formatting rules are exact:
+The formatter follows the exact product-copy table above.
 
-| Device count | Text |
-| --- | --- |
-| 0 | `HDMI device: Not connected` |
-| 1 | `HDMI device: <device name>` |
-| 2+ | `HDMI devices (N): <name 1>, <name 2>, ...` |
+It remains `private static`, rather than widening production visibility solely for tests. This matches the existing private-static geometry helper pattern in `DrumConfigStageTests`; tests use direct reflection with `BindingFlags.NonPublic | BindingFlags.Static`.
 
-The formatter is pure and contains no graphics or input dependencies. Existing reflection-based stage tests can exercise it headlessly.
-
-### 3. Render the Current Snapshot
+### 4. Render the Current Snapshot
 
 During `DrumConfigStage.OnDraw`, read the current snapshot:
 
@@ -109,19 +127,19 @@ var deviceNames = _input?.ModularInputManager.ConnectedMidiDeviceNames
 
 Render the formatted text below the existing title at virtual position `(20, 40)` using the existing font and `DarkText` color.
 
-The stage must read the property on each draw rather than caching it in `OnActivate`. The existing three-second hot-plug scan then updates the displayed text automatically without another timer or event subscription.
+The stage reads the property on each draw rather than caching it in `OnActivate`. The existing three-second hot-plug scan then updates the displayed text automatically without another timer or event subscription.
 
-### 4. Preserve Existing Interaction
+### 5. Preserve Existing Interaction
 
 The status line is informational only.
 
 It must not:
 
-- Block opening a lane popup when disconnected.
+- Block opening a lane popup when no device is detected.
 - Disable keyboard capture.
 - Close or reset an open popup when device state changes.
 - Change bindings or thresholds.
-- Add focusable controls.
+- Add focusable controls or hit-test rectangles.
 
 ## Data Flow
 
@@ -134,20 +152,30 @@ Existing hot-plug timer expires
 Next DrumConfigStage draw
   -> ConnectedMidiDeviceNames returns a fresh snapshot
   -> FormatHdmiDeviceStatus formats the snapshot
-  -> Stage draws the status line
+  -> Stage draws one informational status line
 ```
 
 No new persistent state is introduced.
 
+## Diagnostics and Privacy Boundary
+
+Connected device count remains the only MIDI-device data published to crash context. Device names are display-only and remain outside:
+
+- `CrashContextPublisher.PublishInput`.
+- Breadcrumb fields.
+- Structured crash-report metadata.
+
+This preserves the existing low-detail diagnostics contract while allowing the local configuration page to identify the attached hardware.
+
 ## Error Handling
 
-- No MIDI source: display `HDMI device: Not connected`.
-- No connected devices: display `HDMI device: Not connected`.
-- Device enumeration failure: existing MIDI handling treats the discovered set as empty; the UI shows disconnected.
-- Device names with unexpected characters: render the backend-provided name as normal text using the existing font behavior.
-- Windows pad-selection crash: capture the managed crash report and stop verification. Diagnosis belongs in a separate issue.
+- No MIDI source: display `HDMI device: None detected (keyboard still works)`.
+- No connected devices: display the same message.
+- Device enumeration failure: existing MIDI handling treats the discovered set as empty; the UI shows the no-device message.
+- Device names with unexpected characters: render the backend-provided name through the existing font path.
+- Windows pad-selection crash: retain the managed crash report and stop verification. Diagnosis belongs in a separate issue.
 
-No broad exception handling should be added to `DrumConfigStage` for this feature.
+No broad exception handling is added to `DrumConfigStage`.
 
 ## Testing Strategy
 
@@ -165,21 +193,25 @@ Tests assert display names only, not stable IDs or concrete device instances.
 
 Add headless tests to `DrumConfigStageTests`:
 
-- Empty input formats the disconnected message.
+- Empty input formats `HDMI device: None detected (keyboard still works)`.
 - One name formats the singular message.
 - Multiple names format count and comma-separated names.
 
-No screenshot or pixel tests are needed for a single text line.
+The formatter stays private and is tested through the direct reflection pattern already used in this test file.
+
+### Draw Wiring
+
+No automated screenshot, pixel, or graphics-device test is added. `OnDraw` is excluded from coverage and the new wiring is a small read-format-draw block beside the existing title. The manual Windows verification is the integration gate for the live draw path.
 
 ### Manual Windows Verification
 
 With the actual drum device:
 
-1. Open Drum Mapping while disconnected and confirm the disconnected message.
-2. Connect the device without leaving the page.
-3. Confirm the device name appears within the existing hot-plug interval.
-4. Disconnect the device and confirm the status returns to disconnected.
-5. Confirm keyboard assignment works in both states.
+1. Open Drum Mapping while disconnected and confirm the exact no-device message.
+2. Confirm keyboard assignment still works.
+3. Connect the device without leaving the page.
+4. Confirm the device name appears within the existing hot-plug interval.
+5. Disconnect the device and confirm the no-device message returns.
 6. Confirm a connected pad still captures its existing `MIDI.<note>` binding.
 
 If selecting a lane crashes, retain the managed crash report and move the investigation to the separate Windows bug.
@@ -195,15 +227,16 @@ No new production files or dependencies are required.
 
 ## Acceptance Criteria
 
-- The Drum Mapping page shows `HDMI device: Not connected` when no existing MIDI device is active.
+- The Drum Mapping page shows `HDMI device: None detected (keyboard still works)` when no existing MIDI device is active.
 - One connected device is shown by name.
 - Multiple devices show their count and names.
 - Connect and disconnect changes appear through the existing hot-plug scan without reopening the page.
-- Keyboard assignment remains available while disconnected.
+- Keyboard assignment remains available while no device is detected.
 - Existing MIDI note capture, bindings, popup behavior, and velocity thresholds remain unchanged.
+- Crash context continues publishing count only; device names are not added.
 - Focused tests cover empty, connected, multiple-device, and refreshed snapshots.
 - Manual Windows verification is completed using the real hardware.
 
 ## Scope Estimate
 
-One engineer day. The production change should remain two small code edits plus focused tests and manual Windows verification.
+One engineer day. The production change remains two small code edits plus focused tests and manual Windows verification.

--- a/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
+++ b/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
@@ -14,7 +14,9 @@ This is a small visibility feature. It does not change device discovery, input r
 
 The requested user-facing label is **HDMI device**. This is a deliberate product term, not a description of the transport layer: DTXManiaCX has no HDMI input abstraction, and the connected drum hardware is enumerated by the existing MIDI backend through `MidiInputSource.DeviceNames`.
 
-Internal APIs and types remain named **MIDI**. If the real Windows drum hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops and device discovery moves to a separate Windows investigation. This ticket must not add a second discovery path.
+This terminology may be technically imprecise, but it is retained because the project lead explicitly requested it. The design mitigates the main UX risk by making the disconnected message explain that keyboard assignment still works. Internal APIs and types remain named **MIDI**.
+
+If the real Windows drum hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops and device discovery moves to a separate Windows investigation. This ticket must not add a second discovery path.
 
 Exact copy:
 

--- a/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
+++ b/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
@@ -1,0 +1,209 @@
+# HPA-520 — HDMI Device Status in Drum Mapping
+
+**Date:** 2026-08-06  
+**Status:** Approved for implementation planning  
+**Linear:** HPA-520
+
+## Summary
+
+Show the currently connected drum device on the existing Drum Mapping page so the player can confirm that the expected hardware is visible before assigning pads.
+
+This is a small visibility feature. It does not change device discovery, input routing, bindings, velocity thresholds, or the capture popup workflow.
+
+## Terminology and Implementation Assumption
+
+The requested user-facing term is **HDMI device**. DTXManiaCX does not currently have an HDMI input abstraction. The connected drum hardware already enters the application through the existing MIDI device backend and is exposed by `MidiInputSource.DeviceNames`.
+
+Therefore:
+
+- User-facing copy uses **HDMI device** as requested.
+- Internal APIs and types remain named **MIDI**.
+- HPA-520 surfaces the device names already reported by `MidiInputSource`.
+- If the real Windows hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops. Device discovery must then be investigated separately instead of adding a second Windows-specific discovery path to this ticket.
+
+## Goals
+
+1. Show a clear disconnected state when no drum device is detected.
+2. Show the connected device name when one device is detected.
+3. Show device count and names when multiple devices are detected.
+4. Reflect connect and disconnect changes while the page remains open.
+5. Preserve keyboard assignment and all existing drum binding behavior.
+6. Keep the implementation small and reuse the existing device lifecycle.
+
+## Non-Goals
+
+- Debugging or fixing the Windows-only pad-selection crash.
+- Adding a new device enumeration backend.
+- Adding a manual rescan button.
+- Persisting a preferred device.
+- Device-specific bindings.
+- Adding a standalone device settings screen.
+- Redesigning the Drum Mapping page.
+- Changing MIDI capture, velocity thresholds, or hot-plug timing.
+
+## Existing Architecture
+
+`MidiInputSource` owns MIDI device enumeration and lifecycle. It already:
+
+- Tracks active devices.
+- Returns connected names through a locked `DeviceNames` snapshot.
+- Handles zero devices without failure.
+- Refreshes devices through `RefreshDevices()`.
+
+`ModularInputManager` owns the registered input sources. It already:
+
+- Exposes `MidiAvailable`.
+- Exposes `ConnectedMidiDeviceCount`.
+- Calls the existing device refresh path every three seconds through the hot-plug scan.
+
+`DrumConfigStage` owns the Drum Mapping page and renders the page title, drum kit, reset control, and capture popup.
+
+The missing seam is a read-only device-name snapshot at the `ModularInputManager` boundary.
+
+## Chosen Design
+
+### 1. Expose Connected Device Names
+
+Add a read-only property to `ModularInputManager`:
+
+```csharp
+public IReadOnlyList<string> ConnectedMidiDeviceNames =>
+    _midiInputSource?.DeviceNames ?? Array.Empty<string>();
+```
+
+The property delegates to the existing source snapshot. It must not:
+
+- Trigger device enumeration.
+- Return device objects or stable identifiers.
+- Expose mutable internal collections.
+- Cache names independently of `MidiInputSource`.
+
+`MidiInputSource.DeviceNames` already returns a new sorted list while holding its synchronization lock, so the stage receives a safe snapshot.
+
+### 2. Format Status Text in the Stage
+
+Add a private static formatter to `DrumConfigStage`:
+
+```csharp
+private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
+```
+
+Formatting rules are exact:
+
+| Device count | Text |
+| --- | --- |
+| 0 | `HDMI device: Not connected` |
+| 1 | `HDMI device: <device name>` |
+| 2+ | `HDMI devices (N): <name 1>, <name 2>, ...` |
+
+The formatter is pure and contains no graphics or input dependencies. Existing reflection-based stage tests can exercise it headlessly.
+
+### 3. Render the Current Snapshot
+
+During `DrumConfigStage.OnDraw`, read the current snapshot:
+
+```csharp
+var deviceNames = _input?.ModularInputManager.ConnectedMidiDeviceNames
+    ?? Array.Empty<string>();
+```
+
+Render the formatted text below the existing title at virtual position `(20, 40)` using the existing font and `DarkText` color.
+
+The stage must read the property on each draw rather than caching it in `OnActivate`. The existing three-second hot-plug scan then updates the displayed text automatically without another timer or event subscription.
+
+### 4. Preserve Existing Interaction
+
+The status line is informational only.
+
+It must not:
+
+- Block opening a lane popup when disconnected.
+- Disable keyboard capture.
+- Close or reset an open popup when device state changes.
+- Change bindings or thresholds.
+- Add focusable controls.
+
+## Data Flow
+
+```text
+Existing hot-plug timer expires
+  -> ModularInputManager.ScanForNewDevices()
+  -> MidiInputSource.RefreshDevices()
+  -> MidiInputSource active device collection changes
+
+Next DrumConfigStage draw
+  -> ConnectedMidiDeviceNames returns a fresh snapshot
+  -> FormatHdmiDeviceStatus formats the snapshot
+  -> Stage draws the status line
+```
+
+No new persistent state is introduced.
+
+## Error Handling
+
+- No MIDI source: display `HDMI device: Not connected`.
+- No connected devices: display `HDMI device: Not connected`.
+- Device enumeration failure: existing MIDI handling treats the discovered set as empty; the UI shows disconnected.
+- Device names with unexpected characters: render the backend-provided name as normal text using the existing font behavior.
+- Windows pad-selection crash: capture the managed crash report and stop verification. Diagnosis belongs in a separate issue.
+
+No broad exception handling should be added to `DrumConfigStage` for this feature.
+
+## Testing Strategy
+
+### Input Boundary Tests
+
+Add tests to `ModularInputManagerTests` using the existing fake MIDI backend:
+
+- No devices returns an empty name snapshot.
+- Multiple devices return sorted display names.
+- Refreshing from one device set to another changes the returned snapshot.
+
+Tests assert display names only, not stable IDs or concrete device instances.
+
+### Stage Formatter Tests
+
+Add headless tests to `DrumConfigStageTests`:
+
+- Empty input formats the disconnected message.
+- One name formats the singular message.
+- Multiple names format count and comma-separated names.
+
+No screenshot or pixel tests are needed for a single text line.
+
+### Manual Windows Verification
+
+With the actual drum device:
+
+1. Open Drum Mapping while disconnected and confirm the disconnected message.
+2. Connect the device without leaving the page.
+3. Confirm the device name appears within the existing hot-plug interval.
+4. Disconnect the device and confirm the status returns to disconnected.
+5. Confirm keyboard assignment works in both states.
+6. Confirm a connected pad still captures its existing `MIDI.<note>` binding.
+
+If selecting a lane crashes, retain the managed crash report and move the investigation to the separate Windows bug.
+
+## File Impact
+
+- Modify `DTXMania.Game/Lib/Input/ModularInputManager.cs`.
+- Modify `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`.
+- Modify `DTXMania.Test/Input/ModularInputManagerTests.cs`.
+- Modify `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`.
+
+No new production files or dependencies are required.
+
+## Acceptance Criteria
+
+- The Drum Mapping page shows `HDMI device: Not connected` when no existing MIDI device is active.
+- One connected device is shown by name.
+- Multiple devices show their count and names.
+- Connect and disconnect changes appear through the existing hot-plug scan without reopening the page.
+- Keyboard assignment remains available while disconnected.
+- Existing MIDI note capture, bindings, popup behavior, and velocity thresholds remain unchanged.
+- Focused tests cover empty, connected, multiple-device, and refreshed snapshots.
+- Manual Windows verification is completed using the real hardware.
+
+## Scope Estimate
+
+One engineer day. The production change should remain two small code edits plus focused tests and manual Windows verification.

--- a/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
+++ b/docs/superpowers/specs/2026-08-06-hpa-520-hdmi-device-status-design.md
@@ -12,26 +12,28 @@ This is a small visibility feature. It does not change device discovery, input r
 
 ## Product Copy Decision
 
-The requested user-facing label is **HDMI device**. DTXManiaCX does not have an HDMI input abstraction; the connected drum hardware is enumerated by the existing MIDI backend and exposed through `MidiInputSource.DeviceNames`.
+The requested user-facing label is **HDMI device**. This is a deliberate product term, not a description of the transport layer: DTXManiaCX has no HDMI input abstraction, and the connected drum hardware is enumerated by the existing MIDI backend through `MidiInputSource.DeviceNames`.
 
-The label is retained as an explicit product requirement, but the disconnected copy must not imply that the whole assignment screen is unusable. The exact copy is:
+Internal APIs and types remain named **MIDI**. If the real Windows drum hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops and device discovery moves to a separate Windows investigation. This ticket must not add a second discovery path.
+
+Exact copy:
 
 | Device count | Text |
 | --- | --- |
 | 0 | `HDMI device: None detected (keyboard still works)` |
 | 1 | `HDMI device: <device name>` |
-| 2+ | `HDMI devices (N): <name 1>, <name 2>, ...` |
+| 2+ | `HDMI devices (N): <first name>, +<N-1> more` |
 
-Internal APIs and types remain named **MIDI**. If the real Windows drum hardware does not appear in `MidiInputSource.DeviceNames`, implementation stops and device discovery moves to a separate Windows investigation. This ticket must not add a second discovery path.
+The disconnected copy must not imply that keyboard assignment is disabled. For multiple devices, preserve the first sorted device name and summarize the remainder instead of joining an unbounded list.
 
 ## Goals
 
-1. Show a clear no-device state without suggesting that keyboard assignment is disabled.
+1. Show a clear no-device state without suggesting that keyboard assignment is unavailable.
 2. Show the connected device name when one device is detected.
-3. Show device count and names when multiple devices are detected.
+3. Summarize multiple connected devices without overflowing the page.
 4. Reflect connect and disconnect changes while the page remains open.
 5. Preserve keyboard assignment and all existing drum-binding behavior.
-6. Keep the implementation small and reuse the existing device lifecycle.
+6. Keep the implementation small and reuse the existing device lifecycle and text-layout helper.
 
 ## Non-Goals
 
@@ -43,6 +45,8 @@ Internal APIs and types remain named **MIDI**. If the real Windows drum hardware
 - Adding a standalone device settings screen.
 - Redesigning the Drum Mapping page.
 - Changing MIDI capture, velocity thresholds, hot-plug timing, or crash diagnostics.
+- Adding a new text truncation implementation.
+- Adding a screenshot-based automated test.
 
 ## Existing Architecture
 
@@ -58,11 +62,16 @@ Internal APIs and types remain named **MIDI**. If the real Windows drum hardware
 - Exposes `MidiAvailable`.
 - Exposes `ConnectedMidiDeviceCount`.
 - Calls the existing device-refresh path every three seconds through the hot-plug scan.
-- Uses device names in local diagnostics output, but publishes only device count to crash context.
+- Uses device names in local diagnostics output, while publishing only device count to crash context.
 
-`DrumConfigStage` owns the Drum Mapping page and renders the page title, drum kit, reset control, and capture popup.
+`DrumConfigStage` owns the Drum Mapping page and renders the page title, drum kit, Reset control, and capture popup.
 
-The only missing seam is a read-only device-name snapshot at the `ModularInputManager` boundary for UI use.
+`TextHelper.TruncateToWidth(string, float, IFont)` already provides measured ellipsis truncation for the stage font type.
+
+The missing seams are:
+
+1. A read-only device-name snapshot at the `ModularInputManager` boundary for UI use.
+2. A bounded status line that cannot overlap the Reset control or clip outside the virtual render target.
 
 ## Chosen Design
 
@@ -87,11 +96,11 @@ The property delegates to the existing source snapshot. It must not:
 - Cache names independently of `MidiInputSource`.
 - Feed device names into telemetry, breadcrumbs, or crash reports.
 
-`MidiInputSource.DeviceNames` already returns a new sorted list while holding its synchronization lock, so the stage receives a safe snapshot.
+`MidiInputSource.DeviceNames` already returns a new sorted list while holding its synchronization lock. The per-frame snapshot allocation is accepted: the collection is tiny, reading live state avoids a stale stage cache, and there is no measured performance problem to justify another synchronization mechanism.
 
 ### 2. Clarify the Existing Count Contract
 
-Update the XML documentation for `ConnectedMidiDeviceCount` so the two APIs are not contradictory:
+Update the XML documentation for `ConnectedMidiDeviceCount` so the count and name APIs have explicit, different consumers:
 
 ```csharp
 /// <summary>
@@ -102,9 +111,9 @@ Update the XML documentation for `ConnectedMidiDeviceCount` so the two APIs are 
 public int ConnectedMidiDeviceCount => _midiInputSource?.DeviceCount ?? 0;
 ```
 
-`Game1` and `CrashContextPublisher.PublishInput` continue using count only. No diagnostic schema changes are part of HPA-520.
+`Game1` and `CrashContextPublisher.PublishInput` continue using count only. No diagnostic schema change is part of HPA-520.
 
-### 3. Format Status Text in the Stage
+### 3. Format Compact Status Text
 
 Add a private static formatter to `DrumConfigStage`:
 
@@ -112,20 +121,42 @@ Add a private static formatter to `DrumConfigStage`:
 private static string FormatHdmiDeviceStatus(IReadOnlyList<string> deviceNames)
 ```
 
-The formatter follows the exact product-copy table above.
+Rules:
 
-It remains `private static`, rather than widening production visibility solely for tests. This matches the existing private-static geometry helper pattern in `DrumConfigStageTests`; tests use direct reflection with `BindingFlags.NonPublic | BindingFlags.Static`.
+```csharp
+if (deviceNames == null || deviceNames.Count == 0)
+    return "HDMI device: None detected (keyboard still works)";
 
-### 4. Render the Current Snapshot
+if (deviceNames.Count == 1)
+    return $"HDMI device: {deviceNames[0]}";
 
-During `DrumConfigStage.OnDraw`, read the current snapshot:
+return $"HDMI devices ({deviceNames.Count}): {deviceNames[0]}, +{deviceNames.Count - 1} more";
+```
+
+The source snapshot is already sorted with `StringComparer.Ordinal`; the UI intentionally inherits that order and does not re-sort or alter the shared source behavior.
+
+The formatter remains `private static`, rather than widening production visibility solely for tests. This matches the existing private-static helper pattern in `DrumConfigStageTests`.
+
+### 4. Render Below Reset and Bound the Width
+
+The Reset button occupies the top-right area and ends at virtual `y = 42`. Draw the status below it at `(20, 48)`.
+
+During `DrumConfigStage.OnDraw`, read the current snapshot, format it, and reuse the existing measured truncation helper:
 
 ```csharp
 var deviceNames = _input?.ModularInputManager.ConnectedMidiDeviceNames
     ?? Array.Empty<string>();
+var status = FormatHdmiDeviceStatus(deviceNames);
+var visibleStatus = TextHelper.TruncateToWidth(status, vw - 40, _font);
+
+_font.DrawString(
+    _spriteBatch,
+    visibleStatus,
+    new Vector2(20, 48),
+    DarkText);
 ```
 
-Render the formatted text below the existing title at virtual position `(20, 40)` using the existing font and `DarkText` color.
+`vw - 40` leaves 20 pixels of margin on both sides of the virtual target. Moving the line below the Reset control removes the horizontal collision; truncation protects against a single unusually long device name and render-target clipping.
 
 The stage reads the property on each draw rather than caching it in `OnActivate`. The existing three-second hot-plug scan then updates the displayed text automatically without another timer or event subscription.
 
@@ -150,32 +181,22 @@ Existing hot-plug timer expires
   -> MidiInputSource active device collection changes
 
 Next DrumConfigStage draw
-  -> ConnectedMidiDeviceNames returns a fresh snapshot
-  -> FormatHdmiDeviceStatus formats the snapshot
-  -> Stage draws one informational status line
+  -> ConnectedMidiDeviceNames returns a fresh sorted snapshot
+  -> FormatHdmiDeviceStatus produces compact copy
+  -> TextHelper.TruncateToWidth bounds the measured string
+  -> Stage draws the status below the Reset control
 ```
 
 No new persistent state is introduced.
 
-## Diagnostics and Privacy Boundary
-
-Connected device count remains the only MIDI-device data published to crash context. Device names are display-only and remain outside:
-
-- `CrashContextPublisher.PublishInput`.
-- Breadcrumb fields.
-- Structured crash-report metadata.
-
-This preserves the existing low-detail diagnostics contract while allowing the local configuration page to identify the attached hardware.
-
 ## Error Handling
 
-- No MIDI source: display `HDMI device: None detected (keyboard still works)`.
-- No connected devices: display the same message.
-- Device enumeration failure: existing MIDI handling treats the discovered set as empty; the UI shows the no-device message.
-- Device names with unexpected characters: render the backend-provided name through the existing font path.
+- No MIDI source or connected device: show the exact no-device copy.
+- Device enumeration failure: existing MIDI handling produces an empty discovered set; the UI shows the no-device copy.
+- Long or unusual device names: the existing font path handles unsupported characters, and `TextHelper.TruncateToWidth` bounds the rendered width.
 - Windows pad-selection crash: retain the managed crash report and stop verification. Diagnosis belongs in a separate issue.
 
-No broad exception handling is added to `DrumConfigStage`.
+No broad exception handling should be added to `DrumConfigStage` for this feature.
 
 ## Testing Strategy
 
@@ -193,28 +214,53 @@ Tests assert display names only, not stable IDs or concrete device instances.
 
 Add headless tests to `DrumConfigStageTests`:
 
-- Empty input formats `HDMI device: None detected (keyboard still works)`.
+- Empty input formats the exact no-device message.
 - One name formats the singular message.
-- Multiple names format count and comma-separated names.
+- Multiple names preserve the first sorted name and summarize the remaining count.
 
-The formatter stays private and is tested through the direct reflection pattern already used in this test file.
+Do not duplicate `TextHelper` tests. The draw site must call the existing helper; the helper already owns measurement and ellipsis behavior.
 
-### Draw Wiring
+### Local macOS Visual Smoke
 
-No automated screenshot, pixel, or graphics-device test is added. `OnDraw` is excluded from coverage and the new wiring is a small read-format-draw block beside the existing title. The manual Windows verification is the integration gate for the live draw path.
+After implementation, launch the macOS build with no MIDI hardware, navigate to Config → Drum Mapping, and capture a screenshot through the existing Game API/MCP screenshot path or the normal OS screenshot tool.
+
+Confirm:
+
+- Exact no-device copy is visible.
+- The line is below and clear of the Reset control.
+- The line does not cover the drum kit header area.
+
+A long/multi-device runtime screenshot is not required because the current Game API cannot inject device discovery names. Compact plural formatting is covered by unit tests, and width bounding reuses the existing tested `TextHelper` implementation.
 
 ### Manual Windows Verification
 
 With the actual drum device:
 
 1. Open Drum Mapping while disconnected and confirm the exact no-device message.
-2. Confirm keyboard assignment still works.
-3. Connect the device without leaving the page.
-4. Confirm the device name appears within the existing hot-plug interval.
-5. Disconnect the device and confirm the no-device message returns.
-6. Confirm a connected pad still captures its existing `MIDI.<note>` binding.
+2. Connect the device without leaving the page.
+3. Confirm its name appears within the existing hot-plug interval.
+4. If the backend exposes multiple ports, confirm the compact `+N more` summary.
+5. Disconnect the device and confirm the no-device status returns.
+6. Confirm keyboard assignment works in both states.
+7. Confirm a connected pad still captures its existing `MIDI.<note>` binding.
 
 If selecting a lane crashes, retain the managed crash report and move the investigation to the separate Windows bug.
+
+## Validation Gates
+
+Local macOS:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Pull request CI:
+
+- Confirm the Windows `build-and-test-windows` job is green.
+- Confirm the macOS build/test job and all other required PR checks remain green.
+
+The plan does not require pretending that a macOS-only implementation environment can execute the Windows suite locally.
 
 ## File Impact
 
@@ -227,16 +273,19 @@ No new production files or dependencies are required.
 
 ## Acceptance Criteria
 
-- The Drum Mapping page shows `HDMI device: None detected (keyboard still works)` when no existing MIDI device is active.
+- No device shows `HDMI device: None detected (keyboard still works)`.
 - One connected device is shown by name.
-- Multiple devices show their count and names.
+- Multiple devices show total count, first name, and `+N more`.
+- The status is drawn below the Reset control and truncated to the virtual viewport width.
 - Connect and disconnect changes appear through the existing hot-plug scan without reopening the page.
 - Keyboard assignment remains available while no device is detected.
 - Existing MIDI note capture, bindings, popup behavior, and velocity thresholds remain unchanged.
-- Crash context continues publishing count only; device names are not added.
+- Crash context continues publishing count only; device names remain UI-only.
 - Focused tests cover empty, connected, multiple-device, and refreshed snapshots.
+- A local macOS no-device screenshot confirms the basic layout.
 - Manual Windows verification is completed using the real hardware.
+- Windows PR CI is green.
 
 ## Scope Estimate
 
-One engineer day. The production change remains two small code edits plus focused tests and manual Windows verification.
+One engineer day. The production change remains two small code edits plus focused tests and platform-appropriate verification.


### PR DESCRIPTION
## Summary

- Add an approved design spec for showing connected drum-device status on the Drum Mapping page.
- Add a task-by-task implementation plan with exact code seams, tests, validation commands, and Windows hardware verification.
- Keep the Windows-only pad-selection crash explicitly out of scope and define it as a stop condition requiring a separate managed-crash investigation.

## Design direction

The requested user-facing term remains `HDMI device`, while the implementation reuses the existing MIDI device lifecycle and `MidiInputSource.DeviceNames` snapshot. The page reads the current names during draw, so the existing three-second hot-plug scan updates the status without a new timer, event bus, rescan control, or settings screen.

Exact no-device copy is now locked as:

`HDMI device: None detected (keyboard still works)`

This preserves the requested HDMI terminology without implying that keyboard assignment is unavailable.

## Planned implementation scope

- Expose connected MIDI display names through `ModularInputManager` for UI use.
- Clarify that `ConnectedMidiDeviceCount` remains the telemetry/crash-context boundary.
- Add a private pure HDMI-status formatter to `DrumConfigStage`.
- Render one informational status line below the Drum Mapping heading.
- Add focused input-boundary and formatter tests.
- Verify connected, disconnected, reconnect, keyboard-fallback, and MIDI-capture behavior on Windows hardware.

## Review follow-ups addressed

- Clarified product copy and added keyboard fallback to the empty state.
- Documented that device names must not enter telemetry, breadcrumbs, or crash reports.
- Kept the formatter private and tested through the existing local reflection pattern.
- Kept draw wiring as a manual Windows integration gate; no screenshot test added.
- Replaced the vague full-suite gate with exact macOS and Windows build/test commands from `CLAUDE.md`.

## Validation

Documentation-only PR. The design and plan were reviewed against current `main` code for `MidiInputSource`, `ModularInputManager`, `DrumConfigStage`, their existing tests, and repository build/test guidance.

## Tracking

Linear: HPA-520