### PR TITLE
docs: plan HPA-530 title-screen crash inbox

### DIFF
--- a/docs/superpowers/plans/2026-08-07-hpa-530-title-screen-crash-inbox.md
+++ b/docs/superpowers/plans/2026-08-07-hpa-530-title-screen-crash-inbox.md
@@ -1,0 +1,430 @@
+# HPA-530 Title-Screen Crash Inbox and GitHub Handoff Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a non-blocking title-screen crash inbox for retained schema-v2 text reports, with persistent acknowledgement, safe GitHub/file-manager handoff, dismissal, and confirmed deletion.
+
+**Architecture:** Extend the existing HPA-529 crash-reporting subsystem instead of recreating its superseded ZIP/inbox-state design. `CrashReportStore` remains the storage/retention owner, `CrashReportRuntime` composes a narrow `ICrashReportInbox`, `IStageGame` exposes only that facade, and `TitleStage` delegates banner/panel behavior to a focused notification component.
+
+**Tech Stack:** .NET 8, C#, MonoGame, xUnit, Moq, `System.Diagnostics.Process`, existing DTXManiaCX crash-reporting and stage abstractions.
+
+## Global Constraints
+
+- Support only the shipped `DTXMANIACX-CRASH-REPORT 2` plain-text format.
+- Do not add ZIP handling, emergency-report branching, or `inbox-state.json`.
+- Keep one latest-five retention policy owned by `CrashReportStore`.
+- Encode acknowledgement by atomically renaming `*.txt` to `*.ack.txt`.
+- Never expose crash-report paths, parsers, `CrashReportStore`, or `IExternalLauncher` directly to `TitleStage`.
+- The title UI may render only `CrashReportSummary` plus acknowledgement state.
+- GitHub handoff is manual: open the new-issue page and instruct the player to inspect and attach the `.txt` report themselves.
+- Never invoke `cmd /c`, PowerShell, `sh -c`, or concatenate dynamic values into shell commands.
+- Windows launcher uses `ProcessStartInfo.UseShellExecute = true`.
+- macOS launcher uses `/usr/bin/open` with separate `--` and target arguments.
+- Linux launcher support is out of scope.
+- All failures are non-fatal and must not block normal title-screen startup.
+
+---
+
+## File structure
+
+Expected new files:
+
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs` — bounded schema-v2 header parsing.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportInbox.cs` — inbox facade and action orchestration.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/ExternalLauncher.cs` — validated Windows/macOS external launch behavior.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/GitHubCrashIssueBuilder.cs` — deterministic GitHub URL construction/validation.
+- `DTXMania.Game/Lib/Stage/CrashReportNotification.cs` — title-only banner/panel state and rendering/input coordination.
+- focused tests under `DTXMania.Test/CrashReporting/` and `DTXMania.Test/Stage/`.
+
+Expected modified files:
+
+- `CrashReportContracts.cs` — public inbox contract and no-op implementation.
+- `CrashReportStore.cs` — discovery, acknowledgement, deletion, and retention recognition for `.ack.txt`.
+- `CrashReportRuntime.cs` — compose inbox and expose it through `IGameCrashDiagnostics`.
+- `IStageGame.cs` — expose `ICrashReportInbox`.
+- `Game1.cs` — forward the injected inbox through `BaseGame`.
+- `TitleStage.cs` — instantiate/update/draw the notification component and gate normal input while the panel is open.
+- existing crash/stage contract tests where required by public interface changes.
+
+Do not create a generic modal framework or a generic process runner beyond the smallest test seam required by this ticket.
+
+---
+
+### Task 1: Add schema-v2 discovery and persistent acknowledgement
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs`
+- Modify: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs`
+- Modify: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportSummaryReaderTests.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportStoreTests.cs`
+
+**Interfaces:**
+- Produces: `CrashReportInboxItem`, `ICrashReportInbox` contract types used by later tasks.
+- Produces: `CrashReportStore.GetReports()`, `Acknowledge(reportId)`, and `Delete(reportId)`-style internal operations; exact method visibility should follow existing store testability conventions.
+- Consumes: existing `CrashReportSummary`, `CrashReportTextWriter.Header`, and `AppPaths.GetCrashReportsRoot()` behavior.
+
+- [ ] **Step 1: Lock the filename/state contract with failing tests**
+
+Add tests proving the store recognizes both:
+
+```text
+crash-20260806-123456Z-a1b2c3.txt
+crash-20260806-123456Z-a1b2c3.ack.txt
+```
+
+The tests must assert that both forms participate in one newest-first retained set and one latest-five retention limit.
+
+- [ ] **Step 2: Add bounded header-reader tests**
+
+Cover a valid schema-v2 header, missing keys, corrupt header version, and a report containing a very large exception section. The reader must stop at `--- EXCEPTION ---` and return only the approved summary fields.
+
+For corrupt headers assert:
+
+```text
+ReportId            <- filename-derived
+CapturedAtUtc       <- filename timestamp when parseable
+BuildId             <- Unknown
+OperatingSystem     <- Unknown
+ProcessArchitecture <- Unknown
+StageOrMilestone    <- Unknown
+ExceptionType       <- Unknown
+```
+
+- [ ] **Step 3: Implement the minimal header reader**
+
+Parse only the leading schema-v2 header with a small fixed line/character bound. Do not expose a general report parser and do not read report sections after the exception marker.
+
+- [ ] **Step 4: Implement discovery and acknowledgement in `CrashReportStore`**
+
+Update filename recognition so pending and acknowledged forms are both valid retained reports. Acknowledge by same-directory atomic rename from the pending form to `.ack.txt`; treat an already acknowledged report as success/idempotent.
+
+Deletion resolves the current filename by report ID and deletes only files inside the configured crash-report root.
+
+- [ ] **Step 5: Add the public inbox data contract and no-op implementation**
+
+Add:
+
+```csharp
+public sealed record CrashReportInboxItem(
+    CrashReportSummary Summary,
+    bool IsAcknowledged);
+
+public readonly record struct CrashReportActionResult(
+    bool Succeeded,
+    string? ErrorCode = null);
+
+public interface ICrashReportInbox
+{
+    IReadOnlyList<CrashReportInboxItem> GetReports();
+    CrashReportActionResult OpenGitHubIssue(string reportId);
+    CrashReportActionResult OpenReportFolder(string reportId);
+    CrashReportActionResult Dismiss(string reportId);
+    CrashReportActionResult Delete(string reportId);
+}
+```
+
+Also add an empty implementation returning no reports and bounded failure/no-op action results suitable for a disabled crash runtime.
+
+- [ ] **Step 6: Run focused tests**
+
+Run the crash-report summary/store tests plus the existing crash-reporting suite. Verify existing HPA-529 capture still writes the pending `.txt` form and retention still caps the combined set at five.
+
+- [ ] **Step 7: Commit**
+
+Commit this slice independently with a message similar to:
+
+```text
+feat: add crash report inbox storage state
+```
+
+---
+
+### Task 2: Add safe GitHub and platform handoff
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/GitHubCrashIssueBuilder.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/ExternalLauncher.cs`
+- Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportInbox.cs`
+- Test: `DTXMania.Test/CrashReporting/GitHubCrashIssueBuilderTests.cs`
+- Test: `DTXMania.Test/CrashReporting/ExternalLauncherTests.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportInboxTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1 store operations and `ICrashReportInbox` contract.
+- Produces: production `CrashReportInbox` used by `CrashReportRuntime` in Task 3.
+- Produces: internal `IExternalLauncher` seam used only by the inbox and tests.
+
+- [ ] **Step 1: Write GitHub URL-builder tests first**
+
+Assert the generated URL targets exactly:
+
+```text
+https://github.com/cwchanap/DTXManiaCX/issues/new
+```
+
+Allow only report ID, build ID, OS, architecture, stage/milestone, exception type, schema-v2 format identifier, and manual `.txt` attachment instructions in the title/body query values.
+
+Add rejection tests for HTTP, alternate hosts, alternate repositories, and alternate GitHub paths.
+
+- [ ] **Step 2: Implement `GitHubCrashIssueBuilder`**
+
+Keep URL construction deterministic and side-effect free. Return a `Uri`; keep validation in the same focused component so callers cannot bypass host/path constraints accidentally.
+
+- [ ] **Step 3: Write external-launcher tests around `ProcessStartInfo`**
+
+Use the smallest injectable process-start seam necessary to inspect the launch request without starting a real process.
+
+Windows assertions:
+
+```text
+UseShellExecute = true
+no cmd.exe
+no powershell
+no composed command shell string
+```
+
+macOS assertions:
+
+```text
+FileName = /usr/bin/open
+UseShellExecute = false
+ArgumentList[0] = --
+ArgumentList[1] = <validated URI or internal directory>
+no sh -c
+```
+
+Also cover unsupported platform, start exception, and non-zero macOS result as bounded failures.
+
+- [ ] **Step 4: Implement `IExternalLauncher`**
+
+Support URI and directory launch only. Directory launch receives the internally resolved crash-report root from composition; do not accept arbitrary stage-supplied paths.
+
+- [ ] **Step 5: Write inbox action tests**
+
+Using a real `CrashReportStore` rooted in a temporary test directory plus a fake launcher, assert:
+
+- successful GitHub launch acknowledges the selected report;
+- successful folder launch acknowledges the selected report;
+- launcher failure leaves it pending;
+- `Dismiss` acknowledges without deleting;
+- `Delete` deletes whichever filename currently represents the report;
+- launcher success followed by acknowledgement failure returns an acknowledgement error and leaves the report pending.
+
+- [ ] **Step 6: Implement `CrashReportInbox` orchestration**
+
+Each public action resolves the report by ID at call time. Never accept a path from the caller. For launcher-backed actions, perform `validate -> launch -> acknowledge` in that order.
+
+Map raw filesystem/process exceptions to short stable error codes; never surface raw exception messages through the public result.
+
+- [ ] **Step 7: Run focused tests**
+
+Run all new crash-inbox/launcher tests plus the existing crash-reporting suite.
+
+- [ ] **Step 8: Commit**
+
+Commit this slice independently with a message similar to:
+
+```text
+feat: add crash report github handoff
+```
+
+---
+
+### Task 3: Compose the inbox through the existing game/stage seams
+
+**Files:**
+- Modify: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs`
+- Modify: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs`
+- Modify: `DTXMania.Game/Lib/Stage/IStageGame.cs`
+- Modify: `DTXMania.Game/Game1.cs`
+- Test: `DTXMania.Test/CrashReporting/CrashReportRuntimeTests.cs`
+- Test: `DTXMania.Test/Stage/IStageGameContractTests.cs`
+- Test: `DTXMania.Test/BaseGameTests.cs`
+
+**Interfaces:**
+- Consumes: production `CrashReportInbox` from Task 2.
+- Produces: `IGameCrashDiagnostics.CrashReportInbox` and `IStageGame.CrashReportInbox` used by `TitleStage` in Task 4.
+
+- [ ] **Step 1: Add contract tests for the new narrow property**
+
+Extend diagnostics/stage contract tests so `BaseGame` exposes an injected `ICrashReportInbox` without exposing `CrashReportStore`, launcher, or runtime lifetime methods.
+
+- [ ] **Step 2: Extend `IGameCrashDiagnostics`**
+
+Add:
+
+```csharp
+ICrashReportInbox CrashReportInbox { get; }
+```
+
+The disabled runtime must expose the no-op inbox created in Task 1.
+
+- [ ] **Step 3: Compose the production inbox in `CrashReportRuntime`**
+
+Reuse the same `CrashReportStore` instance already owned by the runtime. Compose `GitHubCrashIssueBuilder`, the platform launcher, and the internally resolved crash-report root there.
+
+Do not create crash-report services from `BaseGame` or `TitleStage`.
+
+- [ ] **Step 4: Forward through `BaseGame` / `IStageGame`**
+
+Add a read-only `CrashReportInbox` property to `IStageGame` and forward the injected diagnostics inbox from `BaseGame`.
+
+Update test-only `IStageGame` stubs with the no-op inbox; do not add nullable checks throughout stage code.
+
+- [ ] **Step 5: Run contract/runtime tests**
+
+Run the diagnostics runtime, `IStageGame`, and `BaseGame` tests. Verify the crash-disabled bootstrap path still starts successfully with an empty inbox.
+
+- [ ] **Step 6: Commit**
+
+Commit this slice independently with a message similar to:
+
+```text
+feat: expose crash inbox to title stage
+```
+
+---
+
+### Task 4: Add the non-blocking title banner and review panel
+
+**Files:**
+- Create: `DTXMania.Game/Lib/Stage/CrashReportNotification.cs`
+- Modify: `DTXMania.Game/Lib/Stage/TitleStage.cs`
+- Test: `DTXMania.Test/Stage/CrashReportNotificationTests.cs`
+- Test: `DTXMania.Test/Stage/TitleStageTests.cs`
+
+**Interfaces:**
+- Consumes: `IStageGame.CrashReportInbox` from Task 3.
+- Produces: final player-facing title-screen recovery UX.
+
+- [ ] **Step 1: Write notification state-machine tests before rendering code**
+
+Use a fake `ICrashReportInbox` and test the component without filesystem or real process launches.
+
+Cover:
+
+- zero reports -> hidden banner and closed panel;
+- pending reports -> one banner with pending count;
+- acknowledged-only reports -> no banner but retained reports remain reviewable through F8;
+- open panel -> selected report defaults to newest pending report, otherwise newest retained report;
+- Previous/Next wraps or clamps consistently; choose one behavior and assert it in tests;
+- successful dismiss closes the panel and refreshes counts;
+- delete requires confirmation;
+- successful delete selects the nearest remaining report or closes when empty;
+- action failures keep the panel open and expose a retryable error state.
+
+Prefer clamp-at-ends navigation unless an existing title UI convention clearly favors wrapping.
+
+- [ ] **Step 2: Implement `CrashReportNotification` as a title-specific component**
+
+Keep it focused on:
+
+- current inbox snapshot;
+- selected index;
+- panel open/closed state;
+- focused action;
+- delete confirmation state;
+- short visible error code/message;
+- banner/panel geometry and draw helpers.
+
+Do not turn it into a reusable modal framework.
+
+- [ ] **Step 3: Integrate activation and refresh into `TitleStage`**
+
+On title activation, create/refresh the notification from `_game.CrashReportInbox` after normal title resources are available. The lookup is bounded to the retained latest-five reports.
+
+On deactivation/disposal, clear stage-owned notification state only; the inbox/runtime remains process-owned.
+
+- [ ] **Step 4: Gate input correctly**
+
+In `OnUpdate`:
+
+1. update keyboard/mouse states as today;
+2. process F8/banner activation;
+3. if the crash panel is open, route input to it first and skip normal title-menu `HandleInput()` / `HandleMouseInput()` for that frame;
+4. otherwise preserve current title behavior exactly.
+
+Use existing virtual mouse mapping and existing remappable commands where practical:
+
+```text
+MoveLeft / MoveRight -> previous / next report
+MoveUp / MoveDown    -> action focus
+Activate             -> execute focused action
+Back / Escape        -> close panel
+```
+
+When delete confirmation is active, consume only confirm/cancel actions.
+
+- [ ] **Step 5: Draw the banner and panel after the existing title menu**
+
+Keep drawing inside the existing title `SpriteBatch` flow. Use existing title font/primitive resources where possible instead of introducing new skin assets in this ticket.
+
+The panel may render only:
+
+```text
+Report position
+Report ID
+Captured UTC
+Build ID
+OS / architecture
+Stage or milestone
+Exception type
+Pending / Acknowledged
+```
+
+Never render report-body content.
+
+- [ ] **Step 6: Extend `TitleStageTests` for input leakage**
+
+Add tests around extracted/internal helper seams as needed so:
+
+- F8 opens the crash panel without selecting a title menu item;
+- panel activation input cannot trigger GAME START / CONFIG / EXIT in the same frame;
+- closed-panel behavior still uses the existing title menu path unchanged.
+
+Avoid constructing real MonoGame graphics devices merely to test state transitions.
+
+- [ ] **Step 7: Run focused and full relevant tests**
+
+Run the new stage/component tests, existing `TitleStageTests`, stage contract tests, and crash-reporting tests. Then run the repository's standard unit-test command used by CI.
+
+- [ ] **Step 8: Perform supported-platform smoke verification**
+
+On macOS, verify the production launcher can open both:
+
+```text
+/usr/bin/open -- https://github.com/cwchanap/DTXManiaCX/issues/new
+/usr/bin/open -- <resolved CrashReports directory>
+```
+
+Record OS/runtime details and observed results in the implementation PR. Do not claim automated macOS E2E coverage.
+
+On Windows, confirm the unit tests inspect `UseShellExecute = true` and prove no command-shell construction exists.
+
+- [ ] **Step 9: Commit**
+
+Commit this slice independently with a message similar to:
+
+```text
+feat: add title crash report inbox ui
+```
+
+---
+
+## Final verification
+
+Before marking HPA-530 complete:
+
+- [ ] Run the complete crash-reporting test suite.
+- [ ] Run the complete title/stage test suite.
+- [ ] Run the repository's normal Windows/macOS unit-test CI commands locally where available.
+- [ ] Confirm HPA-529 crash capture still creates `crash-*.txt`, never `.ack.txt`, for a newly captured crash.
+- [ ] Confirm title activation with no reports is behaviorally unchanged.
+- [ ] Confirm one pending report shows one non-blocking banner.
+- [ ] Confirm successful GitHub/folder launch acknowledges but does not delete.
+- [ ] Confirm launcher failure keeps the report pending and retryable.
+- [ ] Confirm dismiss persists acknowledgement across restart.
+- [ ] Confirm confirmed delete removes the report and refreshes the count.
+- [ ] Confirm acknowledged and pending reports together never exceed the existing latest-five retention limit.
+- [ ] Confirm no `inbox-state.json`, ZIP support, shell command construction, automatic upload, or Linux launcher code was introduced.

--- a/docs/superpowers/plans/2026-08-07-hpa-530-title-screen-crash-inbox.md
+++ b/docs/superpowers/plans/2026-08-07-hpa-530-title-screen-crash-inbox.md
@@ -4,69 +4,82 @@
 
 **Goal:** Add a non-blocking title-screen crash inbox for retained schema-v2 text reports, with persistent acknowledgement, safe GitHub/file-manager handoff, dismissal, and confirmed deletion.
 
-**Architecture:** Extend the existing HPA-529 crash-reporting subsystem instead of recreating its superseded ZIP/inbox-state design. `CrashReportStore` remains the storage/retention owner, `CrashReportRuntime` composes a narrow `ICrashReportInbox`, `IStageGame` exposes a default empty facade plus the production override from `BaseGame`, and `TitleStage` delegates all crash-notification interaction state to a focused `CrashReportNotification` component.
+**Architecture:** Extend the shipped HPA-529 text-only crash-reporting subsystem. `CrashReportStore` remains the storage/retention owner, `CrashReportRuntime` composes a narrow `ICrashReportInbox`, `IStageGame` exposes a default empty facade plus the production `BaseGame` forwarding, and `TitleStage` delegates notification state/input to one focused component.
 
-**Tech Stack:** .NET 8, C#, MonoGame, xUnit, Moq, `System.Diagnostics.Process`, existing DTXManiaCX crash-reporting and stage abstractions.
+**Tech Stack:** .NET 8, C#, MonoGame, xUnit, Moq, `System.Diagnostics.Process`, existing DTXManiaCX crash-reporting/stage/input abstractions.
 
-## Global Constraints
+## Global constraints
 
-- Support only the shipped `DTXMANIACX-CRASH-REPORT 2` plain-text format.
+- Support only `DTXMANIACX-CRASH-REPORT 2` text reports.
 - Do not add ZIP handling, emergency-report branching, or `inbox-state.json`.
-- Keep one latest-five retention policy owned by `CrashReportStore`.
-- Retained filename regex is case-insensitive: `^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$`.
-- Filename-derived report ID is authoritative for inbox identity and actions.
-- Encode acknowledgement by atomically renaming pending `*.txt` to `*.ack.txt`.
-- Collapse a pending+ack duplicate pair to one logical inbox item; pending wins until cleanup reconciles the duplicate.
-- `CrashReportSummary.FileName` from discovery is the current physical basename; title UI must not display or depend on it.
-- Header reads are bounded to 32 lines / 16 KiB; string values are normalized to at most 256 characters with ASCII controls replaced by spaces and empty values mapped to `Unknown`.
-- Never expose crash-report paths, parsers, `CrashReportStore`, or `IExternalLauncher` directly to `TitleStage`.
-- The title UI may render only `CrashReportSummary` plus acknowledgement state.
-- GitHub handoff is manual: open the new-issue page and instruct the player to inspect and attach the `.txt` report themselves.
-- URI-escape every dynamic GitHub query value before launch.
-- Never invoke `cmd /c`, PowerShell, `sh -c`, or concatenate dynamic values into shell commands.
-- Windows launcher uses `ProcessStartInfo.UseShellExecute = true`.
-- macOS launcher uses `/usr/bin/open` with separate `--` and target arguments.
+- Keep one latest-five logical retention policy in `CrashReportStore`.
+- Valid retained-name regex is case-insensitive: `^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$`.
+- Filename-derived report ID is authoritative.
+- Acknowledge with same-directory `File.Move(..., overwrite: true)` from pending `.txt` to `.ack.txt`.
+- If both variants exist, discovery returns one logical item; acknowledgement overwrites the stale ack twin; delete removes both variants. Do not add a duplicate-reconciliation pass or conflict error state.
+- `CrashReportSummary.FileName` represents the physical basename represented by that summary; title UI does not need it.
+- Header reads stop at 32 lines, 16 KiB, or `--- EXCEPTION ---`, whichever comes first; one overlong line must also respect the character budget.
+- Normalize header strings to 256 characters, replace ASCII controls with spaces, trim, and map empty values to `Unknown`.
+- Never expose paths, parser, store, or launcher directly to `TitleStage`.
+- GitHub handoff is manual; URI-escape all dynamic values and validate exact HTTPS host/path before launch.
+- Never invoke `cmd /c`, PowerShell, `sh -c`, or concatenate shell commands.
+- Keep both Windows/macOS launcher command builders in shared `Lib/Diagnostics/CrashReporting` code, not the `Platform/` compile split.
+- Windows uses `UseShellExecute = true`; macOS uses `/usr/bin/open` with separate `--` and target arguments.
+- Successful GitHub **and report-folder** launches acknowledge after process launch, matching HPA-530 acceptance criteria.
+- F8 is a fixed raw, non-remappable title shortcut; do not add `InputCommandType` or configuration.
+- `CrashReportNotification.HandleInput(...) -> bool` is the single notification input-ownership seam; consumed input must not reach title actions.
+- Do not add a second `InputStateManager` to `TitleStage` solely for this feature.
+- `EmptyCrashReportInbox` returns no reports and silent successful no-op actions.
 - Linux launcher support is out of scope.
-- F8 is a fixed, raw, non-remappable title diagnostic shortcut for this ticket; do not add a new `InputCommandType`.
-- `CrashReportNotification` owns notification input and returns whether it consumed the frame; consumed input must never reach normal title actions.
-- `EmptyCrashReportInbox` returns no reports and successful no-op action results.
-- All failures are non-fatal and must not block normal title-screen startup.
 
 ---
 
 ## File structure
 
-Expected new files:
+**Create:**
 
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs` — bounded schema-v2 header parsing and value normalization.
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportInbox.cs` — inbox facade and action orchestration.
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/ExternalLauncher.cs` — validated Windows/macOS external launch behavior.
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/GitHubCrashIssueBuilder.cs` — deterministic GitHub URL construction/validation.
-- `DTXMania.Game/Lib/Stage/CrashReportNotification.cs` — title-only banner/panel state, hit-testing, input ownership, and rendering coordination.
-- focused tests under `DTXMania.Test/CrashReporting/` and `DTXMania.Test/Stage/`.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs`
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportInbox.cs`
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/GitHubCrashIssueBuilder.cs`
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/ExternalLauncher.cs`
+- `DTXMania.Game/Lib/Stage/CrashReportNotification.cs`
+- focused tests under `DTXMania.Test/CrashReporting/` and `DTXMania.Test/Stage/`
 
-Expected modified files:
+**Modify:**
 
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs` — public inbox contract, `IGameCrashDiagnostics.CrashReportInbox`, and no-op implementation.
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs` — discovery, filename identity, duplicate reconciliation, acknowledgement, deletion, internal `RootPath`, and retention recognition for `.ack.txt`.
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs` — compose inbox and expose it through `IGameCrashDiagnostics`.
-- `DTXMania.Game/Lib/Stage/IStageGame.cs` — default `CrashReportInbox => EmptyCrashReportInbox.Instance` property.
-- `DTXMania.Game/Game1.cs` — forward the injected production inbox through `BaseGame`.
-- `DTXMania.Game/Lib/Stage/TitleStage.cs` — instantiate/update/draw the notification component and honor its consumed-input result.
-- existing crash/stage contract tests where required by public interface changes.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs`
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs`
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs`
+- `DTXMania.Game/Lib/Stage/IStageGame.cs`
+- `DTXMania.Game/Game1.cs`
+- `DTXMania.Game/Lib/Stage/TitleStage.cs`
+- focused existing contract tests as needed
 
-Do not create a generic modal framework, generic process runner, new layout framework, new key-binding configuration, or configurable GitHub destination.
-
-## Risks to keep visible during implementation
-
-1. **Duplicate pending/ack variants** can create ghost items or inconsistent retention if storage methods invent different filename rules. Lock identity behavior in Task 1 before other work.
-2. **Back/Escape leakage** can call `TitleStage.RequestExit()` while the panel is open. Make `CrashReportNotification` the single input-ownership boundary and verify the consumed-frame guard.
-3. **Hand-edited/corrupt headers** can create very large or control-character-containing UI/URI values. Clamp and normalize in the reader, then URI-escape in the builder.
-4. **F8 can also be mapped elsewhere**. Treat raw F8 as the title diagnostic shortcut and consume the frame when it opens/reopens the panel; do not expand the key-binding system.
+Do not move/generalize `IConfigOverlayPanel`, create a generic modal/process/layout abstraction, or introduce a new key-binding setting.
 
 ---
 
-### Task 1: Add schema-v2 discovery and persistent acknowledgement
+## Platform-aware test commands
+
+Use the test project that matches the environment:
+
+**macOS local development:**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+**Windows / Windows CI:**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj
+```
+
+For each filtered command below, use the same project substitution. New tests under `DTXMania.Test/CrashReporting/` and `DTXMania.Test/Stage/` are picked up automatically by the Mac test project's glob unless they introduce excluded graphics dependencies; these tests must remain graphics-independent.
+
+---
+
+### Task 1: Add schema-v2 discovery and acknowledgement
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs`
@@ -75,14 +88,11 @@ Do not create a generic modal framework, generic process runner, new layout fram
 - Test: `DTXMania.Test/CrashReporting/CrashReportSummaryReaderTests.cs`
 - Test: `DTXMania.Test/CrashReporting/CrashReportStoreTests.cs`
 
-**Interfaces:**
-- Produces: `CrashReportInboxItem`, `CrashReportActionResult`, `ICrashReportInbox`, and `EmptyCrashReportInbox` used by later tasks.
-- Produces: internal `CrashReportStore.GetReports()`, `Acknowledge(reportId)`, `Delete(reportId)`, and `RootPath` behavior used by Task 2/3.
-- Consumes: existing `CrashReportSummary`, `CrashReportTextWriter.Header`, and the store root configured by HPA-529.
+**Produces:** `CrashReportInboxItem`, `CrashReportActionResult`, `ICrashReportInbox`, `EmptyCrashReportInbox`, plus internal store discovery/ack/delete/root behavior used later.
 
-- [ ] **Step 1: Lock retained filename and logical identity behavior with failing tests**
+- [ ] **Step 1: Lock filename and logical-ID behavior with failing tests**
 
-Use these exact valid examples:
+Use exact valid examples:
 
 ```text
 crash-20260806-123456Z-a1b2c3.txt
@@ -92,89 +102,75 @@ crash-20260806-123456Z-a1b2c3.ack.txt
 Assert:
 
 ```text
-regex: ^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$
-report id from pending: crash-20260806-123456Z-a1b2c3
-report id from ack:     crash-20260806-123456Z-a1b2c3
+pending ID -> crash-20260806-123456Z-a1b2c3
+ack ID     -> crash-20260806-123456Z-a1b2c3
 ```
 
-Also assert malformed names and `.tmp` files are ignored.
+Ignore malformed names and `.tmp` files.
 
-- [ ] **Step 2: Lock duplicate-variant recovery behavior**
+- [ ] **Step 2: Lock the minimal duplicate behavior**
 
-Create both physical variants for one report ID and assert:
+Create both variants for one ID and assert:
 
-- discovery returns one logical item, not two;
-- pending is canonical and `IsAcknowledged == false`;
-- `CrashReportSummary.FileName` is the pending basename;
-- `Cleanup()` removes the acknowledged duplicate;
-- `Delete(reportId)` removes both approved variants if both still exist;
-- the duplicate pair counts as one logical report for latest-five retention.
+- discovery returns one logical item;
+- pending wins while both exist;
+- `Acknowledge(reportId)` moves pending onto `.ack.txt` with overwrite and leaves one acknowledged artifact;
+- `Delete(reportId)` removes both approved variants if both exist;
+- retention counts the pair as one logical report.
 
-- [ ] **Step 3: Add bounded header-reader tests**
+Do **not** add `Cleanup()` duplicate reconciliation or an acknowledgement-conflict error.
+
+- [ ] **Step 3: Add bounded summary-reader tests**
 
 Cover:
 
 - valid schema-v2 header;
-- missing keys;
-- corrupt header version;
-- filename/header `ReportId` mismatch;
-- report containing a very large exception section;
+- missing/corrupt header;
+- filename/header ID mismatch;
 - more than 32 header lines;
 - more than 16 KiB before the exception marker;
-- 10,000-character `BuildId`;
-- control characters in `ExceptionType` and other string fields;
-- empty string fields.
+- one single line larger than 16 KiB;
+- 10,000-character field value;
+- embedded ASCII controls/newlines;
+- empty field values;
+- huge exception body after `--- EXCEPTION ---`.
 
-Expected normalization:
+Expected fallback:
 
 ```text
-ReportId            <- filename-derived authoritative value
-CapturedAtUtc       <- header when valid, otherwise filename timestamp when parseable
-BuildId             <- bounded normalized value or Unknown
-OperatingSystem     <- bounded normalized value or Unknown
-ProcessArchitecture <- bounded normalized value or Unknown
-StageOrMilestone    <- bounded normalized value or Unknown
-ExceptionType       <- bounded normalized value or Unknown
+ReportId            <- filename-derived
+CapturedAtUtc       <- valid header, else filename timestamp when parseable
+BuildId             <- normalized header or Unknown
+OperatingSystem     <- normalized header or Unknown
+ProcessArchitecture <- normalized header or Unknown
+StageOrMilestone    <- normalized header or Unknown
+ExceptionType       <- normalized header or Unknown
 FileName            <- current physical basename
 ```
 
-The reader must stop before `--- EXCEPTION ---` and never return free-form report content.
+- [ ] **Step 4: Implement `CrashReportSummaryReader` minimally**
 
-- [ ] **Step 4: Implement the minimal `CrashReportSummaryReader`**
+Implement one bounded schema-v2 header parser. The 16-KiB cap must be enforced while reading, not after an unbounded `ReadLine()` has already allocated a huge line.
 
-Implement only the schema-v2 header contract:
-
-```text
-max header lines: 32
-max header characters: 16 KiB
-max normalized string field: 256 chars
-ASCII controls: replace with spaces
-trimmed empty value: Unknown
-```
-
-Do not add a general crash-report parser.
+Do not parse report-body sections.
 
 - [ ] **Step 5: Extend `CrashReportStore` around one filename policy**
 
-Use one retained-name helper/regex for discovery, cleanup, acknowledgement, deletion, and retention.
+Use one retained-name helper for discovery, retention, acknowledgement, and delete.
 
 Required behavior:
 
-- expose `internal string RootPath => _rootPath` for crash-runtime composition;
-- discover pending and acknowledged forms newest-first;
-- group by filename-derived report ID;
-- cleanup acknowledged duplicate when a pending twin exists;
-- acknowledge by same-directory rename;
-- if acknowledgement sees both variants, remove the ack duplicate first; return a bounded conflict error if reconciliation fails rather than deleting the pending canonical file;
-- treat already-acknowledged reports as idempotent success;
-- delete both approved variants for a report ID;
-- apply latest-five retention to logical reports after duplicate reconciliation.
+- expose `internal string RootPath => _rootPath` for composition;
+- discover newest-first logical reports;
+- group physical variants by filename-derived ID;
+- pending wins if both variants exist;
+- acknowledge pending with same-directory `File.Move(..., overwrite: true)`;
+- already-acknowledged report is idempotent success;
+- delete both approved variants for the requested ID;
+- latest-five retention operates on logical IDs and deletes all variants for stale IDs;
+- no report-body reads for ordering.
 
-Do not open report bodies for retention ordering; the timestamp prefix is already sortable.
-
-- [ ] **Step 6: Add the public inbox contract and silent empty implementation**
-
-Add:
+- [ ] **Step 6: Add public inbox contracts and empty singleton**
 
 ```csharp
 public sealed record CrashReportInboxItem(
@@ -195,25 +191,31 @@ public interface ICrashReportInbox
 }
 ```
 
-`EmptyCrashReportInbox` behavior is exact:
+`EmptyCrashReportInbox`:
 
 ```text
-GetReports()                  -> empty
-OpenGitHubIssue(reportId)     -> success, no-op
-OpenReportFolder(reportId)    -> success, no-op
-Dismiss(reportId)             -> success, no-op
-Delete(reportId)              -> success, no-op
+GetReports()               -> empty
+OpenGitHubIssue(...)        -> success/no-op
+OpenReportFolder(...)       -> success/no-op
+Dismiss(...)                -> success/no-op
+Delete(...)                 -> success/no-op
 ```
 
-- [ ] **Step 7: Run Task 1 verification**
+- [ ] **Step 7: Run Task 1 tests**
 
-Run:
+macOS:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~CrashReporting"
+```
+
+Windows/CI:
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReporting"
 ```
 
-Verify existing HPA-529 capture tests still create pending `crash-*.txt`, never `.ack.txt`, and the combined retained logical set stays capped at five.
+Verify existing capture tests still create only pending `crash-*.txt` names and logical retention remains five.
 
 - [ ] **Step 8: Commit**
 
@@ -234,14 +236,11 @@ git commit -m "feat: add crash report inbox storage state"
 - Test: `DTXMania.Test/CrashReporting/ExternalLauncherTests.cs`
 - Test: `DTXMania.Test/CrashReporting/CrashReportInboxTests.cs`
 
-**Interfaces:**
-- Consumes: Task 1 store operations, `RootPath`, normalized `CrashReportSummary`, and `ICrashReportInbox` contract.
-- Produces: production `CrashReportInbox` used by `CrashReportRuntime` in Task 3.
-- Produces: internal `IExternalLauncher` seam used only by inbox composition and tests.
+**Produces:** production `CrashReportInbox` and shared, testable launcher command builders.
 
-- [ ] **Step 1: Write GitHub URL-builder tests first**
+- [ ] **Step 1: Write GitHub URL tests first**
 
-Assert the generated URL targets exactly:
+Generated destination must be exactly:
 
 ```text
 https://github.com/cwchanap/DTXManiaCX/issues/new
@@ -255,36 +254,33 @@ Allow only:
 - architecture;
 - stage/milestone;
 - exception type;
-- `DTXMANIACX-CRASH-REPORT 2`;
+- schema-v2 identifier;
 - manual `.txt` attachment instructions.
 
-Add tests proving:
-
-- HTTP is rejected;
-- alternate host is rejected;
-- alternate repository/path is rejected;
-- 10,000-character source values are already clamped by the reader/builder boundary;
-- embedded control/newline-style input cannot break query structure;
-- every dynamic query value is URI-escaped;
-- report-body content never appears in the URI.
+Assert every dynamic value is escaped. Keep rejection tests for HTTP, wrong host, wrong repository, and wrong path because the Linear acceptance criteria explicitly require target validation.
 
 - [ ] **Step 2: Implement `GitHubCrashIssueBuilder`**
 
-Keep it deterministic and side-effect free. Build from the normalized summary, URI-escape dynamic values, return a `Uri`, and validate scheme/host/path in this component before returning a launchable target.
+Keep it deterministic and side-effect free. Return a validated `Uri`; do not accept a configurable destination.
 
-Do not add configuration for the one supported repository.
+- [ ] **Step 3: Write shared launcher command-shape tests**
 
-- [ ] **Step 3: Write external-launcher tests around `ProcessStartInfo`**
+`ExternalLauncher.cs` stays outside `Platform/` so both builders compile into the Mac and Windows game projects.
 
-Use the smallest injectable process-start seam necessary to inspect the launch request without starting a real process.
+Expose internal pure builders:
+
+```csharp
+CreateWindowsStartInfo(string target)
+CreateMacStartInfo(string target)
+```
 
 Windows assertions:
 
 ```text
+FileName = <target>
 UseShellExecute = true
 no cmd.exe
 no powershell
-no composed command shell string
 ```
 
 macOS assertions:
@@ -293,44 +289,59 @@ macOS assertions:
 FileName = /usr/bin/open
 UseShellExecute = false
 ArgumentList[0] = --
-ArgumentList[1] = <validated URI or CrashReportStore.RootPath>
+ArgumentList[1] = <target>
 no sh -c
 ```
 
-Also cover unsupported platform, process-start exception, and non-zero macOS result as bounded failures.
+This deliberately does **not** follow the folder-picker `Platform/` compile split, because the opposite platform file is removed at compile time and would make cross-platform command-shape tests impossible from one test assembly.
 
-- [ ] **Step 4: Implement `IExternalLauncher`**
+- [ ] **Step 4: Implement `ExternalLauncher`**
 
-Support URI and directory launch only. Directory launch receives `CrashReportStore.RootPath` from crash-reporting composition; do not accept arbitrary stage-supplied paths.
+Branch at runtime (`RuntimeInformation`/equivalent), not by platform-specific source-file inclusion.
 
-Follow the existing repository pattern of creating testable `ProcessStartInfo` rather than introducing a general process-execution service.
+Support only:
 
-- [ ] **Step 5: Write inbox action tests with a real temporary store plus fake launcher**
+- validated GitHub URI;
+- internally resolved crash-report root directory.
+
+Map unsupported platform, process-start exception, null process, and non-zero macOS exit to stable failure codes. Do not introduce a general process execution framework.
+
+- [ ] **Step 5: Write inbox action tests**
+
+Use a temporary real store and fake launcher.
 
 Assert:
 
-- successful GitHub launch acknowledges the selected pending report;
-- successful folder launch acknowledges the selected pending report;
-- launcher failure leaves it pending;
-- `Dismiss` acknowledges without deleting;
-- `Delete` removes the logical report;
-- dual pending+ack delete leaves no ghost variant;
-- launcher success followed by acknowledgement failure returns a bounded acknowledgement error and preserves the pending canonical file;
-- missing report returns a bounded stable error rather than a raw exception.
+- successful GitHub launch -> acknowledge;
+- successful folder launch -> acknowledge;
+- failed launch -> remain pending;
+- launch success + acknowledgement failure -> bounded retryable acknowledgement error;
+- Dismiss -> acknowledge without launch/delete;
+- Delete -> remove the logical report.
+
+The external-launch acknowledgement behavior is intentional and required by HPA-530; do not change it to Dismiss-only semantics in this task.
 
 - [ ] **Step 6: Implement `CrashReportInbox` orchestration**
 
-Each public action resolves the report by ID at call time. Never accept a path from the caller.
+Every action resolves by report ID at call time. Never accept a path from the caller.
 
-Launcher-backed order is exact:
+Launcher-backed order:
 
 ```text
-resolve -> build/validate target -> launch -> acknowledge -> refresh
+resolve -> build/validate -> launch -> acknowledge -> refresh
 ```
 
-Map raw filesystem/process exceptions to short stable error codes; never surface raw exception messages through the public result.
+Never surface raw filesystem/process exception messages.
 
-- [ ] **Step 7: Run Task 2 verification**
+- [ ] **Step 7: Run Task 2 tests**
+
+macOS:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~CrashReporting"
+```
+
+Windows/CI:
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReporting"
@@ -345,7 +356,7 @@ git commit -m "feat: add crash report github handoff"
 
 ---
 
-### Task 3: Compose the inbox through the existing game/stage seams
+### Task 3: Compose through existing game/stage seams
 
 **Files:**
 - Modify: `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs`
@@ -356,56 +367,51 @@ git commit -m "feat: add crash report github handoff"
 - Test: `DTXMania.Test/Stage/IStageGameContractTests.cs`
 - Test: `DTXMania.Test/BaseGameTests.cs`
 
-**Interfaces:**
-- Consumes: production `CrashReportInbox` from Task 2.
-- Produces: `IGameCrashDiagnostics.CrashReportInbox` and production `BaseGame.CrashReportInbox` used by `TitleStage` in Task 4.
-- Keeps test-only/simple `IStageGame` implementations source-compatible through a default empty inbox property.
+- [ ] **Step 1: Add diagnostics contract tests**
 
-- [ ] **Step 1: Add contract tests for the narrow diagnostics property**
-
-Assert `IGameCrashDiagnostics` exposes:
+`IGameCrashDiagnostics` exposes only:
 
 ```csharp
 ICrashReportInbox CrashReportInbox { get; }
 ```
 
-and does not expose `CrashReportStore`, launcher, parser, root path, or crash-runtime lifetime operations.
+for this feature. Do not expose store, launcher, parser, root path, or runtime lifetime operations.
 
-- [ ] **Step 2: Extend `IGameCrashDiagnostics` and disabled runtime behavior**
+- [ ] **Step 2: Extend enabled/disabled runtime behavior**
 
-Enabled runtime returns the composed production inbox.
-
-Disabled/bootstrap-degraded runtime returns `EmptyCrashReportInbox.Instance`; verify it produces no reports and never creates title-visible action errors.
+Enabled runtime exposes the production inbox. Disabled/bootstrap-degraded runtime exposes `EmptyCrashReportInbox.Instance`.
 
 - [ ] **Step 3: Compose the production inbox in `CrashReportRuntime`**
 
-Reuse the same `CrashReportStore` instance already owned by the runtime. Construct the summary reader, GitHub builder, external launcher, and inbox there.
+Reuse the runtime-owned `CrashReportStore`; use `store.RootPath` for folder handoff so the open-directory target cannot diverge from the injected store.
 
-Use `CrashReportStore.RootPath` for directory handoff so production and injected test stores cannot diverge from the path opened by the inbox.
+Compose summary reader, GitHub builder, launcher, and inbox here only.
 
-Do not create crash-report services from `BaseGame` or `TitleStage`.
+- [ ] **Step 4: Add default stage property and production forwarding**
 
-- [ ] **Step 4: Add the default `IStageGame` property and production forwarding**
-
-Add:
+`IStageGame`:
 
 ```csharp
 ICrashReportInbox CrashReportInbox => EmptyCrashReportInbox.Instance;
 ```
 
-to `IStageGame` as a default interface member.
+`BaseGame` explicitly forwards the real diagnostics inbox.
 
-`BaseGame` explicitly forwards the real injected diagnostics inbox.
+Do not modify every test stub solely for this property.
 
-Do **not** update every test stub solely to satisfy this property; existing minimal implementations should inherit the default behavior.
+- [ ] **Step 5: Run Task 3 tests**
 
-- [ ] **Step 5: Run Task 3 verification**
+macOS:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~CrashReportRuntime|FullyQualifiedName~IStageGameContractTests|FullyQualifiedName~BaseGameTests"
+```
+
+Windows/CI:
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReportRuntime|FullyQualifiedName~IStageGameContractTests|FullyQualifiedName~BaseGameTests"
 ```
-
-Verify the crash-disabled bootstrap path still starts successfully and stage stubs that do not override `CrashReportInbox` receive the empty singleton.
 
 - [ ] **Step 6: Commit**
 
@@ -416,7 +422,7 @@ git commit -m "feat: expose crash inbox to title stage"
 
 ---
 
-### Task 4: Add the non-blocking title banner and review panel
+### Task 4: Add title banner and review panel
 
 **Files:**
 - Create: `DTXMania.Game/Lib/Stage/CrashReportNotification.cs`
@@ -424,137 +430,135 @@ git commit -m "feat: expose crash inbox to title stage"
 - Test: `DTXMania.Test/Stage/CrashReportNotificationTests.cs`
 - Test: `DTXMania.Test/Stage/TitleStageTests.cs`
 
-**Interfaces:**
-- Consumes: `IStageGame.CrashReportInbox` from Task 3.
-- Produces: final player-facing title-screen recovery UX.
-- Produces: `CrashReportNotification.TryHandleInput(...) -> bool`, where `true` means the normal title input path must not run that frame.
+**Produces:** one title-specific notification component with `HandleInput(...) -> bool consumed`.
 
-- [ ] **Step 1: Write notification state-machine tests before rendering code**
+- [ ] **Step 1: Write component state tests before drawing code**
 
-Use a fake `ICrashReportInbox` and test without filesystem, graphics-device, or real process launches.
+Use fake `ICrashReportInbox`; no filesystem, process, or graphics device.
 
 Cover:
 
-- zero reports -> hidden banner and closed panel;
-- pending reports -> one banner with pending count;
-- acknowledged-only reports -> no banner but retained reports remain reviewable through F8;
-- opening defaults to newest pending report, otherwise newest retained report;
+- zero reports -> hidden/closed;
+- pending reports -> one summarized banner;
+- acknowledged-only -> no banner but F8 can review retained items;
+- open defaults to newest pending, else newest retained;
 - Previous/Next clamps at ends;
-- successful dismiss closes the panel and refreshes counts;
+- successful Dismiss closes and refreshes;
 - delete requires confirmation;
-- successful delete selects the nearest remaining report or closes when empty;
-- action failures keep the panel open and expose a retryable bounded error;
-- private component layout constants produce stable banner/panel hit regions without a new layout abstraction.
+- delete selects nearest remaining item or closes when empty;
+- action errors stay visible/retryable.
 
-- [ ] **Step 2: Lock raw F8 and consumed-input semantics in tests**
+- [ ] **Step 2: Lock input ownership and F8 behavior**
 
-Assert:
+Tests assert:
 
-- F8 is detected from raw previous/current `KeyboardState`, edge-triggered once;
-- F8 does not require an `InputCommandType` mapping;
-- F8 with no retained reports is a no-op and does not consume normal title input;
-- F8 opening/reopening the panel returns `true` from `TryHandleInput` and consumes that frame;
-- banner click opening the panel also consumes that frame;
-- when the panel is open, all handled navigation/actions return consumed;
-- Back/Escape while open closes the panel and returns consumed;
-- delete confirmation consumes confirm/cancel input until resolved.
+- raw F8 uses the title's current/previous keyboard snapshots and is edge-triggered;
+- no new `InputCommandType` is needed;
+- F8 with no reports returns not-consumed;
+- F8/banner click that opens/reopens returns consumed;
+- while open, panel navigation/actions consume input;
+- Back/Escape closes and consumes;
+- delete confirmation consumes confirm/cancel until resolved.
 
-- [ ] **Step 3: Implement `CrashReportNotification` as the sole notification state owner**
+- [ ] **Step 3: Implement `CrashReportNotification` as a focused title component**
 
-Keep it focused on:
+Own:
 
-- current inbox snapshot;
-- selected index;
-- panel open/closed state;
-- focused action;
-- delete confirmation state;
-- short visible error code/message;
-- banner hit-testing;
-- raw F8 edge detection;
-- private banner/panel geometry constants;
+- snapshot/selected index;
+- open/closed state;
+- action focus;
+- delete confirmation;
+- bounded error text;
+- banner/panel hit regions;
 - draw helpers.
 
-Do not turn it into a reusable modal framework.
-
-- [ ] **Step 4: Integrate activation and refresh into `TitleStage`**
-
-On title activation, create/refresh the notification from `_game.CrashReportInbox` after normal title resources are available. The lookup remains bounded to the latest-five retained logical reports.
-
-On deactivation/disposal, clear stage-owned notification state only; the inbox/runtime remains process-owned.
-
-- [ ] **Step 5: Make input gating one explicit guard**
-
-After updating keyboard/mouse state in `TitleStage.OnUpdate`, call the notification first:
+Expose:
 
 ```csharp
-if (_crashReportNotification?.TryHandleInput(/* current input state */) == true)
+bool HandleInput(...)
+```
+
+Use existing `InputCommandType` checks for remappable panel commands and the title's already-polled keyboard/mouse snapshots for F8/click edges.
+
+Do not instantiate a second `InputStateManager`. Do not move/generalize `IConfigOverlayPanel`. `UIElement.HandleInput` is the naming/consumption precedent, not a requirement to restructure `TitleStage` input around `IInputState`.
+
+- [ ] **Step 4: Integrate activation/refresh into `TitleStage`**
+
+Create/refresh after title resources are available. Clear only stage-owned notification state during deactivation/disposal; runtime/inbox remains process-owned.
+
+Use existing `MapMouseToVirtual` for notification mouse coordinates.
+
+- [ ] **Step 5: Add one explicit consumed-input guard**
+
+After the title updates current/previous keyboard and mouse states:
+
+```csharp
+if (_crashReportNotification?.HandleInput(/* current title input */) == true)
 {
     return;
 }
 ```
 
-Only if it returns `false` may existing title `HandleInput()` / `HandleMouseInput()` run.
+Only then run the existing title `HandleInput()` / `HandleMouseInput()` path.
 
-Required behavior:
+Panel commands:
 
 ```text
-MoveLeft / MoveRight -> previous / next report
+MoveLeft / MoveRight -> previous / next
 MoveUp / MoveDown    -> action focus
-Activate             -> execute focused action
-Back / Escape        -> close panel when open
-raw F8               -> open/reopen crash panel
+Activate             -> focused action
+Back / Escape        -> close panel
+raw F8               -> open/reopen
 ```
 
-The critical regression case is explicit: **Back/Escape with the panel open closes the panel and must never call `RequestExit()` in the same frame.**
+Critical regression: open-panel Back/Escape closes the panel and **never calls `RequestExit()` in the same frame**.
 
-- [ ] **Step 6: Draw the banner and panel after the existing title menu**
+- [ ] **Step 6: Draw after the existing title menu**
 
-Keep drawing inside the existing title `SpriteBatch` flow. Reuse existing title font/primitive resources; do not add skin assets.
+Reuse title font/white-pixel/SpriteBatch resources. Keep geometry private to `CrashReportNotification`; do not add skin assets or a layout framework.
 
-The panel may render only:
+Render only:
 
 ```text
-Report position
-Report ID
-Captured UTC
-Build ID
+position
+report ID
+captured UTC
+build ID
 OS / architecture
-Stage or milestone
-Exception type
+stage / milestone
+exception type
 Pending / Acknowledged
 ```
 
-Never render `CrashReportSummary.FileName` or report-body content.
+Never render report-body content.
 
-- [ ] **Step 7: Add one thin `TitleStage` input-isolation regression test**
+- [ ] **Step 7: Add one thin `TitleStage` leakage regression test**
 
-Keep the detailed state tests in `CrashReportNotificationTests`. Add only enough `TitleStageTests` coverage to prove:
+Keep detailed state tests in `CrashReportNotificationTests`. `TitleStageTests` need only prove:
 
-- notification-consumed input skips GAME START / CONFIG / EXIT handling;
+- consumed notification input skips GAME START / CONFIG / EXIT;
 - open-panel Back/Escape cannot call `RequestExit()`;
-- closed notification with no interaction still reaches the existing menu path.
+- non-consumed closed state still reaches existing title menu behavior.
 
-Avoid creating a real MonoGame graphics device merely for state transitions.
+- [ ] **Step 8: Run Task 4 tests**
 
-- [ ] **Step 8: Run Task 4 verification**
+macOS:
 
 ```bash
-dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~DTXMania.Test.Stage"
-dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReporting"
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~DTXMania.Test.Stage|FullyQualifiedName~CrashReporting"
 ```
 
-- [ ] **Step 9: Perform supported-platform smoke verification**
+Windows/CI:
 
-On macOS, verify the production launcher can open both:
-
-```text
-/usr/bin/open -- https://github.com/cwchanap/DTXManiaCX/issues/new
-/usr/bin/open -- <resolved CrashReports directory>
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~DTXMania.Test.Stage|FullyQualifiedName~CrashReporting"
 ```
 
-Record OS/runtime details and observed results in the implementation PR. Do not claim automated macOS E2E coverage.
+- [ ] **Step 9: Perform platform smoke verification**
 
-On Windows, confirm the unit tests inspect `UseShellExecute = true` and prove no command-shell construction exists.
+macOS: verify production `/usr/bin/open -- <target>` for both GitHub URI and crash-report directory and record OS/runtime/results in the implementation PR.
+
+Windows: verify the shared command-builder tests assert `UseShellExecute = true` and no shell construction; CI supplies Windows execution coverage.
 
 - [ ] **Step 10: Commit**
 
@@ -567,26 +571,24 @@ git commit -m "feat: add title crash report inbox ui"
 
 ## Final verification
 
-Before marking HPA-530 complete:
+Before completing HPA-530:
 
-- [ ] Run `dotnet test DTXMania.Test/DTXMania.Test.csproj`.
-- [ ] Run the repository's normal Windows/macOS unit-test CI commands where available.
-- [ ] Confirm HPA-529 crash capture still creates pending `crash-*.txt`, never `.ack.txt`, for a newly captured crash.
-- [ ] Confirm the exact retained-name regex rejects arbitrary files and recognizes both pending/ack forms.
-- [ ] Confirm dual pending+ack files for the same ID collapse to one inbox item and cleanup reconciles the duplicate.
-- [ ] Confirm acknowledged and pending logical reports together never exceed the existing latest-five retention limit.
-- [ ] Confirm a 10,000-character or control-character-containing header field cannot become an unbounded/malformed GitHub URI or UI value.
-- [ ] Confirm GitHub dynamic query values are URI-escaped and only approved summary fields are present.
-- [ ] Confirm title activation with no reports is behaviorally unchanged.
-- [ ] Confirm disabled/bootstrap crash reporting produces no banner and silent no-op inbox actions.
-- [ ] Confirm one pending report shows one non-blocking banner.
-- [ ] Confirm raw F8 is edge-triggered, non-remappable, and consumes the frame only when it opens/reopens the crash panel.
-- [ ] Confirm Back/Escape with the panel open closes the panel and does **not** call `RequestExit()`.
-- [ ] Confirm panel activation/navigation input cannot leak into GAME START / CONFIG / EXIT in the same frame.
+- [ ] On macOS run `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj`; on Windows/CI run `dotnet test DTXMania.Test/DTXMania.Test.csproj`.
+- [ ] Confirm new crash captures still create pending `crash-*.txt`, never `.ack.txt`.
+- [ ] Confirm exact retained-name policy rejects arbitrary files and groups pending/ack variants by logical ID.
+- [ ] Confirm acknowledgement overwrites a stale ack twin without a separate reconciliation/error subsystem.
+- [ ] Confirm pending+ack logical reports together never exceed latest five.
+- [ ] Confirm reader stops at 32 lines, 16 KiB, and the exception marker; a single giant line is bounded.
+- [ ] Confirm long/control-containing fields are normalized and cannot create malformed UI/URI values.
+- [ ] Confirm all GitHub dynamic values are escaped and exact HTTPS host/path validation rejects unexpected targets.
+- [ ] Confirm shared launcher code exposes testable Windows and macOS `ProcessStartInfo` command shapes without `Platform/` compile splitting.
+- [ ] Confirm disabled/bootstrap crash reporting produces no banner and no-op inbox behavior.
+- [ ] Confirm raw F8 is edge-triggered/non-remappable and consumes only when opening/reopening the panel.
+- [ ] Confirm Back/Escape with the panel open closes it and does **not** call `RequestExit()`.
+- [ ] Confirm notification-consumed input cannot trigger GAME START / CONFIG / EXIT in the same frame.
 - [ ] Confirm successful GitHub/folder launch acknowledges but does not delete.
-- [ ] Confirm launcher failure keeps the report pending and retryable.
-- [ ] Confirm dismiss persists acknowledgement across restart.
-- [ ] Confirm confirmed delete removes the logical report without leaving a duplicate physical variant.
-- [ ] Confirm macOS uses `/usr/bin/open`, separate `--`, and separate target argument.
-- [ ] Confirm Windows uses `UseShellExecute = true` without a command shell.
-- [ ] Confirm no `inbox-state.json`, ZIP support, shell command construction, automatic upload, generic modal/process framework, new key-binding setting, or Linux launcher code was introduced.
+- [ ] Confirm failed launch remains pending/retryable.
+- [ ] Confirm Dismiss persists acknowledgement.
+- [ ] Confirm Delete requires confirmation and removes all approved variants for that logical ID.
+- [ ] Confirm macOS uses `/usr/bin/open`, separate `--`, and separate target; Windows uses `UseShellExecute = true`; neither uses a command shell.
+- [ ] Confirm no `inbox-state.json`, ZIP support, automatic upload, generic modal/process/layout framework, new key-binding setting, or Linux launcher was introduced.

--- a/docs/superpowers/plans/2026-08-07-hpa-530-title-screen-crash-inbox.md
+++ b/docs/superpowers/plans/2026-08-07-hpa-530-title-screen-crash-inbox.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a non-blocking title-screen crash inbox for retained schema-v2 text reports, with persistent acknowledgement, safe GitHub/file-manager handoff, dismissal, and confirmed deletion.
 
-**Architecture:** Extend the existing HPA-529 crash-reporting subsystem instead of recreating its superseded ZIP/inbox-state design. `CrashReportStore` remains the storage/retention owner, `CrashReportRuntime` composes a narrow `ICrashReportInbox`, `IStageGame` exposes only that facade, and `TitleStage` delegates banner/panel behavior to a focused notification component.
+**Architecture:** Extend the existing HPA-529 crash-reporting subsystem instead of recreating its superseded ZIP/inbox-state design. `CrashReportStore` remains the storage/retention owner, `CrashReportRuntime` composes a narrow `ICrashReportInbox`, `IStageGame` exposes a default empty facade plus the production override from `BaseGame`, and `TitleStage` delegates all crash-notification interaction state to a focused `CrashReportNotification` component.
 
 **Tech Stack:** .NET 8, C#, MonoGame, xUnit, Moq, `System.Diagnostics.Process`, existing DTXManiaCX crash-reporting and stage abstractions.
 
@@ -13,14 +13,23 @@
 - Support only the shipped `DTXMANIACX-CRASH-REPORT 2` plain-text format.
 - Do not add ZIP handling, emergency-report branching, or `inbox-state.json`.
 - Keep one latest-five retention policy owned by `CrashReportStore`.
-- Encode acknowledgement by atomically renaming `*.txt` to `*.ack.txt`.
+- Retained filename regex is case-insensitive: `^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$`.
+- Filename-derived report ID is authoritative for inbox identity and actions.
+- Encode acknowledgement by atomically renaming pending `*.txt` to `*.ack.txt`.
+- Collapse a pending+ack duplicate pair to one logical inbox item; pending wins until cleanup reconciles the duplicate.
+- `CrashReportSummary.FileName` from discovery is the current physical basename; title UI must not display or depend on it.
+- Header reads are bounded to 32 lines / 16 KiB; string values are normalized to at most 256 characters with ASCII controls replaced by spaces and empty values mapped to `Unknown`.
 - Never expose crash-report paths, parsers, `CrashReportStore`, or `IExternalLauncher` directly to `TitleStage`.
 - The title UI may render only `CrashReportSummary` plus acknowledgement state.
 - GitHub handoff is manual: open the new-issue page and instruct the player to inspect and attach the `.txt` report themselves.
+- URI-escape every dynamic GitHub query value before launch.
 - Never invoke `cmd /c`, PowerShell, `sh -c`, or concatenate dynamic values into shell commands.
 - Windows launcher uses `ProcessStartInfo.UseShellExecute = true`.
 - macOS launcher uses `/usr/bin/open` with separate `--` and target arguments.
 - Linux launcher support is out of scope.
+- F8 is a fixed, raw, non-remappable title diagnostic shortcut for this ticket; do not add a new `InputCommandType`.
+- `CrashReportNotification` owns notification input and returns whether it consumed the frame; consumed input must never reach normal title actions.
+- `EmptyCrashReportInbox` returns no reports and successful no-op action results.
 - All failures are non-fatal and must not block normal title-screen startup.
 
 ---
@@ -29,24 +38,31 @@
 
 Expected new files:
 
-- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs` — bounded schema-v2 header parsing.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportSummaryReader.cs` — bounded schema-v2 header parsing and value normalization.
 - `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportInbox.cs` — inbox facade and action orchestration.
 - `DTXMania.Game/Lib/Diagnostics/CrashReporting/ExternalLauncher.cs` — validated Windows/macOS external launch behavior.
 - `DTXMania.Game/Lib/Diagnostics/CrashReporting/GitHubCrashIssueBuilder.cs` — deterministic GitHub URL construction/validation.
-- `DTXMania.Game/Lib/Stage/CrashReportNotification.cs` — title-only banner/panel state and rendering/input coordination.
+- `DTXMania.Game/Lib/Stage/CrashReportNotification.cs` — title-only banner/panel state, hit-testing, input ownership, and rendering coordination.
 - focused tests under `DTXMania.Test/CrashReporting/` and `DTXMania.Test/Stage/`.
 
 Expected modified files:
 
-- `CrashReportContracts.cs` — public inbox contract and no-op implementation.
-- `CrashReportStore.cs` — discovery, acknowledgement, deletion, and retention recognition for `.ack.txt`.
-- `CrashReportRuntime.cs` — compose inbox and expose it through `IGameCrashDiagnostics`.
-- `IStageGame.cs` — expose `ICrashReportInbox`.
-- `Game1.cs` — forward the injected inbox through `BaseGame`.
-- `TitleStage.cs` — instantiate/update/draw the notification component and gate normal input while the panel is open.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs` — public inbox contract, `IGameCrashDiagnostics.CrashReportInbox`, and no-op implementation.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportStore.cs` — discovery, filename identity, duplicate reconciliation, acknowledgement, deletion, internal `RootPath`, and retention recognition for `.ack.txt`.
+- `DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs` — compose inbox and expose it through `IGameCrashDiagnostics`.
+- `DTXMania.Game/Lib/Stage/IStageGame.cs` — default `CrashReportInbox => EmptyCrashReportInbox.Instance` property.
+- `DTXMania.Game/Game1.cs` — forward the injected production inbox through `BaseGame`.
+- `DTXMania.Game/Lib/Stage/TitleStage.cs` — instantiate/update/draw the notification component and honor its consumed-input result.
 - existing crash/stage contract tests where required by public interface changes.
 
-Do not create a generic modal framework or a generic process runner beyond the smallest test seam required by this ticket.
+Do not create a generic modal framework, generic process runner, new layout framework, new key-binding configuration, or configurable GitHub destination.
+
+## Risks to keep visible during implementation
+
+1. **Duplicate pending/ack variants** can create ghost items or inconsistent retention if storage methods invent different filename rules. Lock identity behavior in Task 1 before other work.
+2. **Back/Escape leakage** can call `TitleStage.RequestExit()` while the panel is open. Make `CrashReportNotification` the single input-ownership boundary and verify the consumed-frame guard.
+3. **Hand-edited/corrupt headers** can create very large or control-character-containing UI/URI values. Clamp and normalize in the reader, then URI-escape in the builder.
+4. **F8 can also be mapped elsewhere**. Treat raw F8 as the title diagnostic shortcut and consume the frame when it opens/reopens the panel; do not expand the key-binding system.
 
 ---
 
@@ -60,48 +76,103 @@ Do not create a generic modal framework or a generic process runner beyond the s
 - Test: `DTXMania.Test/CrashReporting/CrashReportStoreTests.cs`
 
 **Interfaces:**
-- Produces: `CrashReportInboxItem`, `ICrashReportInbox` contract types used by later tasks.
-- Produces: `CrashReportStore.GetReports()`, `Acknowledge(reportId)`, and `Delete(reportId)`-style internal operations; exact method visibility should follow existing store testability conventions.
-- Consumes: existing `CrashReportSummary`, `CrashReportTextWriter.Header`, and `AppPaths.GetCrashReportsRoot()` behavior.
+- Produces: `CrashReportInboxItem`, `CrashReportActionResult`, `ICrashReportInbox`, and `EmptyCrashReportInbox` used by later tasks.
+- Produces: internal `CrashReportStore.GetReports()`, `Acknowledge(reportId)`, `Delete(reportId)`, and `RootPath` behavior used by Task 2/3.
+- Consumes: existing `CrashReportSummary`, `CrashReportTextWriter.Header`, and the store root configured by HPA-529.
 
-- [ ] **Step 1: Lock the filename/state contract with failing tests**
+- [ ] **Step 1: Lock retained filename and logical identity behavior with failing tests**
 
-Add tests proving the store recognizes both:
+Use these exact valid examples:
 
 ```text
 crash-20260806-123456Z-a1b2c3.txt
 crash-20260806-123456Z-a1b2c3.ack.txt
 ```
 
-The tests must assert that both forms participate in one newest-first retained set and one latest-five retention limit.
-
-- [ ] **Step 2: Add bounded header-reader tests**
-
-Cover a valid schema-v2 header, missing keys, corrupt header version, and a report containing a very large exception section. The reader must stop at `--- EXCEPTION ---` and return only the approved summary fields.
-
-For corrupt headers assert:
+Assert:
 
 ```text
-ReportId            <- filename-derived
-CapturedAtUtc       <- filename timestamp when parseable
-BuildId             <- Unknown
-OperatingSystem     <- Unknown
-ProcessArchitecture <- Unknown
-StageOrMilestone    <- Unknown
-ExceptionType       <- Unknown
+regex: ^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$
+report id from pending: crash-20260806-123456Z-a1b2c3
+report id from ack:     crash-20260806-123456Z-a1b2c3
 ```
 
-- [ ] **Step 3: Implement the minimal header reader**
+Also assert malformed names and `.tmp` files are ignored.
 
-Parse only the leading schema-v2 header with a small fixed line/character bound. Do not expose a general report parser and do not read report sections after the exception marker.
+- [ ] **Step 2: Lock duplicate-variant recovery behavior**
 
-- [ ] **Step 4: Implement discovery and acknowledgement in `CrashReportStore`**
+Create both physical variants for one report ID and assert:
 
-Update filename recognition so pending and acknowledged forms are both valid retained reports. Acknowledge by same-directory atomic rename from the pending form to `.ack.txt`; treat an already acknowledged report as success/idempotent.
+- discovery returns one logical item, not two;
+- pending is canonical and `IsAcknowledged == false`;
+- `CrashReportSummary.FileName` is the pending basename;
+- `Cleanup()` removes the acknowledged duplicate;
+- `Delete(reportId)` removes both approved variants if both still exist;
+- the duplicate pair counts as one logical report for latest-five retention.
 
-Deletion resolves the current filename by report ID and deletes only files inside the configured crash-report root.
+- [ ] **Step 3: Add bounded header-reader tests**
 
-- [ ] **Step 5: Add the public inbox data contract and no-op implementation**
+Cover:
+
+- valid schema-v2 header;
+- missing keys;
+- corrupt header version;
+- filename/header `ReportId` mismatch;
+- report containing a very large exception section;
+- more than 32 header lines;
+- more than 16 KiB before the exception marker;
+- 10,000-character `BuildId`;
+- control characters in `ExceptionType` and other string fields;
+- empty string fields.
+
+Expected normalization:
+
+```text
+ReportId            <- filename-derived authoritative value
+CapturedAtUtc       <- header when valid, otherwise filename timestamp when parseable
+BuildId             <- bounded normalized value or Unknown
+OperatingSystem     <- bounded normalized value or Unknown
+ProcessArchitecture <- bounded normalized value or Unknown
+StageOrMilestone    <- bounded normalized value or Unknown
+ExceptionType       <- bounded normalized value or Unknown
+FileName            <- current physical basename
+```
+
+The reader must stop before `--- EXCEPTION ---` and never return free-form report content.
+
+- [ ] **Step 4: Implement the minimal `CrashReportSummaryReader`**
+
+Implement only the schema-v2 header contract:
+
+```text
+max header lines: 32
+max header characters: 16 KiB
+max normalized string field: 256 chars
+ASCII controls: replace with spaces
+trimmed empty value: Unknown
+```
+
+Do not add a general crash-report parser.
+
+- [ ] **Step 5: Extend `CrashReportStore` around one filename policy**
+
+Use one retained-name helper/regex for discovery, cleanup, acknowledgement, deletion, and retention.
+
+Required behavior:
+
+- expose `internal string RootPath => _rootPath` for crash-runtime composition;
+- discover pending and acknowledged forms newest-first;
+- group by filename-derived report ID;
+- cleanup acknowledged duplicate when a pending twin exists;
+- acknowledge by same-directory rename;
+- if acknowledgement sees both variants, remove the ack duplicate first; return a bounded conflict error if reconciliation fails rather than deleting the pending canonical file;
+- treat already-acknowledged reports as idempotent success;
+- delete both approved variants for a report ID;
+- apply latest-five retention to logical reports after duplicate reconciliation.
+
+Do not open report bodies for retention ordering; the timestamp prefix is already sortable.
+
+- [ ] **Step 6: Add the public inbox contract and silent empty implementation**
 
 Add:
 
@@ -124,18 +195,31 @@ public interface ICrashReportInbox
 }
 ```
 
-Also add an empty implementation returning no reports and bounded failure/no-op action results suitable for a disabled crash runtime.
-
-- [ ] **Step 6: Run focused tests**
-
-Run the crash-report summary/store tests plus the existing crash-reporting suite. Verify existing HPA-529 capture still writes the pending `.txt` form and retention still caps the combined set at five.
-
-- [ ] **Step 7: Commit**
-
-Commit this slice independently with a message similar to:
+`EmptyCrashReportInbox` behavior is exact:
 
 ```text
-feat: add crash report inbox storage state
+GetReports()                  -> empty
+OpenGitHubIssue(reportId)     -> success, no-op
+OpenReportFolder(reportId)    -> success, no-op
+Dismiss(reportId)             -> success, no-op
+Delete(reportId)              -> success, no-op
+```
+
+- [ ] **Step 7: Run Task 1 verification**
+
+Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReporting"
+```
+
+Verify existing HPA-529 capture tests still create pending `crash-*.txt`, never `.ack.txt`, and the combined retained logical set stays capped at five.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add DTXMania.Game/Lib/Diagnostics/CrashReporting DTXMania.Test/CrashReporting
+git commit -m "feat: add crash report inbox storage state"
 ```
 
 ---
@@ -151,9 +235,9 @@ feat: add crash report inbox storage state
 - Test: `DTXMania.Test/CrashReporting/CrashReportInboxTests.cs`
 
 **Interfaces:**
-- Consumes: Task 1 store operations and `ICrashReportInbox` contract.
+- Consumes: Task 1 store operations, `RootPath`, normalized `CrashReportSummary`, and `ICrashReportInbox` contract.
 - Produces: production `CrashReportInbox` used by `CrashReportRuntime` in Task 3.
-- Produces: internal `IExternalLauncher` seam used only by the inbox and tests.
+- Produces: internal `IExternalLauncher` seam used only by inbox composition and tests.
 
 - [ ] **Step 1: Write GitHub URL-builder tests first**
 
@@ -163,13 +247,32 @@ Assert the generated URL targets exactly:
 https://github.com/cwchanap/DTXManiaCX/issues/new
 ```
 
-Allow only report ID, build ID, OS, architecture, stage/milestone, exception type, schema-v2 format identifier, and manual `.txt` attachment instructions in the title/body query values.
+Allow only:
 
-Add rejection tests for HTTP, alternate hosts, alternate repositories, and alternate GitHub paths.
+- report ID;
+- build ID;
+- OS;
+- architecture;
+- stage/milestone;
+- exception type;
+- `DTXMANIACX-CRASH-REPORT 2`;
+- manual `.txt` attachment instructions.
+
+Add tests proving:
+
+- HTTP is rejected;
+- alternate host is rejected;
+- alternate repository/path is rejected;
+- 10,000-character source values are already clamped by the reader/builder boundary;
+- embedded control/newline-style input cannot break query structure;
+- every dynamic query value is URI-escaped;
+- report-body content never appears in the URI.
 
 - [ ] **Step 2: Implement `GitHubCrashIssueBuilder`**
 
-Keep URL construction deterministic and side-effect free. Return a `Uri`; keep validation in the same focused component so callers cannot bypass host/path constraints accidentally.
+Keep it deterministic and side-effect free. Build from the normalized summary, URI-escape dynamic values, return a `Uri`, and validate scheme/host/path in this component before returning a launchable target.
+
+Do not add configuration for the one supported repository.
 
 - [ ] **Step 3: Write external-launcher tests around `ProcessStartInfo`**
 
@@ -190,43 +293,54 @@ macOS assertions:
 FileName = /usr/bin/open
 UseShellExecute = false
 ArgumentList[0] = --
-ArgumentList[1] = <validated URI or internal directory>
+ArgumentList[1] = <validated URI or CrashReportStore.RootPath>
 no sh -c
 ```
 
-Also cover unsupported platform, start exception, and non-zero macOS result as bounded failures.
+Also cover unsupported platform, process-start exception, and non-zero macOS result as bounded failures.
 
 - [ ] **Step 4: Implement `IExternalLauncher`**
 
-Support URI and directory launch only. Directory launch receives the internally resolved crash-report root from composition; do not accept arbitrary stage-supplied paths.
+Support URI and directory launch only. Directory launch receives `CrashReportStore.RootPath` from crash-reporting composition; do not accept arbitrary stage-supplied paths.
 
-- [ ] **Step 5: Write inbox action tests**
+Follow the existing repository pattern of creating testable `ProcessStartInfo` rather than introducing a general process-execution service.
 
-Using a real `CrashReportStore` rooted in a temporary test directory plus a fake launcher, assert:
+- [ ] **Step 5: Write inbox action tests with a real temporary store plus fake launcher**
 
-- successful GitHub launch acknowledges the selected report;
-- successful folder launch acknowledges the selected report;
+Assert:
+
+- successful GitHub launch acknowledges the selected pending report;
+- successful folder launch acknowledges the selected pending report;
 - launcher failure leaves it pending;
 - `Dismiss` acknowledges without deleting;
-- `Delete` deletes whichever filename currently represents the report;
-- launcher success followed by acknowledgement failure returns an acknowledgement error and leaves the report pending.
+- `Delete` removes the logical report;
+- dual pending+ack delete leaves no ghost variant;
+- launcher success followed by acknowledgement failure returns a bounded acknowledgement error and preserves the pending canonical file;
+- missing report returns a bounded stable error rather than a raw exception.
 
 - [ ] **Step 6: Implement `CrashReportInbox` orchestration**
 
-Each public action resolves the report by ID at call time. Never accept a path from the caller. For launcher-backed actions, perform `validate -> launch -> acknowledge` in that order.
+Each public action resolves the report by ID at call time. Never accept a path from the caller.
+
+Launcher-backed order is exact:
+
+```text
+resolve -> build/validate target -> launch -> acknowledge -> refresh
+```
 
 Map raw filesystem/process exceptions to short stable error codes; never surface raw exception messages through the public result.
 
-- [ ] **Step 7: Run focused tests**
+- [ ] **Step 7: Run Task 2 verification**
 
-Run all new crash-inbox/launcher tests plus the existing crash-reporting suite.
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReporting"
+```
 
 - [ ] **Step 8: Commit**
 
-Commit this slice independently with a message similar to:
-
-```text
-feat: add crash report github handoff
+```bash
+git add DTXMania.Game/Lib/Diagnostics/CrashReporting DTXMania.Test/CrashReporting
+git commit -m "feat: add crash report github handoff"
 ```
 
 ---
@@ -244,44 +358,60 @@ feat: add crash report github handoff
 
 **Interfaces:**
 - Consumes: production `CrashReportInbox` from Task 2.
-- Produces: `IGameCrashDiagnostics.CrashReportInbox` and `IStageGame.CrashReportInbox` used by `TitleStage` in Task 4.
+- Produces: `IGameCrashDiagnostics.CrashReportInbox` and production `BaseGame.CrashReportInbox` used by `TitleStage` in Task 4.
+- Keeps test-only/simple `IStageGame` implementations source-compatible through a default empty inbox property.
 
-- [ ] **Step 1: Add contract tests for the new narrow property**
+- [ ] **Step 1: Add contract tests for the narrow diagnostics property**
 
-Extend diagnostics/stage contract tests so `BaseGame` exposes an injected `ICrashReportInbox` without exposing `CrashReportStore`, launcher, or runtime lifetime methods.
-
-- [ ] **Step 2: Extend `IGameCrashDiagnostics`**
-
-Add:
+Assert `IGameCrashDiagnostics` exposes:
 
 ```csharp
 ICrashReportInbox CrashReportInbox { get; }
 ```
 
-The disabled runtime must expose the no-op inbox created in Task 1.
+and does not expose `CrashReportStore`, launcher, parser, root path, or crash-runtime lifetime operations.
+
+- [ ] **Step 2: Extend `IGameCrashDiagnostics` and disabled runtime behavior**
+
+Enabled runtime returns the composed production inbox.
+
+Disabled/bootstrap-degraded runtime returns `EmptyCrashReportInbox.Instance`; verify it produces no reports and never creates title-visible action errors.
 
 - [ ] **Step 3: Compose the production inbox in `CrashReportRuntime`**
 
-Reuse the same `CrashReportStore` instance already owned by the runtime. Compose `GitHubCrashIssueBuilder`, the platform launcher, and the internally resolved crash-report root there.
+Reuse the same `CrashReportStore` instance already owned by the runtime. Construct the summary reader, GitHub builder, external launcher, and inbox there.
+
+Use `CrashReportStore.RootPath` for directory handoff so production and injected test stores cannot diverge from the path opened by the inbox.
 
 Do not create crash-report services from `BaseGame` or `TitleStage`.
 
-- [ ] **Step 4: Forward through `BaseGame` / `IStageGame`**
+- [ ] **Step 4: Add the default `IStageGame` property and production forwarding**
 
-Add a read-only `CrashReportInbox` property to `IStageGame` and forward the injected diagnostics inbox from `BaseGame`.
+Add:
 
-Update test-only `IStageGame` stubs with the no-op inbox; do not add nullable checks throughout stage code.
+```csharp
+ICrashReportInbox CrashReportInbox => EmptyCrashReportInbox.Instance;
+```
 
-- [ ] **Step 5: Run contract/runtime tests**
+to `IStageGame` as a default interface member.
 
-Run the diagnostics runtime, `IStageGame`, and `BaseGame` tests. Verify the crash-disabled bootstrap path still starts successfully with an empty inbox.
+`BaseGame` explicitly forwards the real injected diagnostics inbox.
+
+Do **not** update every test stub solely to satisfy this property; existing minimal implementations should inherit the default behavior.
+
+- [ ] **Step 5: Run Task 3 verification**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReportRuntime|FullyQualifiedName~IStageGameContractTests|FullyQualifiedName~BaseGameTests"
+```
+
+Verify the crash-disabled bootstrap path still starts successfully and stage stubs that do not override `CrashReportInbox` receive the empty singleton.
 
 - [ ] **Step 6: Commit**
 
-Commit this slice independently with a message similar to:
-
-```text
-feat: expose crash inbox to title stage
+```bash
+git add DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportContracts.cs DTXMania.Game/Lib/Diagnostics/CrashReporting/CrashReportRuntime.cs DTXMania.Game/Lib/Stage/IStageGame.cs DTXMania.Game/Game1.cs DTXMania.Test
+git commit -m "feat: expose crash inbox to title stage"
 ```
 
 ---
@@ -297,26 +427,39 @@ feat: expose crash inbox to title stage
 **Interfaces:**
 - Consumes: `IStageGame.CrashReportInbox` from Task 3.
 - Produces: final player-facing title-screen recovery UX.
+- Produces: `CrashReportNotification.TryHandleInput(...) -> bool`, where `true` means the normal title input path must not run that frame.
 
 - [ ] **Step 1: Write notification state-machine tests before rendering code**
 
-Use a fake `ICrashReportInbox` and test the component without filesystem or real process launches.
+Use a fake `ICrashReportInbox` and test without filesystem, graphics-device, or real process launches.
 
 Cover:
 
 - zero reports -> hidden banner and closed panel;
 - pending reports -> one banner with pending count;
 - acknowledged-only reports -> no banner but retained reports remain reviewable through F8;
-- open panel -> selected report defaults to newest pending report, otherwise newest retained report;
-- Previous/Next wraps or clamps consistently; choose one behavior and assert it in tests;
+- opening defaults to newest pending report, otherwise newest retained report;
+- Previous/Next clamps at ends;
 - successful dismiss closes the panel and refreshes counts;
 - delete requires confirmation;
 - successful delete selects the nearest remaining report or closes when empty;
-- action failures keep the panel open and expose a retryable error state.
+- action failures keep the panel open and expose a retryable bounded error;
+- private component layout constants produce stable banner/panel hit regions without a new layout abstraction.
 
-Prefer clamp-at-ends navigation unless an existing title UI convention clearly favors wrapping.
+- [ ] **Step 2: Lock raw F8 and consumed-input semantics in tests**
 
-- [ ] **Step 2: Implement `CrashReportNotification` as a title-specific component**
+Assert:
+
+- F8 is detected from raw previous/current `KeyboardState`, edge-triggered once;
+- F8 does not require an `InputCommandType` mapping;
+- F8 with no retained reports is a no-op and does not consume normal title input;
+- F8 opening/reopening the panel returns `true` from `TryHandleInput` and consumes that frame;
+- banner click opening the panel also consumes that frame;
+- when the panel is open, all handled navigation/actions return consumed;
+- Back/Escape while open closes the panel and returns consumed;
+- delete confirmation consumes confirm/cancel input until resolved.
+
+- [ ] **Step 3: Implement `CrashReportNotification` as the sole notification state owner**
 
 Keep it focused on:
 
@@ -326,39 +469,47 @@ Keep it focused on:
 - focused action;
 - delete confirmation state;
 - short visible error code/message;
-- banner/panel geometry and draw helpers.
+- banner hit-testing;
+- raw F8 edge detection;
+- private banner/panel geometry constants;
+- draw helpers.
 
 Do not turn it into a reusable modal framework.
 
-- [ ] **Step 3: Integrate activation and refresh into `TitleStage`**
+- [ ] **Step 4: Integrate activation and refresh into `TitleStage`**
 
-On title activation, create/refresh the notification from `_game.CrashReportInbox` after normal title resources are available. The lookup is bounded to the retained latest-five reports.
+On title activation, create/refresh the notification from `_game.CrashReportInbox` after normal title resources are available. The lookup remains bounded to the latest-five retained logical reports.
 
 On deactivation/disposal, clear stage-owned notification state only; the inbox/runtime remains process-owned.
 
-- [ ] **Step 4: Gate input correctly**
+- [ ] **Step 5: Make input gating one explicit guard**
 
-In `OnUpdate`:
+After updating keyboard/mouse state in `TitleStage.OnUpdate`, call the notification first:
 
-1. update keyboard/mouse states as today;
-2. process F8/banner activation;
-3. if the crash panel is open, route input to it first and skip normal title-menu `HandleInput()` / `HandleMouseInput()` for that frame;
-4. otherwise preserve current title behavior exactly.
+```csharp
+if (_crashReportNotification?.TryHandleInput(/* current input state */) == true)
+{
+    return;
+}
+```
 
-Use existing virtual mouse mapping and existing remappable commands where practical:
+Only if it returns `false` may existing title `HandleInput()` / `HandleMouseInput()` run.
+
+Required behavior:
 
 ```text
 MoveLeft / MoveRight -> previous / next report
 MoveUp / MoveDown    -> action focus
 Activate             -> execute focused action
-Back / Escape        -> close panel
+Back / Escape        -> close panel when open
+raw F8               -> open/reopen crash panel
 ```
 
-When delete confirmation is active, consume only confirm/cancel actions.
+The critical regression case is explicit: **Back/Escape with the panel open closes the panel and must never call `RequestExit()` in the same frame.**
 
-- [ ] **Step 5: Draw the banner and panel after the existing title menu**
+- [ ] **Step 6: Draw the banner and panel after the existing title menu**
 
-Keep drawing inside the existing title `SpriteBatch` flow. Use existing title font/primitive resources where possible instead of introducing new skin assets in this ticket.
+Keep drawing inside the existing title `SpriteBatch` flow. Reuse existing title font/primitive resources; do not add skin assets.
 
 The panel may render only:
 
@@ -373,23 +524,26 @@ Exception type
 Pending / Acknowledged
 ```
 
-Never render report-body content.
+Never render `CrashReportSummary.FileName` or report-body content.
 
-- [ ] **Step 6: Extend `TitleStageTests` for input leakage**
+- [ ] **Step 7: Add one thin `TitleStage` input-isolation regression test**
 
-Add tests around extracted/internal helper seams as needed so:
+Keep the detailed state tests in `CrashReportNotificationTests`. Add only enough `TitleStageTests` coverage to prove:
 
-- F8 opens the crash panel without selecting a title menu item;
-- panel activation input cannot trigger GAME START / CONFIG / EXIT in the same frame;
-- closed-panel behavior still uses the existing title menu path unchanged.
+- notification-consumed input skips GAME START / CONFIG / EXIT handling;
+- open-panel Back/Escape cannot call `RequestExit()`;
+- closed notification with no interaction still reaches the existing menu path.
 
-Avoid constructing real MonoGame graphics devices merely to test state transitions.
+Avoid creating a real MonoGame graphics device merely for state transitions.
 
-- [ ] **Step 7: Run focused and full relevant tests**
+- [ ] **Step 8: Run Task 4 verification**
 
-Run the new stage/component tests, existing `TitleStageTests`, stage contract tests, and crash-reporting tests. Then run the repository's standard unit-test command used by CI.
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~DTXMania.Test.Stage"
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~CrashReporting"
+```
 
-- [ ] **Step 8: Perform supported-platform smoke verification**
+- [ ] **Step 9: Perform supported-platform smoke verification**
 
 On macOS, verify the production launcher can open both:
 
@@ -402,12 +556,11 @@ Record OS/runtime details and observed results in the implementation PR. Do not 
 
 On Windows, confirm the unit tests inspect `UseShellExecute = true` and prove no command-shell construction exists.
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
-Commit this slice independently with a message similar to:
-
-```text
-feat: add title crash report inbox ui
+```bash
+git add DTXMania.Game/Lib/Stage/CrashReportNotification.cs DTXMania.Game/Lib/Stage/TitleStage.cs DTXMania.Test/Stage
+git commit -m "feat: add title crash report inbox ui"
 ```
 
 ---
@@ -416,15 +569,24 @@ feat: add title crash report inbox ui
 
 Before marking HPA-530 complete:
 
-- [ ] Run the complete crash-reporting test suite.
-- [ ] Run the complete title/stage test suite.
-- [ ] Run the repository's normal Windows/macOS unit-test CI commands locally where available.
-- [ ] Confirm HPA-529 crash capture still creates `crash-*.txt`, never `.ack.txt`, for a newly captured crash.
+- [ ] Run `dotnet test DTXMania.Test/DTXMania.Test.csproj`.
+- [ ] Run the repository's normal Windows/macOS unit-test CI commands where available.
+- [ ] Confirm HPA-529 crash capture still creates pending `crash-*.txt`, never `.ack.txt`, for a newly captured crash.
+- [ ] Confirm the exact retained-name regex rejects arbitrary files and recognizes both pending/ack forms.
+- [ ] Confirm dual pending+ack files for the same ID collapse to one inbox item and cleanup reconciles the duplicate.
+- [ ] Confirm acknowledged and pending logical reports together never exceed the existing latest-five retention limit.
+- [ ] Confirm a 10,000-character or control-character-containing header field cannot become an unbounded/malformed GitHub URI or UI value.
+- [ ] Confirm GitHub dynamic query values are URI-escaped and only approved summary fields are present.
 - [ ] Confirm title activation with no reports is behaviorally unchanged.
+- [ ] Confirm disabled/bootstrap crash reporting produces no banner and silent no-op inbox actions.
 - [ ] Confirm one pending report shows one non-blocking banner.
+- [ ] Confirm raw F8 is edge-triggered, non-remappable, and consumes the frame only when it opens/reopens the crash panel.
+- [ ] Confirm Back/Escape with the panel open closes the panel and does **not** call `RequestExit()`.
+- [ ] Confirm panel activation/navigation input cannot leak into GAME START / CONFIG / EXIT in the same frame.
 - [ ] Confirm successful GitHub/folder launch acknowledges but does not delete.
 - [ ] Confirm launcher failure keeps the report pending and retryable.
 - [ ] Confirm dismiss persists acknowledgement across restart.
-- [ ] Confirm confirmed delete removes the report and refreshes the count.
-- [ ] Confirm acknowledged and pending reports together never exceed the existing latest-five retention limit.
-- [ ] Confirm no `inbox-state.json`, ZIP support, shell command construction, automatic upload, or Linux launcher code was introduced.
+- [ ] Confirm confirmed delete removes the logical report without leaving a duplicate physical variant.
+- [ ] Confirm macOS uses `/usr/bin/open`, separate `--`, and separate target argument.
+- [ ] Confirm Windows uses `UseShellExecute = true` without a command shell.
+- [ ] Confirm no `inbox-state.json`, ZIP support, shell command construction, automatic upload, generic modal/process framework, new key-binding setting, or Linux launcher code was introduced.

--- a/docs/superpowers/specs/2026-08-07-hpa-530-title-screen-crash-inbox-design.md
+++ b/docs/superpowers/specs/2026-08-07-hpa-530-title-screen-crash-inbox-design.md
@@ -10,53 +10,31 @@
 
 HPA-529 shipped a deliberately simplified crash-reporting format:
 
-- one retained artifact per crash;
-- plain-text `DTXMANIACX-CRASH-REPORT 2` files only;
+- one plain-text `DTXMANIACX-CRASH-REPORT 2` artifact per crash;
 - one latest-five retention policy in `CrashReportStore`;
 - no ZIP bundle;
 - no emergency fallback format;
 - no `inbox-state.json`.
 
-The original HPA-530 ticket predates that schema-v2 amendment and still references ZIP reports, emergency fallback reports, and a separate inbox-state file. Those statements are obsolete for this implementation. HPA-530 must extend the shipped text-only model rather than recreate the removed architecture.
-
-HPA-530 does reintroduce the name `ICrashReportInbox`, but only as a new narrow stage-facing facade for schema-v2 discovery and actions. This does **not** revive the obsolete HPA-519 ZIP/inbox-state design or its old persistence contract.
+The older HPA-519/HPA-530 text that describes ZIPs, emergency reports, or a persisted inbox-state file is obsolete. HPA-530 reintroduces only a **narrow title-facing inbox facade** over the shipped text reports; it does not revive the obsolete inbox architecture.
 
 ## Goals
 
 - Notify the player non-blockingly when retained crash reports have not been acknowledged.
-- Let the player review only the safe, allowlisted report header summary.
-- Let the player open a prefilled DTXManiaCX GitHub issue and manually attach the selected `.txt` report.
-- Let the player open the crash-report directory, dismiss a report, or delete it after confirmation.
-- Keep acknowledgement persistent across restarts without adding a second state file.
-- Keep title-screen code independent of crash-report parsing, filesystem paths, process launching, and retention rules.
-- Keep all failure modes recoverable in-game and never block normal startup.
+- Review only the safe schema-v2 header summary in-game.
+- Open a prefilled DTXManiaCX GitHub issue and let the player manually attach the selected `.txt` report.
+- Open the crash-report directory, dismiss a report, or delete it after confirmation.
+- Persist acknowledgement without a second state file.
+- Keep parsing, paths, process launching, and retention out of `TitleStage`.
+- Keep failures retryable and non-fatal.
 
 ## Non-goals
 
-- Automatic upload or GitHub API submission.
-- GitHub authentication or submission confirmation.
+- Automatic upload, GitHub API use, authentication, or submission confirmation.
 - Viewing exception bodies, stack traces, logs, breadcrumbs, or context sections in-game.
-- ZIP handling or emergency-report special cases.
-- A second retention policy.
-- A dedicated crash-management stage.
-- Linux external-launch support in this ticket.
-- Native dumps, hang reports, screenshots, or telemetry.
-- A generic modal framework, generic process runner, or configurable GitHub destination.
-
-## Existing integration points
-
-The implementation extends the seams already introduced by HPA-529:
-
-- `CrashReportStore` owns the crash-report root, atomic writes, cleanup, and latest-five retention.
-- `CrashReportSummary` already models the safe fields required by the title UI.
-- `CrashReportTextWriter` writes a fixed schema-v2 header before the free-form report sections.
-- `CrashReportRuntime` is the process-owned diagnostics composition root.
-- `IGameCrashDiagnostics` is injected into `BaseGame` and is the correct route for exposing a narrow inbox service.
-- `IStageGame` is the stage-facing game contract used by `TitleStage` and already uses default interface members for optional diagnostics hooks.
-- `TitleStage` already owns title rendering and keyboard/mouse handling.
-- `AppPaths.GetCrashReportsRoot()` remains the only production path source for crash reports.
-
-No static service locator should be introduced.
+- ZIP or emergency-report compatibility.
+- Linux launcher support in this ticket.
+- A reusable crash-management stage, generic modal framework, generic process runner, or configurable GitHub destination.
 
 ## Architecture
 
@@ -64,115 +42,102 @@ No static service locator should be introduced.
 CrashReportRuntime
   └─ CrashReportInbox : ICrashReportInbox
        ├─ CrashReportStore
-       │    ├─ discover retained report names
-       │    ├─ acknowledge by atomic rename
-       │    ├─ delete by report ID
-       │    └─ expose internal RootPath for composition
+       │    ├─ discover pending/acknowledged text reports
+       │    ├─ acknowledge by same-directory rename
+       │    ├─ delete by logical report ID
+       │    └─ retain latest five logical reports
        ├─ CrashReportSummaryReader
        │    └─ bounded schema-v2 header parsing
        ├─ GitHubCrashIssueBuilder
-       └─ IExternalLauncher
+       └─ ExternalLauncher
 
 IGameCrashDiagnostics
   └─ CrashReportInbox
 
 BaseGame
-  └─ forwards real inbox
+  └─ forwards production inbox
 
 IStageGame
   └─ CrashReportInbox => EmptyCrashReportInbox.Instance by default
 
 TitleStage
   └─ CrashReportNotification
-       ├─ compact banner
-       ├─ review panel state
-       └─ input ownership via TryHandleInput(...)
+       ├─ banner/review-panel state
+       └─ HandleInput(...) -> bool consumed
 ```
 
-`TitleStage` depends only on `ICrashReportInbox`. It must not receive `CrashReportStore`, `IExternalLauncher`, the crash-report root path, or a parser directly.
+`TitleStage` receives only `ICrashReportInbox`. It never receives `CrashReportStore`, a parser, a launcher, or a crash-report path.
 
 ## Retained file identity and acknowledgement
 
-Acknowledgement is encoded in the retained report filename.
-
-Pending report:
+Pending form:
 
 ```text
 crash-20260806-123456Z-a1b2c3.txt
 ```
 
-Acknowledged report:
+Acknowledged form:
 
 ```text
 crash-20260806-123456Z-a1b2c3.ack.txt
 ```
 
-The retained-name contract is normative and case-insensitive:
+The retained-name contract is case-insensitive:
 
 ```text
 ^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$
 ```
 
-### Identity rules
+Rules:
 
-1. New reports created by HPA-529 always use the pending `.txt` form.
-2. The logical report ID is always derived from the retained filename by stripping `.ack.txt` when present, otherwise `.txt`.
-3. The filename-derived report ID is authoritative for inbox lookup and actions. A header `ReportId` is accepted only when it matches the filename-derived ID; otherwise the filename-derived value wins.
-4. `CrashReportSummary.FileName` returned by discovery is the **current physical basename** (`*.txt` or `*.ack.txt`). The title UI should not display or depend on it.
-5. Acknowledgement is an atomic same-directory rename from pending `.txt` to `.ack.txt`.
-6. Both pending and acknowledged reports participate in the same latest-five retention policy.
-7. `CrashReportStore` remains the only owner of retention and filesystem mutation.
-8. Temporary `.tmp` behavior remains unchanged.
+1. New HPA-529 captures always create the pending `.txt` form.
+2. Logical report ID is derived from the filename by stripping `.ack.txt` or `.txt`.
+3. Filename-derived report ID is authoritative for inbox lookup/actions. A header `ReportId` is used only when it matches.
+4. `CrashReportSummary.FileName` means the physical artifact basename represented by that summary at that time. Capture summaries therefore contain `.txt`; discovery of an acknowledged artifact may contain `.ack.txt`. The title UI does not need this field.
+5. Acknowledgement uses `File.Move(pendingPath, acknowledgedPath, overwrite: true)` in the same directory.
+6. If both physical variants exist because the directory was manually modified, discovery groups them into one logical item and prefers pending state. A subsequent acknowledgement overwrites the stale acknowledged twin. No separate reconciliation pass or acknowledgement-conflict state is added.
+7. Delete removes both approved physical variants for the requested logical report ID.
+8. Retention groups by logical report ID and keeps the latest five logical reports. When a stale logical report is removed, delete all of its approved variants.
+9. Temporary `.tmp` behavior remains unchanged.
 
-### Duplicate physical variants
+The timestamp appears before the acknowledgement suffix, so logical ordering remains filename-derived; report bodies never need to be opened for retention ordering.
 
-A manually altered or interrupted directory may contain both forms for one report ID. Treat them as one logical report, never two inbox items.
+## Safe summary discovery
 
-- Discovery collapses duplicate variants by report ID and prefers the pending file as canonical.
-- `Cleanup()` removes an acknowledged duplicate when its pending twin exists, then applies latest-five retention to logical report IDs.
-- `Acknowledge(reportId)` resolves the pending form first. If an acknowledged duplicate already exists, remove that duplicate before the pending-to-ack rename; if that cleanup fails, return a bounded acknowledgement-conflict error and preserve the pending file.
-- `Delete(reportId)` removes both approved physical variants for that report ID so a duplicate cannot reappear as a ghost item.
+`CrashReportSummaryReader` reads only the schema-v2 header and never becomes a general report parser.
 
-The timestamp portion precedes the acknowledgement suffix, so filename-derived chronological ordering remains cheap; no report body needs to be opened for retention ordering.
+It recognizes only these allowlisted fields:
 
-## Report discovery and safe summary parsing
+- `ReportId`;
+- `CapturedAtUtc`;
+- `BuildId`;
+- `OperatingSystem`;
+- `ProcessArchitecture`;
+- `StageOrMilestone`;
+- `ExceptionType`.
 
-Add one bounded schema-v2 header reader owned by the crash-reporting subsystem.
+The reader:
 
-Discovery recognizes only the approved pending and acknowledged filename forms in the crash-report root. It never recursively scans directories and never follows arbitrary paths supplied by the UI.
-
-The header reader:
-
-- reads only the beginning of the selected report;
-- requires `DTXMANIACX-CRASH-REPORT 2` when available;
-- parses only these allowlisted keys:
-  - `ReportId`;
-  - `CapturedAtUtc`;
-  - `BuildId`;
-  - `OperatingSystem`;
-  - `ProcessArchitecture`;
-  - `StageOrMilestone`;
-  - `ExceptionType`;
-- stops before `--- EXCEPTION ---`;
-- reads at most 32 header lines and 16 KiB of header text;
+- stops at `--- EXCEPTION ---`;
+- stops after 32 header lines;
+- stops after 16 KiB of header text, including a malformed single overlong line;
+- never performs an unbounded `ReadLine()` on attacker/hand-edited content beyond the remaining character budget;
 - normalizes each string field to at most 256 characters;
-- replaces ASCII control characters with spaces before display or handoff;
-- trims values and maps empty values to `Unknown`;
-- never returns exception text or other report sections to the UI.
+- replaces ASCII control characters with spaces;
+- trims values and maps empty/missing values to `Unknown`;
+- never returns exception/report-body text to the UI.
 
-If the header is corrupt or incomplete, discovery still returns a usable inbox item:
+Both the line and character bounds are intentional: the line bound limits normal parser work, while the character bound prevents one malformed line from allocating unbounded text.
 
-- derive report ID from the filename;
-- derive capture time from the filename timestamp when parseable;
-- set unavailable summary fields to `Unknown`.
+For a corrupt or incomplete header:
 
-A corrupt report remains dismissible, openable in the report folder, and deletable.
+- use filename-derived report ID;
+- use the filename timestamp when parseable;
+- use `Unknown` for unavailable summary fields.
 
-The reader is deliberately not a general report parser.
+The report remains dismissible, folder-openable, and deletable.
 
 ## Inbox contract
-
-Expose a narrow public contract suitable for `IStageGame`:
 
 ```csharp
 public sealed record CrashReportInboxItem(
@@ -193,46 +158,49 @@ public interface ICrashReportInbox
 }
 ```
 
-The interface accepts report IDs rather than file paths. The implementation resolves the current retained item internally for every action, preventing `TitleStage` from constructing or retaining arbitrary filesystem paths.
+The public contract takes report IDs, never paths. Every action resolves the current physical artifact internally.
 
-`GetReports()` returns at most one item per logical report ID, newest-first, and remains bounded by the existing latest-five policy.
+`GetReports()` returns the latest retained logical reports newest-first.
 
 ### Disabled runtime behavior
 
-`EmptyCrashReportInbox` is a silent no-op singleton:
+`EmptyCrashReportInbox` follows the existing null-object diagnostics pattern:
 
-- `GetReports()` returns an empty list;
-- all action methods return `Succeeded = true` without side effects.
+```text
+GetReports()               -> empty
+OpenGitHubIssue(...)        -> success, no-op
+OpenReportFolder(...)       -> success, no-op
+Dismiss(...)                -> success, no-op
+Delete(...)                 -> success, no-op
+```
 
-The empty inbox never causes a banner because it never returns reports, and accidental calls do not create misleading “crash reporting disabled” UI errors.
+These action calls are unreachable from the title UI because there are no items, and the no-op contract avoids introducing a separate disabled-feature state solely for defensive callers.
 
 ## Acknowledgement semantics
 
-A report becomes acknowledged only after one of these actions succeeds:
+A report becomes acknowledged only after one of these succeeds:
 
-- browser launch for `OpenGitHubIssue`;
-- report-directory launch for `OpenReportFolder`;
+- GitHub browser launch;
+- report-directory launch;
 - `Dismiss`.
 
-Opening GitHub or the report folder does not delete the report and does not mean the player submitted an issue.
+This preserves the existing HPA-530 product requirement: successful external handoff counts as acknowledgement even though it does **not** prove an issue was submitted.
 
-For launcher-backed actions:
+Launcher-backed order is:
 
-1. Resolve the report by ID.
-2. Build and validate the target internally.
-3. Launch the target.
-4. Only after launch succeeds, persist acknowledgement.
-5. Refresh the inbox snapshot.
+```text
+resolve -> build/validate target -> launch -> acknowledge -> refresh
+```
 
-If launch fails, the report remains pending and the action returns a retryable error.
+If launch fails, the report remains pending and the panel stays retryable.
 
-If launch succeeds but acknowledgement persistence fails, the report remains pending and the UI displays an acknowledgement error. The external target may already be open; the user can retry acknowledgement through `Dismiss` rather than requiring hidden recovery logic.
+If launch succeeds but acknowledgement rename fails, return a bounded acknowledgement error and keep the report pending. The external target may already be open; the user can retry or use Dismiss.
 
-Dismiss performs acknowledgement without launching anything and closes the review panel on success.
+Delete removes the report rather than acknowledging it.
 
 ## GitHub issue handoff
 
-`OpenGitHubIssue` constructs one HTTPS URL targeting exactly:
+The only destination is:
 
 ```text
 https://github.com/cwchanap/DTXManiaCX/issues/new
@@ -242,106 +210,99 @@ The generated title/body may contain only:
 
 - report ID;
 - app/build ID;
-- operating system;
+- OS;
 - process architecture;
-- stage or startup milestone;
+- stage/startup milestone;
 - exception type;
-- report format identifier `DTXMANIACX-CRASH-REPORT 2`;
-- instructions telling the player to inspect and manually attach the selected `.txt` crash report.
+- `DTXMANIACX-CRASH-REPORT 2`;
+- manual instructions to inspect and attach the `.txt` report.
 
-Every dynamic query value comes from the bounded normalized summary and is URI-escaped before assembly. Do not concatenate unescaped summary values into the query string.
+Every dynamic query value is URI-escaped. Do not embed exception messages, stacks, logs, breadcrumbs, arbitrary report text, paths, usernames, song identity, configuration content, or report contents.
 
-Do not embed exception messages, stack traces, logs, breadcrumbs, arbitrary report text, full paths, usernames, song identity, configuration content, or report-file contents in the URL.
+Even though the destination is constant today, validate the final URI before launch because HPA-530 explicitly requires rejection of unexpected launch targets:
 
-Before launch, validate that the final URI:
+- scheme must be `https`;
+- host must be `github.com`;
+- path must be `/cwchanap/DTXManiaCX/issues/new`.
 
-- uses `https`;
-- has host `github.com`;
-- has path `/cwchanap/DTXManiaCX/issues/new`.
-
-The URL builder and validator are deterministic and unit-tested independently from process launching.
+Keep focused validator tests for wrong scheme, host, repository, and path. They are cheap tripwires on a security-sensitive boundary and match the ticket acceptance criteria.
 
 ## External launcher
 
-Keep platform process details behind `IExternalLauncher`.
+Keep platform launching in shared crash-reporting code:
 
-Suggested contract:
-
-```csharp
-internal interface IExternalLauncher
-{
-    ExternalLaunchResult OpenUri(Uri uri);
-    ExternalLaunchResult OpenDirectory(string directoryPath);
-}
+```text
+DTXMania.Game/Lib/Diagnostics/CrashReporting/ExternalLauncher.cs
 ```
 
-The production launcher validates platform support and returns a bounded error code rather than throwing into the title stage.
+Do **not** place Windows/macOS implementations under the existing `Platform/` compile split. The game projects compile-remove the opposite folder-picker implementation, which would prevent one test project from exercising both launcher command shapes.
+
+`ExternalLauncher` branches at runtime and exposes internal pure builders such as:
+
+```csharp
+internal static ProcessStartInfo CreateWindowsStartInfo(string target);
+internal static ProcessStartInfo CreateMacStartInfo(string target);
+```
+
+Both builders compile into the shared game assembly and are unit-testable on either development platform.
 
 ### Windows
 
-Use `Process.Start` with `ProcessStartInfo.UseShellExecute = true` for the already validated HTTPS URI or internally resolved crash-report directory.
+Use `Process.Start` with:
 
-Never invoke `cmd.exe`, `cmd /c`, PowerShell, or build a command shell string.
+```text
+UseShellExecute = true
+FileName = <validated URI or internally resolved directory>
+```
+
+Never invoke `cmd`, PowerShell, or construct a command-shell string.
 
 ### macOS
 
-Use `/usr/bin/open` through `ProcessStartInfo` with `UseShellExecute = false` and `ArgumentList`:
+Use `/usr/bin/open` with `UseShellExecute = false` and separate `ArgumentList` entries:
 
 ```text
 /usr/bin/open -- <target>
 ```
 
-`--` and the target must be separate arguments. Never invoke `sh -c` or concatenate dynamic values into a shell command.
+Never invoke `sh -c` or concatenate a shell command.
 
-A non-zero exit code, process-start exception, or unsupported platform returns a retryable failure.
-
-The directory launch target is always `CrashReportStore.RootPath`, which is initialized from `AppPaths.GetCrashReportsRoot()` in production. `RootPath` is internal to crash-reporting composition and is never exposed through `IStageGame`.
+The directory target is always the store-owned crash-report root. Unsupported platform, process-start exception, or non-zero macOS result maps to a bounded retryable error.
 
 ## Title-screen UX
 
 ### Banner
 
-When `TitleStage` activates, query the inbox once and show a compact upper-right notification only when one or more reports are pending.
-
-Example:
+On title activation, query the inbox and show one compact upper-right banner only when pending reports exist:
 
 ```text
 CRASH REPORT AVAILABLE
 2 reports saved · Click or press F8 to review
 ```
 
-Requirements:
+The banner never steals focus or blocks normal title navigation while closed.
 
-- never delays startup;
-- never takes initial focus;
-- does not block normal title-menu navigation while closed;
-- one banner summarizes all pending reports;
-- mouse click on the banner or F8 opens the review panel;
-- F8 may reopen the panel while acknowledged retained reports still exist;
-- if no retained reports exist, F8 is a no-op.
+### F8
 
-### F8 policy
+F8 is a fixed, raw, non-remappable diagnostic shortcut for this ticket.
 
-F8 is a fixed, non-remappable title diagnostic shortcut for this ticket.
-
-- Read raw `Keys.F8` and edge-trigger it from previous/current keyboard state.
-- Do not add a new `InputCommandType` or key-assignment setting.
-- If F8 is also mapped to another command, the crash notification consumes that title-screen frame when it activates/reopens the panel, so the mapped title action does not also execute.
-
-This keeps the diagnostic shortcut explicit without expanding configuration scope.
+- Edge-trigger from the already available title keyboard state.
+- Do not add an `InputCommandType` or key-binding setting.
+- F8 with no retained reports is a no-op.
+- If F8 opens/reopens the panel, that frame is consumed so another mapped title action cannot also fire.
 
 ### Review panel
 
-The panel displays only `CrashReportSummary` plus acknowledgement state:
+Display only:
 
-- report position, for example `2 / 5`;
+- report position;
 - report ID;
-- captured UTC time;
+- captured UTC;
 - build ID;
 - OS / architecture;
-- stage or milestone;
+- stage/milestone;
 - exception type;
-- `Pending` or `Acknowledged` state.
+- Pending/Acknowledged state.
 
 Actions:
 
@@ -352,173 +313,129 @@ Actions:
 - Dismiss;
 - Delete Report.
 
-Delete requires a second in-panel confirmation before calling `Delete`.
-
-After deletion, select the nearest remaining report. If no report remains, close the panel and remove the banner.
+Delete requires in-panel confirmation. After deletion, select the nearest remaining report; close when none remain.
 
 ### Input ownership
 
-`CrashReportNotification` owns all notification interaction state:
+`CrashReportNotification` owns its open/closed state, selection, focused action, delete confirmation, error text, and banner/panel hit regions.
 
-- open/closed;
-- current selection;
-- action focus;
-- delete confirmation;
-- retryable error text;
-- banner hit-testing;
-- raw F8 activation.
-
-It exposes a focused input seam such as:
+Expose one focused method:
 
 ```csharp
-bool TryHandleInput(...)
+bool HandleInput(...)
 ```
 
-`true` means notification input was consumed and `TitleStage` must not call its normal `HandleInput()` or `HandleMouseInput()` for that frame.
+`true` means the notification consumed this frame and `TitleStage` must skip its normal `HandleInput()` / `HandleMouseInput()` calls.
 
-When the panel is closed, `TryHandleInput` returns `true` only when F8 or the banner click opens the panel; otherwise title behavior is unchanged.
+Use the existing `InputCommandType` path for remappable panel navigation and the title's existing keyboard/mouse snapshots for F8 and mouse edge detection:
 
-When the panel is open, notification input is always handled first and consumed before normal title input.
+```text
+MoveLeft / MoveRight -> previous / next
+MoveUp / MoveDown    -> action focus
+Activate             -> focused action
+Back / Escape        -> close panel
+raw F8               -> open/reopen
+```
 
-Use existing remappable commands for panel navigation where practical:
+**Back/Escape while the panel is open must close the panel and must never fall through to `TitleStage.RequestExit()` in the same frame.**
 
-- MoveLeft / MoveRight: previous / next report;
-- MoveUp / MoveDown: move action focus;
-- Activate: execute focused action;
-- Back or Escape: close panel.
+### Existing UI abstraction decision
 
-**Back/Escape while the panel is open must close the panel and must never fall through to `TitleStage.RequestExit()`.**
+The existing `UIElement/IInputState` and config-overlay patterns were reviewed, but HPA-530 should not force either abstraction into `TitleStage`:
 
-When delete confirmation is visible, only confirmation/cancel input is consumed until the confirmation resolves.
+- `UIElement.HandleInput(IInputState)` provides a useful bool-consumed convention and hit testing, but `IInputState` exposes raw input only and not the remappable `InputCommandType` commands required by this panel.
+- `InputStateManager` polls keyboard/mouse/gamepad itself; adding a second polling owner beside `TitleStage` would duplicate input state and timing solely for this feature.
+- `IConfigOverlayPanel` is config-specific and has no mouse/remappable-command contract; moving/generalizing it would be unrelated refactoring.
 
-Mouse buttons remain clickable through virtual-coordinate hit testing.
-
-### Layout
-
-Keep banner/panel rectangles and spacing as private constants owned by `CrashReportNotification` for this ticket. Do not create a new layout abstraction unless implementation reveals multiple consumers; there are none today.
+Therefore reuse the **single consumed-input pattern and existing virtual-coordinate mapping**, but keep `CrashReportNotification` as a small title-specific component. Geometry remains private constants; no new layout framework is needed.
 
 ## Error handling
 
-Inbox and launcher failures are non-fatal.
-
-The panel keeps a short visible error message for retryable failures such as:
+Show short retryable errors for:
 
 - report no longer exists;
-- report could not be acknowledged;
-- duplicate acknowledgement state could not be reconciled;
-- report could not be deleted;
+- acknowledgement failed;
+- delete failed;
 - browser launch failed;
-- file-manager launch failed;
-- external launch unsupported on this platform.
+- folder launch failed;
+- unsupported external launch.
 
-A launcher failure leaves the report pending and keeps the panel open.
+Never expose raw filesystem/process exception messages.
 
-A corrupt report header does not produce an error panel by itself; it displays bounded `Unknown` summary values and remains actionable.
-
-The title stage must not catch and expose raw exception messages from filesystem or process APIs.
+A corrupt summary renders normalized `Unknown` values and remains actionable.
 
 ## Testing strategy
 
-### Storage and parsing
+### Storage and reader
 
-Unit tests cover:
+Cover:
 
-- exact retained-name regex for pending and acknowledged forms;
-- filename-derived report ID for both forms;
-- `CrashReportSummary.FileName` tracking the current physical basename;
-- discovery collapsing pending+ack duplicates to one logical inbox item with pending precedence;
-- duplicate cleanup and delete behavior;
-- newest-first ordering;
-- shared latest-five retention across both filename forms;
-- atomic pending-to-acknowledged rename;
-- deletion of pending and acknowledged reports;
-- corrupt/missing headers falling back to filename-derived ID/time plus `Unknown` fields;
-- 32-line / 16-KiB header read bounds;
-- 256-character field bounds and ASCII-control normalization;
-- bounded parsing that never reads or returns the free-form exception section;
-- existing capture still emits only pending `crash-*.txt` names.
+- pending/ack filename regex and ID derivation;
+- newest-first logical ordering and latest-five retention;
+- pending+ack duplicate discovery collapsing to one item;
+- acknowledgement overwrite of a stale ack twin;
+- deletion removing both approved variants;
+- valid/corrupt/mismatched headers;
+- 32-line and 16-KiB header bounds, including a single huge line;
+- 256-character field clamp/control normalization;
+- no reads past the exception marker;
+- HPA-529 capture still emitting pending `.txt` only.
 
-### GitHub handoff and launcher
+### GitHub and launcher
 
-Unit tests cover:
+Cover:
 
-- exact GitHub host/path validation;
-- rejection of HTTP, alternate hosts, alternate repositories, and alternate paths;
-- query content limited to approved summary fields;
-- long and control-character-containing header values cannot produce unbounded or malformed launch URIs;
-- dynamic query values are URI-escaped;
-- Windows `UseShellExecute = true` and no command shell;
-- macOS `/usr/bin/open`, separate `--`, separate target argument, and no shell concatenation;
-- non-zero exit/start failure mapped to retryable errors;
-- directory launch restricted to the store-owned crash-report root.
+- allowed summary fields only;
+- dynamic URI escaping;
+- exact scheme/host/path validation and rejection cases;
+- Windows `UseShellExecute = true`, with no command shell;
+- macOS `/usr/bin/open`, separate `--` and target arguments;
+- unsupported/start/non-zero failures;
+- folder target restricted to the store-owned root.
 
 ### Inbox actions
 
-Tests using a temporary real store plus a fake launcher verify:
+Using a temporary real store and fake launcher:
 
-- successful GitHub launch acknowledges;
-- successful folder launch acknowledges;
-- failed launch leaves the report pending;
-- dismiss acknowledges without deleting;
-- delete removes the logical report, including a duplicate physical variant if present;
-- acknowledgement persistence failure is surfaced without deleting the pending report;
-- disabled/empty inbox returns no reports and silent successful no-op actions.
+- successful GitHub/folder launch acknowledges;
+- failed launch leaves pending;
+- launch success + acknowledgement failure is retryable;
+- Dismiss acknowledges without launch;
+- Delete removes the logical report.
 
 ### Title UI
 
-Component-first tests verify:
+Keep state tests on `CrashReportNotification` and only a thin guard test in `TitleStage`:
 
-- no reports means no banner and unchanged menu behavior;
-- pending reports produce one summarized banner;
-- raw edge-triggered F8 and banner click open the panel;
-- acknowledged reports remain reviewable but do not contribute to banner count;
-- notification input consumption prevents title-menu input leakage;
-- Back/Escape while open closes the panel and cannot request game exit;
-- Previous/Next navigation works across retained reports;
-- delete confirmation is required;
-- launcher errors remain visible and retryable.
+- no reports -> no banner;
+- pending count banner;
+- raw F8/banner click opens and consumes the frame;
+- acknowledged reports remain reviewable;
+- Back/Escape closes without requesting exit;
+- menu actions cannot leak through consumed notification input;
+- delete confirmation and retryable errors.
 
-Keep most behavioral tests on `CrashReportNotification` with a fake `ICrashReportInbox`. Add only a thin `TitleStage` guard test for the consumed-input contract; do not inflate the existing title tests into a graphics-heavy fixture.
+## Risks
 
-### Platform smoke verification
-
-On supported macOS, manually verify that `/usr/bin/open -- <target>` works for both the GitHub URI and crash-report directory. Record the command shape and observed result in the implementation PR.
-
-Windows behavior is covered by unit tests around `ProcessStartInfo`; no command-shell invocation is permitted.
-
-## Risks and mitigations
-
-1. **Pending/ack filename divergence or duplicate twins** — lock the regex/identity contract in store tests, collapse to one logical item, and reconcile duplicates in `Cleanup()`.
-2. **Panel Back/Escape accidentally exits the game** — make `CrashReportNotification.TryHandleInput` the ownership boundary and verify open-panel Back/Escape never reaches title exit handling.
-3. **Corrupt or hand-edited header creates hostile UI/URI values** — bound header bytes/lines/field lengths, normalize control characters, and URI-escape every dynamic query value.
-4. **F8 conflicts with a remapped input command** — define F8 as a fixed raw title diagnostic shortcut and consume the frame when it opens/reopens the crash panel.
-
-## Implementation boundaries
-
-HPA-530 should not refactor unrelated title-menu code, generalize a cross-game modal framework, add asynchronous background scanning, or introduce a general-purpose process-execution abstraction.
-
-The expected implementation remains small enough for one ticket and approximately two engineer days: one storage/handoff slice plus one title-UI integration slice, with focused tests around each boundary.
+1. **Filename-policy drift** — use one helper/regex for discovery, retention, acknowledge, and delete.
+2. **Back/Escape leakage** — one bool-consumed notification input guard plus regression test.
+3. **Corrupt header UI/URI abuse** — bounded reads, normalized fields, URI escaping.
+4. **Platform test blind spot** — keep both command builders in shared code rather than platform compile-split files.
 
 ## Acceptance criteria
 
-- No retained reports means no banner and unchanged title-menu behavior.
+- No retained reports means no banner and unchanged title behavior.
 - Pending reports produce one non-blocking summarized banner.
-- Schema-v2 `.txt` reports are the only supported report format.
-- Acknowledgement persists through the `.ack.txt` filename state; no `inbox-state.json` exists.
-- The exact retained-name contract supports only pending `crash-*.txt` and acknowledged `crash-*.ack.txt` forms.
-- Filename-derived report ID is authoritative; dual pending+ack files collapse to one logical inbox item.
-- Pending and acknowledged reports share the single latest-five `CrashReportStore` retention policy.
-- Existing crash capture still creates pending `crash-*.txt`, never `.ack.txt`.
-- Title UI displays only bounded allowlisted summary fields and never parses report sections directly.
-- Raw edge-triggered F8 and banner click open the review panel without leaking input into normal title actions.
-- F8 remains fixed/non-remappable for this ticket; no new `InputCommandType` is added.
-- Back/Escape while the panel is open closes the panel and never requests game exit.
-- Opening GitHub or the report folder acknowledges only after successful process launch and never deletes the report.
+- Only schema-v2 text reports are supported; no `inbox-state.json` or ZIP path is reintroduced.
+- Filename-derived report ID is authoritative; pending/ack forms share one latest-five logical retention policy.
+- New crashes still create pending `.txt`, never `.ack.txt`.
+- Title UI reads only bounded allowlisted header summary fields.
+- Raw F8 and banner click open the panel without input leakage.
+- Back/Escape while open closes the panel and never requests game exit.
+- Successful GitHub **or report-folder** launch acknowledges only after successful process launch and never deletes the report.
 - Dismiss acknowledges without deleting.
-- Delete requires in-panel confirmation and removes the logical report without leaving a duplicate variant behind.
-- Disabled/bootstrap crash reporting yields an empty inbox, no banner, and silent no-op inbox actions.
-- Launcher failures remain visible, pending, and retryable.
-- GitHub URLs target only `https://github.com/cwchanap/DTXManiaCX/issues/new`, URI-escape all dynamic values, and contain only approved bounded summary fields plus manual `.txt` attachment instructions.
-- Windows launcher uses `UseShellExecute = true` without a command shell.
-- macOS launcher uses `/usr/bin/open` with separate `--` and target arguments and without shell concatenation.
-- Unsupported platforms fail safely in-game.
+- Delete requires confirmation.
+- Disabled crash reporting exposes an empty no-op inbox and no banner.
+- GitHub target is exactly validated HTTPS `github.com/cwchanap/DTXManiaCX/issues/new`; dynamic query values are escaped.
+- Windows uses `UseShellExecute = true`; macOS uses `/usr/bin/open` with separate `--` and target arguments; neither uses a command shell.
+- Both Windows and macOS command shapes are unit-testable from shared code.

--- a/docs/superpowers/specs/2026-08-07-hpa-530-title-screen-crash-inbox-design.md
+++ b/docs/superpowers/specs/2026-08-07-hpa-530-title-screen-crash-inbox-design.md
@@ -19,6 +19,8 @@ HPA-529 shipped a deliberately simplified crash-reporting format:
 
 The original HPA-530 ticket predates that schema-v2 amendment and still references ZIP reports, emergency fallback reports, and a separate inbox-state file. Those statements are obsolete for this implementation. HPA-530 must extend the shipped text-only model rather than recreate the removed architecture.
 
+HPA-530 does reintroduce the name `ICrashReportInbox`, but only as a new narrow stage-facing facade for schema-v2 discovery and actions. This does **not** revive the obsolete HPA-519 ZIP/inbox-state design or its old persistence contract.
+
 ## Goals
 
 - Notify the player non-blockingly when retained crash reports have not been acknowledged.
@@ -39,18 +41,20 @@ The original HPA-530 ticket predates that schema-v2 amendment and still referenc
 - A dedicated crash-management stage.
 - Linux external-launch support in this ticket.
 - Native dumps, hang reports, screenshots, or telemetry.
+- A generic modal framework, generic process runner, or configurable GitHub destination.
 
 ## Existing integration points
 
-The implementation should extend the seams already introduced by HPA-529:
+The implementation extends the seams already introduced by HPA-529:
 
 - `CrashReportStore` owns the crash-report root, atomic writes, cleanup, and latest-five retention.
 - `CrashReportSummary` already models the safe fields required by the title UI.
 - `CrashReportTextWriter` writes a fixed schema-v2 header before the free-form report sections.
 - `CrashReportRuntime` is the process-owned diagnostics composition root.
 - `IGameCrashDiagnostics` is injected into `BaseGame` and is the correct route for exposing a narrow inbox service.
-- `IStageGame` is the stage-facing game contract used by `TitleStage`.
+- `IStageGame` is the stage-facing game contract used by `TitleStage` and already uses default interface members for optional diagnostics hooks.
 - `TitleStage` already owns title rendering and keyboard/mouse handling.
+- `AppPaths.GetCrashReportsRoot()` remains the only production path source for crash reports.
 
 No static service locator should be introduced.
 
@@ -58,30 +62,36 @@ No static service locator should be introduced.
 
 ```text
 CrashReportRuntime
-  └─ ICrashReportInbox
+  └─ CrashReportInbox : ICrashReportInbox
        ├─ CrashReportStore
-       │    ├─ discover schema-v2 .txt reports
-       │    ├─ parse safe header summaries
+       │    ├─ discover retained report names
        │    ├─ acknowledge by atomic rename
-       │    └─ delete
+       │    ├─ delete by report ID
+       │    └─ expose internal RootPath for composition
+       ├─ CrashReportSummaryReader
+       │    └─ bounded schema-v2 header parsing
        ├─ GitHubCrashIssueBuilder
        └─ IExternalLauncher
 
 IGameCrashDiagnostics
   └─ CrashReportInbox
 
-BaseGame / IStageGame
-  └─ CrashReportInbox
+BaseGame
+  └─ forwards real inbox
+
+IStageGame
+  └─ CrashReportInbox => EmptyCrashReportInbox.Instance by default
 
 TitleStage
   └─ CrashReportNotification
        ├─ compact banner
-       └─ lightweight review panel
+       ├─ review panel state
+       └─ input ownership via TryHandleInput(...)
 ```
 
 `TitleStage` depends only on `ICrashReportInbox`. It must not receive `CrashReportStore`, `IExternalLauncher`, the crash-report root path, or a parser directly.
 
-## Report acknowledgement without `inbox-state.json`
+## Retained file identity and acknowledgement
 
 Acknowledgement is encoded in the retained report filename.
 
@@ -97,23 +107,39 @@ Acknowledged report:
 crash-20260806-123456Z-a1b2c3.ack.txt
 ```
 
-Rules:
+The retained-name contract is normative and case-insensitive:
 
-1. New reports created by HPA-529 always use the pending form.
-2. Acknowledgement is an atomic same-directory rename to the `.ack.txt` form.
-3. The report ID inside the schema-v2 header never changes.
-4. Both pending and acknowledged reports count toward the single latest-five retention limit.
-5. `CrashReportStore` remains the only owner of retention.
-6. Temporary `.tmp` behavior remains unchanged.
-7. Deleting a report removes whichever physical filename currently represents that report ID.
+```text
+^crash-\d{8}-\d{6}Z-[0-9a-f]{6}(?:\.ack)?\.txt$
+```
 
-This keeps the report itself as the single durable artifact while still preserving acknowledgement across restarts.
+### Identity rules
+
+1. New reports created by HPA-529 always use the pending `.txt` form.
+2. The logical report ID is always derived from the retained filename by stripping `.ack.txt` when present, otherwise `.txt`.
+3. The filename-derived report ID is authoritative for inbox lookup and actions. A header `ReportId` is accepted only when it matches the filename-derived ID; otherwise the filename-derived value wins.
+4. `CrashReportSummary.FileName` returned by discovery is the **current physical basename** (`*.txt` or `*.ack.txt`). The title UI should not display or depend on it.
+5. Acknowledgement is an atomic same-directory rename from pending `.txt` to `.ack.txt`.
+6. Both pending and acknowledged reports participate in the same latest-five retention policy.
+7. `CrashReportStore` remains the only owner of retention and filesystem mutation.
+8. Temporary `.tmp` behavior remains unchanged.
+
+### Duplicate physical variants
+
+A manually altered or interrupted directory may contain both forms for one report ID. Treat them as one logical report, never two inbox items.
+
+- Discovery collapses duplicate variants by report ID and prefers the pending file as canonical.
+- `Cleanup()` removes an acknowledged duplicate when its pending twin exists, then applies latest-five retention to logical report IDs.
+- `Acknowledge(reportId)` resolves the pending form first. If an acknowledged duplicate already exists, remove that duplicate before the pending-to-ack rename; if that cleanup fails, return a bounded acknowledgement-conflict error and preserve the pending file.
+- `Delete(reportId)` removes both approved physical variants for that report ID so a duplicate cannot reappear as a ghost item.
+
+The timestamp portion precedes the acknowledgement suffix, so filename-derived chronological ordering remains cheap; no report body needs to be opened for retention ordering.
 
 ## Report discovery and safe summary parsing
 
 Add one bounded schema-v2 header reader owned by the crash-reporting subsystem.
 
-Discovery recognizes only the two approved filename forms in the crash-report root. It never recursively scans directories and never follows arbitrary paths supplied by the UI.
+Discovery recognizes only the approved pending and acknowledged filename forms in the crash-report root. It never recursively scans directories and never follows arbitrary paths supplied by the UI.
 
 The header reader:
 
@@ -128,7 +154,10 @@ The header reader:
   - `StageOrMilestone`;
   - `ExceptionType`;
 - stops before `--- EXCEPTION ---`;
-- applies a small line/character bound so a malformed file cannot cause unbounded reads;
+- reads at most 32 header lines and 16 KiB of header text;
+- normalizes each string field to at most 256 characters;
+- replaces ASCII control characters with spaces before display or handoff;
+- trims values and maps empty values to `Unknown`;
 - never returns exception text or other report sections to the UI.
 
 If the header is corrupt or incomplete, discovery still returns a usable inbox item:
@@ -138,6 +167,8 @@ If the header is corrupt or incomplete, discovery still returns a usable inbox i
 - set unavailable summary fields to `Unknown`.
 
 A corrupt report remains dismissible, openable in the report folder, and deletable.
+
+The reader is deliberately not a general report parser.
 
 ## Inbox contract
 
@@ -162,11 +193,18 @@ public interface ICrashReportInbox
 }
 ```
 
-The interface intentionally accepts report IDs rather than file paths. The implementation resolves the current retained item internally each time, preventing `TitleStage` from constructing or retaining arbitrary filesystem paths.
+The interface accepts report IDs rather than file paths. The implementation resolves the current retained item internally for every action, preventing `TitleStage` from constructing or retaining arbitrary filesystem paths.
 
-`GetReports()` returns the current retained set newest-first. The set is bounded by the existing latest-five policy.
+`GetReports()` returns at most one item per logical report ID, newest-first, and remains bounded by the existing latest-five policy.
 
-Provide a no-op implementation for the disabled crash runtime so title-screen code requires no feature flag or null checks.
+### Disabled runtime behavior
+
+`EmptyCrashReportInbox` is a silent no-op singleton:
+
+- `GetReports()` returns an empty list;
+- all action methods return `Succeeded = true` without side effects.
+
+The empty inbox never causes a banner because it never returns reports, and accidental calls do not create misleading “crash reporting disabled” UI errors.
 
 ## Acknowledgement semantics
 
@@ -180,10 +218,11 @@ Opening GitHub or the report folder does not delete the report and does not mean
 
 For launcher-backed actions:
 
-1. Resolve and validate the target internally.
-2. Launch the target.
-3. Only after launch succeeds, rename the selected pending report to the acknowledged filename.
-4. Refresh the inbox snapshot.
+1. Resolve the report by ID.
+2. Build and validate the target internally.
+3. Launch the target.
+4. Only after launch succeeds, persist acknowledgement.
+5. Refresh the inbox snapshot.
 
 If launch fails, the report remains pending and the action returns a retryable error.
 
@@ -193,7 +232,7 @@ Dismiss performs acknowledgement without launching anything and closes the revie
 
 ## GitHub issue handoff
 
-`OpenGitHubIssue` constructs one HTTPS URL targeting exactly the DTXManiaCX new-issue path:
+`OpenGitHubIssue` constructs one HTTPS URL targeting exactly:
 
 ```text
 https://github.com/cwchanap/DTXManiaCX/issues/new
@@ -210,6 +249,8 @@ The generated title/body may contain only:
 - report format identifier `DTXMANIACX-CRASH-REPORT 2`;
 - instructions telling the player to inspect and manually attach the selected `.txt` crash report.
 
+Every dynamic query value comes from the bounded normalized summary and is URI-escaped before assembly. Do not concatenate unescaped summary values into the query string.
+
 Do not embed exception messages, stack traces, logs, breadcrumbs, arbitrary report text, full paths, usernames, song identity, configuration content, or report-file contents in the URL.
 
 Before launch, validate that the final URI:
@@ -218,7 +259,7 @@ Before launch, validate that the final URI:
 - has host `github.com`;
 - has path `/cwchanap/DTXManiaCX/issues/new`.
 
-The URL builder and validator should be deterministic and unit-tested independently from process launching.
+The URL builder and validator are deterministic and unit-tested independently from process launching.
 
 ## External launcher
 
@@ -254,7 +295,7 @@ Use `/usr/bin/open` through `ProcessStartInfo` with `UseShellExecute = false` an
 
 A non-zero exit code, process-start exception, or unsupported platform returns a retryable failure.
 
-The directory launch target is always the internally resolved `AppPaths.GetCrashReportsRoot()` value. The stage cannot request another directory.
+The directory launch target is always `CrashReportStore.RootPath`, which is initialized from `AppPaths.GetCrashReportsRoot()` in production. `RootPath` is internal to crash-reporting composition and is never exposed through `IStageGame`.
 
 ## Title-screen UX
 
@@ -273,11 +314,21 @@ Requirements:
 
 - never delays startup;
 - never takes initial focus;
-- does not block normal title-menu navigation while the panel is closed;
+- does not block normal title-menu navigation while closed;
 - one banner summarizes all pending reports;
 - mouse click on the banner or F8 opens the review panel;
-- F8 may also reopen the panel while acknowledged retained reports still exist;
+- F8 may reopen the panel while acknowledged retained reports still exist;
 - if no retained reports exist, F8 is a no-op.
+
+### F8 policy
+
+F8 is a fixed, non-remappable title diagnostic shortcut for this ticket.
+
+- Read raw `Keys.F8` and edge-trigger it from previous/current keyboard state.
+- Do not add a new `InputCommandType` or key-assignment setting.
+- If F8 is also mapped to another command, the crash notification consumes that title-screen frame when it activates/reopens the panel, so the mapped title action does not also execute.
+
+This keeps the diagnostic shortcut explicit without expanding configuration scope.
 
 ### Review panel
 
@@ -307,9 +358,27 @@ After deletion, select the nearest remaining report. If no report remains, close
 
 ### Input ownership
 
-When the panel is closed, existing title-menu behavior remains unchanged except for the dedicated F8 shortcut and banner hit-test.
+`CrashReportNotification` owns all notification interaction state:
 
-When the panel is open, panel input is processed before the normal title-menu input path and the title stage returns without executing menu actions for that frame.
+- open/closed;
+- current selection;
+- action focus;
+- delete confirmation;
+- retryable error text;
+- banner hit-testing;
+- raw F8 activation.
+
+It exposes a focused input seam such as:
+
+```csharp
+bool TryHandleInput(...)
+```
+
+`true` means notification input was consumed and `TitleStage` must not call its normal `HandleInput()` or `HandleMouseInput()` for that frame.
+
+When the panel is closed, `TryHandleInput` returns `true` only when F8 or the banner click opens the panel; otherwise title behavior is unchanged.
+
+When the panel is open, notification input is always handled first and consumed before normal title input.
 
 Use existing remappable commands for panel navigation where practical:
 
@@ -318,9 +387,15 @@ Use existing remappable commands for panel navigation where practical:
 - Activate: execute focused action;
 - Back or Escape: close panel.
 
-Mouse buttons remain clickable through virtual-coordinate hit testing.
+**Back/Escape while the panel is open must close the panel and must never fall through to `TitleStage.RequestExit()`.**
 
 When delete confirmation is visible, only confirmation/cancel input is consumed until the confirmation resolves.
+
+Mouse buttons remain clickable through virtual-coordinate hit testing.
+
+### Layout
+
+Keep banner/panel rectangles and spacing as private constants owned by `CrashReportNotification` for this ticket. Do not create a new layout abstraction unless implementation reveals multiple consumers; there are none today.
 
 ## Error handling
 
@@ -330,6 +405,7 @@ The panel keeps a short visible error message for retryable failures such as:
 
 - report no longer exists;
 - report could not be acknowledged;
+- duplicate acknowledgement state could not be reconciled;
 - report could not be deleted;
 - browser launch failed;
 - file-manager launch failed;
@@ -337,7 +413,7 @@ The panel keeps a short visible error message for retryable failures such as:
 
 A launcher failure leaves the report pending and keeps the panel open.
 
-A corrupt report header does not produce an error panel by itself; it displays `Unknown` summary values and remains actionable.
+A corrupt report header does not produce an error panel by itself; it displays bounded `Unknown` summary values and remains actionable.
 
 The title stage must not catch and expose raw exception messages from filesystem or process APIs.
 
@@ -345,60 +421,77 @@ The title stage must not catch and expose raw exception messages from filesystem
 
 ### Storage and parsing
 
-Unit tests should cover:
+Unit tests cover:
 
-- discovery of pending and acknowledged schema-v2 files;
+- exact retained-name regex for pending and acknowledged forms;
+- filename-derived report ID for both forms;
+- `CrashReportSummary.FileName` tracking the current physical basename;
+- discovery collapsing pending+ack duplicates to one logical inbox item with pending precedence;
+- duplicate cleanup and delete behavior;
 - newest-first ordering;
 - shared latest-five retention across both filename forms;
 - atomic pending-to-acknowledged rename;
 - deletion of pending and acknowledged reports;
 - corrupt/missing headers falling back to filename-derived ID/time plus `Unknown` fields;
-- bounded parsing that never reads or returns the free-form exception section.
+- 32-line / 16-KiB header read bounds;
+- 256-character field bounds and ASCII-control normalization;
+- bounded parsing that never reads or returns the free-form exception section;
+- existing capture still emits only pending `crash-*.txt` names.
 
 ### GitHub handoff and launcher
 
-Unit tests should cover:
+Unit tests cover:
 
 - exact GitHub host/path validation;
 - rejection of HTTP, alternate hosts, alternate repositories, and alternate paths;
 - query content limited to approved summary fields;
+- long and control-character-containing header values cannot produce unbounded or malformed launch URIs;
+- dynamic query values are URI-escaped;
 - Windows `UseShellExecute = true` and no command shell;
 - macOS `/usr/bin/open`, separate `--`, separate target argument, and no shell concatenation;
 - non-zero exit/start failure mapped to retryable errors;
-- directory launch restricted to the internally resolved crash-report root.
+- directory launch restricted to the store-owned crash-report root.
 
 ### Inbox actions
 
-Tests using a temporary real store plus a fake launcher should verify:
+Tests using a temporary real store plus a fake launcher verify:
 
 - successful GitHub launch acknowledges;
 - successful folder launch acknowledges;
 - failed launch leaves the report pending;
 - dismiss acknowledges without deleting;
-- delete removes the selected report;
-- acknowledgement persistence failure is surfaced without deleting the report.
+- delete removes the logical report, including a duplicate physical variant if present;
+- acknowledgement persistence failure is surfaced without deleting the pending report;
+- disabled/empty inbox returns no reports and silent successful no-op actions.
 
 ### Title UI
 
-Stage/component tests should verify:
+Component-first tests verify:
 
 - no reports means no banner and unchanged menu behavior;
 - pending reports produce one summarized banner;
-- F8 and banner click open the panel;
-- panel input does not leak into title-menu actions;
-- Previous/Next navigation works across retained reports;
+- raw edge-triggered F8 and banner click open the panel;
 - acknowledged reports remain reviewable but do not contribute to banner count;
+- notification input consumption prevents title-menu input leakage;
+- Back/Escape while open closes the panel and cannot request game exit;
+- Previous/Next navigation works across retained reports;
 - delete confirmation is required;
-- launcher errors remain visible and retryable;
-- Escape/Back closes the panel.
+- launcher errors remain visible and retryable.
 
-Prefer fake `ICrashReportInbox` implementations for title tests so MonoGame graphics and filesystem setup are not required for the behavioral state machine.
+Keep most behavioral tests on `CrashReportNotification` with a fake `ICrashReportInbox`. Add only a thin `TitleStage` guard test for the consumed-input contract; do not inflate the existing title tests into a graphics-heavy fixture.
 
 ### Platform smoke verification
 
 On supported macOS, manually verify that `/usr/bin/open -- <target>` works for both the GitHub URI and crash-report directory. Record the command shape and observed result in the implementation PR.
 
 Windows behavior is covered by unit tests around `ProcessStartInfo`; no command-shell invocation is permitted.
+
+## Risks and mitigations
+
+1. **Pending/ack filename divergence or duplicate twins** — lock the regex/identity contract in store tests, collapse to one logical item, and reconcile duplicates in `Cleanup()`.
+2. **Panel Back/Escape accidentally exits the game** — make `CrashReportNotification.TryHandleInput` the ownership boundary and verify open-panel Back/Escape never reaches title exit handling.
+3. **Corrupt or hand-edited header creates hostile UI/URI values** — bound header bytes/lines/field lengths, normalize control characters, and URI-escape every dynamic query value.
+4. **F8 conflicts with a remapped input command** — define F8 as a fixed raw title diagnostic shortcut and consume the frame when it opens/reopens the crash panel.
 
 ## Implementation boundaries
 
@@ -412,14 +505,20 @@ The expected implementation remains small enough for one ticket and approximatel
 - Pending reports produce one non-blocking summarized banner.
 - Schema-v2 `.txt` reports are the only supported report format.
 - Acknowledgement persists through the `.ack.txt` filename state; no `inbox-state.json` exists.
+- The exact retained-name contract supports only pending `crash-*.txt` and acknowledged `crash-*.ack.txt` forms.
+- Filename-derived report ID is authoritative; dual pending+ack files collapse to one logical inbox item.
 - Pending and acknowledged reports share the single latest-five `CrashReportStore` retention policy.
-- Title UI displays only allowlisted summary fields and never parses report sections directly.
-- F8 and banner click open the review panel without leaking input into normal title actions.
+- Existing crash capture still creates pending `crash-*.txt`, never `.ack.txt`.
+- Title UI displays only bounded allowlisted summary fields and never parses report sections directly.
+- Raw edge-triggered F8 and banner click open the review panel without leaking input into normal title actions.
+- F8 remains fixed/non-remappable for this ticket; no new `InputCommandType` is added.
+- Back/Escape while the panel is open closes the panel and never requests game exit.
 - Opening GitHub or the report folder acknowledges only after successful process launch and never deletes the report.
 - Dismiss acknowledges without deleting.
-- Delete requires in-panel confirmation.
+- Delete requires in-panel confirmation and removes the logical report without leaving a duplicate variant behind.
+- Disabled/bootstrap crash reporting yields an empty inbox, no banner, and silent no-op inbox actions.
 - Launcher failures remain visible, pending, and retryable.
-- GitHub URLs target only `https://github.com/cwchanap/DTXManiaCX/issues/new` and contain only approved summary fields plus manual `.txt` attachment instructions.
+- GitHub URLs target only `https://github.com/cwchanap/DTXManiaCX/issues/new`, URI-escape all dynamic values, and contain only approved bounded summary fields plus manual `.txt` attachment instructions.
 - Windows launcher uses `UseShellExecute = true` without a command shell.
 - macOS launcher uses `/usr/bin/open` with separate `--` and target arguments and without shell concatenation.
 - Unsupported platforms fail safely in-game.

--- a/docs/superpowers/specs/2026-08-07-hpa-530-title-screen-crash-inbox-design.md
+++ b/docs/superpowers/specs/2026-08-07-hpa-530-title-screen-crash-inbox-design.md
@@ -1,0 +1,425 @@
+# HPA-530 Title-Screen Crash Inbox and GitHub Handoff — Design
+
+**Date:** 2026-08-07  
+**Status:** Approved for implementation planning  
+**Linear:** HPA-530 — Add title-screen crash inbox and GitHub issue handoff  
+**Depends on:** HPA-529 — Add process-boundary crash capture and sanitized local bundles  
+**Scope:** Surface retained schema-v2 crash reports on the title screen and provide an explicit manual GitHub reporting handoff without reintroducing the superseded ZIP/inbox-state architecture.
+
+## Context
+
+HPA-529 shipped a deliberately simplified crash-reporting format:
+
+- one retained artifact per crash;
+- plain-text `DTXMANIACX-CRASH-REPORT 2` files only;
+- one latest-five retention policy in `CrashReportStore`;
+- no ZIP bundle;
+- no emergency fallback format;
+- no `inbox-state.json`.
+
+The original HPA-530 ticket predates that schema-v2 amendment and still references ZIP reports, emergency fallback reports, and a separate inbox-state file. Those statements are obsolete for this implementation. HPA-530 must extend the shipped text-only model rather than recreate the removed architecture.
+
+## Goals
+
+- Notify the player non-blockingly when retained crash reports have not been acknowledged.
+- Let the player review only the safe, allowlisted report header summary.
+- Let the player open a prefilled DTXManiaCX GitHub issue and manually attach the selected `.txt` report.
+- Let the player open the crash-report directory, dismiss a report, or delete it after confirmation.
+- Keep acknowledgement persistent across restarts without adding a second state file.
+- Keep title-screen code independent of crash-report parsing, filesystem paths, process launching, and retention rules.
+- Keep all failure modes recoverable in-game and never block normal startup.
+
+## Non-goals
+
+- Automatic upload or GitHub API submission.
+- GitHub authentication or submission confirmation.
+- Viewing exception bodies, stack traces, logs, breadcrumbs, or context sections in-game.
+- ZIP handling or emergency-report special cases.
+- A second retention policy.
+- A dedicated crash-management stage.
+- Linux external-launch support in this ticket.
+- Native dumps, hang reports, screenshots, or telemetry.
+
+## Existing integration points
+
+The implementation should extend the seams already introduced by HPA-529:
+
+- `CrashReportStore` owns the crash-report root, atomic writes, cleanup, and latest-five retention.
+- `CrashReportSummary` already models the safe fields required by the title UI.
+- `CrashReportTextWriter` writes a fixed schema-v2 header before the free-form report sections.
+- `CrashReportRuntime` is the process-owned diagnostics composition root.
+- `IGameCrashDiagnostics` is injected into `BaseGame` and is the correct route for exposing a narrow inbox service.
+- `IStageGame` is the stage-facing game contract used by `TitleStage`.
+- `TitleStage` already owns title rendering and keyboard/mouse handling.
+
+No static service locator should be introduced.
+
+## Architecture
+
+```text
+CrashReportRuntime
+  └─ ICrashReportInbox
+       ├─ CrashReportStore
+       │    ├─ discover schema-v2 .txt reports
+       │    ├─ parse safe header summaries
+       │    ├─ acknowledge by atomic rename
+       │    └─ delete
+       ├─ GitHubCrashIssueBuilder
+       └─ IExternalLauncher
+
+IGameCrashDiagnostics
+  └─ CrashReportInbox
+
+BaseGame / IStageGame
+  └─ CrashReportInbox
+
+TitleStage
+  └─ CrashReportNotification
+       ├─ compact banner
+       └─ lightweight review panel
+```
+
+`TitleStage` depends only on `ICrashReportInbox`. It must not receive `CrashReportStore`, `IExternalLauncher`, the crash-report root path, or a parser directly.
+
+## Report acknowledgement without `inbox-state.json`
+
+Acknowledgement is encoded in the retained report filename.
+
+Pending report:
+
+```text
+crash-20260806-123456Z-a1b2c3.txt
+```
+
+Acknowledged report:
+
+```text
+crash-20260806-123456Z-a1b2c3.ack.txt
+```
+
+Rules:
+
+1. New reports created by HPA-529 always use the pending form.
+2. Acknowledgement is an atomic same-directory rename to the `.ack.txt` form.
+3. The report ID inside the schema-v2 header never changes.
+4. Both pending and acknowledged reports count toward the single latest-five retention limit.
+5. `CrashReportStore` remains the only owner of retention.
+6. Temporary `.tmp` behavior remains unchanged.
+7. Deleting a report removes whichever physical filename currently represents that report ID.
+
+This keeps the report itself as the single durable artifact while still preserving acknowledgement across restarts.
+
+## Report discovery and safe summary parsing
+
+Add one bounded schema-v2 header reader owned by the crash-reporting subsystem.
+
+Discovery recognizes only the two approved filename forms in the crash-report root. It never recursively scans directories and never follows arbitrary paths supplied by the UI.
+
+The header reader:
+
+- reads only the beginning of the selected report;
+- requires `DTXMANIACX-CRASH-REPORT 2` when available;
+- parses only these allowlisted keys:
+  - `ReportId`;
+  - `CapturedAtUtc`;
+  - `BuildId`;
+  - `OperatingSystem`;
+  - `ProcessArchitecture`;
+  - `StageOrMilestone`;
+  - `ExceptionType`;
+- stops before `--- EXCEPTION ---`;
+- applies a small line/character bound so a malformed file cannot cause unbounded reads;
+- never returns exception text or other report sections to the UI.
+
+If the header is corrupt or incomplete, discovery still returns a usable inbox item:
+
+- derive report ID from the filename;
+- derive capture time from the filename timestamp when parseable;
+- set unavailable summary fields to `Unknown`.
+
+A corrupt report remains dismissible, openable in the report folder, and deletable.
+
+## Inbox contract
+
+Expose a narrow public contract suitable for `IStageGame`:
+
+```csharp
+public sealed record CrashReportInboxItem(
+    CrashReportSummary Summary,
+    bool IsAcknowledged);
+
+public readonly record struct CrashReportActionResult(
+    bool Succeeded,
+    string? ErrorCode = null);
+
+public interface ICrashReportInbox
+{
+    IReadOnlyList<CrashReportInboxItem> GetReports();
+    CrashReportActionResult OpenGitHubIssue(string reportId);
+    CrashReportActionResult OpenReportFolder(string reportId);
+    CrashReportActionResult Dismiss(string reportId);
+    CrashReportActionResult Delete(string reportId);
+}
+```
+
+The interface intentionally accepts report IDs rather than file paths. The implementation resolves the current retained item internally each time, preventing `TitleStage` from constructing or retaining arbitrary filesystem paths.
+
+`GetReports()` returns the current retained set newest-first. The set is bounded by the existing latest-five policy.
+
+Provide a no-op implementation for the disabled crash runtime so title-screen code requires no feature flag or null checks.
+
+## Acknowledgement semantics
+
+A report becomes acknowledged only after one of these actions succeeds:
+
+- browser launch for `OpenGitHubIssue`;
+- report-directory launch for `OpenReportFolder`;
+- `Dismiss`.
+
+Opening GitHub or the report folder does not delete the report and does not mean the player submitted an issue.
+
+For launcher-backed actions:
+
+1. Resolve and validate the target internally.
+2. Launch the target.
+3. Only after launch succeeds, rename the selected pending report to the acknowledged filename.
+4. Refresh the inbox snapshot.
+
+If launch fails, the report remains pending and the action returns a retryable error.
+
+If launch succeeds but acknowledgement persistence fails, the report remains pending and the UI displays an acknowledgement error. The external target may already be open; the user can retry acknowledgement through `Dismiss` rather than requiring hidden recovery logic.
+
+Dismiss performs acknowledgement without launching anything and closes the review panel on success.
+
+## GitHub issue handoff
+
+`OpenGitHubIssue` constructs one HTTPS URL targeting exactly the DTXManiaCX new-issue path:
+
+```text
+https://github.com/cwchanap/DTXManiaCX/issues/new
+```
+
+The generated title/body may contain only:
+
+- report ID;
+- app/build ID;
+- operating system;
+- process architecture;
+- stage or startup milestone;
+- exception type;
+- report format identifier `DTXMANIACX-CRASH-REPORT 2`;
+- instructions telling the player to inspect and manually attach the selected `.txt` crash report.
+
+Do not embed exception messages, stack traces, logs, breadcrumbs, arbitrary report text, full paths, usernames, song identity, configuration content, or report-file contents in the URL.
+
+Before launch, validate that the final URI:
+
+- uses `https`;
+- has host `github.com`;
+- has path `/cwchanap/DTXManiaCX/issues/new`.
+
+The URL builder and validator should be deterministic and unit-tested independently from process launching.
+
+## External launcher
+
+Keep platform process details behind `IExternalLauncher`.
+
+Suggested contract:
+
+```csharp
+internal interface IExternalLauncher
+{
+    ExternalLaunchResult OpenUri(Uri uri);
+    ExternalLaunchResult OpenDirectory(string directoryPath);
+}
+```
+
+The production launcher validates platform support and returns a bounded error code rather than throwing into the title stage.
+
+### Windows
+
+Use `Process.Start` with `ProcessStartInfo.UseShellExecute = true` for the already validated HTTPS URI or internally resolved crash-report directory.
+
+Never invoke `cmd.exe`, `cmd /c`, PowerShell, or build a command shell string.
+
+### macOS
+
+Use `/usr/bin/open` through `ProcessStartInfo` with `UseShellExecute = false` and `ArgumentList`:
+
+```text
+/usr/bin/open -- <target>
+```
+
+`--` and the target must be separate arguments. Never invoke `sh -c` or concatenate dynamic values into a shell command.
+
+A non-zero exit code, process-start exception, or unsupported platform returns a retryable failure.
+
+The directory launch target is always the internally resolved `AppPaths.GetCrashReportsRoot()` value. The stage cannot request another directory.
+
+## Title-screen UX
+
+### Banner
+
+When `TitleStage` activates, query the inbox once and show a compact upper-right notification only when one or more reports are pending.
+
+Example:
+
+```text
+CRASH REPORT AVAILABLE
+2 reports saved · Click or press F8 to review
+```
+
+Requirements:
+
+- never delays startup;
+- never takes initial focus;
+- does not block normal title-menu navigation while the panel is closed;
+- one banner summarizes all pending reports;
+- mouse click on the banner or F8 opens the review panel;
+- F8 may also reopen the panel while acknowledged retained reports still exist;
+- if no retained reports exist, F8 is a no-op.
+
+### Review panel
+
+The panel displays only `CrashReportSummary` plus acknowledgement state:
+
+- report position, for example `2 / 5`;
+- report ID;
+- captured UTC time;
+- build ID;
+- OS / architecture;
+- stage or milestone;
+- exception type;
+- `Pending` or `Acknowledged` state.
+
+Actions:
+
+- Previous;
+- Next;
+- Open GitHub Issue;
+- Open Report Folder;
+- Dismiss;
+- Delete Report.
+
+Delete requires a second in-panel confirmation before calling `Delete`.
+
+After deletion, select the nearest remaining report. If no report remains, close the panel and remove the banner.
+
+### Input ownership
+
+When the panel is closed, existing title-menu behavior remains unchanged except for the dedicated F8 shortcut and banner hit-test.
+
+When the panel is open, panel input is processed before the normal title-menu input path and the title stage returns without executing menu actions for that frame.
+
+Use existing remappable commands for panel navigation where practical:
+
+- MoveLeft / MoveRight: previous / next report;
+- MoveUp / MoveDown: move action focus;
+- Activate: execute focused action;
+- Back or Escape: close panel.
+
+Mouse buttons remain clickable through virtual-coordinate hit testing.
+
+When delete confirmation is visible, only confirmation/cancel input is consumed until the confirmation resolves.
+
+## Error handling
+
+Inbox and launcher failures are non-fatal.
+
+The panel keeps a short visible error message for retryable failures such as:
+
+- report no longer exists;
+- report could not be acknowledged;
+- report could not be deleted;
+- browser launch failed;
+- file-manager launch failed;
+- external launch unsupported on this platform.
+
+A launcher failure leaves the report pending and keeps the panel open.
+
+A corrupt report header does not produce an error panel by itself; it displays `Unknown` summary values and remains actionable.
+
+The title stage must not catch and expose raw exception messages from filesystem or process APIs.
+
+## Testing strategy
+
+### Storage and parsing
+
+Unit tests should cover:
+
+- discovery of pending and acknowledged schema-v2 files;
+- newest-first ordering;
+- shared latest-five retention across both filename forms;
+- atomic pending-to-acknowledged rename;
+- deletion of pending and acknowledged reports;
+- corrupt/missing headers falling back to filename-derived ID/time plus `Unknown` fields;
+- bounded parsing that never reads or returns the free-form exception section.
+
+### GitHub handoff and launcher
+
+Unit tests should cover:
+
+- exact GitHub host/path validation;
+- rejection of HTTP, alternate hosts, alternate repositories, and alternate paths;
+- query content limited to approved summary fields;
+- Windows `UseShellExecute = true` and no command shell;
+- macOS `/usr/bin/open`, separate `--`, separate target argument, and no shell concatenation;
+- non-zero exit/start failure mapped to retryable errors;
+- directory launch restricted to the internally resolved crash-report root.
+
+### Inbox actions
+
+Tests using a temporary real store plus a fake launcher should verify:
+
+- successful GitHub launch acknowledges;
+- successful folder launch acknowledges;
+- failed launch leaves the report pending;
+- dismiss acknowledges without deleting;
+- delete removes the selected report;
+- acknowledgement persistence failure is surfaced without deleting the report.
+
+### Title UI
+
+Stage/component tests should verify:
+
+- no reports means no banner and unchanged menu behavior;
+- pending reports produce one summarized banner;
+- F8 and banner click open the panel;
+- panel input does not leak into title-menu actions;
+- Previous/Next navigation works across retained reports;
+- acknowledged reports remain reviewable but do not contribute to banner count;
+- delete confirmation is required;
+- launcher errors remain visible and retryable;
+- Escape/Back closes the panel.
+
+Prefer fake `ICrashReportInbox` implementations for title tests so MonoGame graphics and filesystem setup are not required for the behavioral state machine.
+
+### Platform smoke verification
+
+On supported macOS, manually verify that `/usr/bin/open -- <target>` works for both the GitHub URI and crash-report directory. Record the command shape and observed result in the implementation PR.
+
+Windows behavior is covered by unit tests around `ProcessStartInfo`; no command-shell invocation is permitted.
+
+## Implementation boundaries
+
+HPA-530 should not refactor unrelated title-menu code, generalize a cross-game modal framework, add asynchronous background scanning, or introduce a general-purpose process-execution abstraction.
+
+The expected implementation remains small enough for one ticket and approximately two engineer days: one storage/handoff slice plus one title-UI integration slice, with focused tests around each boundary.
+
+## Acceptance criteria
+
+- No retained reports means no banner and unchanged title-menu behavior.
+- Pending reports produce one non-blocking summarized banner.
+- Schema-v2 `.txt` reports are the only supported report format.
+- Acknowledgement persists through the `.ack.txt` filename state; no `inbox-state.json` exists.
+- Pending and acknowledged reports share the single latest-five `CrashReportStore` retention policy.
+- Title UI displays only allowlisted summary fields and never parses report sections directly.
+- F8 and banner click open the review panel without leaking input into normal title actions.
+- Opening GitHub or the report folder acknowledges only after successful process launch and never deletes the report.
+- Dismiss acknowledges without deleting.
+- Delete requires in-panel confirmation.
+- Launcher failures remain visible, pending, and retryable.
+- GitHub URLs target only `https://github.com/cwchanap/DTXManiaCX/issues/new` and contain only approved summary fields plus manual `.txt` attachment instructions.
+- Windows launcher uses `UseShellExecute = true` without a command shell.
+- macOS launcher uses `/usr/bin/open` with separate `--` and target arguments and without shell concatenation.
+- Unsupported platforms fail safely in-game.


### PR DESCRIPTION
## Summary

- Add the HPA-530 design spec for the title-screen crash inbox and manual GitHub issue handoff.
- Add a four-task implementation plan covering storage/acknowledgement, external handoff, composition, and title-screen UI.
- Reconcile HPA-530 with the merged HPA-529 schema-v2 design: plain-text `.txt` reports only, no ZIP/emergency split, and no `inbox-state.json`.

## Design direction

The design keeps the HPA-529 KISS simplification intact:

- persist acknowledgement by renaming `crash-*.txt` to `crash-*.ack.txt`;
- keep pending and acknowledged reports under the single latest-five `CrashReportStore` retention policy;
- expose only a narrow `ICrashReportInbox` to `TitleStage`;
- keep parsing, paths, GitHub URL construction, and platform launching behind the crash-reporting subsystem;
- use validated HTTPS GitHub handoff plus manual `.txt` attachment instructions;
- keep Windows/macOS launcher behavior shell-free and testable.

## Review follow-up

Second-pass review was evaluated against the codebase rather than applied wholesale.

Accepted/simplified:

- remove the duplicate-file reconciliation subsystem and acknowledgement-conflict state; discovery groups by logical ID, acknowledgement uses same-directory `File.Move(..., overwrite: true)`, and delete removes both approved variants;
- keep both Windows/macOS `ProcessStartInfo` builders in shared crash-reporting code rather than the existing `Platform/` compile split, so both command shapes remain unit-testable;
- align notification input with the existing bool-consumed UI convention while keeping `TitleStage`'s existing input polling and remappable `InputCommandType` path;
- make verification commands platform-aware: `DTXMania.Test.Mac.csproj` for macOS local runs and `DTXMania.Test.csproj` for Windows/CI.

Deliberately retained:

- `CrashReportSummary.FileName` continues to mean the physical artifact represented by that summary; inbox actions still resolve by report ID and title UI does not depend on the filename;
- successful GitHub **and folder** launch still acknowledges, matching HPA-530 acceptance criteria;
- `EmptyCrashReportInbox` remains a null-object success/no-op implementation;
- both line and character header-read bounds remain, because a line-count bound alone does not protect against one huge line;
- final GitHub scheme/host/path validation and rejection tests remain, matching HPA-530's explicit target-validation requirement.

## Implementation plan

The work remains split into four independently reviewable gates:

1. Schema-v2 discovery and persistent acknowledgement.
2. Safe GitHub and platform handoff.
3. Runtime/game/stage composition through existing narrow interfaces.
4. Non-blocking title banner and review panel with input-isolation tests.

## Validation

- Branch diff contains only the two documentation files.
- The PR remains documentation-only; no production code is changed.
- No ZIP handling, `inbox-state.json`, automatic upload, generic modal/process/layout framework, new key-binding setting, or Linux launcher is introduced by the plan.

Linear: HPA-530