### PR TITLE
feat: show measure lines during gameplay

### DIFF
--- a/DTXMania.Game/Lib/Song/Components/BGMEvent.cs
+++ b/DTXMania.Game/Lib/Song/Components/BGMEvent.cs
@@ -72,13 +72,7 @@ namespace DTXMania.Game.Lib.Song.Components
         /// <param name="bpm">Base BPM of the song</param>
         public void CalculateTimeMs(double bpm)
         {
-            if (bpm <= 0)
-                throw new ArgumentException("BPM must be greater than 0", nameof(bpm));
-
-            // Formula: (((bar*192)+tick)/192) * (60000/BPM) * 4 (4 beats per measure in 4/4 time)
-            var totalTicks = (Bar * 192) + Tick;
-            var measures = totalTicks / 192.0;  // 192 ticks = 1 measure
-            TimeMs = measures * (60000.0 / bpm) * 4.0;  // 4 beats per measure
+            TimeMs = ChartTimeCalculator.CalculateTimeMs(Bar, Tick, bpm);
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/Components/ChartManager.cs
+++ b/DTXMania.Game/Lib/Song/Components/ChartManager.cs
@@ -13,6 +13,7 @@ namespace DTXMania.Game.Lib.Song.Components
         #region Private Fields
 
         private readonly List<Note> _notes;
+        private readonly List<MeasureLine> _measureLines;
         private readonly double _bpm;
         private int _lastActiveIndex = 0; // Optimization for sequential access
 
@@ -40,6 +41,11 @@ namespace DTXMania.Game.Lib.Song.Components
         /// </summary>
         public IReadOnlyList<Note> AllNotes => _notes.AsReadOnly();
 
+        /// <summary>
+        /// All measure lines in the chart (read-only)
+        /// </summary>
+        public IReadOnlyList<MeasureLine> AllMeasureLines => _measureLines.AsReadOnly();
+
         #endregion
 
         #region Constructors
@@ -55,6 +61,7 @@ namespace DTXMania.Game.Lib.Song.Components
 
             _bpm = parsedChart.Bpm;
             _notes = new List<Note>(parsedChart.Notes);
+            _measureLines = new List<MeasureLine>(parsedChart.MeasureLines);
             DurationMs = parsedChart.DurationMs;
 
             // Ensure all notes have calculated timing
@@ -105,6 +112,33 @@ namespace DTXMania.Game.Lib.Song.Components
                 {
                     yield return note;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Gets measure lines within the active time window.
+        /// </summary>
+        /// <param name="songTimeMs">Current song time in milliseconds</param>
+        /// <param name="lookAheadMs">How far ahead to look for measure lines (in milliseconds)</param>
+        /// <param name="gracePeriodMs">How far into the past to include measure lines (in milliseconds)</param>
+        /// <returns>Measure lines in the active time window</returns>
+        public IEnumerable<MeasureLine> GetActiveMeasureLines(
+            double songTimeMs,
+            double lookAheadMs,
+            double gracePeriodMs)
+        {
+            var clampedGraceMs = Math.Max(0.0, gracePeriodMs);
+            var startTime = songTimeMs - clampedGraceMs;
+            var endTime = songTimeMs + lookAheadMs;
+
+            foreach (var line in _measureLines)
+            {
+                if (line.TimeMs < startTime)
+                    continue;
+                if (line.TimeMs > endTime)
+                    yield break;
+
+                yield return line;
             }
         }
 

--- a/DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs
+++ b/DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    internal static class ChartTimeCalculator
+    {
+        private const int TicksPerMeasure = 192;
+
+        internal static double CalculateTimeMs(int bar, int tick, double bpm)
+        {
+            if (bpm <= 0)
+                throw new ArgumentException(
+                    "BPM must be greater than 0",
+                    nameof(bpm));
+
+            var totalTicks = (bar * TicksPerMeasure) + tick;
+            var measures = totalTicks / (double)TicksPerMeasure;
+            return measures * (60000.0 / bpm) * 4.0;
+        }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Components/MeasureLine.cs
+++ b/DTXMania.Game/Lib/Song/Components/MeasureLine.cs
@@ -1,0 +1,8 @@
+namespace DTXMania.Game.Lib.Song.Components
+{
+    public sealed class MeasureLine
+    {
+        public int Bar { get; init; }
+        public double TimeMs { get; init; }
+    }
+}

--- a/DTXMania.Game/Lib/Song/Components/Note.cs
+++ b/DTXMania.Game/Lib/Song/Components/Note.cs
@@ -87,14 +87,7 @@ namespace DTXMania.Game.Lib.Song.Components
         /// <param name="bpm">Base BPM of the song</param>
         public void CalculateTimeMs(double bpm)
         {
-            if (bpm <= 0)
-                throw new ArgumentException("BPM must be greater than 0", nameof(bpm));
-
-            // Formula: (((bar*192)+tick)/192) * (60000/BPM) * 4 (4 beats per measure in 4/4 time)
-            var totalTicks = (Bar * 192) + Tick;
-            var measures = totalTicks / 192.0;  // 192 ticks = 1 measure
-            TimeMs = measures * (60000.0 / bpm) * 4.0;  // 4 beats per measure
-
+            TimeMs = ChartTimeCalculator.CalculateTimeMs(Bar, Tick, bpm);
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Song/Components/ParsedChart.cs
+++ b/DTXMania.Game/Lib/Song/Components/ParsedChart.cs
@@ -33,6 +33,11 @@ namespace DTXMania.Game.Lib.Song.Components
         public List<BGMEvent> BGMEvents { get; } = new List<BGMEvent>();
 
         /// <summary>
+        /// Ordered measure boundaries generated from retained chart events.
+        /// </summary>
+        public List<MeasureLine> MeasureLines { get; } = new List<MeasureLine>();
+
+        /// <summary>
         /// Resolved WAV id → absolute audio file path. Populated by DTXChartParser
         /// during parse from #WAVxx definitions. Used by ChipSoundCache to preload
         /// per-note drum chip sounds. Empty when the chart has no #WAVxx lines.
@@ -235,6 +240,25 @@ namespace DTXMania.Game.Lib.Song.Components
 
             // Sort BGM events by time for efficient playback scheduling
             BGMEvents.Sort((a, b) => a.TimeMs.CompareTo(b.TimeMs));
+
+            MeasureLines.Clear();
+
+            var highestOccupiedBar = -1;
+            if (Notes.Count > 0)
+                highestOccupiedBar = Math.Max(highestOccupiedBar, Notes.Max(note => note.Bar));
+            if (BGMEvents.Count > 0)
+                highestOccupiedBar = Math.Max(
+                    highestOccupiedBar,
+                    BGMEvents.Max(bgmEvent => bgmEvent.Bar));
+
+            for (var bar = 0; highestOccupiedBar >= 0 && bar <= highestOccupiedBar + 1; bar++)
+            {
+                MeasureLines.Add(new MeasureLine
+                {
+                    Bar = bar,
+                    TimeMs = ChartTimeCalculator.CalculateTimeMs(bar, 0, Bpm)
+                });
+            }
 
             // Debug: Report parsing summary
 #if DEBUG

--- a/DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs
+++ b/DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs
@@ -102,6 +102,14 @@ namespace DTXMania.Game.Lib.Stage.Performance
         public double ScrollPixelsPerMs => _scrollPixelsPerMs;
 
         /// <summary>
+        /// Grace period below the judgement line for measure lines, in milliseconds.
+        /// </summary>
+        public double MeasureLinePastGraceMs =>
+            _scrollPixelsPerMs > 0
+                ? DropGracePeriod / _scrollPixelsPerMs
+                : 0.0;
+
+        /// <summary>
         /// Current effective look-ahead time in milliseconds (for GetActiveNotes consistency)
         /// </summary>
         public double EffectiveLookAheadMs { get; private set; }
@@ -216,6 +224,44 @@ namespace DTXMania.Game.Lib.Stage.Performance
 
             // Draw lane flash effects on top of everything
             DrawLaneFlashEffects(spriteBatch);
+        }
+
+        /// <summary>
+        /// Renders scrolling measure lines on the gameplay lane panel.
+        /// </summary>
+        /// <param name="spriteBatch">SpriteBatch for drawing</param>
+        /// <param name="measureLines">Measure lines currently visible on screen</param>
+        /// <param name="currentSongTimeMs">Current song time in milliseconds</param>
+        [ExcludeFromCodeCoverage]
+        public void DrawMeasureLines(
+            SpriteBatch spriteBatch,
+            IEnumerable<MeasureLine> measureLines,
+            double currentSongTimeMs)
+        {
+            if (!IsReady || spriteBatch == null || measureLines == null)
+                return;
+
+            foreach (var line in measureLines)
+            {
+                var lineY = GetNoteScreenY(line.TimeMs, currentSongTimeMs);
+                var destination =
+                    PerformanceUILayout.MeasureLine.GetDestinationRect(lineY);
+                if (destination.Bottom <= 0 ||
+                    lineY > JudgementY + DropGracePeriod)
+                {
+                    continue;
+                }
+
+                spriteBatch.Draw(
+                    _whiteTexture,
+                    destination,
+                    null,
+                    PerformanceUILayout.MeasureLine.Color,
+                    0f,
+                    Vector2.Zero,
+                    SpriteEffects.None,
+                    PerformanceUILayout.MeasureLine.Depth);
+            }
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/Stage/PerformanceStage.cs
+++ b/DTXMania.Game/Lib/Stage/PerformanceStage.cs
@@ -326,8 +326,10 @@ namespace DTXMania.Game.Lib.Stage
                 return;
 
 
-            // Draw components in proper Z-order (BackToFront sorting):
-            // Background (1.0f) → Lanes (0.8f) → Pads (0.75f) → Notes (0.7f) → JudgementLine (0.6f) → JudgementTexts (0.5f)
+            // BackToFront depth order:
+            // Background (1.0f) → Lanes (0.8f) → Measure lines (0.78f) →
+            // fallback notes (0.70f) → JudgementLine (0.6f) →
+            // Pads (0.1f) → sprite notes (0.05f).
 
             // Base pass: Background → Lanes → Pads → Notes → Judgement Line → Judgement Texts
             _spriteBatch.Begin(SpriteSortMode.BackToFront, BlendState.AlphaBlend);
@@ -337,6 +339,9 @@ namespace DTXMania.Game.Lib.Stage
 
             // Draw lane backgrounds
             DrawLaneBackgrounds();
+
+            // Draw scrolling measure boundaries above lanes and behind gameplay objects
+            DrawMeasureLines();
 
             // Draw pad indicators (above lane backgrounds, below notes)
             DrawPads();
@@ -1009,6 +1014,34 @@ namespace DTXMania.Game.Lib.Stage
                     }
                 }
             }
+        }
+
+        private void DrawMeasureLines()
+        {
+            if (_noteRenderer == null ||
+                _chartManager == null ||
+                _songTimer == null ||
+                _currentGameTime == null)
+            {
+                return;
+            }
+
+            if (!_songTimer.IsPlaying && !_songTimer.IsPaused)
+                return;
+
+            var currentTimeMs = _songTimer.GetCurrentMs(_currentGameTime);
+            var lookAheadMs = _noteRenderer.EffectiveLookAheadMs > 0
+                ? _noteRenderer.EffectiveLookAheadMs
+                : PerformanceUILayout.NoteDefaultLookAheadMs;
+            var activeLines = _chartManager.GetActiveMeasureLines(
+                currentTimeMs,
+                lookAheadMs,
+                _noteRenderer.MeasureLinePastGraceMs);
+
+            _noteRenderer.DrawMeasureLines(
+                _spriteBatch,
+                activeLines,
+                currentTimeMs);
         }
 
         /// <summary>

--- a/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
+++ b/DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs
@@ -778,6 +778,26 @@ namespace DTXMania.Game.Lib.UI.Layout
         }
 
         /// <summary>
+        /// Gameplay measure-line configuration.
+        /// </summary>
+        public static class MeasureLine
+        {
+            public const int Height = 2;
+            public const float Depth = 0.78f;
+            public static readonly Color Color = new Color(169, 169, 169);
+
+            public static Rectangle GetDestinationRect(double centerY)
+            {
+                var top = (int)Math.Floor(centerY - (Height / 2.0));
+                return new Rectangle(
+                    HitBar.Bounds.X,
+                    top,
+                    HitBar.Bounds.Width,
+                    Height);
+            }
+        }
+
+        /// <summary>
         /// NX drum pad row destinations for the 4x3 7_pads.png sprite sheet.
         /// </summary>
         public static class DrumPads

--- a/DTXMania.Test/Song/ChartManagerTests.cs
+++ b/DTXMania.Test/Song/ChartManagerTests.cs
@@ -34,6 +34,74 @@ namespace DTXMania.Test.Song
         }
 
         [Fact]
+        public void Constructor_FinalizedChart_ShouldCopyMeasureLines()
+        {
+            var parsedChart = CreateTestChart();
+            var manager = new ChartManager(parsedChart);
+            var expectedBars = parsedChart.MeasureLines.Select(line => line.Bar).ToArray();
+
+            parsedChart.MeasureLines.Clear();
+
+            Assert.Equal(expectedBars, manager.AllMeasureLines.Select(line => line.Bar));
+        }
+
+        [Fact]
+        public void GetActiveMeasureLines_ShouldIncludeLookAheadAndPastGrace()
+        {
+            var manager = new ChartManager(CreateTestChart());
+
+            var active = manager
+                .GetActiveMeasureLines(2100.0, 2000.0, 100.0)
+                .Select(line => line.Bar)
+                .ToArray();
+
+            Assert.Equal(new[] { 1, 2 }, active);
+        }
+
+        [Fact]
+        public void GetActiveMeasureLines_NegativeGrace_ShouldClampToZero()
+        {
+            var manager = new ChartManager(CreateTestChart());
+
+            var active = manager
+                .GetActiveMeasureLines(2000.0, 0.0, -500.0)
+                .Select(line => line.Bar)
+                .ToArray();
+
+            Assert.Equal(new[] { 1 }, active);
+        }
+
+        [Fact]
+        public void GetActiveMeasureLines_ShouldExcludeLinesOutsideWindow()
+        {
+            var manager = new ChartManager(CreateTestChart());
+
+            var active = manager
+                .GetActiveMeasureLines(2100.0, 1000.0, 50.0)
+                .ToArray();
+
+            Assert.Empty(active);
+        }
+
+        [Fact]
+        public void GetActiveMeasureLines_LaterQuery_ShouldNotAffectEarlierNoteQuery()
+        {
+            var parsedChart = CreateTestChart();
+            var manager = new ChartManager(parsedChart);
+            var freshManager = new ChartManager(parsedChart);
+
+            manager.GetActiveMeasureLines(4000.0, 2000.0, 0.0).ToArray();
+            var actual = manager.GetActiveNotes(500.0, 1000.0)
+                .Select(note => note.TimeMs)
+                .ToArray();
+            var expected = freshManager.GetActiveNotes(500.0, 1000.0)
+                .Select(note => note.TimeMs)
+                .ToArray();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void GetActiveNotes_ReturnsNotesInTimeRange()
         {
             // Arrange

--- a/DTXMania.Test/Song/ChartManagerTests.cs
+++ b/DTXMania.Test/Song/ChartManagerTests.cs
@@ -9,6 +9,7 @@ namespace DTXMania.Test.Song
     /// Unit tests for ChartManager
     /// Tests runtime note management functionality for Phase 2 implementation
     /// </summary>
+    [Trait("Category", "Unit")]
     public class ChartManagerTests
     {
         [Fact]

--- a/DTXMania.Test/Song/ChartTimeCalculatorTests.cs
+++ b/DTXMania.Test/Song/ChartTimeCalculatorTests.cs
@@ -1,0 +1,38 @@
+using System;
+using DTXMania.Game.Lib.Song.Components;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Song")]
+    public class ChartTimeCalculatorTests
+    {
+        [Theory]
+        [InlineData(0, 0, 120.0, 0.0)]
+        [InlineData(0, 96, 120.0, 1000.0)]
+        [InlineData(1, 0, 120.0, 2000.0)]
+        [InlineData(5, 48, 120.0, 10500.0)]
+        [InlineData(1, 0, 60.0, 4000.0)]
+        [InlineData(1, 0, 240.0, 1000.0)]
+        public void CalculateTimeMs_ValidPosition_ShouldMatchCurrentClock(
+            int bar,
+            int tick,
+            double bpm,
+            double expectedMs)
+        {
+            var actualMs = ChartTimeCalculator.CalculateTimeMs(bar, tick, bpm);
+
+            Assert.Equal(expectedMs, actualMs, precision: 3);
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(-120.0)]
+        public void CalculateTimeMs_NonPositiveBpm_ShouldThrowArgumentException(
+            double bpm)
+        {
+            Assert.Throws<ArgumentException>(
+                () => ChartTimeCalculator.CalculateTimeMs(1, 0, bpm));
+        }
+    }
+}

--- a/DTXMania.Test/Song/ParsedChartTests.cs
+++ b/DTXMania.Test/Song/ParsedChartTests.cs
@@ -335,6 +335,71 @@ namespace DTXMania.Test.Song
             Assert.Equal(3000.0, chart.BGMEvents[1].TimeMs);
         }
 
+        [Fact]
+        public void FinalizeChart_SparseNotes_ShouldGenerateEveryBoundaryThroughTerminal()
+        {
+            var chart = new ParsedChart { Bpm = 120.0 };
+            chart.AddNote(new Note(0, 0, 0, 0x11, "01"));
+            chart.AddNote(new Note(0, 2, 0, 0x11, "01"));
+
+            chart.FinalizeChart();
+
+            Assert.Equal(new[] { 0, 1, 2, 3 },
+                chart.MeasureLines.Select(line => line.Bar));
+            Assert.Equal(new[] { 0.0, 2000.0, 4000.0, 6000.0 },
+                chart.MeasureLines.Select(line => line.TimeMs));
+        }
+
+        [Fact]
+        public void FinalizeChart_BgmOnly_ShouldGenerateMeasureBoundaries()
+        {
+            var chart = new ParsedChart { Bpm = 120.0 };
+            chart.AddBGMEvent(new BGMEvent(1, 0, "01"));
+
+            chart.FinalizeChart();
+
+            Assert.Equal(new[] { 0, 1, 2 },
+                chart.MeasureLines.Select(line => line.Bar));
+        }
+
+        [Fact]
+        public void FinalizeChart_EmptyChart_ShouldGenerateNoMeasureBoundaries()
+        {
+            var chart = new ParsedChart();
+
+            chart.FinalizeChart();
+
+            Assert.Empty(chart.MeasureLines);
+        }
+
+        [Fact]
+        public void FinalizeChart_WhenCalledTwice_ShouldNotDuplicateMeasureBoundaries()
+        {
+            var chart = new ParsedChart { Bpm = 120.0 };
+            chart.AddNote(new Note(0, 1, 0, 0x11, "01"));
+            chart.FinalizeChart();
+            var firstBoundaries = chart.MeasureLines
+                .Select(line => (line.Bar, line.TimeMs))
+                .ToArray();
+
+            chart.FinalizeChart();
+
+            Assert.Equal(firstBoundaries,
+                chart.MeasureLines.Select(line => (line.Bar, line.TimeMs)).ToArray());
+        }
+
+        [Fact]
+        public void FinalizeChart_TerminalBoundary_ShouldNotExtendDuration()
+        {
+            var chart = new ParsedChart { Bpm = 120.0 };
+            chart.AddNote(new Note(0, 2, 0, 0x11, "01"));
+
+            chart.FinalizeChart();
+
+            Assert.Equal(4500.0, chart.DurationMs, precision: 3);
+            Assert.Equal(6000.0, chart.MeasureLines[^1].TimeMs, precision: 3);
+        }
+
         #endregion
 
         #region GetNotesInTimeRange Tests

--- a/DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs
+++ b/DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs
@@ -97,6 +97,31 @@ public class NoteRendererLogicTests
         Assert.True(renderer.ShouldDropNote(note, 1200.0));
     }
 
+    [Theory]
+    [InlineData(0.5, 40.0)]
+    [InlineData(0.25, 80.0)]
+    public void MeasureLinePastGraceMs_PositiveScroll_ShouldKeepTwentyPixels(
+        double pixelsPerMs,
+        double expectedMs)
+    {
+        var renderer = CreateRenderer();
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", pixelsPerMs);
+
+        Assert.Equal(expectedMs, renderer.MeasureLinePastGraceMs, precision: 3);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-0.5)]
+    public void MeasureLinePastGraceMs_NonPositiveScroll_ShouldReturnZero(
+        double pixelsPerMs)
+    {
+        var renderer = CreateRenderer();
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", pixelsPerMs);
+
+        Assert.Equal(0.0, renderer.MeasureLinePastGraceMs);
+    }
+
     [Fact]
     public void Update_ShouldAdvanceAnimationAndDecayFlashAlpha()
     {
@@ -143,6 +168,53 @@ public class NoteRendererLogicTests
 
         var exception = Record.Exception(() =>
             renderer.DrawNotes((SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)), new[] { new Note() }, 1000.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawMeasureLines_WhenRendererIsNotReady_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateRenderer();
+
+        var exception = Record.Exception(() => renderer.DrawMeasureLines(
+            (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)),
+            new[] { new MeasureLine { Bar = 0, TimeMs = 0.0 } },
+            0.0));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawMeasureLines_WhenInputIsNull_ShouldReturnWithoutThrowing()
+    {
+        var renderer = CreateReadyRenderer();
+        var spriteBatch =
+            (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+        var exception = Record.Exception(() =>
+        {
+            renderer.DrawMeasureLines(null!, Array.Empty<MeasureLine>(), 0.0);
+            renderer.DrawMeasureLines(spriteBatch, null!, 0.0);
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Theory]
+    [InlineData(-10000.0)]
+    [InlineData(10000.0)]
+    public void DrawMeasureLines_WhenLineIsOffscreen_ShouldReturnWithoutThrowing(
+        double currentSongTimeMs)
+    {
+        var renderer = CreateReadyRenderer();
+        var spriteBatch =
+            (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+        var exception = Record.Exception(() => renderer.DrawMeasureLines(
+            spriteBatch,
+            new[] { new MeasureLine { Bar = 0, TimeMs = 0.0 } },
+            currentSongTimeMs));
 
         Assert.Null(exception);
     }

--- a/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+++ b/DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
@@ -2804,6 +2804,98 @@ public class PerformanceStageDeterministicTests
     }
 
     [Fact]
+    public void DrawMeasureLines_WhenRequiredCollaboratorIsMissing_ShouldNotThrow()
+    {
+        var stage = CreateStage();
+
+        var exception = Record.Exception(
+            () => ReflectionHelpers.InvokePrivateMethod(stage, "DrawMeasureLines"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawMeasureLines_WhenTimerIsPlaying_ShouldQueryAndCullSafely()
+    {
+        var stage = CreateStage();
+        var renderer = CreateNoteRenderer();
+        var parsedChart = new ParsedChart("draw-measure-lines.dtx") { Bpm = 120.0 };
+        parsedChart.AddNote(new Note(0, 1, 0, 0x11, "01"));
+        parsedChart.FinalizeChart();
+
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 5.0);
+        ReflectionHelpers.SetPrivateField(
+            renderer,
+            "<EffectiveLookAheadMs>k__BackingField",
+            3000.0);
+        ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", renderer);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_chartManager",
+            new ChartManager(parsedChart));
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreatePlayingSongTimer());
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_currentGameTime",
+            new GameTime(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_spriteBatch",
+            CreateSpriteBatchStub(new Viewport(0, 0, 1280, 720)));
+
+        var exception = Record.Exception(
+            () => ReflectionHelpers.InvokePrivateMethod(stage, "DrawMeasureLines"));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DrawMeasureLines_WhenTimerIsPaused_ShouldUseFrozenLogicalTime()
+    {
+        var stage = CreateStage();
+        var renderer = CreateNoteRenderer();
+        var parsedChart = new ParsedChart("draw-paused-measure-lines.dtx")
+        {
+            Bpm = 120.0
+        };
+        parsedChart.AddNote(new Note(0, 1, 0, 0x11, "01"));
+        parsedChart.FinalizeChart();
+        var timer = new SongTimer(150);
+        timer.Play(new GameTime(TimeSpan.Zero, TimeSpan.Zero));
+        timer.Pause(new GameTime(TimeSpan.FromMilliseconds(1000), TimeSpan.Zero));
+
+        ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 5.0);
+        ReflectionHelpers.SetPrivateField(
+            renderer,
+            "<EffectiveLookAheadMs>k__BackingField",
+            3000.0);
+        ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", renderer);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_chartManager",
+            new ChartManager(parsedChart));
+        ReflectionHelpers.SetPrivateField(stage, "_songTimer", timer);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_currentGameTime",
+            new GameTime(TimeSpan.FromMilliseconds(5000), TimeSpan.FromSeconds(0.016)));
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_spriteBatch",
+            CreateSpriteBatchStub(new Viewport(0, 0, 1280, 720)));
+
+        var exception = Record.Exception(
+            () => ReflectionHelpers.InvokePrivateMethod(stage, "DrawMeasureLines"));
+
+        Assert.Null(exception);
+        Assert.Equal(
+            1500.0,
+            timer.GetCurrentMs(new GameTime(
+                TimeSpan.FromMilliseconds(5000),
+                TimeSpan.Zero)));
+    }
+
+    [Fact]
     public void DrawNoteOverlays_WhenRendererIsReadyAndActiveNoteIsOffscreen_ShouldCompleteWithoutThrowing()
     {
         var stage = CreateStage();

--- a/DTXMania.Test/UI/PerformanceUILayoutMoreTests.cs
+++ b/DTXMania.Test/UI/PerformanceUILayoutMoreTests.cs
@@ -360,6 +360,20 @@ namespace DTXMania.Test.UI
             Assert.Equal(PerformanceUILayout.JudgelineY, PerformanceUILayout.HitBar.Position.Y);
         }
 
+        [Fact]
+        public void MeasureLine_Layout_ShouldMatchLanePanelAndRealDepthOrder()
+        {
+            var destination = PerformanceUILayout.MeasureLine.GetDestinationRect(601.25);
+
+            Assert.Equal(PerformanceUILayout.HitBar.Bounds.X, destination.X);
+            Assert.Equal(600, destination.Y);
+            Assert.Equal(PerformanceUILayout.HitBar.Bounds.Width, destination.Width);
+            Assert.Equal(2, destination.Height);
+            Assert.Equal(new Color(169, 169, 169), PerformanceUILayout.MeasureLine.Color);
+            Assert.True(0.8f > PerformanceUILayout.MeasureLine.Depth);
+            Assert.True(PerformanceUILayout.MeasureLine.Depth > 0.70f);
+        }
+
         #endregion
 
         #region SpriteJudgementTextAssets Tests

--- a/docs/superpowers/plans/2026-08-08-hpa-518-gameplay-measure-lines.md
+++ b/docs/superpowers/plans/2026-08-08-hpa-518-gameplay-measure-lines.md
@@ -1,0 +1,1010 @@
+# HPA-518 Gameplay Measure Lines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a visible two-pixel measure boundary across the gameplay lane panel, synchronized with notes and present through empty measures.
+
+**Architecture:** Extract the current fixed 4/4 timing formula into one internal calculator, generate explicit measure-boundary events when `ParsedChart` is finalized, and copy/query those events independently in `ChartManager`. `PerformanceStage` supplies the current song time and visible window to `NoteRenderer`, which reuses its time-to-Y mapping and white texture to draw a layout-defined neutral-gray line.
+
+**Tech Stack:** .NET 8, C#, MonoGame 3.8, xUnit, Moq, existing reflection-based renderer/stage test helpers.
+
+## Global Constraints
+
+- Use the current base-BPM, 4/4 calculation with exactly `192` ticks per measure; do not add channel `02`, `03`, or `08` timing support.
+- Generate boundaries only from retained `ParsedChart.Notes` and `ParsedChart.BGMEvents`, for bars `0` through `highestOccupiedBar + 1` inclusive.
+- Measure lines must not change `DurationMs`, song completion, judgement, autoplay, audio, scoring, or persistence.
+- Keep measure-line queries independent from the note-only `_lastActiveIndex` cursor.
+- Draw with `NoteRenderer._whiteTexture`, `new Color(169, 169, 169)`, height `2`, full `HitBar.Bounds` width, and depth `0.78f`; do not sample or modify skin assets.
+- Convert the renderer's existing `20`-pixel drop grace to milliseconds from the active scroll speed; return zero grace when pixels-per-millisecond is zero or negative.
+- Do not modify `DTXChartParser`, the generated E2E fixture, either project file, or any legacy file under `DTXManiaNX/`.
+- Prefix every repository shell command with `rtk`.
+- Execute implementation from an isolated worktree on branch `codex/hpa-518-measure-lines`, created with `superpowers:using-git-worktrees` after this plan is approved.
+- Use xUnit names in `Scenario_ShouldExpect` form and preserve the existing Mac-safe test exclusions.
+- Follow RED, focused GREEN, task review, then commit for every implementation task.
+- Source of truth: [`2026-08-08-hpa-518-measure-lines-design.md`](../specs/2026-08-08-hpa-518-measure-lines-design.md).
+
+## File Responsibility Map
+
+- Create `DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs`: own the current fixed-clock bar/tick-to-millisecond formula.
+- Create `DTXMania.Game/Lib/Song/Components/MeasureLine.cs`: immutable boundary value with `Bar` and `TimeMs`.
+- Modify `DTXMania.Game/Lib/Song/Components/Note.cs`: delegate existing note timing to `ChartTimeCalculator`.
+- Modify `DTXMania.Game/Lib/Song/Components/BGMEvent.cs`: delegate existing BGM timing to `ChartTimeCalculator`.
+- Modify `DTXMania.Game/Lib/Song/Components/ParsedChart.cs`: own and repeat-safely regenerate the explicit boundary list during finalization.
+- Modify `DTXMania.Game/Lib/Song/Components/ChartManager.cs`: copy the finalized boundary list and expose a cursor-independent active-window query.
+- Modify `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs`: own measure-line destination geometry, color, and depth.
+- Modify `DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs`: expose the speed-derived grace and draw active lines with the existing mapping and white texture.
+- Modify `DTXMania.Game/Lib/Stage/PerformanceStage.cs`: query and draw measure lines during the base pass and correct the stale depth comment.
+- Create `DTXMania.Test/Song/ChartTimeCalculatorTests.cs`: direct calculator contract tests.
+- Modify `DTXMania.Test/Song/ParsedChartTests.cs`: boundary generation, empty/BGM-only, repeat-safety, and duration tests.
+- Modify `DTXMania.Test/Song/ChartManagerTests.cs`: copy, active-window, grace, and query-isolation tests.
+- Modify `DTXMania.Test/UI/PerformanceUILayoutMoreTests.cs`: geometry, color, and real-depth ordering tests.
+- Modify `DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs`: grace conversion and renderer guard tests.
+- Modify `DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs`: playing/paused integration and missing-collaborator guards.
+
+## Baseline Evidence
+
+On 2026-08-08, the proposed combined filter for the seven existing affected
+test classes passed `397` tests on `DTXMania.Test.Mac.csproj`. Package restore
+required network access; the run reported only the repository's existing
+warning set.
+
+---
+
+### Task 1: Extract the Current Chart-Time Formula
+
+**Files:**
+
+- Create: `DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs`
+- Create: `DTXMania.Test/Song/ChartTimeCalculatorTests.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/Note.cs:84-98`
+- Modify: `DTXMania.Game/Lib/Song/Components/BGMEvent.cs:69-82`
+
+**Interfaces:**
+
+- Consumes: integer `bar`, integer `tick`, and positive `double bpm` values already used by `Note` and `BGMEvent`.
+- Produces: `internal static double ChartTimeCalculator.CalculateTimeMs(int bar, int tick, double bpm)` for Tasks 2–5.
+
+- [ ] **Step 1: Add direct failing tests for the shared calculator**
+
+Create `DTXMania.Test/Song/ChartTimeCalculatorTests.cs` with:
+
+```csharp
+using System;
+using DTXMania.Game.Lib.Song.Components;
+using Xunit;
+
+namespace DTXMania.Test.Song
+{
+    [Trait("Category", "Song")]
+    public class ChartTimeCalculatorTests
+    {
+        [Theory]
+        [InlineData(0, 0, 120.0, 0.0)]
+        [InlineData(0, 96, 120.0, 1000.0)]
+        [InlineData(1, 0, 120.0, 2000.0)]
+        [InlineData(5, 48, 120.0, 10500.0)]
+        [InlineData(1, 0, 60.0, 4000.0)]
+        [InlineData(1, 0, 240.0, 1000.0)]
+        public void CalculateTimeMs_ValidPosition_ShouldMatchCurrentClock(
+            int bar,
+            int tick,
+            double bpm,
+            double expectedMs)
+        {
+            var actualMs = ChartTimeCalculator.CalculateTimeMs(bar, tick, bpm);
+
+            Assert.Equal(expectedMs, actualMs, precision: 3);
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(-120.0)]
+        public void CalculateTimeMs_NonPositiveBpm_ShouldThrowArgumentException(
+            double bpm)
+        {
+            Assert.Throws<ArgumentException>(
+                () => ChartTimeCalculator.CalculateTimeMs(1, 0, bpm));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the calculator test and observe RED**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ChartTimeCalculatorTests'
+```
+
+Expected: FAIL during compilation because `ChartTimeCalculator` does not exist.
+
+- [ ] **Step 3: Implement the calculator and delegate both existing models**
+
+Create `DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs`:
+
+```csharp
+using System;
+
+namespace DTXMania.Game.Lib.Song.Components
+{
+    internal static class ChartTimeCalculator
+    {
+        private const int TicksPerMeasure = 192;
+
+        internal static double CalculateTimeMs(int bar, int tick, double bpm)
+        {
+            if (bpm <= 0)
+                throw new ArgumentException(
+                    "BPM must be greater than 0",
+                    nameof(bpm));
+
+            var totalTicks = (bar * TicksPerMeasure) + tick;
+            var measures = totalTicks / (double)TicksPerMeasure;
+            return measures * (60000.0 / bpm) * 4.0;
+        }
+    }
+}
+```
+
+Replace `Note.CalculateTimeMs(...)` with:
+
+```csharp
+public void CalculateTimeMs(double bpm)
+{
+    TimeMs = ChartTimeCalculator.CalculateTimeMs(Bar, Tick, bpm);
+}
+```
+
+Replace `BGMEvent.CalculateTimeMs(...)` with:
+
+```csharp
+public void CalculateTimeMs(double bpm)
+{
+    TimeMs = ChartTimeCalculator.CalculateTimeMs(Bar, Tick, bpm);
+}
+```
+
+- [ ] **Step 4: Run calculator and parity tests and observe GREEN**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ChartTimeCalculatorTests|FullyQualifiedName~NoteTests|FullyQualifiedName~BGMEventTests'
+```
+
+Expected: PASS; existing note/BGM results and invalid-BPM behavior remain unchanged.
+
+- [ ] **Step 5: Review and commit the timing extraction**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git status --short
+rtk sed -n '1,160p' DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs
+rtk sed -n '1,160p' DTXMania.Test/Song/ChartTimeCalculatorTests.cs
+rtk git diff -- DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs DTXMania.Game/Lib/Song/Components/Note.cs DTXMania.Game/Lib/Song/Components/BGMEvent.cs DTXMania.Test/Song/ChartTimeCalculatorTests.cs
+rtk git add DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs DTXMania.Game/Lib/Song/Components/Note.cs DTXMania.Game/Lib/Song/Components/BGMEvent.cs DTXMania.Test/Song/ChartTimeCalculatorTests.cs
+rtk git commit -m "refactor: share chart timing calculation"
+```
+
+### Task 2: Generate Explicit Measure Boundaries
+
+**Files:**
+
+- Create: `DTXMania.Game/Lib/Song/Components/MeasureLine.cs`
+- Modify: `DTXMania.Game/Lib/Song/Components/ParsedChart.cs:22-34,228-253`
+- Modify: `DTXMania.Test/Song/ParsedChartTests.cs:286-337`
+
+**Interfaces:**
+
+- Consumes: `ChartTimeCalculator.CalculateTimeMs(int, int, double)` from Task 1 and retained `Note.Bar`/`BGMEvent.Bar` values.
+- Produces: `public List<MeasureLine> ParsedChart.MeasureLines { get; }`, populated during `FinalizeChart()` with ordered bars `0..highestOccupiedBar + 1`.
+
+- [ ] **Step 1: Add failing ParsedChart boundary tests**
+
+Add these methods to the existing `FinalizeChart Tests` region in `ParsedChartTests`:
+
+```csharp
+[Fact]
+public void FinalizeChart_SparseNotes_ShouldGenerateEveryBoundaryThroughTerminal()
+{
+    var chart = new ParsedChart { Bpm = 120.0 };
+    chart.AddNote(new Note(0, 0, 0, 0x11, "01"));
+    chart.AddNote(new Note(0, 2, 0, 0x11, "01"));
+
+    chart.FinalizeChart();
+
+    Assert.Equal(new[] { 0, 1, 2, 3 },
+        chart.MeasureLines.Select(line => line.Bar));
+    Assert.Equal(new[] { 0.0, 2000.0, 4000.0, 6000.0 },
+        chart.MeasureLines.Select(line => line.TimeMs));
+}
+
+[Fact]
+public void FinalizeChart_BgmOnly_ShouldGenerateMeasureBoundaries()
+{
+    var chart = new ParsedChart { Bpm = 120.0 };
+    chart.AddBGMEvent(new BGMEvent(1, 0, "01"));
+
+    chart.FinalizeChart();
+
+    Assert.Equal(new[] { 0, 1, 2 },
+        chart.MeasureLines.Select(line => line.Bar));
+}
+
+[Fact]
+public void FinalizeChart_EmptyChart_ShouldGenerateNoMeasureBoundaries()
+{
+    var chart = new ParsedChart();
+
+    chart.FinalizeChart();
+
+    Assert.Empty(chart.MeasureLines);
+}
+
+[Fact]
+public void FinalizeChart_WhenCalledTwice_ShouldNotDuplicateMeasureBoundaries()
+{
+    var chart = new ParsedChart { Bpm = 120.0 };
+    chart.AddNote(new Note(0, 1, 0, 0x11, "01"));
+    chart.FinalizeChart();
+    var firstBoundaries = chart.MeasureLines
+        .Select(line => (line.Bar, line.TimeMs))
+        .ToArray();
+
+    chart.FinalizeChart();
+
+    Assert.Equal(firstBoundaries,
+        chart.MeasureLines.Select(line => (line.Bar, line.TimeMs)).ToArray());
+}
+
+[Fact]
+public void FinalizeChart_TerminalBoundary_ShouldNotExtendDuration()
+{
+    var chart = new ParsedChart { Bpm = 120.0 };
+    chart.AddNote(new Note(0, 2, 0, 0x11, "01"));
+
+    chart.FinalizeChart();
+
+    Assert.Equal(4500.0, chart.DurationMs, precision: 3);
+    Assert.Equal(6000.0, chart.MeasureLines[^1].TimeMs, precision: 3);
+}
+```
+
+The repeat-safety assertion deliberately covers only `MeasureLines`; do not change the existing behavior where every `FinalizeChart()` call adds the duration buffer.
+
+- [ ] **Step 2: Run ParsedChart tests and observe RED**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ParsedChartTests'
+```
+
+Expected: FAIL during compilation because `MeasureLines` and `MeasureLine` do not exist.
+
+- [ ] **Step 3: Add the model and repeat-safe generation**
+
+Create `DTXMania.Game/Lib/Song/Components/MeasureLine.cs`:
+
+```csharp
+namespace DTXMania.Game.Lib.Song.Components
+{
+    public sealed class MeasureLine
+    {
+        public int Bar { get; init; }
+        public double TimeMs { get; init; }
+    }
+}
+```
+
+Add this property beside `Notes` and `BGMEvents` in `ParsedChart`:
+
+```csharp
+/// <summary>
+/// Ordered measure boundaries generated from retained chart events.
+/// </summary>
+public List<MeasureLine> MeasureLines { get; } = new List<MeasureLine>();
+```
+
+In `FinalizeChart()`, after sorting `Notes` and `BGMEvents` and before the debug summary, add:
+
+```csharp
+MeasureLines.Clear();
+
+var highestOccupiedBar = -1;
+if (Notes.Count > 0)
+    highestOccupiedBar = Math.Max(highestOccupiedBar, Notes.Max(note => note.Bar));
+if (BGMEvents.Count > 0)
+    highestOccupiedBar = Math.Max(
+        highestOccupiedBar,
+        BGMEvents.Max(bgmEvent => bgmEvent.Bar));
+
+for (var bar = 0; bar <= highestOccupiedBar + 1; bar++)
+{
+    MeasureLines.Add(new MeasureLine
+    {
+        Bar = bar,
+        TimeMs = ChartTimeCalculator.CalculateTimeMs(bar, 0, Bpm)
+    });
+}
+```
+
+Do not assign `DurationMs` from the boundary list.
+
+- [ ] **Step 4: Run ParsedChart tests and observe GREEN**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ParsedChartTests'
+```
+
+Expected: PASS, including the existing sorting and duration-buffer tests.
+
+- [ ] **Step 5: Review and commit measure generation**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git status --short
+rtk sed -n '1,120p' DTXMania.Game/Lib/Song/Components/MeasureLine.cs
+rtk git diff -- DTXMania.Game/Lib/Song/Components/MeasureLine.cs DTXMania.Game/Lib/Song/Components/ParsedChart.cs DTXMania.Test/Song/ParsedChartTests.cs
+rtk git add DTXMania.Game/Lib/Song/Components/MeasureLine.cs DTXMania.Game/Lib/Song/Components/ParsedChart.cs DTXMania.Test/Song/ParsedChartTests.cs
+rtk git commit -m "feat: generate chart measure boundaries"
+```
+
+### Task 3: Add Cursor-Independent Runtime Queries
+
+**Files:**
+
+- Modify: `DTXMania.Game/Lib/Song/Components/ChartManager.cs:12-72,76-109`
+- Modify: `DTXMania.Test/Song/ChartManagerTests.cs:12-174`
+
+**Interfaces:**
+
+- Consumes: finalized `ParsedChart.MeasureLines` from Task 2.
+- Produces: `IReadOnlyList<MeasureLine> AllMeasureLines` and `IEnumerable<MeasureLine> GetActiveMeasureLines(double songTimeMs, double lookAheadMs, double gracePeriodMs)`.
+
+- [ ] **Step 1: Add failing copy, window, clamp, and isolation tests**
+
+Add these tests to `ChartManagerTests`:
+
+```csharp
+[Fact]
+public void Constructor_FinalizedChart_ShouldCopyMeasureLines()
+{
+    var parsedChart = CreateTestChart();
+    var manager = new ChartManager(parsedChart);
+    var expectedBars = parsedChart.MeasureLines.Select(line => line.Bar).ToArray();
+
+    parsedChart.MeasureLines.Clear();
+
+    Assert.Equal(expectedBars, manager.AllMeasureLines.Select(line => line.Bar));
+}
+
+[Fact]
+public void GetActiveMeasureLines_ShouldIncludeLookAheadAndPastGrace()
+{
+    var manager = new ChartManager(CreateTestChart());
+
+    var active = manager
+        .GetActiveMeasureLines(2100.0, 2000.0, 100.0)
+        .Select(line => line.Bar)
+        .ToArray();
+
+    Assert.Equal(new[] { 1, 2 }, active);
+}
+
+[Fact]
+public void GetActiveMeasureLines_NegativeGrace_ShouldClampToZero()
+{
+    var manager = new ChartManager(CreateTestChart());
+
+    var active = manager
+        .GetActiveMeasureLines(2000.0, 0.0, -500.0)
+        .Select(line => line.Bar)
+        .ToArray();
+
+    Assert.Equal(new[] { 1 }, active);
+}
+
+[Fact]
+public void GetActiveMeasureLines_ShouldExcludeLinesOutsideWindow()
+{
+    var manager = new ChartManager(CreateTestChart());
+
+    var active = manager
+        .GetActiveMeasureLines(2100.0, 1000.0, 50.0)
+        .ToArray();
+
+    Assert.Empty(active);
+}
+
+[Fact]
+public void GetActiveMeasureLines_LaterQuery_ShouldNotAffectEarlierNoteQuery()
+{
+    var parsedChart = CreateTestChart();
+    var manager = new ChartManager(parsedChart);
+    var freshManager = new ChartManager(parsedChart);
+
+    manager.GetActiveMeasureLines(4000.0, 2000.0, 0.0).ToArray();
+    var actual = manager.GetActiveNotes(500.0, 1000.0)
+        .Select(note => note.TimeMs)
+        .ToArray();
+    var expected = freshManager.GetActiveNotes(500.0, 1000.0)
+        .Select(note => note.TimeMs)
+        .ToArray();
+
+    Assert.Equal(expected, actual);
+}
+```
+
+- [ ] **Step 2: Run ChartManager tests and observe RED**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ChartManagerTests'
+```
+
+Expected: FAIL during compilation because `AllMeasureLines` and `GetActiveMeasureLines` do not exist.
+
+- [ ] **Step 3: Copy and expose the measure-line collection**
+
+Add a field beside `_notes`:
+
+```csharp
+private readonly List<MeasureLine> _measureLines;
+```
+
+Add a read-only property beside `AllNotes`:
+
+```csharp
+public IReadOnlyList<MeasureLine> AllMeasureLines => _measureLines.AsReadOnly();
+```
+
+In the constructor, immediately after copying notes, copy the finalized lines:
+
+```csharp
+_measureLines = new List<MeasureLine>(parsedChart.MeasureLines);
+```
+
+Add this independent ordered scan after `GetActiveNotes(...)`:
+
+```csharp
+public IEnumerable<MeasureLine> GetActiveMeasureLines(
+    double songTimeMs,
+    double lookAheadMs,
+    double gracePeriodMs)
+{
+    var clampedGraceMs = Math.Max(0.0, gracePeriodMs);
+    var startTime = songTimeMs - clampedGraceMs;
+    var endTime = songTimeMs + lookAheadMs;
+
+    foreach (var line in _measureLines)
+    {
+        if (line.TimeMs < startTime)
+            continue;
+        if (line.TimeMs > endTime)
+            yield break;
+
+        yield return line;
+    }
+}
+```
+
+Do not call `FindStartIndex(...)`, `BinarySearchStartIndex(...)`, or mutate `_lastActiveIndex` from this method.
+
+- [ ] **Step 4: Run ChartManager tests and observe GREEN**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ChartManagerTests'
+```
+
+Expected: PASS; existing note-query tests remain green and the copied line list survives mutation of the parsed source list.
+
+- [ ] **Step 5: Review and commit the runtime query**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git diff -- DTXMania.Game/Lib/Song/Components/ChartManager.cs DTXMania.Test/Song/ChartManagerTests.cs
+rtk git add DTXMania.Game/Lib/Song/Components/ChartManager.cs DTXMania.Test/Song/ChartManagerTests.cs
+rtk git commit -m "feat: query active measure lines"
+```
+
+### Task 4: Add Layout and Renderer Behavior
+
+**Files:**
+
+- Modify: `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs:758-781`
+- Modify: `DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs:42-48,82-108,193-219,415-426`
+- Modify: `DTXMania.Test/UI/PerformanceUILayoutMoreTests.cs:333-363`
+- Modify: `DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs:18-99,140-149`
+
+**Interfaces:**
+
+- Consumes: `MeasureLine.TimeMs` from Task 2 and the existing `NoteRenderer.GetNoteScreenY(...)`, `_whiteTexture`, `JudgementY`, and `_scrollPixelsPerMs`.
+- Produces: `PerformanceUILayout.MeasureLine.GetDestinationRect(double)`, layout `Color`/`Depth`, `double NoteRenderer.MeasureLinePastGraceMs`, and `void NoteRenderer.DrawMeasureLines(SpriteBatch, IEnumerable<MeasureLine>, double)` for Task 5.
+
+- [ ] **Step 1: Add failing layout and grace tests**
+
+Add to `PerformanceUILayoutMoreTests`:
+
+```csharp
+[Fact]
+public void MeasureLine_Layout_ShouldMatchLanePanelAndRealDepthOrder()
+{
+    var destination = PerformanceUILayout.MeasureLine.GetDestinationRect(601.25);
+
+    Assert.Equal(PerformanceUILayout.HitBar.Bounds.X, destination.X);
+    Assert.Equal(600, destination.Y);
+    Assert.Equal(PerformanceUILayout.HitBar.Bounds.Width, destination.Width);
+    Assert.Equal(2, destination.Height);
+    Assert.Equal(new Color(169, 169, 169), PerformanceUILayout.MeasureLine.Color);
+    Assert.True(0.8f > PerformanceUILayout.MeasureLine.Depth);
+    Assert.True(PerformanceUILayout.MeasureLine.Depth > 0.70f);
+}
+```
+
+Add to `NoteRendererLogicTests`:
+
+```csharp
+[Theory]
+[InlineData(0.5, 40.0)]
+[InlineData(0.25, 80.0)]
+public void MeasureLinePastGraceMs_PositiveScroll_ShouldKeepTwentyPixels(
+    double pixelsPerMs,
+    double expectedMs)
+{
+    var renderer = CreateRenderer();
+    ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", pixelsPerMs);
+
+    Assert.Equal(expectedMs, renderer.MeasureLinePastGraceMs, precision: 3);
+}
+
+[Theory]
+[InlineData(0.0)]
+[InlineData(-0.5)]
+public void MeasureLinePastGraceMs_NonPositiveScroll_ShouldReturnZero(
+    double pixelsPerMs)
+{
+    var renderer = CreateRenderer();
+    ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", pixelsPerMs);
+
+    Assert.Equal(0.0, renderer.MeasureLinePastGraceMs);
+}
+
+[Fact]
+public void DrawMeasureLines_WhenRendererIsNotReady_ShouldReturnWithoutThrowing()
+{
+    var renderer = CreateRenderer();
+
+    var exception = Record.Exception(() => renderer.DrawMeasureLines(
+        (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch)),
+        new[] { new MeasureLine { Bar = 0, TimeMs = 0.0 } },
+        0.0));
+
+    Assert.Null(exception);
+}
+
+[Fact]
+public void DrawMeasureLines_WhenInputIsNull_ShouldReturnWithoutThrowing()
+{
+    var renderer = CreateReadyRenderer();
+    var spriteBatch =
+        (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+    var exception = Record.Exception(() =>
+    {
+        renderer.DrawMeasureLines(null!, Array.Empty<MeasureLine>(), 0.0);
+        renderer.DrawMeasureLines(spriteBatch, null!, 0.0);
+    });
+
+    Assert.Null(exception);
+}
+
+[Theory]
+[InlineData(-10000.0)]
+[InlineData(10000.0)]
+public void DrawMeasureLines_WhenLineIsOffscreen_ShouldReturnWithoutThrowing(
+    double currentSongTimeMs)
+{
+    var renderer = CreateReadyRenderer();
+    var spriteBatch =
+        (SpriteBatch)RuntimeHelpers.GetUninitializedObject(typeof(SpriteBatch));
+
+    var exception = Record.Exception(() => renderer.DrawMeasureLines(
+        spriteBatch,
+        new[] { new MeasureLine { Bar = 0, TimeMs = 0.0 } },
+        currentSongTimeMs));
+
+    Assert.Null(exception);
+}
+```
+
+- [ ] **Step 2: Run layout and renderer tests and observe RED**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~PerformanceUILayoutMoreTests|FullyQualifiedName~NoteRendererLogicTests'
+```
+
+Expected: FAIL during compilation because the measure-line layout, grace property, and draw method do not exist.
+
+- [ ] **Step 3: Add the layout-owned geometry, color, and depth**
+
+Add this nested class immediately after `PerformanceUILayout.HitBar`:
+
+```csharp
+public static class MeasureLine
+{
+    public const int Height = 2;
+    public const float Depth = 0.78f;
+    public static readonly Color Color = new Color(169, 169, 169);
+
+    public static Rectangle GetDestinationRect(double centerY)
+    {
+        var top = (int)Math.Floor(centerY - (Height / 2.0));
+        return new Rectangle(
+            HitBar.Bounds.X,
+            top,
+            HitBar.Bounds.Width,
+            Height);
+    }
+}
+```
+
+- [ ] **Step 4: Add the renderer grace property and thin draw loop**
+
+Add this property beside `ScrollPixelsPerMs`:
+
+```csharp
+public double MeasureLinePastGraceMs =>
+    _scrollPixelsPerMs > 0
+        ? DropGracePeriod / _scrollPixelsPerMs
+        : 0.0;
+```
+
+Add this method beside `DrawNotes(...)`:
+
+```csharp
+[ExcludeFromCodeCoverage]
+public void DrawMeasureLines(
+    SpriteBatch spriteBatch,
+    IEnumerable<MeasureLine> measureLines,
+    double currentSongTimeMs)
+{
+    if (!IsReady || spriteBatch == null || measureLines == null)
+        return;
+
+    foreach (var line in measureLines)
+    {
+        var lineY = GetNoteScreenY(line.TimeMs, currentSongTimeMs);
+        var destination =
+            PerformanceUILayout.MeasureLine.GetDestinationRect(lineY);
+        if (destination.Bottom <= 0 ||
+            lineY > JudgementY + DropGracePeriod)
+        {
+            continue;
+        }
+
+        spriteBatch.Draw(
+            _whiteTexture,
+            destination,
+            null,
+            PerformanceUILayout.MeasureLine.Color,
+            0f,
+            Vector2.Zero,
+            SpriteEffects.None,
+            PerformanceUILayout.MeasureLine.Depth);
+    }
+}
+```
+
+Do not read `_drumChipsTexture`, add a source rectangle, or add a texture-dimension branch.
+
+- [ ] **Step 5: Run layout and renderer tests and observe GREEN**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~PerformanceUILayoutMoreTests|FullyQualifiedName~NoteRendererLogicTests'
+```
+
+Expected: PASS; the existing `GetNoteScreenY_AndShouldDropNote_ShouldUseConfiguredScrollSpeed` test remains the parity guard for line/note positioning.
+
+- [ ] **Step 6: Review and commit renderer behavior**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git diff -- DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs DTXMania.Test/UI/PerformanceUILayoutMoreTests.cs DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs
+rtk git add DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs DTXMania.Test/UI/PerformanceUILayoutMoreTests.cs DTXMania.Test/Stage/Performance/NoteRendererLogicTests.cs
+rtk git commit -m "feat: render gameplay measure lines"
+```
+
+### Task 5: Wire Measure Lines into PerformanceStage
+
+**Files:**
+
+- Modify: `DTXMania.Game/Lib/Stage/PerformanceStage.cs:320-353,1014-1032`
+- Modify: `DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs:2783-2880`
+
+**Interfaces:**
+
+- Consumes: `ChartManager.GetActiveMeasureLines(...)`, `NoteRenderer.EffectiveLookAheadMs`, `NoteRenderer.MeasureLinePastGraceMs`, and `NoteRenderer.DrawMeasureLines(...)` from Tasks 3–4.
+- Produces: private `PerformanceStage.DrawMeasureLines()` called during the existing base render pass while the timer is playing or paused.
+
+- [ ] **Step 1: Add failing stage guard and active-path tests**
+
+Add to `PerformanceStageDeterministicTests` near the existing `DrawNotes` tests:
+
+```csharp
+[Fact]
+public void DrawMeasureLines_WhenRequiredCollaboratorIsMissing_ShouldNotThrow()
+{
+    var stage = CreateStage();
+
+    var exception = Record.Exception(
+        () => ReflectionHelpers.InvokePrivateMethod(stage, "DrawMeasureLines"));
+
+    Assert.Null(exception);
+}
+
+[Fact]
+public void DrawMeasureLines_WhenTimerIsPlaying_ShouldQueryAndCullSafely()
+{
+    var stage = CreateStage();
+    var renderer = CreateNoteRenderer();
+    var parsedChart = new ParsedChart("draw-measure-lines.dtx") { Bpm = 120.0 };
+    parsedChart.AddNote(new Note(0, 1, 0, 0x11, "01"));
+    parsedChart.FinalizeChart();
+
+    ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 5.0);
+    ReflectionHelpers.SetPrivateField(
+        renderer,
+        "<EffectiveLookAheadMs>k__BackingField",
+        3000.0);
+    ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", renderer);
+    ReflectionHelpers.SetPrivateField(
+        stage,
+        "_chartManager",
+        new ChartManager(parsedChart));
+    ReflectionHelpers.SetPrivateField(stage, "_songTimer", CreatePlayingSongTimer());
+    ReflectionHelpers.SetPrivateField(
+        stage,
+        "_currentGameTime",
+        new GameTime(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(0.016)));
+    ReflectionHelpers.SetPrivateField(
+        stage,
+        "_spriteBatch",
+        CreateSpriteBatchStub(new Viewport(0, 0, 1280, 720)));
+
+    var exception = Record.Exception(
+        () => ReflectionHelpers.InvokePrivateMethod(stage, "DrawMeasureLines"));
+
+    Assert.Null(exception);
+}
+
+[Fact]
+public void DrawMeasureLines_WhenTimerIsPaused_ShouldUseFrozenLogicalTime()
+{
+    var stage = CreateStage();
+    var renderer = CreateNoteRenderer();
+    var parsedChart = new ParsedChart("draw-paused-measure-lines.dtx")
+    {
+        Bpm = 120.0
+    };
+    parsedChart.AddNote(new Note(0, 1, 0, 0x11, "01"));
+    parsedChart.FinalizeChart();
+    var timer = new SongTimer(150);
+    timer.Play(new GameTime(TimeSpan.Zero, TimeSpan.Zero));
+    timer.Pause(new GameTime(TimeSpan.FromMilliseconds(1000), TimeSpan.Zero));
+
+    ReflectionHelpers.SetPrivateField(renderer, "_scrollPixelsPerMs", 5.0);
+    ReflectionHelpers.SetPrivateField(
+        renderer,
+        "<EffectiveLookAheadMs>k__BackingField",
+        3000.0);
+    ReflectionHelpers.SetPrivateField(stage, "_noteRenderer", renderer);
+    ReflectionHelpers.SetPrivateField(
+        stage,
+        "_chartManager",
+        new ChartManager(parsedChart));
+    ReflectionHelpers.SetPrivateField(stage, "_songTimer", timer);
+    ReflectionHelpers.SetPrivateField(
+        stage,
+        "_currentGameTime",
+        new GameTime(TimeSpan.FromMilliseconds(5000), TimeSpan.FromSeconds(0.016)));
+    ReflectionHelpers.SetPrivateField(
+        stage,
+        "_spriteBatch",
+        CreateSpriteBatchStub(new Viewport(0, 0, 1280, 720)));
+
+    var exception = Record.Exception(
+        () => ReflectionHelpers.InvokePrivateMethod(stage, "DrawMeasureLines"));
+
+    Assert.Null(exception);
+    Assert.Equal(
+        1500.0,
+        timer.GetCurrentMs(new GameTime(
+            TimeSpan.FromMilliseconds(5000),
+            TimeSpan.Zero)));
+}
+```
+
+- [ ] **Step 2: Run the stage tests and observe RED**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~PerformanceStageDeterministicTests'
+```
+
+Expected: FAIL because reflection cannot find the private `DrawMeasureLines` method.
+
+- [ ] **Step 3: Add the stage query/draw method**
+
+Add this method immediately before the existing private `DrawNotes()` method:
+
+```csharp
+private void DrawMeasureLines()
+{
+    if (_noteRenderer == null ||
+        _chartManager == null ||
+        _songTimer == null ||
+        _currentGameTime == null)
+    {
+        return;
+    }
+
+    if (!_songTimer.IsPlaying && !_songTimer.IsPaused)
+        return;
+
+    var currentTimeMs = _songTimer.GetCurrentMs(_currentGameTime);
+    var lookAheadMs = _noteRenderer.EffectiveLookAheadMs > 0
+        ? _noteRenderer.EffectiveLookAheadMs
+        : PerformanceUILayout.NoteDefaultLookAheadMs;
+    var activeLines = _chartManager.GetActiveMeasureLines(
+        currentTimeMs,
+        lookAheadMs,
+        _noteRenderer.MeasureLinePastGraceMs);
+
+    _noteRenderer.DrawMeasureLines(
+        _spriteBatch,
+        activeLines,
+        currentTimeMs);
+}
+```
+
+- [ ] **Step 4: Insert the base-pass call and correct the stale depth comment**
+
+Call `DrawMeasureLines()` immediately after `DrawLaneBackgrounds()` and before `DrawPads()`/`DrawNotes()`:
+
+```csharp
+// Draw lane backgrounds
+DrawLaneBackgrounds();
+
+// Draw scrolling measure boundaries above lanes and behind gameplay objects
+DrawMeasureLines();
+
+// Draw pad indicators
+DrawPads();
+
+// Draw scrolling notes
+DrawNotes();
+```
+
+Replace the stale Z-order comment with the actual depth values:
+
+```csharp
+// BackToFront depth order:
+// Background (1.0f) → Lanes (0.8f) → Measure lines (0.78f) →
+// fallback notes (0.70f) → JudgementLine (0.6f) →
+// Pads (0.1f) → sprite notes (0.05f).
+```
+
+Do not change `PadRenderer.BaseDepth`.
+
+- [ ] **Step 5: Run stage and complete focused tests and observe GREEN**
+
+Run:
+
+```bash
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~PerformanceStageDeterministicTests'
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter 'FullyQualifiedName~ChartTimeCalculatorTests|FullyQualifiedName~NoteTests|FullyQualifiedName~BGMEventTests|FullyQualifiedName~ParsedChartTests|FullyQualifiedName~ChartManagerTests|FullyQualifiedName~PerformanceUILayoutMoreTests|FullyQualifiedName~NoteRendererLogicTests|FullyQualifiedName~PerformanceStageDeterministicTests'
+```
+
+Expected: PASS; no graphics-dependent test project changes are required.
+
+- [ ] **Step 6: Review and commit stage integration**
+
+Run:
+
+```bash
+rtk git diff --check
+rtk git diff -- DTXMania.Game/Lib/Stage/PerformanceStage.cs DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+rtk git add DTXMania.Game/Lib/Stage/PerformanceStage.cs DTXMania.Test/Stage/Performance/PerformanceStageDeterministicTests.cs
+rtk git commit -m "feat: show measure lines during gameplay"
+```
+
+### Task 6: Complete Integration and Visual Verification
+
+**Files:**
+
+- Verify only: all files changed in Tasks 1–5.
+- Do not modify: `DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs`, skin PNG files, project files, or `DTXManiaNX/`.
+
+**Interfaces:**
+
+- Consumes: the complete HPA-518 implementation.
+- Produces: build/test evidence plus screenshots demonstrating visible line behavior in both bundled skins.
+
+- [ ] **Step 1: Verify the intended scope**
+
+Run:
+
+```bash
+rtk git status --short
+rtk git diff --stat main...HEAD
+rtk git diff --check main...HEAD
+rtk rg -n 'MeasureLine|ChartTimeCalculator' DTXMania.Game DTXMania.Test
+```
+
+Expected: only the files listed in the responsibility map changed; no asset, parser, E2E fixture, project, or legacy files appear.
+
+- [ ] **Step 2: Build and run the complete Mac-safe suite**
+
+Run:
+
+```bash
+rtk dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+Expected: build succeeds with zero errors and the full Mac-safe suite passes.
+
+- [ ] **Step 3: Perform the real gameplay visual check**
+
+Run:
+
+```bash
+rtk dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Using a chart spanning at least two occupied bars, capture evidence for both the default System skin and CX Neon that confirms:
+
+- the neutral-gray line is visible and spans `HitBar.Bounds` from `x=295` for `558` pixels;
+- empty measures retain their boundaries;
+- lines render in front of lane backgrounds and behind notes, pads, and the judgement line;
+- pausing freezes line motion;
+- scroll speeds `50`, `100`, and `400` keep boundaries aligned with notes;
+- crossing the judgement line retains approximately `20` pixels of below-line travel;
+- gameplay reaches Result without duration or completion regressions.
+
+- [ ] **Step 4: Use Windows CI as the authoritative graphics/E2E gate**
+
+After the implementation branch is published, inspect the existing `Build and
+Test` workflow without modifying it. Require green results for the Windows
+build/full unit-test job and the gameplay-E2E job, which runs both
+`Category=E2E` and `Category=E2E-Support` against the unchanged fixture.
+
+Expected: Windows build, full unit suite, unchanged gameplay smoke, and support
+tests pass. If the branch has not been published, record these as pending CI
+evidence rather than claiming a local Windows pass.
+
+- [ ] **Step 5: Final whole-branch review**
+
+Review `main...HEAD` against every acceptance criterion in the design. Confirm especially that measure lines do not affect `DurationMs`, the query does not touch `_lastActiveIndex`, and rendering never reads the drum-chip texture. Resolve concrete findings with focused tests and a separate `fix:` commit, then repeat Steps 1–4 as applicable.
+
+No verification-only commit is expected when the branch is already clean.

--- a/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
+++ b/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
@@ -130,8 +130,10 @@ public sealed class MeasureLine
 `FinalizeChart()` it determines the highest occupied measure across both
 `Notes` and `BGMEvents`:
 
-- Clear `MeasureLines` before generation so repeated finalization is
-  idempotent and cannot duplicate boundaries.
+- Clear `MeasureLines` before generation so a repeated finalization cannot
+  duplicate boundaries. This makes measure-line generation repeat-safe; it
+  does not change the existing behavior where `FinalizeChart()` adds the
+  duration buffer on every call.
 - If neither collection has an event, `MeasureLines` stays empty.
 - Otherwise, generate bars `0` through `highestOccupiedBar + 1`, inclusive.
 - Every line uses tick `0` and `ChartTimeCalculator.CalculateTimeMs(...)`.
@@ -175,7 +177,7 @@ time.
 
 ### Layout and rendering
 
-Add `PerformanceUILayout.MeasureLine` constants:
+Add `PerformanceUILayout.MeasureLine` constants and a pure destination helper:
 
 - destination `X`: `HitBar.Bounds.X` (`295`)
 - destination width: `HitBar.Bounds.Width` (`558`)
@@ -183,6 +185,8 @@ Add `PerformanceUILayout.MeasureLine` constants:
 - color: neutral gray `new Color(169, 169, 169)`, matching the upper row of
   NX's bundled strip while remaining visible in both bundled skins
 - layer depth: `0.78f`
+- `GetDestinationRect(double centerY)`: floor `centerY - 1` for the top edge
+  and return the full-width two-pixel destination rectangle
 
 `NoteRenderer` gains an `[ExcludeFromCodeCoverage]` thin draw loop named
 `DrawMeasureLines(...)`. It uses
@@ -279,7 +283,8 @@ Extend `ParsedChartTests` with:
 - events in measures `0` and `2` produce lines for bars `0`, `1`, `2`, and `3`;
 - a BGM-only chart generates boundaries;
 - an empty chart generates none;
-- calling `FinalizeChart()` twice does not duplicate boundaries;
+- calling `FinalizeChart()` twice does not duplicate boundaries, without
+  changing the method's existing duration-buffer behavior;
 - line times use the fixed current clock;
 - terminal lines do not extend `DurationMs`.
 

--- a/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
+++ b/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [HPA-518](https://linear.app/cwchanap/issue/HPA-518/measure-line-in-game-play-stage)  
 **Date:** 2026-08-08  
-**Status:** Revised after design review
+**Status:** Revised after asset and reuse review
 
 ## Context
 
@@ -12,8 +12,8 @@ DTXManiaNX.
 
 NX represents measure and beat lines as timeline chips. It synthesizes a bar
 line at each measure boundary, scrolls that chip with the same distance model
-as playable chips, and draws a two-pixel strip from the drum-chip texture
-across the lane panel. NX also supports beat lines, measure-number text,
+as playable chips, and draws a two-pixel strip across the lane panel. NX also
+supports beat lines, measure-number text,
 metronome sounds, reverse mode, and lane-visibility settings; those adjacent
 features are not implied by the singular measure-line request.
 
@@ -23,9 +23,8 @@ DTXManiaCX already has the relevant visual seams:
 - `NoteRenderer.SetScrollSpeed(...)` owns scroll speed and visible look-ahead.
 - `PerformanceUILayout.HitBar.Bounds` defines the full lane-panel width at
   `x=295`, width `558`.
-- `TexturePath.DrumChips` resolves the active skin's
-  `Graphics/7_chips_drums.png`; the bundled skins retain NX's bar-line strip at
-  source `y=769`, height `2`.
+- `NoteRenderer` already owns a one-pixel white texture for solid rectangle
+  rendering.
 - `PerformanceStage.OnDraw(...)` already draws lane backgrounds before notes,
   leaving a stable layer for measure lines between them.
 
@@ -42,10 +41,8 @@ drum notes.
 - Preserve empty measures between occupied measures.
 - Keep line motion exactly aligned with note motion at every configured scroll
   speed, play speed, pause state, and frame time.
-- Match the NX drum-lane geometry and use the active skin's NX-compatible line
-  strip when it is available.
-- Degrade safely to a solid two-pixel line when a custom skin lacks the
-  expected source strip.
+- Match the NX drum-lane geometry with a visible neutral-gray two-pixel line
+  in both bundled skins.
 - Keep parsing, model, rendering, and stage wiring independently testable in
   the Mac-safe unit suite.
 
@@ -133,6 +130,8 @@ public sealed class MeasureLine
 `FinalizeChart()` it determines the highest occupied measure across both
 `Notes` and `BGMEvents`:
 
+- Clear `MeasureLines` before generation so repeated finalization is
+  idempotent and cannot duplicate boundaries.
 - If neither collection has an event, `MeasureLines` stays empty.
 - Otherwise, generate bars `0` through `highestOccupiedBar + 1`, inclusive.
 - Every line uses tick `0` and `ChartTimeCalculator.CalculateTimeMs(...)`.
@@ -165,38 +164,39 @@ distance stable at every scroll speed instead of applying an arbitrary fixed
 time window. If `ScrollPixelsPerMs` is zero or negative, the exposed grace is
 zero; negative query input is also clamped to zero.
 
-`GetActiveMeasureLines(...)` performs binary search against `_measureLines`
-only. It must not call the note-only `FindStartIndex(...)`, reuse
-`_lastActiveIndex`, or introduce one cursor shared by both collections. A line
-query therefore cannot change the result of a later note query, including a
-note query that moves backward in time.
+`GetActiveMeasureLines(...)` performs a plain ordered scan of `_measureLines`,
+skipping entries before the lower bound and stopping after the upper bound.
+The expected collection is only a few hundred entries, so a second custom
+binary-search implementation is unnecessary. The method must not call the
+note-only `FindStartIndex(...)`, reuse `_lastActiveIndex`, or introduce one
+cursor shared by both collections. A line query therefore cannot change the
+result of a later note query, including a note query that moves backward in
+time.
 
 ### Layout and rendering
 
-Add `PerformanceUILayout.MeasureLine` constants/helpers:
+Add `PerformanceUILayout.MeasureLine` constants:
 
 - destination `X`: `HitBar.Bounds.X` (`295`)
 - destination width: `HitBar.Bounds.Width` (`558`)
 - destination height: `2`
-- source `X`: `0`
-- source `Y`: `769`
-- source width: `min(texture.Width, HitBar.Bounds.Width)`
-- source height: `2`
-- layer depth: `0.75f`, between lane backgrounds (`0.8f`) and notes (`0.7f`)
+- color: neutral gray `new Color(169, 169, 169)`, matching the upper row of
+  NX's bundled strip while remaining visible in both bundled skins
+- layer depth: `0.78f`
 
-`NoteRenderer` gains `DrawMeasureLines(...)`. It uses
+`NoteRenderer` gains an `[ExcludeFromCodeCoverage]` thin draw loop named
+`DrawMeasureLines(...)`. It uses
 `GetNoteScreenY(line.TimeMs, currentSongTimeMs)` and centers the two-pixel
-destination on that Y position. The renderer draws the active skin's drum-chip
-source strip when the underlying texture is large enough. If the texture is
-missing, disposed, narrower than one pixel, or shorter than source row `770`,
-it draws the same destination rectangle with the renderer's existing white
-texture. If neither texture is available, drawing is a no-op.
+destination on that Y position. It draws destination
+`(295, centeredY, 558, 2)` from the renderer's existing `_whiteTexture` with
+the layout color and no source rectangle. If `_whiteTexture` is unavailable,
+drawing is a no-op.
 
-The source rectangle is therefore
-`(0, 769, min(texture.Width, 558), 2)`, while the destination remains
-`(295, centeredY, 558, 2)`. A source narrower than the lane panel is stretched
-across the full destination width. A texture height below `771` cannot contain
-both source rows and selects the solid fallback.
+This asset-independent path is required by the shipped files: the default
+System texture has visible pixels at source rows `769`–`770`, but the same
+rows are fully transparent in both the CX Neon texture and its skin-generator
+source. A dimension-only texture guard would therefore accept CX Neon's
+`718x776` image and still draw an invisible line.
 
 The renderer applies top-of-screen culling and a measure-line-specific
 20-pixel below-judgement grace. Current stage note queries start at
@@ -206,18 +206,21 @@ claim of note-query parity. `NoteRenderer` exposes the corresponding
 time-domain grace through a read-only property for the stage query so callers
 do not duplicate the conversion.
 
-Measure-line drawing must not change the ready state for playable notes and
-must share the existing texture reload/disposal lifecycle. Invalid or null
-inputs remain safe no-ops, matching existing `NoteRenderer` draw methods.
+Measure-line drawing must not change the ready state for playable notes.
+Invalid or null inputs remain safe no-ops, matching existing `NoteRenderer`
+draw methods.
 
 ### Performance-stage integration
 
 `PerformanceStage.OnDraw(...)` calls `DrawMeasureLines()` after
 `DrawLaneBackgrounds()` and before `DrawNotes()`. Its call order relative to
 `DrawPads()` is not a layering contract because `SpriteSortMode.BackToFront`
-uses depth: measure lines remain at `0.75f`, while current pads intentionally
-render at `0.1f`. The implementation updates the stale `OnDraw` depth comment
-but does not change `PadRenderer.BaseDepth` or pad behavior. The stage method
+uses depth. Measure lines render at `0.78f`: numerically below lane backgrounds
+at `0.8f` and above the note depths actually in use (`0.70f` for rectangle
+fallbacks and `0.05f` for sprites), the judgement line at `0.6f`, and pads at
+`0.1f`. The distinct value also avoids reusing the stale `0.75f` pad depth in
+the current stage comment. The implementation corrects that comment but does
+not change `PadRenderer.BaseDepth` or pad behavior. The stage method
 uses the same values as note rendering:
 
 1. Read `currentTimeMs` from `SongTimer`.
@@ -242,7 +245,7 @@ DTXChartParser
   -> ChartManager copied runtime collections
   -> PerformanceStage current time + visible window
   -> NoteRenderer shared time-to-Y mapping
-  -> active-skin NX strip or solid fallback
+  -> solid neutral-gray two-pixel line
 ```
 
 ## Error and Compatibility Behavior
@@ -254,9 +257,9 @@ DTXChartParser
   behavior; HPA-518 neither worsens nor silently claims to fix that limitation.
 - The highest occupied measure comes only from the current gameplay model's
   `Notes` and `BGMEvents`; discarded raw DTX channels do not extend the list.
-- Custom skins with an NX-compatible `7_chips_drums.png` retain authored line
-  appearance. Short or missing custom textures receive the solid fallback.
-- The default and CX Neon assets are reused unchanged.
+- Measure-line visibility does not depend on drum-chip texture dimensions or
+  alpha content; custom and bundled skins use the same layout-defined color.
+- The default and CX Neon assets remain unchanged.
 - No configuration or persisted-data migration is required.
 - Existing `TimeMs == 0` recalculation gates in `AddNote` and `ChartManager`
   remain unchanged. Measure-line generation always calls
@@ -276,8 +279,14 @@ Extend `ParsedChartTests` with:
 - events in measures `0` and `2` produce lines for bars `0`, `1`, `2`, and `3`;
 - a BGM-only chart generates boundaries;
 - an empty chart generates none;
+- calling `FinalizeChart()` twice does not duplicate boundaries;
 - line times use the fixed current clock;
 - terminal lines do not extend `DurationMs`.
+
+Tests that hand-build a `ParsedChart` for measure-line behavior call
+`FinalizeChart()` before constructing `ChartManager`, matching the production
+parser path. Generation remains in `ParsedChart` because the collection is
+derived chart state and is the intended seam for a future timing map.
 
 ### Runtime query tests
 
@@ -297,14 +306,14 @@ Extend `ChartManagerTests` to verify:
 Extend `PerformanceUILayoutMoreTests` and `NoteRendererLogicTests` to verify:
 
 - destination geometry is `x=295`, width `558`, height `2`;
-- source geometry is
-  `x=0`, `y=769`, width `min(texture.Width, 558)`, height `2`;
+- layout constants expose the neutral-gray color and `0.78f` depth;
 - line Y uses the same calculation as a note at the same `TimeMs`;
 - the time-domain grace corresponds to 20 pixels at multiple scroll speeds;
 - zero or negative scroll pixels produce zero past-grace milliseconds;
-- line depth stays between lane and note depths;
-- offscreen and null inputs are safe;
-- short/missing textures select the solid fallback.
+- depth constants satisfy `0.8f > MeasureLine.Depth > 0.70f`, placing the line
+  visually in front of lane backgrounds and behind every note, judgement, and
+  pad depth currently in use under `BackToFront` sorting;
+- offscreen and null inputs are safe.
 
 Extend `PerformanceStageDeterministicTests` to verify the stage supplies the
 current song time, renderer look-ahead, and active chart lines without drawing
@@ -312,10 +321,11 @@ when required collaborators are absent.
 
 ### End-to-end and visual verification
 
-Use the existing generated gameplay E2E fixture with a sparse multi-measure
-note pattern. The automated smoke remains behavioral rather than pixel-based:
-it must still reach Result successfully. Capture a gameplay screenshot during
-manual verification and confirm:
+Leave the generated gameplay E2E fixture unchanged. It already contains events
+in bars `000` and `001`, which generate boundaries at bars `0`, `1`, and `2`;
+the automated smoke remains behavioral rather than pixel-based and must still
+reach Result successfully. Capture a gameplay screenshot during manual
+verification and confirm:
 
 - the measure line spans the full drum panel;
 - it is behind notes and above lane backgrounds;
@@ -358,9 +368,9 @@ graphics-dependent tests.
 - Empty measures between occupied measures retain their boundaries.
 - The line uses the same time-to-Y mapping and visible look-ahead as notes.
 - The line spans the current `HitBar.Bounds` width and renders below notes.
-- Default and CX Neon skins use the NX bar-line source strip; incompatible
-  custom skins receive a safe solid fallback.
-- Empty/malformed chart state and missing texture resources do not crash.
+- Default, CX Neon, and custom skins render a visible solid measure line
+  without depending on drum-chip texture content.
+- Empty/malformed chart state and missing renderer resources do not crash.
 - Measure lines do not affect chart duration, judgement, audio, scoring, or
   persistence.
 - Focused model, runtime-query, layout, renderer, and stage tests pass on macOS.

--- a/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
+++ b/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
@@ -1,0 +1,334 @@
+# HPA-518 NX-Style Gameplay Measure Lines Design
+
+**Issue:** [HPA-518](https://linear.app/cwchanap/issue/HPA-518/measure-line-in-game-play-stage)  
+**Date:** 2026-08-08  
+**Status:** Draft for review
+
+## Context
+
+The Performance stage scrolls playable drum notes over the ten-lane panel but
+does not show measure boundaries. HPA-518 asks for a measure line similar to
+DTXManiaNX.
+
+NX represents measure and beat lines as timeline chips. It synthesizes a bar
+line at each measure boundary, scrolls that chip with the same distance model
+as playable chips, and draws a two-pixel strip from the drum-chip texture
+across the lane panel. NX also supports beat lines, measure-number text,
+metronome sounds, reverse mode, and lane-visibility settings; those adjacent
+features are not implied by the singular measure-line request.
+
+DTXManiaCX already has the relevant visual seams:
+
+- `NoteRenderer.GetNoteScreenY(...)` owns the current time-to-screen mapping.
+- `NoteRenderer.SetScrollSpeed(...)` owns scroll speed and visible look-ahead.
+- `PerformanceUILayout.HitBar.Bounds` defines the full lane-panel width at
+  `x=295`, width `558`.
+- `TexturePath.DrumChips` resolves the active skin's
+  `Graphics/7_chips_drums.png`; the bundled skins retain NX's bar-line strip at
+  source `y=769`, height `2`.
+- `PerformanceStage.OnDraw(...)` already draws lane backgrounds before notes,
+  leaving a stable layer for measure lines between them.
+
+The missing seam is chart state. `ParsedChart` retains playable `Note` objects
+and channel `01` `BGMEvent` objects, while `DTXChartParser` discards every other
+unmapped timeline channel. A renderer cannot reliably infer boundaries from
+the currently visible notes because an entire measure may contain no playable
+drum notes.
+
+## Goals
+
+- Show one horizontal measure line at every measure boundary represented by
+  the current parsed gameplay chart.
+- Preserve empty measures between occupied measures.
+- Keep line motion exactly aligned with note motion at every configured scroll
+  speed, play speed, pause state, and frame time.
+- Match the NX drum-lane geometry and use the active skin's NX-compatible line
+  strip when it is available.
+- Degrade safely to a solid two-pixel line when a custom skin lacks the
+  expected source strip.
+- Keep parsing, model, rendering, and stage wiring independently testable in
+  the Mac-safe unit suite.
+
+## Non-goals
+
+- Beat/subdivision lines corresponding to NX channel `0x51`.
+- Measure-number text or performance-information UI.
+- Metronome sounds at measure boundaries.
+- A setting to hide measure lines or other NX lane-display modes.
+- Reverse-mode rendering; CX does not currently expose reverse gameplay.
+- Parsing channel `0xC2` bar/beat-line visibility directives.
+- Full DTX timing support for channel `02` measure lengths, channel `03`
+  direct BPM changes, or channel `08` BPM-table changes.
+- Changing judgement, autoplay, audio scheduling, score persistence, or song
+  completion timing.
+- Adding or modifying skin assets.
+
+## Approaches Considered
+
+### Explicit measure-line events in `ParsedChart` (selected)
+
+Add a small `MeasureLine` timeline model, generate the ordered boundary list
+when the chart is finalized, copy it into `ChartManager`, and render its active
+window with `NoteRenderer`.
+
+This preserves empty measures, makes timing testable without graphics, and
+gives a future DTX timing-map implementation one explicit collection to
+recalculate. It adds only the state required by HPA-518.
+
+### Infer boundaries from playable notes during rendering
+
+Rejected. Grouping visible notes by `Note.Bar` cannot recover a measure that
+contains no playable drum note. It also makes the renderer responsible for
+chart semantics and can produce duplicate or disappearing boundaries as the
+visible note window changes.
+
+### Build a complete DTX tempo and measure-length map first
+
+Deferred. It is the correct long-term timing architecture, but it expands this
+visual feature into a parser and playback-timing migration. HPA-518 will use
+the same fixed 4/4, base-BPM clock that current CX notes and BGM events use, so
+the new lines remain aligned with current gameplay. The design leaves one
+calculator seam for the future timing work.
+
+## Chosen Architecture
+
+### Shared current-timing calculator
+
+Add a focused `ChartTimeCalculator` under
+`DTXMania.Game/Lib/Song/Components/`. It contains the existing
+`192`-ticks-per-measure, base-BPM 4/4 calculation:
+
+```csharp
+internal static class ChartTimeCalculator
+{
+    internal const int TicksPerMeasure = 192;
+
+    internal static double CalculateTimeMs(int bar, int tick, double bpm);
+}
+```
+
+`Note.CalculateTimeMs(...)`, `BGMEvent.CalculateTimeMs(...)`, and measure-line
+generation delegate to this helper. Moving the current formula must be
+behavior-preserving; existing note and BGM timing tests remain parity guards.
+The helper name deliberately avoids claiming support for a complete DTX tempo
+map.
+
+### Measure-line model and generation
+
+Add `DTXMania.Game/Lib/Song/Components/MeasureLine.cs`:
+
+```csharp
+public sealed class MeasureLine
+{
+    public int Bar { get; init; }
+    public double TimeMs { get; init; }
+}
+```
+
+`ParsedChart` owns a get-only `List<MeasureLine> MeasureLines`. During
+`FinalizeChart()` it determines the highest occupied measure across both
+`Notes` and `BGMEvents`:
+
+- If neither collection has an event, `MeasureLines` stays empty.
+- Otherwise, generate bars `0` through `highestOccupiedBar + 1`, inclusive.
+- Every line uses tick `0` and `ChartTimeCalculator.CalculateTimeMs(...)`.
+- Sort by `TimeMs`, matching the other chart collections.
+- Measure lines do not contribute to `DurationMs`; adding the terminal boundary
+  must not lengthen gameplay or delay Result.
+
+The inclusive terminal boundary matches NX's post-final boundary and lets it
+enter the look-ahead window when the existing gameplay duration permits. A
+later timing-map change can replace each `TimeMs` without changing rendering.
+
+`ChartManager` copies the finalized collection and exposes:
+
+```csharp
+public IReadOnlyList<MeasureLine> AllMeasureLines { get; }
+
+public IEnumerable<MeasureLine> GetActiveMeasureLines(
+    double songTimeMs,
+    double lookAheadMs,
+    double gracePeriodMs);
+```
+
+The active range is
+`[songTimeMs - gracePeriodMs, songTimeMs + lookAheadMs]`. The small past
+window prevents a two-pixel line from disappearing one frame before it crosses
+the judgement line. `NoteRenderer` exposes the existing 20-pixel drop grace as
+milliseconds (`DropGracePeriod / ScrollPixelsPerMs`), and `PerformanceStage`
+passes that speed-derived value into this query. This keeps the below-line
+distance stable at every scroll speed instead of applying an arbitrary fixed
+time window. Negative input grace is clamped to zero. The list is sorted and
+queried without mutating note iteration state.
+
+### Layout and rendering
+
+Add `PerformanceUILayout.MeasureLine` constants/helpers:
+
+- destination `X`: `HitBar.Bounds.X` (`295`)
+- destination width: `HitBar.Bounds.Width` (`558`)
+- destination height: `2`
+- source `Y`: `769`
+- source height: `2`
+- layer depth: `0.75f`, between lane backgrounds (`0.8f`) and notes (`0.7f`)
+
+`NoteRenderer` gains `DrawMeasureLines(...)`. It uses
+`GetNoteScreenY(line.TimeMs, currentSongTimeMs)` and centers the two-pixel
+destination on that Y position. The renderer draws the active skin's drum-chip
+source strip when the underlying texture is large enough. If the texture is
+missing, disposed, narrower than one pixel, or shorter than source row `770`,
+it draws the same destination rectangle with the renderer's existing white
+texture. If neither texture is available, drawing is a no-op.
+
+The renderer applies the same top-of-screen culling and 20-pixel
+below-judgement grace used by scrolling notes. It exposes the corresponding
+time-domain grace through a read-only property for the stage query; callers do
+not duplicate the conversion.
+
+Measure-line drawing must not change the ready state for playable notes and
+must share the existing texture reload/disposal lifecycle. Invalid or null
+inputs remain safe no-ops, matching existing `NoteRenderer` draw methods.
+
+### Performance-stage integration
+
+`PerformanceStage.OnDraw(...)` calls `DrawMeasureLines()` after
+`DrawLaneBackgrounds()` and before `DrawPads()` / `DrawNotes()`. The stage
+method uses the same values as note rendering:
+
+1. Read `currentTimeMs` from `SongTimer`.
+2. Read look-ahead from `NoteRenderer.EffectiveLookAheadMs`.
+3. Read the speed-derived past-grace window from `NoteRenderer`.
+4. Ask `ChartManager` for active measure lines.
+5. Pass those lines and `currentTimeMs` to `NoteRenderer.DrawMeasureLines(...)`.
+
+The method draws while the timer is playing or paused, using the same guard as
+`DrawNotes()`. Because the renderer maps absolute chart times on every frame,
+pausing freezes lines, play-speed changes remain synchronized through the song
+clock, and scroll-speed changes reposition notes and lines together.
+
+## Data Flow
+
+```text
+DTXChartParser
+  -> ParsedChart Notes + BGMEvents
+  -> ParsedChart.FinalizeChart
+       -> ChartTimeCalculator
+       -> ordered MeasureLines
+  -> ChartManager copied runtime collections
+  -> PerformanceStage current time + visible window
+  -> NoteRenderer shared time-to-Y mapping
+  -> active-skin NX strip or solid fallback
+```
+
+## Error and Compatibility Behavior
+
+- Empty charts produce no measure lines and no draw calls.
+- Sparse charts still produce every intervening boundary.
+- A BGM-only chart produces boundaries from its occupied measures.
+- Unsupported DTX tempo and measure-length channels keep their current CX
+  behavior; HPA-518 neither worsens nor silently claims to fix that limitation.
+- Custom skins with an NX-compatible `7_chips_drums.png` retain authored line
+  appearance. Short or missing custom textures receive the solid fallback.
+- The default and CX Neon assets are reused unchanged.
+- No configuration or persisted-data migration is required.
+
+## Testing
+
+### Timing and model tests
+
+Extend `NoteTests`, `BGMEventTests`, and/or add focused calculator tests to
+prove moving the formula preserves current results at multiple BPMs and tick
+positions.
+
+Extend `ParsedChartTests` with:
+
+- events in measures `0` and `2` produce lines for bars `0`, `1`, `2`, and `3`;
+- a BGM-only chart generates boundaries;
+- an empty chart generates none;
+- line times use the fixed current clock;
+- terminal lines do not extend `DurationMs`.
+
+### Runtime query tests
+
+Extend `ChartManagerTests` to verify:
+
+- `AllMeasureLines` is a copied read-only runtime view;
+- the active query includes future lines inside look-ahead;
+- the supplied grace window retains a just-passed line;
+- lines outside both bounds are excluded;
+- note-query state remains unaffected.
+
+### Rendering and stage tests
+
+Extend `PerformanceUILayoutMoreTests` and `NoteRendererLogicTests` to verify:
+
+- destination geometry is `x=295`, width `558`, height `2`;
+- source geometry is `y=769`, height `2`;
+- line Y uses the same calculation as a note at the same `TimeMs`;
+- the time-domain grace corresponds to 20 pixels at multiple scroll speeds;
+- line depth stays between lane and note depths;
+- offscreen and null inputs are safe;
+- short/missing textures select the solid fallback.
+
+Extend `PerformanceStageDeterministicTests` to verify the stage supplies the
+current song time, renderer look-ahead, and active chart lines without drawing
+when required collaborators are absent.
+
+### End-to-end and visual verification
+
+Use the existing generated gameplay E2E fixture with a sparse multi-measure
+note pattern. The automated smoke remains behavioral rather than pixel-based:
+it must still reach Result successfully. Capture a gameplay screenshot during
+manual verification and confirm:
+
+- the measure line spans the full drum panel;
+- it is behind notes and above lane backgrounds;
+- it crosses the judgement line in sync with the authored measure;
+- pause freezes it;
+- scroll speeds `50`, `100`, and `400` keep it aligned with notes;
+- both the default System skin and CX Neon display a valid line.
+
+Run the focused tests first, then the complete Mac-safe suite. Windows CI
+remains the authoritative graphics and gameplay-E2E platform gate.
+
+## Files Expected to Change
+
+**Create:**
+
+- `DTXMania.Game/Lib/Song/Components/ChartTimeCalculator.cs`
+- `DTXMania.Game/Lib/Song/Components/MeasureLine.cs`
+
+**Modify:**
+
+- `DTXMania.Game/Lib/Song/Components/Note.cs`
+- `DTXMania.Game/Lib/Song/Components/BGMEvent.cs`
+- `DTXMania.Game/Lib/Song/Components/ParsedChart.cs`
+- `DTXMania.Game/Lib/Song/Components/ChartManager.cs`
+- `DTXMania.Game/Lib/Song/DTXChartParser.cs`
+- `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs`
+- `DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs`
+- `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+- existing focused test files under `DTXMania.Test/Song/`,
+  `DTXMania.Test/UI/`, and `DTXMania.Test/Stage/Performance/`
+
+No project-file change is expected because both test projects already include
+these source trees, with the Mac project excluding only its known
+graphics-dependent tests.
+
+## Acceptance Criteria
+
+- A horizontal two-pixel measure line is visible at each generated measure
+  boundary in Performance.
+- Empty measures between occupied measures retain their boundaries.
+- The line uses the same time-to-Y mapping and visible look-ahead as notes.
+- The line spans the current `HitBar.Bounds` width and renders below notes.
+- Default and CX Neon skins use the NX bar-line source strip; incompatible
+  custom skins receive a safe solid fallback.
+- Empty/malformed chart state and missing texture resources do not crash.
+- Measure lines do not affect chart duration, judgement, audio, scoring, or
+  persistence.
+- Focused model, runtime-query, layout, renderer, and stage tests pass on macOS.
+- The full Mac-safe suite and Windows gameplay E2E remain green.
+- Beat lines, measure numbers, metronome behavior, reverse mode, visibility
+  configuration, and complete DTX tempo-map support remain explicitly outside
+  HPA-518.

--- a/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
+++ b/docs/superpowers/specs/2026-08-08-hpa-518-measure-lines-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [HPA-518](https://linear.app/cwchanap/issue/HPA-518/measure-line-in-game-play-stage)  
 **Date:** 2026-08-08  
-**Status:** Draft for review
+**Status:** Revised after design review
 
 ## Context
 
@@ -101,7 +101,7 @@ Add a focused `ChartTimeCalculator` under
 ```csharp
 internal static class ChartTimeCalculator
 {
-    internal const int TicksPerMeasure = 192;
+    private const int TicksPerMeasure = 192;
 
     internal static double CalculateTimeMs(int bar, int tick, double bpm);
 }
@@ -112,6 +112,10 @@ generation delegate to this helper. Moving the current formula must be
 behavior-preserving; existing note and BGM timing tests remain parity guards.
 The helper name deliberately avoids claiming support for a complete DTX tempo
 map.
+
+`DTXChartParser` keeps its existing private parse-grid constant and remains
+unchanged. It already calls `ParsedChart.FinalizeChart()` after parsing. This
+feature neither reads raw discarded channels nor expands parser semantics.
 
 ### Measure-line model and generation
 
@@ -158,8 +162,14 @@ the judgement line. `NoteRenderer` exposes the existing 20-pixel drop grace as
 milliseconds (`DropGracePeriod / ScrollPixelsPerMs`), and `PerformanceStage`
 passes that speed-derived value into this query. This keeps the below-line
 distance stable at every scroll speed instead of applying an arbitrary fixed
-time window. Negative input grace is clamped to zero. The list is sorted and
-queried without mutating note iteration state.
+time window. If `ScrollPixelsPerMs` is zero or negative, the exposed grace is
+zero; negative query input is also clamped to zero.
+
+`GetActiveMeasureLines(...)` performs binary search against `_measureLines`
+only. It must not call the note-only `FindStartIndex(...)`, reuse
+`_lastActiveIndex`, or introduce one cursor shared by both collections. A line
+query therefore cannot change the result of a later note query, including a
+note query that moves backward in time.
 
 ### Layout and rendering
 
@@ -168,7 +178,9 @@ Add `PerformanceUILayout.MeasureLine` constants/helpers:
 - destination `X`: `HitBar.Bounds.X` (`295`)
 - destination width: `HitBar.Bounds.Width` (`558`)
 - destination height: `2`
+- source `X`: `0`
 - source `Y`: `769`
+- source width: `min(texture.Width, HitBar.Bounds.Width)`
 - source height: `2`
 - layer depth: `0.75f`, between lane backgrounds (`0.8f`) and notes (`0.7f`)
 
@@ -180,10 +192,19 @@ missing, disposed, narrower than one pixel, or shorter than source row `770`,
 it draws the same destination rectangle with the renderer's existing white
 texture. If neither texture is available, drawing is a no-op.
 
-The renderer applies the same top-of-screen culling and 20-pixel
-below-judgement grace used by scrolling notes. It exposes the corresponding
-time-domain grace through a read-only property for the stage query; callers do
-not duplicate the conversion.
+The source rectangle is therefore
+`(0, 769, min(texture.Width, 558), 2)`, while the destination remains
+`(295, centeredY, 558, 2)`. A source narrower than the lane panel is stretched
+across the full destination width. A texture height below `771` cannot contain
+both source rows and selects the solid fallback.
+
+The renderer applies top-of-screen culling and a measure-line-specific
+20-pixel below-judgement grace. Current stage note queries start at
+`songTimeMs`, so they do not actually supply past notes to `DrawNote`; this
+line grace is intentional visibility behavior for the two-pixel strip, not a
+claim of note-query parity. `NoteRenderer` exposes the corresponding
+time-domain grace through a read-only property for the stage query so callers
+do not duplicate the conversion.
 
 Measure-line drawing must not change the ready state for playable notes and
 must share the existing texture reload/disposal lifecycle. Invalid or null
@@ -192,8 +213,12 @@ inputs remain safe no-ops, matching existing `NoteRenderer` draw methods.
 ### Performance-stage integration
 
 `PerformanceStage.OnDraw(...)` calls `DrawMeasureLines()` after
-`DrawLaneBackgrounds()` and before `DrawPads()` / `DrawNotes()`. The stage
-method uses the same values as note rendering:
+`DrawLaneBackgrounds()` and before `DrawNotes()`. Its call order relative to
+`DrawPads()` is not a layering contract because `SpriteSortMode.BackToFront`
+uses depth: measure lines remain at `0.75f`, while current pads intentionally
+render at `0.1f`. The implementation updates the stale `OnDraw` depth comment
+but does not change `PadRenderer.BaseDepth` or pad behavior. The stage method
+uses the same values as note rendering:
 
 1. Read `currentTimeMs` from `SongTimer`.
 2. Read look-ahead from `NoteRenderer.EffectiveLookAheadMs`.
@@ -227,10 +252,16 @@ DTXChartParser
 - A BGM-only chart produces boundaries from its occupied measures.
 - Unsupported DTX tempo and measure-length channels keep their current CX
   behavior; HPA-518 neither worsens nor silently claims to fix that limitation.
+- The highest occupied measure comes only from the current gameplay model's
+  `Notes` and `BGMEvents`; discarded raw DTX channels do not extend the list.
 - Custom skins with an NX-compatible `7_chips_drums.png` retain authored line
   appearance. Short or missing custom textures receive the solid fallback.
 - The default and CX Neon assets are reused unchanged.
 - No configuration or persisted-data migration is required.
+- Existing `TimeMs == 0` recalculation gates in `AddNote` and `ChartManager`
+  remain unchanged. Measure-line generation always calls
+  `ChartTimeCalculator.CalculateTimeMs(...)` directly, including bar `0`, and
+  does not copy that sentinel pattern.
 
 ## Testing
 
@@ -256,16 +287,21 @@ Extend `ChartManagerTests` to verify:
 - the active query includes future lines inside look-ahead;
 - the supplied grace window retains a just-passed line;
 - lines outside both bounds are excluded;
-- note-query state remains unaffected.
+- note-query state remains unaffected;
+- querying measure lines at a later time and then notes at an earlier time
+  returns the same notes as a fresh `ChartManager`, proving the line query
+  cannot poison `_lastActiveIndex`.
 
 ### Rendering and stage tests
 
 Extend `PerformanceUILayoutMoreTests` and `NoteRendererLogicTests` to verify:
 
 - destination geometry is `x=295`, width `558`, height `2`;
-- source geometry is `y=769`, height `2`;
+- source geometry is
+  `x=0`, `y=769`, width `min(texture.Width, 558)`, height `2`;
 - line Y uses the same calculation as a note at the same `TimeMs`;
 - the time-domain grace corresponds to 20 pixels at multiple scroll speeds;
+- zero or negative scroll pixels produce zero past-grace milliseconds;
 - line depth stays between lane and note depths;
 - offscreen and null inputs are safe;
 - short/missing textures select the solid fallback.
@@ -304,10 +340,10 @@ remains the authoritative graphics and gameplay-E2E platform gate.
 - `DTXMania.Game/Lib/Song/Components/BGMEvent.cs`
 - `DTXMania.Game/Lib/Song/Components/ParsedChart.cs`
 - `DTXMania.Game/Lib/Song/Components/ChartManager.cs`
-- `DTXMania.Game/Lib/Song/DTXChartParser.cs`
 - `DTXMania.Game/Lib/UI/Layout/PerformanceUILayout.cs`
 - `DTXMania.Game/Lib/Stage/Performance/NoteRenderer.cs`
-- `DTXMania.Game/Lib/Stage/PerformanceStage.cs`
+- `DTXMania.Game/Lib/Stage/PerformanceStage.cs` — add measure-line wiring and
+  correct the stale depth-order comment without changing pad depth
 - existing focused test files under `DTXMania.Test/Song/`,
   `DTXMania.Test/UI/`, and `DTXMania.Test/Stage/Performance/`
 


### PR DESCRIPTION
## Summary

- add the reviewed HPA-518 design and implementation plan
- centralize chart-position timing for notes, BGM events, and generated measure boundaries
- generate repeat-safe measure lines from finalized note/BGM occupancy, including sparse and trailing boundaries
- query measure lines independently from note traversal state
- render neutral-gray two-pixel measure lines across the gameplay HitBar in the approved layer order
- wire rendering into playing and paused performance-stage draw states

## Why

Implements [HPA-518: Measure Line In Game Play Stage](https://linear.app/cwchanap/issue/HPA-518/measure-line-in-game-play-stage) so measure boundaries remain readable during gameplay without changing chart duration, judgement, score, audio, or persistence behavior.

The remote diff includes the two design/plan documents that preceded the five implementation commits: 9 commits and 17 changed files in total.

## Validation

- `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --no-restore`: 0 errors, 0 warnings
- full Mac-safe test suite: 8,143 passed
- focused HPA-518 regression suite: 427 passed
- native visual verification in System and CX Neon skins
- native scroll-speed captures at 50, 100, and 400
- unchanged three-bar chart reached Result with 169/169 Perfect and saved score
- final whole-branch implementation review found no Critical, Important, or Minor issues
- design and plan were reviewed and revised before implementation

## Pending CI evidence

The existing Windows build/full-test and gameplay-E2E jobs are the authoritative publication gate and will run on this PR. No workflow, project, fixture, parser-channel, skin asset, or legacy-code changes are included.

## Native evidence limitations

The current runtime exposes no callable gameplay pause input, so pause-freeze remains source/test verified rather than interactively captured. Exact 20-pixel post-hit travel and empty-measure retention are covered by deterministic tests; the native stills were not used for pixel-perfect measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scrolling measure lines to the performance view, positioned according to chart timing.
  * Measure lines now appear within the visible gameplay window, including look-ahead and grace periods.
  * Added consistent visual styling and layering for measure lines.
  * Improved chart timing calculations and validation for invalid BPM values.

* **Tests**
  * Added coverage for measure-line generation, timing, visibility, rendering behavior, and chart edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->