### PR TITLE
chore(deps): update tools and align EF Core packages

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.4.1",
+      "version": "3.8.5",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.4.1",
+      "version": "3.8.5",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.4.1",
+      "version": "3.8.5",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.4.1",
+      "version": "3.8.5",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.4.1",
+      "version": "3.8.5",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/DTXMania.Game/DTXMania.Game.Mac.csproj
+++ b/DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -32,8 +32,8 @@
     <PackageReference Include="FFMpegCore" Version="5.4.0" />
     <PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.18">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -41,8 +41,8 @@
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="NVorbis" Version="0.10.5" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.10" />
   </ItemGroup>
 
   <!-- SIL Open Font License files for Orbitron and ShareTechMono. The OFL

--- a/DTXMania.Game/DTXMania.Game.Windows.csproj
+++ b/DTXMania.Game/DTXMania.Game.Windows.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="FFMpegCore" Version="5.4.0" />
     <PackageReference Include="MMTools.Executables.Windows.X64" Version="1.0.6" />
     <PackageReference Include="Melanchall.DryWetMidi" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.18" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.18">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -33,8 +33,8 @@
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.*" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.*" />
     <PackageReference Include="NVorbis" Version="0.10.5" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="10.0.10" />
   </ItemGroup>
 
   <!-- SIL Open Font License files for Orbitron and ShareTechMono. The OFL

--- a/MCP/MCP.csproj
+++ b/MCP/MCP.csproj
@@ -19,10 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
   </ItemGroup>
 
   <!-- Exclude MonoGame-dependent files from console app compilation -->

--- a/MCP/MCP.csproj
+++ b/MCP/MCP.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />


### PR DESCRIPTION
Replacement for #99. It retains the safe dependency updates and resolves the open review finding by keeping `Microsoft.EntityFrameworkCore.Tools` aligned with `Microsoft.EntityFrameworkCore.Sqlite` at 9.0.18. `ModelContextProtocol` remains at 1.4.0 because `MCP/MCP.csproj` currently fails to build even at its baseline and needs a separate repair/migration with MCP runtime coverage.