### PR TITLE
docs: plan HPA-510 prepared-chart recording commands

### DIFF
--- a/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
+++ b/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
@@ -1,0 +1,356 @@
+# HPA-510 Prepared Chart Recording Commands Implementation Plan
+
+**Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
+**Design:** `docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md`  
+**Target size:** one implementation PR, 2–3 engineer days
+
+## Objective
+
+Add the smallest production API HPA-503 needs to prepare one exact indexed chart in Song Select, explicitly start its declared preview, activate it through the normal player path, and cancel/clean up safely.
+
+Keep the implementation local to existing Song Select, Game API/JSON-RPC, telemetry, and Automation seams. Do not introduce a general automation/session framework.
+
+## File Map
+
+### Game / Song Select
+
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+  - exact active-library chart resolution;
+  - prepared selection/preview state;
+  - programmatic browse projection;
+  - prepare/start/activate/cancel commands;
+  - elapsed preview telemetry;
+  - cleanup on navigation/deactivation.
+- `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
+  - one narrow atomic row+difficulty programmatic selection method.
+- `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
+  - three prepared-recording telemetry fields.
+
+### Game API / transport
+
+- `DTXMania.Game/Lib/GameApi.cs`
+  - four explicit command methods and narrow command result contract.
+- `DTXMania.Game/Lib/GameApiImplementation.cs`
+  - queue each command through the existing main-thread action queue and await its actual result.
+- `DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs`
+  - four explicit authenticated JSON-RPC routes/handlers.
+
+### Automation consumer
+
+- `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
+  - public wrappers for the four new operations.
+- `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
+  - accessors for prepared identity/state/elapsed time.
+
+### Tests
+
+Prefer one focused new Song Select fixture rather than spreading preparation cases across unrelated files:
+
+- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new.
+- `DTXMania.Test/GameApi/GameApiImplementationTests.cs` — extend.
+- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or existing JSON-RPC integration tests — extend only where current seams fit.
+- `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs` — extend.
+- `DTXMania.E2E/Telemetry/E2EGameStateTests.cs` or the current producer/consumer telemetry contract test — extend only if needed to keep game/Automation field names aligned.
+
+Do not add a new E2E harness or recorder test project in this ticket.
+
+---
+
+## Task 1 — Resolve and project an exact indexed chart
+
+**Goal:** given one absolute chart path, identify exactly one active Song Select row + difficulty and show it through the normal UI without synthetic input.
+
+### 1.1 Write failing focused tests first
+
+In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-library hierarchies covering:
+
+- root-level chart;
+- chart below one or more BOX nodes;
+- multi-chart/SET-style row where the requested chart is not the node's primary chart;
+- duplicate song titles with different file paths;
+- path outside active roots;
+- path under an active root but absent from the indexed snapshot;
+- no unique difficulty mapping.
+
+Assertions should verify the resolved node and difficulty come from path identity only. No title matching is allowed.
+
+### 1.2 Add a stage-private resolver
+
+In `SongSelectionStage.cs`:
+
+- require a fully-qualified non-blank path;
+- use the currently applied `SongLibrarySnapshot` as the authoritative library view;
+- normalize with `SongPathIdentity`;
+- require containment under `snapshot.ActiveRoots`;
+- recursively traverse root/BOX nodes and inspect both `DatabaseChart` and `DatabaseSong.Charts`;
+- require one exact normalized chart match;
+- resolve the visible difficulty slot by `SongScore.ChartId` first;
+- for legacy/SET fallback, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart` rather than recreating chart-order rules;
+- retain the ancestor BOX chain and matched `SongChart` in the resolution result.
+
+Keep this helper inside the game assembly. Do not expose library traversal through Game API.
+
+### 1.3 Add one atomic `SongListDisplay` selection seam
+
+Add a small method such as `SetSelection(int index, int difficulty)` that:
+
+- validates the current list/index;
+- applies row and difficulty together;
+- resets scroll target/counters coherently;
+- calls the existing selection update/event path once.
+
+Do not add arbitrary list mutation or remote-navigation methods.
+
+Add focused component/unit coverage if existing `SongListDisplay` tests do not already cover the required event behavior.
+
+### 1.4 Project through normal Song Select browse state
+
+In the prepare path:
+
+- switch to All Songs and default/no-filter projection for the recorder operation;
+- clear/rebuild normal navigation state;
+- reuse existing BOX navigation helpers for the resolved ancestor chain;
+- select the target row+difficulty through the new atomic component method;
+- suppress only automatic preview loading during this synchronous programmatic projection so status/history/image/breadcrumb still update without briefly playing/loading the wrong row's audio.
+
+**Task 1 acceptance:** exact root/nested/SET/duplicate-title selection is deterministic by path, and the normal Song Select UI state points at the requested row/difficulty.
+
+---
+
+## Task 2 — Add prepared preview lifecycle, activation, and telemetry
+
+**Goal:** load the exact chart's preview stopped, play it only on command, measure only actual playback time, and cleanly reuse existing activation.
+
+### 2.1 Write failing preview lifecycle tests
+
+Add cases for:
+
+- prepare loads the requested `SongChart.PreviewFile`, not the node's primary chart preview;
+- missing preview declaration;
+- missing preview file;
+- resource-load/unsupported failure;
+- successful prepare creates no sound instance and does not auto-play after the normal preview delay;
+- first start creates one looped instance at existing preview volume;
+- repeated start while playing creates no second instance;
+- elapsed ms advances only when `ISoundInstance.State == Playing`;
+- playback creation/start failure reports failed state with no BGM/full-song fallback;
+- cancel is idempotent;
+- replacement preparation stops/disposes the old instance once;
+- normal row/difficulty navigation away clears prepared state;
+- Deactivate clears prepared state and resources;
+- no prepared state leaves existing interactive preview behavior unchanged.
+
+Reuse existing `ISound` / `ISoundInstance` mocks and preview tests.
+
+### 2.2 Add minimal stage-owned prepared state
+
+In `SongSelectionStage.cs`, add only:
+
+- resolved prepared selection (node/chart/difficulty/telemetry identity);
+- preview state (`None`, `Prepared`, `Playing`, `Failed`);
+- elapsed milliseconds;
+- a temporary synchronous flag used only to suppress automatic preview loading while prepare projects the selection.
+
+Do not add locks or a session/generation model; mutations and elapsed updates are update-thread-owned.
+
+### 2.3 Load the exact resolved chart preview
+
+Reuse current preview resource methods, but factor enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
+
+Requirements:
+
+- resolve preview relative to the matched chart's `FilePath` directory;
+- use the existing resource manager/sound type support;
+- keep the loaded `_previewSound` but leave `_previewSoundInstance` null;
+- disable normal delayed auto-start while prepared;
+- state = `Prepared`, elapsed = 0 only after load succeeds;
+- any prepare failure leaves no active prepared state.
+
+Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics outside prepared mode.
+
+### 2.4 Implement explicit start/cancel
+
+`StartPreparedPreview`:
+
+- require a prepared resource;
+- create the instance with the existing helper;
+- apply existing preview volume and looping;
+- call `Play()` once;
+- start the existing BGM fade-out;
+- become `Playing`, elapsed = 0;
+- repeated call while already playing is idempotent success.
+
+`CancelPreparedChart`:
+
+- reuse existing stop/dispose/release behavior;
+- clear prepared state/identity/elapsed;
+- remain idempotent.
+
+During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance actually reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
+
+### 2.5 Activate through the existing player path
+
+`ActivatePreparedChart` must:
+
+- require the prepared row/difficulty still be the selected row/difficulty;
+- capture node/difficulty;
+- stop and clear prepared preview before transition;
+- call existing `SelectSong(node)`.
+
+Do not reconstruct transition shared data or call Performance directly.
+
+Extend existing Song Select activation tests to assert the normal selected-song/difficulty/song-id transition contract remains the one used.
+
+### 2.6 Add three telemetry fields
+
+In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry` add only:
+
+- `PreparedChartIdentity`;
+- `PreparedPreviewState`;
+- `PreparedPreviewElapsedMs`.
+
+Identity:
+
+- `chart:<database-id>` when a non-zero chart ID exists;
+- otherwise a root-relative normalized path with no absolute root prefix.
+
+**Task 2 acceptance:** recorder can prepare a stopped preview, start exactly one loop, wait on elapsed telemetry, activate through normal SongTransition, and all exit/replacement paths clean up.
+
+---
+
+## Task 3 — Wire the explicit Game API, JSON-RPC, and Automation client
+
+**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation or transport APIs.
+
+### 3.1 Add Game API contract and queue/await helper
+
+In `GameApi.cs`, add a narrow prepared-command result and four methods equivalent to:
+
+```text
+PrepareVideoChartAsync(chartPath)
+StartPreparedPreviewAsync()
+ActivatePreparedChartAsync()
+CancelPreparedChartAsync()
+```
+
+In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus `TaskCompletionSource` with asynchronous continuations.
+
+The queued action must perform the current-stage check and execute the Song Select command on the update thread. The returned task completes with the actual command result, not merely after enqueue.
+
+Add tests that capture/execute the queued action and verify:
+
+- no stage mutation occurs before the queued action runs;
+- the task completes after execution;
+- non-SongSelect current stage produces a clear failure;
+- stage failure text propagates.
+
+Do not add a reusable dispatcher class.
+
+### 3.2 Add four explicit JSON-RPC handlers
+
+In `JsonRpcServer.cs`:
+
+- add explicit route cases only for the four method names;
+- validate `prepareVideoChart` has object params and a non-empty string `chartPath`;
+- call the corresponding Game API method;
+- return a small `{ success, error? }` result;
+- rely on the existing server-level API key authentication.
+
+Extend current JSON-RPC tests for method routing, invalid prepare params, and command failure shape.
+
+No generic `executeGameAction` endpoint.
+
+### 3.3 Extend `DTXMania.Automation`
+
+In `JsonRpcGameClient.cs`, add the four public async wrappers using existing private `SendAsync`.
+
+Add one small command-result parser shared by the four methods:
+
+- success=true returns normally;
+- missing/false success throws `InvalidOperationException` with server-provided safe error text.
+
+In `GameStateSnapshot.cs`, add accessors for the three prepared telemetry fields.
+
+Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation. Extend the existing producer/consumer telemetry contract test if one is required to keep camel-case field naming locked between game and Automation.
+
+**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only, and can poll prepared telemetry using the existing `GetGameStateAsync` path.
+
+---
+
+## Task 4 — Regression and acceptance validation
+
+### 4.1 Focused tests
+
+Run the new/focused suites first. Use the repository's current project appropriate to the host, for example:
+
+```bash
+# Song Select / Game API / JSON-RPC focused tests
+# Use the relevant test project for the current OS.
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PreparedChart"
+
+# Reusable Automation contract
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj
+```
+
+On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game test suite.
+
+### 4.2 Full regression suite
+
+Run the full platform-appropriate game unit suite plus Automation tests.
+
+At minimum verify:
+
+- existing Song Select preview/BGM tests stay green;
+- existing Song Select navigation/filter/BOX tests stay green;
+- existing SongTransition tests stay green;
+- Game API/JSON-RPC tests stay green;
+- Automation tests stay green.
+
+HPA-510 does **not** need to add OBS/recorder E2E. HPA-503 is the live Windows recording validation consumer.
+
+### 4.3 Manual/API smoke for implementation PR
+
+Use an indexed test chart with preview audio and the existing Game API:
+
+1. enter Song Select;
+2. call prepare with the exact absolute chart path;
+3. verify telemetry reports Prepared and a redacted identity;
+4. take a screenshot and verify the requested row/difficulty/status UI is rendered;
+5. wait long enough to prove normal preview delay does not auto-play;
+6. call start, then poll until prepared elapsed >= 10,000 ms;
+7. call activate and confirm transition follows SongTransition;
+8. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
+
+This smoke is implementation validation only; do not create a permanent recorder harness in HPA-510.
+
+---
+
+## Scope Guardrails for the Implementing Agent
+
+Stop and simplify if the implementation starts adding any of the following:
+
+- recording session IDs/state machines;
+- generic Game API mutation dispatch;
+- a new song repository/query service;
+- title-based or input-driven navigation;
+- alternate chart/difficulty ordering rules instead of current Song Select helpers;
+- a second preview audio abstraction;
+- OBS/process/FFmpeg concerns;
+- render-ready generation counters.
+
+The desired end state is four explicit commands layered on the existing Song Select state machine, with `DTXMania.Automation` wrappers ready for HPA-503.
+
+## Definition of Done
+
+- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, and duplicate-title cases.
+- Outside-root/unindexed/ambiguous/missing-preview/unsupported-preview cases fail clearly.
+- Prepare leaves the exact chart preview loaded but stopped.
+- Start creates exactly one looped instance using existing preview volume/path behavior.
+- Prepared elapsed telemetry advances only while the instance is actually Playing.
+- Cancel/replacement/navigation/deactivation/activation clean up without audio bleed or double disposal.
+- Activation reuses `SelectSong -> SongTransitionStage` and does not jump directly to Performance.
+- Telemetry exposes only prepared identity/state/elapsed, with no absolute path.
+- JSON-RPC commands are explicit and use existing API-key authentication.
+- `DTXMania.Automation` exposes four typed wrappers; generic JSON-RPC remains private.
+- Existing interactive Song Select behavior is unchanged when no prepared chart is active.
+- Platform-appropriate game unit suite and Automation tests pass.

--- a/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
+++ b/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
@@ -10,6 +10,18 @@ Add the smallest production API HPA-503 needs to prepare one exact indexed chart
 
 Keep the implementation local to existing Song Select, Game API/JSON-RPC, telemetry, and Automation seams. Do not introduce a general automation/session framework.
 
+## Global Constraints
+
+- Prepared state remains owned by `SongSelectionStage`.
+- The external contract remains exactly four commands: prepare, start preview, activate, cancel.
+- Exact chart identity is normalized path, never title.
+- All stage mutations execute on the game update thread and the Game API awaits their real result.
+- Activation must respect the existing global stage-transition debounce and must not consume preparation when the debounce blocks the transition.
+- HPA-510 selects the DRUMS slot when one physical DTX chart populates multiple instrument slots with the same `ChartId`.
+- Screenshot completion remains the Song Select render barrier; add no render-generation state machine.
+- The telemetry wire names are exactly `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs`.
+- No recorder session, DB query path, generic mutation API, synthetic key navigation, OBS, process, or FFmpeg work belongs in this PR.
+
 ## File Map
 
 ### Game / Song Select
@@ -18,9 +30,9 @@ Keep the implementation local to existing Song Select, Game API/JSON-RPC, teleme
   - exact active-library chart resolution;
   - prepared selection/preview state;
   - programmatic browse projection;
-  - prepare/start/activate/cancel commands;
-  - elapsed preview telemetry;
-  - cleanup on navigation/deactivation.
+  - clear-on-row/difficulty navigation rules;
+  - debounce-safe prepare/start/activate/cancel commands;
+  - elapsed preview telemetry.
 - `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
   - one narrow atomic row+difficulty programmatic selection method.
 - `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
@@ -40,17 +52,15 @@ Keep the implementation local to existing Song Select, Game API/JSON-RPC, teleme
 - `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
   - public wrappers for the four new operations.
 - `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
-  - accessors for prepared identity/state/elapsed time.
+  - accessors for the three exact camelCase telemetry keys.
 
 ### Tests
 
-Prefer one focused new Song Select fixture rather than spreading preparation cases across unrelated files:
-
-- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new.
+- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new focused fixture.
 - `DTXMania.Test/GameApi/GameApiImplementationTests.cs` — extend.
-- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or existing JSON-RPC integration tests — extend only where current seams fit.
+- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or the existing JSON-RPC integration fixture — extend only where current seams fit.
 - `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs` — extend.
-- `DTXMania.E2E/Telemetry/E2EGameStateTests.cs` or the current producer/consumer telemetry contract test — extend only if needed to keep game/Automation field names aligned.
+- `DTXMania.E2E/AutomationContractTests.cs` — **mandatory** producer/consumer camelCase telemetry contract update.
 
 Do not add a new E2E harness or recorder test project in this ticket.
 
@@ -58,9 +68,9 @@ Do not add a new E2E harness or recorder test project in this ticket.
 
 ## Task 1 — Resolve and project an exact indexed chart
 
-**Goal:** given one absolute chart path, identify exactly one active Song Select row + difficulty and show it through the normal UI without synthetic input.
+**Goal:** given one absolute chart path, identify exactly one active Song Select row + gameplay difficulty and show it through the normal UI without synthetic input.
 
-### 1.1 Write failing focused tests first
+### 1.1 Write failing focused resolver tests first
 
 In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-library hierarchies covering:
 
@@ -68,60 +78,79 @@ In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-librar
 - chart below one or more BOX nodes;
 - multi-chart/SET-style row where the requested chart is not the node's primary chart;
 - duplicate song titles with different file paths;
+- ordinary one-file multi-instrument chart where DRUMS/GUITAR/BASS score slots all carry the same non-zero `ChartId`;
 - path outside active roots;
 - path under an active root but absent from the indexed snapshot;
-- no unique difficulty mapping.
+- a genuinely ambiguous slot mapping after all supported tie-break/fallback rules.
 
-Assertions should verify the resolved node and difficulty come from path identity only. No title matching is allowed.
+For the shared-ChartId fixture, assert the resolver chooses the unique `EInstrumentPart.DRUMS` slot rather than rejecting the row.
 
-### 1.2 Add a stage-private resolver
+Assertions must prove title never participates in identity.
+
+### 1.2 Add a stage-private exact-path resolver
 
 In `SongSelectionStage.cs`:
 
 - require a fully-qualified non-blank path;
-- use the currently applied `SongLibrarySnapshot` as the authoritative library view;
+- use `_appliedLibrarySnapshot` as the authoritative active library;
 - normalize with `SongPathIdentity`;
 - require containment under `snapshot.ActiveRoots`;
 - recursively traverse root/BOX nodes and inspect both `DatabaseChart` and `DatabaseSong.Charts`;
-- require one exact normalized chart match;
-- resolve the visible difficulty slot by `SongScore.ChartId` first;
-- for legacy/SET fallback, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart` rather than recreating chart-order rules;
+- require one exact normalized node/chart match;
 - retain the ancestor BOX chain and matched `SongChart` in the resolution result.
+
+Resolve the visible gameplay slot in this order:
+
+1. Collect non-null `Scores[i]` with non-zero `ChartId == resolvedChart.Id`.
+2. If exactly one matches, use it.
+3. If multiple match, select the **unique DRUMS** candidate when exactly one has `Instrument == EInstrumentPart.DRUMS`.
+4. If no slot was established, scan valid slots with `SongChartHelper.GetCurrentDifficultyChart(node, i)` and match the helper result's normalized `FilePath` to the resolved chart path.
+5. Use the fallback only when exactly one slot matches; otherwise return an explicit ambiguity failure.
+
+Do not recreate SET/chart ordering rules and do not require `ChartId` uniqueness by itself.
 
 Keep this helper inside the game assembly. Do not expose library traversal through Game API.
 
 ### 1.3 Add one atomic `SongListDisplay` selection seam
 
-Add a small method such as `SetSelection(int index, int difficulty)` that:
+Add a small method such as:
 
-- validates the current list/index;
-- applies row and difficulty together;
-- resets scroll target/counters coherently;
-- calls the existing selection update/event path once.
+```text
+SetSelection(int index, int difficulty)
+```
+
+It must:
+
+- validate the current list/index;
+- apply row and difficulty together;
+- reset scroll target/counters coherently;
+- run the existing selection update/event path once.
 
 Do not add arbitrary list mutation or remote-navigation methods.
 
-Add focused component/unit coverage if existing `SongListDisplay` tests do not already cover the required event behavior.
+Add focused `SongListDisplay` coverage if the current component tests do not prove the one-event behavior.
 
 ### 1.4 Project through normal Song Select browse state
 
-In the prepare path:
+In `PrepareVideoChart`:
 
 - switch to All Songs and default/no-filter projection for the recorder operation;
-- clear/rebuild normal navigation state;
+- return to the root browse list and clear the navigation stack;
 - reuse existing BOX navigation helpers for the resolved ancestor chain;
+- set `_isProjectingPreparedSelection = true` in a `try/finally` around the programmatic selection;
 - select the target row+difficulty through the new atomic component method;
-- suppress only automatic preview loading during this synchronous programmatic projection so status/history/image/breadcrumb still update without briefly playing/loading the wrong row's audio.
+- while the flag is true, let status/history/image/breadcrumb presentation update but suppress prepared-state invalidation and automatic preview loading;
+- always clear the flag in `finally`.
 
-**Task 1 acceptance:** exact root/nested/SET/duplicate-title selection is deterministic by path, and the normal Song Select UI state points at the requested row/difficulty.
+**Task 1 acceptance:** exact root/nested/SET/duplicate-title/single-file-multi-instrument selection is deterministic by path, and normal Song Select UI state points at the requested DRUMS gameplay slot.
 
 ---
 
-## Task 2 — Add prepared preview lifecycle, activation, and telemetry
+## Task 2 — Add prepared preview lifecycle, navigation invalidation, activation, and telemetry
 
-**Goal:** load the exact chart's preview stopped, play it only on command, measure only actual playback time, and cleanly reuse existing activation.
+**Goal:** load the exact chart's preview stopped, play it only on command, measure actual playback time, exit prepared mode cleanly on user navigation, and activate only when the normal transition can really start.
 
-### 2.1 Write failing preview lifecycle tests
+### 2.1 Write failing lifecycle and activation tests
 
 Add cases for:
 
@@ -130,17 +159,21 @@ Add cases for:
 - missing preview file;
 - resource-load/unsupported failure;
 - successful prepare creates no sound instance and does not auto-play after the normal preview delay;
+- prepare projection does not clear itself via selection/difficulty events;
 - first start creates one looped instance at existing preview volume;
 - repeated start while playing creates no second instance;
 - elapsed ms advances only when `ISoundInstance.State == Playing`;
 - playback creation/start failure reports failed state with no BGM/full-song fallback;
 - cancel is idempotent;
-- replacement preparation stops/disposes the old instance once;
-- normal row/difficulty navigation away clears prepared state;
-- Deactivate clears prepared state and resources;
+- replacement preparation stops/disposes the old instance exactly once;
+- row navigation away clears preparation and resumes the row's normal interactive preview path;
+- difficulty navigation away clears preparation and resumes the normal primary-chart delayed preview;
+- Deactivate clears prepared state/resources exactly once;
+- activation while `CanPerformStageTransition()` is false returns failure, starts no transition, and preserves prepared state/preview;
+- activation after the debounce gate is available clears preview and uses the existing `selectedSong` / `selectedDifficulty` / `songId` transition data path;
 - no prepared state leaves existing interactive preview behavior unchanged.
 
-Reuse existing `ISound` / `ISoundInstance` mocks and preview tests.
+Reuse existing `ISound` / `ISoundInstance` mocks and Song Select activation tests.
 
 ### 2.2 Add minimal stage-owned prepared state
 
@@ -149,13 +182,15 @@ In `SongSelectionStage.cs`, add only:
 - resolved prepared selection (node/chart/difficulty/telemetry identity);
 - preview state (`None`, `Prepared`, `Playing`, `Failed`);
 - elapsed milliseconds;
-- a temporary synchronous flag used only to suppress automatic preview loading while prepare projects the selection.
+- `_isProjectingPreparedSelection` for the synchronous prepare projection.
 
-Do not add locks or a session/generation model; mutations and elapsed updates are update-thread-owned.
+Do not add locks, session IDs, or a generation/state-machine framework; mutations and elapsed updates are update-thread-owned.
+
+Provide one idempotent prepared cleanup path so cancel, replacement, navigation, activation, and Deactivate share resource release behavior.
 
 ### 2.3 Load the exact resolved chart preview
 
-Reuse current preview resource methods, but factor enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
+Reuse current preview resource methods, factoring only enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
 
 Requirements:
 
@@ -166,9 +201,9 @@ Requirements:
 - state = `Prepared`, elapsed = 0 only after load succeeds;
 - any prepare failure leaves no active prepared state.
 
-Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics outside prepared mode.
+Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics when no preparation exists.
 
-### 2.4 Implement explicit start/cancel
+### 2.4 Implement explicit start/cancel and elapsed tracking
 
 `StartPreparedPreview`:
 
@@ -186,24 +221,68 @@ Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics outs
 - clear prepared state/identity/elapsed;
 - remain idempotent.
 
-During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance actually reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
+During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
 
-### 2.5 Activate through the existing player path
+### 2.5 Clear preparation on real user navigation, not prepare projection
+
+Wire both selection paths.
+
+`OnSongSelectionChanged`:
+
+- if `_isProjectingPreparedSelection` is true, do not clear preparation and skip automatic preview loading for that projection;
+- otherwise, if a prepared chart exists and the selected row moved away, clear it;
+- continue the handler's existing row-selection preview behavior, so normal delayed `LoadPreviewSound(e.SelectedSong)` resumes.
+
+`OnDifficultyChanged`:
+
+- if `_isProjectingPreparedSelection` is true, do not clear preparation;
+- otherwise, if a prepared chart exists and `e.NewDifficulty` differs from the prepared slot, clear it;
+- after that prepared-mode exit, call the existing `LoadPreviewSound(e.Song)` so interactive Song Select resumes its normal primary-chart delayed preview;
+- when no preparation exists, leave today's difficulty-change behavior untouched.
+
+The cleanup path must remain idempotent so existing `StopCurrentPreview` calls cannot double-dispose an instance.
+
+### 2.6 Make activation return a real transition outcome
+
+Current `SelectSong` silently returns when the global debounce rejects the transition. Factor its logic into a small eligibility gate and one shared transition-start body; names may follow existing style, for example:
+
+```text
+CanStartSongSelection(node)
+StartSongSelection(node)
+```
+
+Eligibility must reject:
+
+- null/non-Score node;
+- unavailable `StageManager`;
+- `_game.CanPerformStageTransition() == false`.
+
+The shared start body remains the sole owner of:
+
+```text
+_game.MarkStageTransition()
+selectedSong
+selectedDifficulty
+songId
+StageManager.ChangeStage(StageType.SongTransition, ...)
+```
+
+Normal interactive `SelectSong` uses the same gate/start helpers.
 
 `ActivatePreparedChart` must:
 
-- require the prepared row/difficulty still be the selected row/difficulty;
-- capture node/difficulty;
-- stop and clear prepared preview before transition;
-- call existing `SelectSong(node)`.
+1. require the prepared row/difficulty still equal `_selectedSong` / `_currentDifficulty`;
+2. evaluate the shared eligibility gate;
+3. when blocked, return `success=false` with a clear category such as transition debounce active and leave prepared state/preview intact;
+4. only after the gate succeeds, stop/dispose the prepared preview and clear prepared state;
+5. immediately execute the shared transition-start body on the same update-thread action;
+6. return success only after `ChangeStage` was invoked.
 
-Do not reconstruct transition shared data or call Performance directly.
+Do not wait inside the game for the 0.5-second debounce and do not duplicate transition shared-data construction.
 
-Extend existing Song Select activation tests to assert the normal selected-song/difficulty/song-id transition contract remains the one used.
+### 2.7 Add three producer telemetry fields
 
-### 2.6 Add three telemetry fields
-
-In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry` add only:
+In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry`, add only:
 
 - `PreparedChartIdentity`;
 - `PreparedPreviewState`;
@@ -214,13 +293,21 @@ Identity:
 - `chart:<database-id>` when a non-zero chart ID exists;
 - otherwise a root-relative normalized path with no absolute root prefix.
 
-**Task 2 acceptance:** recorder can prepare a stopped preview, start exactly one loop, wait on elapsed telemetry, activate through normal SongTransition, and all exit/replacement paths clean up.
+The serialized wire names must be exactly:
+
+```text
+preparedChartIdentity
+preparedPreviewState
+preparedPreviewElapsedMs
+```
+
+**Task 2 acceptance:** recorder can prepare a stopped exact-chart preview, start exactly one loop, wait on elapsed telemetry, retry a debounce-blocked activation without losing preparation, activate through the normal SongTransition path, and all navigation/exit paths clean up correctly.
 
 ---
 
-## Task 3 — Wire the explicit Game API, JSON-RPC, and Automation client
+## Task 3 — Wire the explicit Game API, JSON-RPC, Automation client, and telemetry contract
 
-**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation or transport APIs.
+**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation/transport APIs, and lock producer/consumer wire names.
 
 ### 3.1 Add Game API contract and queue/await helper
 
@@ -233,18 +320,22 @@ ActivatePreparedChartAsync()
 CancelPreparedChartAsync()
 ```
 
-In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus `TaskCompletionSource` with asynchronous continuations.
+In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus:
+
+```text
+TaskCompletionSource(..., TaskCreationOptions.RunContinuationsAsynchronously)
+```
 
 The queued action must perform the current-stage check and execute the Song Select command on the update thread. The returned task completes with the actual command result, not merely after enqueue.
 
 Add tests that capture/execute the queued action and verify:
 
 - no stage mutation occurs before the queued action runs;
-- the task completes after execution;
+- the task completes only after execution;
 - non-SongSelect current stage produces a clear failure;
-- stage failure text propagates.
+- stage failure text, including debounce-blocked activation, propagates.
 
-Do not add a reusable dispatcher class.
+Do not copy `ChangeStageAsync`'s fire-and-forget contract and do not add a reusable dispatcher class.
 
 ### 3.2 Add four explicit JSON-RPC handlers
 
@@ -254,9 +345,9 @@ In `JsonRpcServer.cs`:
 - validate `prepareVideoChart` has object params and a non-empty string `chartPath`;
 - call the corresponding Game API method;
 - return a small `{ success, error? }` result;
-- rely on the existing server-level API key authentication.
+- rely on existing server-level API-key authentication.
 
-Extend current JSON-RPC tests for method routing, invalid prepare params, and command failure shape.
+Extend current JSON-RPC tests for method routing, invalid prepare params, normal failures, and debounce failure shape.
 
 No generic `executeGameAction` endpoint.
 
@@ -266,14 +357,33 @@ In `JsonRpcGameClient.cs`, add the four public async wrappers using existing pri
 
 Add one small command-result parser shared by the four methods:
 
-- success=true returns normally;
+- `success=true` returns normally;
 - missing/false success throws `InvalidOperationException` with server-provided safe error text.
 
-In `GameStateSnapshot.cs`, add accessors for the three prepared telemetry fields.
+In `GameStateSnapshot.cs`, add accessors that read the exact keys:
 
-Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation. Extend the existing producer/consumer telemetry contract test if one is required to keep camel-case field naming locked between game and Automation.
+```text
+preparedChartIdentity
+preparedPreviewState
+preparedPreviewElapsedMs
+```
 
-**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only, and can poll prepared telemetry using the existing `GetGameStateAsync` path.
+Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation.
+
+### 3.4 Mandatory game-to-Automation camelCase contract test
+
+Extend:
+
+```text
+DTXMania.E2E/AutomationContractTests.cs
+GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields
+```
+
+The producer `GameTelemetrySnapshot` fixture must set non-default values for all three fields. Serialize it with the existing camelCase serializer and assert the deserialized `GameStateSnapshot` returns those same values through its new accessors.
+
+This is mandatory. Do not replace it with an Automation-only JSON fixture because the purpose is to catch producer property-name drift as well as consumer accessor drift.
+
+**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only and poll all three prepared telemetry values through the existing `GetGameStateAsync` path with the producer/consumer wire contract locked.
 
 ---
 
@@ -281,18 +391,20 @@ Extend `JsonRpcGameClientTests` to assert exact method names/params and error pr
 
 ### 4.1 Focused tests
 
-Run the new/focused suites first. Use the repository's current project appropriate to the host, for example:
+Run the new/focused suites first. Use the repository's host-appropriate game test project, for example:
 
 ```bash
 # Song Select / Game API / JSON-RPC focused tests
-# Use the relevant test project for the current OS.
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PreparedChart"
 
-# Reusable Automation contract
+# Reusable Automation tests
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj
+
+# Existing producer/consumer contract
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~AutomationContractTests"
 ```
 
-On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game test suite.
+On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game unit suite. Run the E2E-support contract on its supported host configuration; no live gameplay launch is required for this contract test.
 
 ### 4.2 Full regression suite
 
@@ -304,7 +416,8 @@ At minimum verify:
 - existing Song Select navigation/filter/BOX tests stay green;
 - existing SongTransition tests stay green;
 - Game API/JSON-RPC tests stay green;
-- Automation tests stay green.
+- Automation tests stay green;
+- `AutomationContractTests` stays green with the three new telemetry fields.
 
 HPA-510 does **not** need to add OBS/recorder E2E. HPA-503 is the live Windows recording validation consumer.
 
@@ -314,12 +427,14 @@ Use an indexed test chart with preview audio and the existing Game API:
 
 1. enter Song Select;
 2. call prepare with the exact absolute chart path;
-3. verify telemetry reports Prepared and a redacted identity;
+3. verify telemetry reports `Prepared` and a redacted identity;
 4. take a screenshot and verify the requested row/difficulty/status UI is rendered;
 5. wait long enough to prove normal preview delay does not auto-play;
 6. call start, then poll until prepared elapsed >= 10,000 ms;
 7. call activate and confirm transition follows SongTransition;
-8. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
+8. separately exercise a debounce-blocked activation and verify preparation remains available for retry;
+9. exercise user difficulty navigation after prepare and verify prepared state clears and the normal primary-chart delayed preview resumes;
+10. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
 
 This smoke is implementation validation only; do not create a permanent recorder harness in HPA-510.
 
@@ -333,8 +448,9 @@ Stop and simplify if the implementation starts adding any of the following:
 - generic Game API mutation dispatch;
 - a new song repository/query service;
 - title-based or input-driven navigation;
-- alternate chart/difficulty ordering rules instead of current Song Select helpers;
+- alternate chart/difficulty ordering rules instead of current Song Select helpers plus the explicit DRUMS tie-break;
 - a second preview audio abstraction;
+- a game-owned debounce wait/retry loop;
 - OBS/process/FFmpeg concerns;
 - render-ready generation counters.
 
@@ -342,15 +458,18 @@ The desired end state is four explicit commands layered on the existing Song Sel
 
 ## Definition of Done
 
-- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, and duplicate-title cases.
-- Outside-root/unindexed/ambiguous/missing-preview/unsupported-preview cases fail clearly.
-- Prepare leaves the exact chart preview loaded but stopped.
+- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, duplicate-title, and ordinary shared-ChartId multi-instrument cases.
+- Shared ChartId across DRUMS/GUITAR/BASS resolves to the unique DRUMS gameplay slot rather than failing as ambiguous.
+- Outside-root/unindexed/truly-ambiguous/missing-preview/unsupported-preview cases fail clearly.
+- Prepare leaves the exact chart preview loaded but stopped and cannot clear itself through projection events.
 - Start creates exactly one looped instance using existing preview volume/path behavior.
 - Prepared elapsed telemetry advances only while the instance is actually Playing.
+- User row/difficulty navigation clears preparation; difficulty exit restores the normal primary-chart delayed preview.
+- Debounce-blocked activation returns failure and preserves preparation; accepted activation clears audio/state and starts the existing SongTransition path.
 - Cancel/replacement/navigation/deactivation/activation clean up without audio bleed or double disposal.
-- Activation reuses `SelectSong -> SongTransitionStage` and does not jump directly to Performance.
-- Telemetry exposes only prepared identity/state/elapsed, with no absolute path.
+- Telemetry exposes only prepared identity/state/elapsed with exact camelCase wire keys and no absolute path.
+- `AutomationContractTests` proves those producer wire keys reach the Automation accessors.
 - JSON-RPC commands are explicit and use existing API-key authentication.
 - `DTXMania.Automation` exposes four typed wrappers; generic JSON-RPC remains private.
 - Existing interactive Song Select behavior is unchanged when no prepared chart is active.
-- Platform-appropriate game unit suite and Automation tests pass.
+- Platform-appropriate game unit suite, Automation tests, and the existing Automation producer/consumer contract pass.

--- a/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
+++ b/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
@@ -1,299 +1,306 @@
 # HPA-510 Prepared Chart Recording Commands Implementation Plan
 
+> **For agentic workers:** implement task-by-task and keep the four-command stage-owned scope. Do not introduce a generic automation/session framework.
+
 **Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
 **Design:** `docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md`  
 **Target size:** one implementation PR, 2–3 engineer days
 
-## Objective
+**Goal:** Let HPA-503 prepare one exact indexed chart in Song Select, explicitly play its preview for CX-reported time, and activate it through the normal SongTransition path.
 
-Add the smallest production API HPA-503 needs to prepare one exact indexed chart in Song Select, explicitly start its declared preview, activate it through the normal player path, and cancel/clean up safely.
+**Architecture:** Keep all prepared state in `SongSelectionStage`. Resolve from the applied library snapshot, rebuild the browse projection with existing navigation reconciliation helpers, expose four awaited Game API/JSON-RPC commands, and reuse HPA-501 Automation transport.
 
-Keep the implementation local to existing Song Select, Game API/JSON-RPC, telemetry, and Automation seams. Do not introduce a general automation/session framework.
+**Tech stack:** .NET 8, MonoGame, xUnit, existing Game API/JSON-RPC, `DTXMania.Automation`, existing Windows E2E harness.
 
-## Global Constraints
+## Global constraints
 
-- Prepared state remains owned by `SongSelectionStage`.
-- The external contract remains exactly four commands: prepare, start preview, activate, cancel.
-- Exact chart identity is normalized path, never title.
-- All stage mutations execute on the game update thread and the Game API awaits their real result.
-- Activation must respect the existing global stage-transition debounce and must not consume preparation when the debounce blocks the transition.
-- HPA-510 selects the DRUMS slot when one physical DTX chart populates multiple instrument slots with the same `ChartId`.
-- Screenshot completion remains the Song Select render barrier; add no render-generation state machine.
-- The telemetry wire names are exactly `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs`.
-- No recorder session, DB query path, generic mutation API, synthetic key navigation, OBS, process, or FFmpeg work belongs in this PR.
+- Exactly four commands: prepare, start preview, activate, cancel.
+- All stage mutations run on the game update thread.
+- Resolve by chart path, never title.
+- No DB query/repository layer.
+- No session ID/state-machine abstraction.
+- No generic mutation/dispatch endpoint.
+- Screenshot completion remains the render barrier.
+- Keep all three accepted telemetry values: prepared identity, state, elapsed ms.
+- Do not expose the absolute chart path in telemetry.
+- Existing interactive Song Select preview behavior must remain unchanged outside prepared mode.
 
-## File Map
+---
+
+## File map
 
 ### Game / Song Select
 
 - `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
-  - exact active-library chart resolution;
-  - prepared selection/preview state;
-  - programmatic browse projection;
-  - clear-on-row/difficulty navigation rules;
-  - debounce-safe prepare/start/activate/cancel commands;
-  - elapsed preview telemetry.
+  - whole-tree exact chart resolver;
+  - stage-owned prepared state;
+  - side-effect-controlled browse projection;
+  - exact-chart preview load/start/cancel;
+  - activation eligibility/start split;
+  - navigation cleanup and telemetry.
 - `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
-  - one narrow atomic row+difficulty programmatic selection method.
+  - atomic `SetSelection(index, difficulty)` seam.
 - `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
-  - three prepared-recording telemetry fields.
+  - three prepared-chart telemetry fields.
 
 ### Game API / transport
 
 - `DTXMania.Game/Lib/GameApi.cs`
-  - four explicit command methods and narrow command result contract.
+  - narrow command result and four methods.
 - `DTXMania.Game/Lib/GameApiImplementation.cs`
-  - queue each command through the existing main-thread action queue and await its actual result.
+  - queue-and-await helper using existing main-thread queue.
 - `DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs`
-  - four explicit authenticated JSON-RPC routes/handlers.
+  - four explicit authenticated routes.
 
-### Automation consumer
+### Automation
 
 - `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
-  - public wrappers for the four new operations.
+  - four public wrappers over private `SendAsync`.
 - `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
-  - accessors for the three exact camelCase telemetry keys.
+  - three prepared telemetry accessors.
 
 ### Tests
 
-- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new focused fixture.
-- `DTXMania.Test/GameApi/GameApiImplementationTests.cs` — extend.
-- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or the existing JSON-RPC integration fixture — extend only where current seams fit.
-- `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs` — extend.
-- `DTXMania.E2E/AutomationContractTests.cs` — **mandatory** producer/consumer camelCase telemetry contract update.
+- Create `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs`.
+- Extend `DTXMania.Test/GameApi/GameApiImplementationTests.cs`.
+- Extend existing JSON-RPC tests where the current seams fit.
+- Extend `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs`.
+- Extend `DTXMania.E2E/AutomationContractTests.cs`.
+- Modify `DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs` to declare its generated WAV as `#PREVIEW`.
+- Create `DTXMania.E2E/PreparedChartRecordingSmokeTests.cs` using the existing `Category=E2E` harness.
 
-Do not add a new E2E harness or recorder test project in this ticket.
+Do not create a recorder test project, fake OBS server, or second E2E harness.
 
 ---
 
-## Task 1 — Resolve and project an exact indexed chart
+## Task 1 — Exact resolver and side-effect-free Song Select projection
 
-**Goal:** given one absolute chart path, identify exactly one active Song Select row + gameplay difficulty and show it through the normal UI without synthetic input.
+**Goal:** resolve an exact active-library chart to one row/difficulty and project it once through normal UI state.
 
-### 1.1 Write failing focused resolver tests first
+### 1.1 Add focused failing resolver tests
 
-In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-library hierarchies covering:
+Cover:
 
 - root-level chart;
-- chart below one or more BOX nodes;
-- multi-chart/SET-style row where the requested chart is not the node's primary chart;
-- duplicate song titles with different file paths;
-- ordinary one-file multi-instrument chart where DRUMS/GUITAR/BASS score slots all carry the same non-zero `ChartId`;
-- path outside active roots;
-- path under an active root but absent from the indexed snapshot;
-- a genuinely ambiguous slot mapping after all supported tie-break/fallback rules.
+- nested BOX chart;
+- SET/multi-chart row where requested chart is not `DatabaseChart`;
+- duplicate titles at different paths;
+- outside-root path;
+- active-root but unindexed path;
+- ordinary single-file multi-instrument row where several score slots share one `ChartId`;
+- unresolved ambiguity.
 
-For the shared-ChartId fixture, assert the resolver chooses the unique `EInstrumentPart.DRUMS` slot rather than rejecting the row.
+The test fixture must assert path identity only; title must never select the result.
 
-Assertions must prove title never participates in identity.
-
-### 1.2 Add a stage-private exact-path resolver
+### 1.2 Add a stage-private whole-tree resolver
 
 In `SongSelectionStage.cs`:
 
-- require a fully-qualified non-blank path;
-- use `_appliedLibrarySnapshot` as the authoritative active library;
-- normalize with `SongPathIdentity`;
-- require containment under `snapshot.ActiveRoots`;
-- recursively traverse root/BOX nodes and inspect both `DatabaseChart` and `DatabaseSong.Charts`;
-- require one exact normalized node/chart match;
-- retain the ancestor BOX chain and matched `SongChart` in the resolution result.
+1. require a fully-qualified non-blank path;
+2. use `_appliedLibrarySnapshot` as the authoritative view;
+3. normalize with `SongPathIdentity`;
+4. require containment under `snapshot.ActiveRoots`;
+5. recursively traverse root/BOX nodes;
+6. inspect both `DatabaseChart` and `DatabaseSong.Charts`;
+7. return exactly one `(node, chart, difficultyIndex, ancestorBoxPaths)`.
 
-Resolve the visible gameplay slot in this order:
-
-1. Collect non-null `Scores[i]` with non-zero `ChartId == resolvedChart.Id`.
-2. If exactly one matches, use it.
-3. If multiple match, select the **unique DRUMS** candidate when exactly one has `Instrument == EInstrumentPart.DRUMS`.
-4. If no slot was established, scan valid slots with `SongChartHelper.GetCurrentDifficultyChart(node, i)` and match the helper result's normalized `FilePath` to the resolved chart path.
-5. Use the fallback only when exactly one slot matches; otherwise return an explicit ambiguity failure.
-
-Do not recreate SET/chart ordering rules and do not require `ChartId` uniqueness by itself.
-
-Keep this helper inside the game assembly. Do not expose library traversal through Game API.
-
-### 1.3 Add one atomic `SongListDisplay` selection seam
-
-Add a small method such as:
+Difficulty precedence:
 
 ```text
-SetSelection(int index, int difficulty)
+matching non-zero ChartId
+-> if one candidate: use it
+-> if several: unique DRUMS candidate
+-> otherwise GetCurrentDifficultyChart(slot) + exact path fallback
+-> fail if still ambiguous
 ```
 
-It must:
+Do not add a new chart-ordering algorithm or database query.
 
-- validate the current list/index;
-- apply row and difficulty together;
-- reset scroll target/counters coherently;
-- run the existing selection update/event path once.
+### 1.3 Add atomic `SongListDisplay.SetSelection`
 
-Do not add arbitrary list mutation or remote-navigation methods.
+Add one internal/public-to-game-assembly method equivalent to:
 
-Add focused `SongListDisplay` coverage if the current component tests do not prove the one-event behavior.
-
-### 1.4 Project through normal Song Select browse state
-
-In `PrepareVideoChart`:
-
-- switch to All Songs and default/no-filter projection for the recorder operation;
-- return to the root browse list and clear the navigation stack;
-- reuse existing BOX navigation helpers for the resolved ancestor chain;
-- set `_isProjectingPreparedSelection = true` in a `try/finally` around the programmatic selection;
-- select the target row+difficulty through the new atomic component method;
-- while the flag is true, let status/history/image/breadcrumb presentation update but suppress prepared-state invalidation and automatic preview loading;
-- always clear the flag in `finally`.
-
-**Task 1 acceptance:** exact root/nested/SET/duplicate-title/single-file-multi-instrument selection is deterministic by path, and normal Song Select UI state points at the requested DRUMS gameplay slot.
-
----
-
-## Task 2 — Add prepared preview lifecycle, navigation invalidation, activation, and telemetry
-
-**Goal:** load the exact chart's preview stopped, play it only on command, measure actual playback time, exit prepared mode cleanly on user navigation, and activate only when the normal transition can really start.
-
-### 2.1 Write failing lifecycle and activation tests
-
-Add cases for:
-
-- prepare loads the requested `SongChart.PreviewFile`, not the node's primary chart preview;
-- missing preview declaration;
-- missing preview file;
-- resource-load/unsupported failure;
-- successful prepare creates no sound instance and does not auto-play after the normal preview delay;
-- prepare projection does not clear itself via selection/difficulty events;
-- first start creates one looped instance at existing preview volume;
-- repeated start while playing creates no second instance;
-- elapsed ms advances only when `ISoundInstance.State == Playing`;
-- playback creation/start failure reports failed state with no BGM/full-song fallback;
-- cancel is idempotent;
-- replacement preparation stops/disposes the old instance exactly once;
-- row navigation away clears preparation and resumes the row's normal interactive preview path;
-- difficulty navigation away clears preparation and resumes the normal primary-chart delayed preview;
-- Deactivate clears prepared state/resources exactly once;
-- activation while `CanPerformStageTransition()` is false returns failure, starts no transition, and preserves prepared state/preview;
-- activation after the debounce gate is available clears preview and uses the existing `selectedSong` / `selectedDifficulty` / `songId` transition data path;
-- no prepared state leaves existing interactive preview behavior unchanged.
-
-Reuse existing `ISound` / `ISoundInstance` mocks and Song Select activation tests.
-
-### 2.2 Add minimal stage-owned prepared state
-
-In `SongSelectionStage.cs`, add only:
-
-- resolved prepared selection (node/chart/difficulty/telemetry identity);
-- preview state (`None`, `Prepared`, `Playing`, `Failed`);
-- elapsed milliseconds;
-- `_isProjectingPreparedSelection` for the synchronous prepare projection.
-
-Do not add locks, session IDs, or a generation/state-machine framework; mutations and elapsed updates are update-thread-owned.
-
-Provide one idempotent prepared cleanup path so cancel, replacement, navigation, activation, and Deactivate share resource release behavior.
-
-### 2.3 Load the exact resolved chart preview
-
-Reuse current preview resource methods, factoring only enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
+```text
+SetSelection(index, difficulty)
+```
 
 Requirements:
 
-- resolve preview relative to the matched chart's `FilePath` directory;
-- use the existing resource manager/sound type support;
-- keep the loaded `_previewSound` but leave `_previewSoundInstance` null;
-- disable normal delayed auto-start while prepared;
-- state = `Prepared`, elapsed = 0 only after load succeeds;
-- any prepare failure leaves no active prepared state.
+- validate current list/index;
+- clamp/validate difficulty using existing semantics;
+- apply row + difficulty as one operation;
+- reset scroll target/counters coherently;
+- invoke the normal selection update/event path exactly once.
 
-Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics when no preparation exists.
+Add focused component coverage for one event and final selected row/difficulty.
 
-### 2.4 Implement explicit start/cancel and elapsed tracking
+### 1.4 Project with existing reconciliation machinery
+
+Do **not** call `NavigateIntoBox` for each ancestor.
+
+Wrap the **entire** prepare projection in `_isProjectingPreparedSelection = true` / `finally false`:
+
+1. switch to All Songs/default recorder browse projection;
+2. clear active filter projection for this operation;
+3. call `RestoreNavigationPaths(ancestorPaths, snapshot)`;
+4. call `RefreshSongListForActiveTab()` once;
+5. find target index in the projected list;
+6. call `SetSelection(targetIndex, difficultyIndex)` once;
+7. update normal breadcrumb/status hints through existing stage paths.
+
+The suppression flag must prevent prepared invalidation and normal automatic preview loading during every projection side effect, including the one final refresh.
+
+**Task 1 acceptance:** nested BOX preparation causes one final list projection/selection, not one stop/load/BGM cycle per ancestor, and the intended row/difficulty is visible.
+
+---
+
+## Task 2 — Prepared preview lifecycle, navigation invalidation, activation, and telemetry
+
+**Goal:** load the exact preview stopped, play exactly one loop, measure actual CX playback, and activate only when the real transition can start.
+
+### 2.1 Add failing lifecycle tests
+
+Cover:
+
+- prepared load uses resolved `SongChart.PreviewFile`, not primary `DatabaseChart`;
+- missing declaration/file/load failure;
+- successful prepare creates no `ISoundInstance`;
+- successful prepared load leaves `_isPreviewDelayActive == false`;
+- waiting beyond the normal preview delay does not auto-start;
+- first start creates one looped instance at existing preview volume;
+- repeated start creates no second instance;
+- elapsed advances only while `State == Playing`;
+- unexpected stop moves state to Failed;
+- replacement/cancel/deactivate clean up exactly once;
+- row navigation away clears prepared state;
+- difficulty navigation away clears prepared state and resumes normal delayed primary-chart preview;
+- `_isProjectingPreparedSelection` prevents prepare from clearing itself;
+- no prepared state preserves today's interactive preview behavior.
+
+Reuse existing `ISound` / `ISoundInstance` mocks.
+
+### 2.2 Add minimal stage-owned prepared state
+
+Add only:
+
+```text
+PreparedChartSelection(node, chart, difficultyIndex, telemetryIdentity)
+PreparedPreviewState
+PreparedPreviewElapsedMs
+_isProjectingPreparedSelection
+```
+
+Use one idempotent prepared cleanup path shared by cancel, replacement, navigation, activation, and Deactivate.
+
+No locks/session/generation framework.
+
+### 2.3 Load the exact preview and explicitly defeat the normal delay timer
+
+Factor only enough path logic to accept a resolved `SongChart` and reuse `TryLoadPreviewSoundFile`.
+
+After `TryLoadPreviewSoundFile` succeeds, explicitly set:
+
+```text
+_previewPlayDelay = 0
+_isPreviewDelayActive = false
+```
+
+This is mandatory because the existing helper sets `_isPreviewDelayActive = true` on every successful load.
+
+Only then publish prepared state:
+
+```text
+_previewSound retained
+_previewSoundInstance == null
+state = Prepared
+elapsed = 0
+```
+
+Any failure leaves no active preparation.
+
+### 2.4 Implement start/cancel and elapsed update
 
 `StartPreparedPreview`:
 
-- require a prepared resource;
-- create the instance with the existing helper;
-- apply existing preview volume and looping;
-- call `Play()` once;
-- start the existing BGM fade-out;
-- become `Playing`, elapsed = 0;
+- require prepared resource;
+- create one instance with existing helper;
+- apply existing volume + looping;
+- `Play()` once;
+- start existing BGM fade-out;
+- state `Playing`, elapsed `0`;
 - repeated call while already playing is idempotent success.
 
 `CancelPreparedChart`:
 
-- reuse existing stop/dispose/release behavior;
-- clear prepared state/identity/elapsed;
-- remain idempotent.
+- reuse existing stop/dispose/release path;
+- clear identity/state/elapsed;
+- idempotent success.
 
-During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
+In `OnUpdate`, add elapsed time only while state is Playing and the instance reports Playing. If it stops unexpectedly, mark Failed and do not substitute another audio source.
 
-### 2.5 Clear preparation on real user navigation, not prepare projection
-
-Wire both selection paths.
+### 2.5 Wire row/difficulty invalidation
 
 `OnSongSelectionChanged`:
 
-- if `_isProjectingPreparedSelection` is true, do not clear preparation and skip automatic preview loading for that projection;
-- otherwise, if a prepared chart exists and the selected row moved away, clear it;
-- continue the handler's existing row-selection preview behavior, so normal delayed `LoadPreviewSound(e.SelectedSong)` resumes.
+- if projecting prepare, skip prepared invalidation and normal auto-preview load;
+- otherwise clear preparation when moving to another row, then continue existing normal selection behavior.
 
 `OnDifficultyChanged`:
 
-- if `_isProjectingPreparedSelection` is true, do not clear preparation;
-- otherwise, if a prepared chart exists and `e.NewDifficulty` differs from the prepared slot, clear it;
-- after that prepared-mode exit, call the existing `LoadPreviewSound(e.Song)` so interactive Song Select resumes its normal primary-chart delayed preview;
-- when no preparation exists, leave today's difficulty-change behavior untouched.
+- if projecting prepare, do not invalidate;
+- otherwise clear when moving away from prepared difficulty;
+- on that prepared-mode exit only, call existing `LoadPreviewSound(e.Song)` to resume normal delayed primary-chart preview;
+- when no prepared chart exists, keep current difficulty behavior unchanged.
 
-The cleanup path must remain idempotent so existing `StopCurrentPreview` calls cannot double-dispose an instance.
+### 2.6 Split transition eligibility from transition start
 
-### 2.6 Make activation return a real transition outcome
+Refactor the existing ~20-line `SelectSong` body into a small shared gate + shared start body.
 
-Current `SelectSong` silently returns when the global debounce rejects the transition. Factor its logic into a small eligibility gate and one shared transition-start body; names may follow existing style, for example:
-
-```text
-CanStartSongSelection(node)
-StartSongSelection(node)
-```
-
-Eligibility must reject:
+Eligibility rejects:
 
 - null/non-Score node;
-- unavailable `StageManager`;
+- missing `StageManager`;
 - `_game.CanPerformStageTransition() == false`.
 
-The shared start body remains the sole owner of:
+The start body remains the only code that performs:
 
 ```text
 _game.MarkStageTransition()
-selectedSong
-selectedDifficulty
-songId
-StageManager.ChangeStage(StageType.SongTransition, ...)
+selectedSong / selectedDifficulty / songId shared data
+StageManager.ChangeStage(SongTransition, ...)
 ```
 
-Normal interactive `SelectSong` uses the same gate/start helpers.
+Normal player `SelectSong` uses the same helpers.
 
-`ActivatePreparedChart` must:
+`ActivatePreparedChart`:
 
-1. require the prepared row/difficulty still equal `_selectedSong` / `_currentDifficulty`;
-2. evaluate the shared eligibility gate;
-3. when blocked, return `success=false` with a clear category such as transition debounce active and leave prepared state/preview intact;
-4. only after the gate succeeds, stop/dispose the prepared preview and clear prepared state;
-5. immediately execute the shared transition-start body on the same update-thread action;
-6. return success only after `ChangeStage` was invoked.
+1. require prepared row/difficulty still matches current selection;
+2. run eligibility;
+3. if blocked, return failure and preserve preparation/preview;
+4. only after eligibility succeeds, clean prepared preview/state;
+5. immediately call shared transition-start body;
+6. return success only after the stage change was invoked.
 
-Do not wait inside the game for the 0.5-second debounce and do not duplicate transition shared-data construction.
+Do not sleep/retry inside the game.
 
-### 2.7 Add three producer telemetry fields
+### 2.7 Add all three producer telemetry fields
 
-In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry`, add only:
+Add:
 
-- `PreparedChartIdentity`;
-- `PreparedPreviewState`;
-- `PreparedPreviewElapsedMs`.
+```text
+PreparedChartIdentity
+PreparedPreviewState
+PreparedPreviewElapsedMs
+```
 
-Identity:
+Identity policy:
 
-- `chart:<database-id>` when a non-zero chart ID exists;
-- otherwise a root-relative normalized path with no absolute root prefix.
+- `chart:<SongChart.Id>` when ID is non-zero;
+- otherwise normalized path relative to the matching active root.
 
-The serialized wire names must be exactly:
+Do not use `GetStableSelectionIdentity`; it identifies the row and commonly returns `song:<id>`, which is not sufficient for an exact chart/difficulty preparation.
+
+Wire names must serialize exactly as:
 
 ```text
 preparedChartIdentity
@@ -301,66 +308,77 @@ preparedPreviewState
 preparedPreviewElapsedMs
 ```
 
-**Task 2 acceptance:** recorder can prepare a stopped exact-chart preview, start exactly one loop, wait on elapsed telemetry, retry a debounce-blocked activation without losing preparation, activate through the normal SongTransition path, and all navigation/exit paths clean up correctly.
+**Task 2 acceptance:** prepared preview stays stopped until commanded, reports 10+ seconds of actual playing time, retries are possible after a blocked activation without losing state, and successful activation uses the normal SongTransition construction.
 
 ---
 
-## Task 3 — Wire the explicit Game API, JSON-RPC, Automation client, and telemetry contract
+## Task 3 — Explicit Game API, JSON-RPC, Automation wrappers, and telemetry contract
 
-**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation/transport APIs, and lock producer/consumer wire names.
+**Goal:** expose only the four required operations and lock their game/consumer contract.
 
-### 3.1 Add Game API contract and queue/await helper
+### 3.1 Add Game API contract + queue-and-await helper
 
-In `GameApi.cs`, add a narrow prepared-command result and four methods equivalent to:
+In `GameApi.cs` add:
 
 ```text
+PreparedChartCommandResult
+- bool Success
+- string? Error
+
 PrepareVideoChartAsync(chartPath)
 StartPreparedPreviewAsync()
 ActivatePreparedChartAsync()
 CancelPreparedChartAsync()
 ```
 
-In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus:
+Do **not** add an error-code enum in this ticket. HPA-503 has no programmatic recovery branch: all command failures fail the recording run, and activation occurs after 10 seconds of preview, well beyond the 0.5-second transition debounce. Add structured codes only when a real caller needs branching.
+
+In `GameApiImplementation.cs`, add one private helper using:
 
 ```text
-TaskCompletionSource(..., TaskCreationOptions.RunContinuationsAsynchronously)
+IGameContext.QueueMainThreadAction
+TaskCompletionSource(...RunContinuationsAsynchronously)
 ```
 
-The queued action must perform the current-stage check and execute the Song Select command on the update thread. The returned task completes with the actual command result, not merely after enqueue.
+The queued action checks current stage, executes the Song Select command, and completes with the real result.
 
-Add tests that capture/execute the queued action and verify:
+Tests must prove:
 
-- no stage mutation occurs before the queued action runs;
-- the task completes only after execution;
-- non-SongSelect current stage produces a clear failure;
-- stage failure text, including debounce-blocked activation, propagates.
+- no mutation before queued action execution;
+- task not completed before action execution;
+- wrong stage returns failure;
+- stage failure text propagates;
+- debounce-blocked activation returns failure rather than queued-success.
 
-Do not copy `ChangeStageAsync`'s fire-and-forget contract and do not add a reusable dispatcher class.
+### 3.2 Add four authenticated JSON-RPC routes
 
-### 3.2 Add four explicit JSON-RPC handlers
+Add only:
 
-In `JsonRpcServer.cs`:
+```text
+prepareVideoChart { chartPath }
+startPreparedPreview
+activatePreparedChart
+cancelPreparedChart
+```
 
-- add explicit route cases only for the four method names;
-- validate `prepareVideoChart` has object params and a non-empty string `chartPath`;
-- call the corresponding Game API method;
-- return a small `{ success, error? }` result;
-- rely on existing server-level API-key authentication.
+Validate prepare params. Return `{ success, error? }` using the existing server authentication and JSON-RPC envelope.
 
-Extend current JSON-RPC tests for method routing, invalid prepare params, normal failures, and debounce failure shape.
+No `executeGameAction`/generic dispatcher and no new error taxonomy.
 
-No generic `executeGameAction` endpoint.
+### 3.3 Extend Automation wrappers
 
-### 3.3 Extend `DTXMania.Automation`
+In `JsonRpcGameClient` add:
 
-In `JsonRpcGameClient.cs`, add the four public async wrappers using existing private `SendAsync`.
+```text
+PrepareVideoChartAsync(path)
+StartPreparedPreviewAsync()
+ActivatePreparedChartAsync()
+CancelPreparedChartAsync()
+```
 
-Add one small command-result parser shared by the four methods:
+Use private `SendAsync` and one small command-result parser. `success=false` throws `InvalidOperationException` with the server's safe error text.
 
-- `success=true` returns normally;
-- missing/false success throws `InvalidOperationException` with server-provided safe error text.
-
-In `GameStateSnapshot.cs`, add accessors that read the exact keys:
+In `GameStateSnapshot` add accessors for exactly:
 
 ```text
 preparedChartIdentity
@@ -368,9 +386,9 @@ preparedPreviewState
 preparedPreviewElapsedMs
 ```
 
-Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation.
+Extend client tests for exact method names/params and error propagation.
 
-### 3.4 Mandatory game-to-Automation camelCase contract test
+### 3.4 Mandatory producer/consumer camelCase contract
 
 Extend:
 
@@ -379,97 +397,120 @@ DTXMania.E2E/AutomationContractTests.cs
 GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields
 ```
 
-The producer `GameTelemetrySnapshot` fixture must set non-default values for all three fields. Serialize it with the existing camelCase serializer and assert the deserialized `GameStateSnapshot` returns those same values through its new accessors.
+Set non-default values for the three game producer fields, serialize through the existing camelCase options, deserialize to `GameStateSnapshot`, and assert all three accessors.
 
-This is mandatory. Do not replace it with an Automation-only JSON fixture because the purpose is to catch producer property-name drift as well as consumer accessor drift.
+Do not replace this with an Automation-only JSON fixture; the point is to catch producer and consumer name drift together.
 
-**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only and poll all three prepared telemetry values through the existing `GetGameStateAsync` path with the producer/consumer wire contract locked.
+**Task 3 acceptance:** HPA-503 can invoke all four commands and poll all three telemetry values through `DTXMania.Automation` only; generic JSON-RPC remains private.
 
 ---
 
-## Task 4 — Regression and acceptance validation
+## Task 4 — Regression suite plus one live prepared-chart E2E
 
-### 4.1 Focused tests
+**Goal:** replace the one-off manual checklist with repeatable proof using machinery already in CI.
 
-Run the new/focused suites first. Use the repository's host-appropriate game test project, for example:
+### 4.1 Focused unit/contract tests
+
+Run the host-appropriate game test project plus Automation tests. Focus first on:
+
+- prepared-chart Song Select tests;
+- existing Song Select preview/BGM tests;
+- Song Select navigation/filter/BOX tests;
+- SongTransition tests;
+- Game API/JSON-RPC tests;
+- Automation JSON-RPC tests;
+- E2E-Support automation contract test.
+
+Example:
 
 ```bash
-# Song Select / Game API / JSON-RPC focused tests
+# Windows game tests
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PreparedChart"
 
-# Reusable Automation tests
+# macOS game tests
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~PreparedChart"
+
+# Automation
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj
 
-# Existing producer/consumer contract
-dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~AutomationContractTests"
+# Producer/consumer contract
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "Category=E2E-Support"
 ```
 
-On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game unit suite. Run the E2E-support contract on its supported host configuration; no live gameplay launch is required for this contract test.
+### 4.2 Reuse the generated E2E fixture for preview audio
 
-### 4.2 Full regression suite
+In `E2EFixtureBuilder.BuildChart()`, add:
 
-Run the full platform-appropriate game unit suite plus Automation tests.
+```text
+#PREVIEW: autoplay-tone.wav
+```
 
-At minimum verify:
+using the existing `AudioFileName` constant rather than adding another generated asset.
 
-- existing Song Select preview/BGM tests stay green;
-- existing Song Select navigation/filter/BOX tests stay green;
-- existing SongTransition tests stay green;
-- Game API/JSON-RPC tests stay green;
-- Automation tests stay green;
-- `AutomationContractTests` stays green with the three new telemetry fields.
+### 4.3 Add one `Category=E2E` prepared-chart live smoke
 
-HPA-510 does **not** need to add OBS/recorder E2E. HPA-503 is the live Windows recording validation consumer.
+Create `PreparedChartRecordingSmokeTests.cs` using existing:
 
-### 4.3 Manual/API smoke for implementation PR
+- `E2EFixtureBuilder`;
+- `E2EGameLaunch.CreateClientBundle`;
+- `JsonRpcGameClient`;
+- `Eventually.UntilAsync`;
+- current stage waits/artifact helpers where reusable.
 
-Use an indexed test chart with preview audio and the existing Game API:
+Required live flow:
 
-1. enter Song Select;
-2. call prepare with the exact absolute chart path;
-3. verify telemetry reports `Prepared` and a redacted identity;
-4. take a screenshot and verify the requested row/difficulty/status UI is rendered;
-5. wait long enough to prove normal preview delay does not auto-play;
-6. call start, then poll until prepared elapsed >= 10,000 ms;
-7. call activate and confirm transition follows SongTransition;
-8. separately exercise a debounce-blocked activation and verify preparation remains available for retry;
-9. exercise user difficulty navigation after prepare and verify prepared state clears and the normal primary-chart delayed preview resumes;
-10. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
+1. build/launch isolated fixture;
+2. enter SongSelect through the existing normal path;
+3. call `PrepareVideoChartAsync(fixture.ChartPath)`;
+4. call screenshot and require non-empty image;
+5. wait longer than the normal automatic preview delay and assert state is `Prepared` with elapsed `0`;
+6. call `StartPreparedPreviewAsync()`;
+7. poll until state is `Playing` and elapsed `>= 10_000`;
+8. call `ActivatePreparedChartAsync()`;
+9. observe `SongTransition` before `Performance`.
 
-This smoke is implementation validation only; do not create a permanent recorder harness in HPA-510.
+Keep this test narrowly about HPA-510. Do not run to Result, inspect persistence, involve OBS, or duplicate `GameplayAutoPlaySmokeTests`' score-bucket purpose.
+
+The existing `.github/workflows/build-and-test.yml` already runs `Category=E2E` on Windows, so no new CI job is required.
+
+### 4.4 Full regression
+
+Run the platform-appropriate full game unit suite and Automation tests. Verify the existing Windows gameplay E2E job remains green.
+
+There is no separate manual smoke checklist after this change; the live E2E is the repeatable acceptance proof.
 
 ---
 
-## Scope Guardrails for the Implementing Agent
+## Primary implementation risks
 
-Stop and simplify if the implementation starts adding any of the following:
+### Projection side effects
 
-- recording session IDs/state machines;
-- generic Game API mutation dispatch;
-- a new song repository/query service;
-- title-based or input-driven navigation;
-- alternate chart/difficulty ordering rules instead of current Song Select helpers plus the explicit DRUMS tie-break;
-- a second preview audio abstraction;
-- a game-owned debounce wait/retry loop;
-- OBS/process/FFmpeg concerns;
-- render-ready generation counters.
+`NavigateIntoBox` repopulates the list at each level, which resets index and fires selection events. Avoid it during prepare projection: use `RestoreNavigationPaths` + one final refresh + one atomic selection under the full suppression scope.
 
-The desired end state is four explicit commands layered on the existing Song Select state machine, with `DTXMania.Automation` wrappers ready for HPA-503.
+### Prepared preview auto-start
 
-## Definition of Done
+`TryLoadPreviewSoundFile` sets `_isPreviewDelayActive = true` on success. Prepared loading must explicitly clear it.
 
-- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, duplicate-title, and ordinary shared-ChartId multi-instrument cases.
-- Shared ChartId across DRUMS/GUITAR/BASS resolves to the unique DRUMS gameplay slot rather than failing as ambiguous.
-- Outside-root/unindexed/truly-ambiguous/missing-preview/unsupported-preview cases fail clearly.
-- Prepare leaves the exact chart preview loaded but stopped and cannot clear itself through projection events.
-- Start creates exactly one looped instance using existing preview volume/path behavior.
-- Prepared elapsed telemetry advances only while the instance is actually Playing.
-- User row/difficulty navigation clears preparation; difficulty exit restores the normal primary-chart delayed preview.
-- Debounce-blocked activation returns failure and preserves preparation; accepted activation clears audio/state and starts the existing SongTransition path.
-- Cancel/replacement/navigation/deactivation/activation clean up without audio bleed or double disposal.
-- Telemetry exposes only prepared identity/state/elapsed with exact camelCase wire keys and no absolute path.
-- `AutomationContractTests` proves those producer wire keys reach the Automation accessors.
-- JSON-RPC commands are explicit and use existing API-key authentication.
-- `DTXMania.Automation` exposes four typed wrappers; generic JSON-RPC remains private.
-- Existing interactive Song Select behavior is unchanged when no prepared chart is active.
-- Platform-appropriate game unit suite, Automation tests, and the existing Automation producer/consumer contract pass.
+### Exact chart identity
+
+`GetStableSelectionIdentity` is row-oriented and can return `song:<id>`. Do not reuse it as exact prepared-chart telemetry identity.
+
+### Activation debounce
+
+`SelectSong` currently no-ops on debounce. Check eligibility before clearing preparation and reuse one shared transition-start body.
+
+---
+
+## Definition of done
+
+- Exact absolute path selects the correct active row/difficulty for root, nested, SET/multi-chart, duplicate-title, and shared-ChartId multi-instrument cases.
+- Prepare projection does not trigger wrong-row preview/BGM cycles while rebuilding BOX hierarchy.
+- Prepare loads the resolved chart preview and explicitly leaves `_isPreviewDelayActive == false`.
+- Start creates exactly one looped preview instance using current volume/BGM behavior.
+- `PreparedPreviewElapsedMs` advances only while the instance reports Playing and reaches at least 10,000 ms in the live smoke.
+- Cancel/replacement/navigation/deactivation clean up without double disposal or audio bleed.
+- Blocked activation returns failure without consuming preparation; successful activation reuses normal SongTransition shared data.
+- Telemetry exposes exactly prepared identity/state/elapsed with no absolute path and passes the mandatory game->Automation camelCase contract test.
+- JSON-RPC exposes only four authenticated commands; generic transport stays private.
+- Focused tests, full unit/Automation regression, and the existing-harness Windows `Category=E2E` prepared-chart smoke pass.
+- No recorder session, generic dispatcher, song repository, fake OBS server, or new E2E framework is introduced.

--- a/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
+++ b/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
@@ -2,13 +2,13 @@
 
 **Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
 **Date:** 2026-08-11  
-**Status:** Revised after implementation review
+**Status:** Revised after second implementation review
 
 ## Context
 
-HPA-501 has landed on `main`, so the reusable `DTXMania.Automation` process and JSON-RPC foundation is available. HPA-510 is now the only code prerequisite blocking HPA-503, the Windows recording vertical slice.
+HPA-501 has landed on `main`, so the reusable `DTXMania.Automation` process and JSON-RPC foundation is available. HPA-510 is the remaining CX-side prerequisite for HPA-503's Windows recording vertical slice.
 
-The recorder does not need general remote control of the game. It needs four narrow operations while Song Select is active:
+The recorder needs exactly four Song Select operations:
 
 ```text
 prepareVideoChart(chartPath)
@@ -17,83 +17,60 @@ activatePreparedChart()
 cancelPreparedChart()
 ```
 
-The implementation should make one exact indexed chart visible through the normal Song Select UI, hold its declared preview audio ready but stopped, play that preview under explicit recorder control, and then activate the chart through the same path a player uses.
+The implementation must prepare one exact indexed chart through normal Song Select state, hold its declared preview audio stopped, play it only on command, and activate it through the same Song Select -> SongTransition path used by a player.
 
-This design deliberately keeps recording preparation inside `SongSelectionStage`. It does not add a game-wide capture session, generic mutation API, recorder state machine, database query layer, or synthetic input navigation.
+Prepared state remains owned by `SongSelectionStage`. Do not add a recorder session, generic mutation endpoint, database query path, or synthetic-input navigation.
 
 ## Goals
 
-- Resolve one caller-supplied **absolute chart path** to the exact chart already present in the active Song Select library.
-- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, ordinary single-file multi-instrument rows, and duplicate titles.
-- Project the resolved chart through the existing Song Select presentation path so status, preview image, play history, selected row, difficulty, and breadcrumb are normal UI state.
-- Load the preview declared by the **resolved chart**, not merely the node's primary chart.
-- Keep the prepared preview stopped until explicitly started.
-- Reuse the existing preview sound resource, volume, looping, and BGM fade behavior.
-- Keep all stage mutations on the game update thread.
-- Activate through the existing Song Select transition construction and report a real success/failure result when the global transition debounce rejects activation.
-- Expose only the prepared identity/state/elapsed telemetry required by HPA-503.
-- Lock the game-to-Automation telemetry contract to the existing camelCase JSON wire format.
-- Extend `DTXMania.Automation` with the four explicit client calls so HPA-503 never needs access to the private generic JSON-RPC transport.
+- Resolve one caller-supplied absolute chart path against the currently applied `SongLibrarySnapshot`.
+- Support root-level charts, nested BOX hierarchy, SET/multi-chart rows, ordinary one-file multi-instrument rows, and duplicate titles.
+- Project the exact row + difficulty through normal Song Select UI state.
+- Load preview audio from the resolved `SongChart`, not merely the row's primary `DatabaseChart`.
+- Keep preview loaded but stopped until `startPreparedPreview`.
+- Reuse current preview volume, loop, BGM fade, sound resource, and cleanup behavior.
+- Keep every stage mutation on the game update thread and await the real command outcome.
+- Reuse the normal `SelectSong` transition construction while surfacing transition-debounce rejection.
+- Expose exactly `PreparedChartIdentity`, `PreparedPreviewState`, and `PreparedPreviewElapsedMs` to HPA-503.
+- Lock the camelCase game -> Automation telemetry contract.
+- Validate the command path once against a live game using the existing E2E fixture/CI machinery.
 
 ## Non-goals
 
-- A general Song Select remote-navigation API.
-- A generic command dispatcher or arbitrary main-thread mutation endpoint.
-- A game-wide recording/capture coordinator or immutable recording session ID.
-- A separate render-generation/readiness state machine. Screenshot completion remains the presentation barrier.
-- OBS, process launch, app-data sandboxing, Result hold timing, or video artifact handling.
-- Changing the normal interactive preview delay or primary-chart preview behavior when no prepared chart is active.
-- Restoring a pre-command filter/tab/breadcrumb after cancellation. The recorder runs in disposable app data; snapshot/restore machinery is unnecessary for MVP.
-- Waiting inside the game for the stage-transition debounce window. A blocked activation returns `success=false`; the preparation remains available for a bounded caller retry.
+- General Song Select remote navigation.
+- Generic game-thread dispatch or arbitrary mutation APIs.
+- A capture/recording session object or state machine.
+- A second song repository/query layer.
+- A new render-readiness state machine; screenshot completion remains the presentation barrier.
+- OBS, process launch, sandbox construction, video finalization, or Result timing.
+- Restoring the pre-command tab/filter/breadcrumb after cancel; HPA-503 uses disposable app data.
+- Changing normal interactive preview behavior when no prepared chart exists.
+- Waiting inside the game for transition debounce to expire.
 - Direct transition to Performance.
 
-## Current Reuse Survey
+## Verified reuse seams
 
-The required building blocks already exist:
+Use the existing code rather than parallel abstractions:
 
-- `SongSelectionStage` owns selection, BOX navigation, status/history/preview UI, preview sound lifecycle, BGM fading, and the player activation path.
-- `SongSelectionStage` already retains the coherent applied `SongLibrarySnapshot`, including `RootSongs` and canonical `ActiveRoots`.
-- `SongSelectionStage.GetNodeChartPaths` already understands that a visible row can represent the primary `DatabaseChart` plus additional `DatabaseSong.Charts`.
-- `SongPathIdentity` already owns path normalization and root-containment primitives.
-- `SongListNode.Scores` carries difficulty slots; persisted multi-chart rows carry `SongScore.ChartId`.
-- `SongListNode.CreateSongNode` can legitimately assign the same `SongChart.Id` to DRUMS, GUITAR, and BASS score slots for one physical DTX file, so `ChartId` alone is not always a unique slot identity.
-- `SongChartHelper.GetCurrentDifficultyChart` is the existing runtime fallback from a visible difficulty slot to its chart and is useful for legacy/SET rows where a direct `ChartId` match is unavailable.
-- `SongListDisplay` already owns row index, difficulty, selection events, scroll target, and normal Song Select presentation updates.
-- `SongSelectionStage.LoadPreviewSound` / `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` already implement the preview resource and playback behavior.
-- `SongSelectionStage.SelectSong` owns the normal transition data but silently returns while `_game.CanPerformStageTransition()` is false, so prepared activation must surface that gate rather than clearing state first.
-- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API. `BaseGame.CaptureScreenshotAsync` demonstrates the existing `TaskCompletionSource(...RunContinuationsAsynchronously)` pattern for an awaited game-thread result.
-- `JsonRpcServer` already authenticates every JSON-RPC request and serializes public DTOs with camelCase property names.
-- `GameTelemetrySnapshot` plus `IStageTelemetryProvider` is the existing producer telemetry seam.
-- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` owns the consumer JSON-RPC transport and keeps `SendAsync` private.
-- `DTXMania.E2E/AutomationContractTests.cs` already performs the producer-to-`GameStateSnapshot` camelCase contract round trip and is the required place to lock the three new telemetry fields.
+- `_appliedLibrarySnapshot`, `GetNodeChartPaths`, and `SongPathIdentity` for exact active-library path resolution.
+- `RestoreNavigationPaths(paths, snapshot)` for rebuilding `_navigationStack`, `_currentSongList`, and `_currentBreadcrumb` without repopulating at every BOX level.
+- `RefreshSongListForActiveTab()` for one final list projection after navigation state is rebuilt.
+- `SongListDisplay` for the final row/difficulty UI selection.
+- `SongListNode.Scores[].ChartId` plus `SongChartHelper.GetCurrentDifficultyChart` for difficulty mapping.
+- `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` for preview lifecycle.
+- `IGameContext.QueueMainThreadAction` plus `TaskCompletionSource(...RunContinuationsAsynchronously)` for awaited game-thread commands.
+- `SelectSong` for normal SongTransition shared-data construction.
+- `JsonRpcServer`'s existing authenticated method switch and `JsonRpcGameClient.SendAsync` for transport.
+- `DTXMania.E2E/AutomationContractTests.cs` for game -> camelCase -> Automation telemetry contract coverage.
+- `E2EFixtureBuilder`, `E2EGameLaunch`, `Eventually`, and the existing Windows `Category=E2E` CI job for one live validation.
 
-The design should extend these seams rather than create parallel infrastructure.
+`GetStableSelectionIdentity` is **not** the prepared-chart telemetry identity seam. It is a row-selection identity: it prefers `song:<DatabaseSongId>` when present and only falls back to the first chart path. HPA-510 must identify the exact resolved chart/difficulty, not merely its row.
 
-## Approaches Considered
+## Chosen architecture
 
-### 1. Stage-owned prepared state plus four explicit commands — selected
+### 1. Minimal stage-owned prepared state
 
-Add a small amount of state and four command methods to `SongSelectionStage`, expose them through explicit Game API / JSON-RPC handlers, and add matching methods to `DTXMania.Automation`.
-
-This gives HPA-503 exactly what it needs while preserving the normal Song Select and transition paths.
-
-### 2. Recorder drives Song Select with repeated key input — rejected
-
-This is already the failure mode HPA-510 exists to remove. It is slow, fragile with nested boxes/filter state, and cannot safely disambiguate duplicate titles.
-
-### 3. Add a general game automation/session coordinator — rejected
-
-HPA-503 owns orchestration. A second lifecycle/session abstraction inside the game would duplicate ownership before a second use case proves it useful.
-
-### 4. Resolve chart paths through a new database repository/service — rejected
-
-The active `SongLibrarySnapshot` is already the authoritative, coherent view used by Song Select. A second DB query path could disagree with the rendered hierarchy and would add unnecessary synchronization.
-
-## Chosen Architecture
-
-### 1. Prepared state is update-thread-owned by `SongSelectionStage`
-
-Keep a minimal stage-local record for the current preparation, for example:
+Keep one update-thread-owned record:
 
 ```text
 PreparedChartSelection
@@ -103,7 +80,7 @@ PreparedChartSelection
 - string telemetryIdentity
 ```
 
-Keep only the additional runtime fields needed for preview control:
+Additional fields:
 
 ```text
 PreparedPreviewState: None | Prepared | Playing | Failed
@@ -111,165 +88,169 @@ PreparedPreviewElapsedMs: double
 _isProjectingPreparedSelection: bool
 ```
 
-No lock is required for this state because every command mutation and elapsed-time update runs on the game update thread. Game telemetry reads the same fields through the existing stage telemetry provider.
+No lock, session ID, generation object, or separate state machine is required.
 
-A preparation is cleared by:
+Prepared state is cleared by:
 
-- `cancelPreparedChart`;
-- preparing a replacement chart;
-- normal interactive row navigation away from the prepared row;
-- normal interactive difficulty navigation away from the prepared slot;
-- successful activation after the transition gate has accepted the request;
+- cancel;
+- replacement prepare;
+- real user row navigation away;
+- real user difficulty navigation away;
+- successful activation after transition eligibility is confirmed;
 - stage deactivation.
 
-`_isProjectingPreparedSelection` suppresses invalidation while `prepareVideoChart` itself projects the target row/difficulty. It also suppresses the normal automatic preview load during that projection; the exact resolved chart preview is loaded explicitly afterward.
+The projection suppression flag is scoped to the **entire prepare projection**, not only the final row selection.
 
-Cleanup remains idempotent. `StopCurrentPreview` already nulls disposed resources, so repeated cleanup must never stop/dispose one instance twice.
+### 2. Exact path resolver over the applied snapshot
 
-### 2. Exact chart resolution uses the applied library snapshot
-
-`prepareVideoChart` accepts only a non-empty, fully-qualified path.
+`prepareVideoChart` accepts only a non-blank fully-qualified chart path.
 
 On the update thread:
 
-1. Require Song Select to have an applied `SongLibrarySnapshot`.
-2. Normalize the requested chart path with `SongPathIdentity`.
-3. Require it to be under one of `snapshot.ActiveRoots`.
+1. Require `_appliedLibrarySnapshot`.
+2. Normalize the requested path with `SongPathIdentity`.
+3. Require containment under one of `snapshot.ActiveRoots`.
 4. Recursively walk `snapshot.RootSongs` and BOX children.
-5. For each Score node, inspect the node's primary `DatabaseChart` and every chart in `DatabaseSong.Charts`.
-6. Match by normalized path using the existing platform path-identity semantics. Never use title/artist text.
-7. Require exactly one visible node/chart match.
-8. Resolve the visible difficulty slot using the following precedence:
-   - collect non-null score slots whose non-zero `SongScore.ChartId` equals the resolved `SongChart.Id`;
-   - if exactly one slot matches, use it;
-   - if multiple slots share that ChartId, use the **unique DRUMS slot** when exactly one candidate has `Instrument == EInstrumentPart.DRUMS`; this is the normal one-file multi-instrument case and matches CX's drum-gameplay path;
-   - if ChartId did not establish a slot, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching that chart's normalized `FilePath` to the requested path;
-   - use the fallback only when it yields one slot; fail rather than guess if ambiguity remains.
-9. Retain the ancestor BOX chain needed to reproduce the normal browse context.
+5. For Score nodes, inspect `DatabaseChart` plus `DatabaseSong.Charts`.
+6. Match normalized chart path only; never title/artist.
+7. Require one exact node/chart match.
+8. Resolve the visible difficulty slot:
+   - collect non-null score slots with matching non-zero `ChartId`;
+   - if exactly one matches, use it;
+   - when several slots share the same ChartId, use the unique DRUMS slot if exactly one candidate is DRUMS;
+   - otherwise scan valid slots through `GetCurrentDifficultyChart(node, index)` and compare the returned chart path to the resolved path;
+   - fail if no unique slot remains.
+9. Return the node, resolved chart, difficulty index, and ancestor BOX paths.
 
-The DRUMS tie-break is required because one physical DTX file can legitimately populate DRUMS/GUITAR/BASS slots with the same `SongChart.Id`. Requiring ChartId uniqueness would reject normal indexed content.
+The DRUMS tie-break is required because a single physical DTX can populate DRUMS/GUITAR/BASS slots with the same `SongChart.Id`.
 
-This handles duplicate titles naturally because title never participates in identity. It also reuses the current SET/multi-chart mapping instead of introducing a second difficulty-order algorithm.
+### 3. Projection uses one existing navigation rebuild and one UI refresh
 
-### 3. Reuse normal browse navigation, but do not synthesize input
+Do **not** call `NavigateIntoBox` once per ancestor. It calls `PopulateSongList()` on each level; `SongListDisplay.CurrentList` resets selection to index 0 and raises `SelectionChanged`, which would repeatedly stop/load the wrong preview during prepare.
 
-Preparation must leave Song Select in a normal browse context with the target row visible.
-
-Use existing stage behavior:
-
-1. Switch to the All Songs projection and clear the active search/filter projection for this recorder operation.
-2. Return to the root browse list and clear the navigation stack.
-3. Reuse `NavigateIntoBox` for each resolved ancestor BOX so the normal breadcrumb/current-list state is rebuilt.
-4. Select the target row and difficulty through `SongListDisplay`.
-
-Add one narrow programmatic selection method to `SongListDisplay`, such as:
+Instead, run the whole projection inside:
 
 ```text
-SetSelection(index, difficulty)
+_isProjectingPreparedSelection = true
+try
+    reset recorder-owned tab/filter projection
+    RestoreNavigationPaths(ancestorPaths, snapshot)
+    RefreshSongListForActiveTab() exactly once
+    SetSelection(targetIndex, difficultyIndex)
+finally
+    _isProjectingPreparedSelection = false
 ```
 
-It should atomically set row + difficulty, reset the scroll target consistently, and raise the existing `SelectionChanged` path once. This avoids the current property-order problem where `CurrentList` can temporarily select row 0 and load the wrong preview before the final index is applied.
+Add one narrow `SongListDisplay.SetSelection(index, difficulty)` method that applies row + difficulty atomically, updates scroll state coherently, and raises the normal selection path once.
 
-This is an internal UI convenience, not a remote navigation API.
+During the suppression scope, normal status/history/image/breadcrumb presentation may update, but prepared-state invalidation and normal automatic preview loading must not run.
 
-During prepare projection, `_isProjectingPreparedSelection` lets normal status/history/image/breadcrumb presentation update while skipping prepared-state invalidation and automatic preview loading. The flag is cleared in `finally` so a projection failure cannot leave normal Song Select behavior suppressed.
+This is an internal UI seam, not a remote navigation API.
 
-### 4. Prepared preview uses the resolved `SongChart`
+### 4. Prepared preview loads the exact resolved chart
 
-This is the one place where blindly reusing current interactive preview loading is incorrect: `LoadPreviewSound(SongListNode)` reads `selectedNode.DatabaseChart`, which is the row's primary chart and may not be the chart selected by the recorder.
-
-Extract/reuse the existing path/load primitives so prepared loading can accept the exact resolved `SongChart`:
+Current `LoadPreviewSound(SongListNode)` hardcodes `selectedNode.DatabaseChart`. Prepared mode must instead resolve:
 
 ```text
-SongChart.FilePath directory
-+ SongChart.PreviewFile
+resolvedChart.FilePath directory
++ resolvedChart.PreviewFile
 -> absolute preview path
--> existing TryLoadPreviewSoundFile
+-> TryLoadPreviewSoundFile
 ```
 
-Prepare fails clearly when:
+Prepare fails for missing declaration, missing file, unreadable/unsupported load, or null sound resource.
 
-- `PreviewFile` is absent;
-- the resolved preview file does not exist;
-- the resource manager reports a load failure or unsupported asset.
+One important existing side effect must be overridden explicitly: successful `TryLoadPreviewSoundFile` sets:
 
-After successful load:
+```text
+_previewPlayDelay = 0
+_isPreviewDelayActive = true
+```
 
-- `_previewSound` is retained exactly as today;
-- automatic preview delay is disabled while a prepared chart exists;
-- no preview instance is created;
-- preview state becomes `Prepared`;
-- elapsed time is zero.
+After the prepared load succeeds, immediately force:
 
-Normal interactive preview behavior remains unchanged when no preparation exists.
+```text
+_previewPlayDelay = 0
+_isPreviewDelayActive = false
+```
 
-### 5. Explicit start owns exactly one looped preview instance
+so the normal one-second timer cannot auto-start the prepared preview.
 
-`startPreparedPreview` requires a prepared chart and loaded preview resource.
+Successful prepare leaves `_previewSound` retained, `_previewSoundInstance == null`, state `Prepared`, and elapsed `0`.
 
-Reuse `CreatePreviewSoundInstance`, `SongSelectionUILayout.Audio.PreviewSoundVolume`, looping, `Play()`, and `StartBGMFade(true)`.
+### 5. Explicit preview start and elapsed telemetry
 
-Behavior:
+`startPreparedPreview`:
 
-- first successful start creates one instance, sets volume/looping, plays, resets elapsed to zero, and reports `Playing`;
-- a repeated start while already playing is idempotent success and does not create another instance;
-- creation/playback failure disposes any partial instance, reports `Failed`, and never substitutes Song Select BGM or full-song audio.
+- requires a prepared chart/resource;
+- creates one instance with the existing helper;
+- applies existing preview volume and `IsLooped = true`;
+- calls `Play()` once;
+- starts the existing BGM fade-out;
+- sets state `Playing` and elapsed `0`;
+- returns idempotent success when already playing without creating a second instance.
 
-In `SongSelectionStage.OnUpdate`, increment `PreparedPreviewElapsedMs` from `GameTime.ElapsedGameTime` only when prepared state is `Playing` **and** the sound instance currently reports `SoundState.Playing`.
+On each Song Select update, increment `PreparedPreviewElapsedMs` only while state is `Playing` **and** the sound instance reports `SoundState.Playing`.
 
-If an explicitly-started instance unexpectedly stops, mark the prepared preview `Failed` rather than silently starting another source. HPA-503 will observe the state/elapsed telemetry and fail its bounded wait.
+If the explicitly-started instance unexpectedly stops, set state `Failed`; do not auto-restart or substitute Song Select BGM/full-song audio.
 
-### 6. Navigation invalidation returns cleanly to interactive preview behavior
+`PreparedPreviewElapsedMs` stays in scope because both HPA-510 and HPA-503 explicitly require CX-reported actual playback time, and HPA-503 polls `>= 10_000`. Caller wall-clock time is not the accepted contract.
 
-Prepared state must not survive when the visible selection no longer represents the prepared chart.
+### 6. User navigation exits prepared mode cleanly
 
 `OnSongSelectionChanged`:
 
-- while `_isProjectingPreparedSelection` is true, do not invalidate preparation and skip its normal automatic preview load;
-- otherwise, when the selected row differs from the prepared row, clear the prepared state first, then continue the handler's existing row-selection behavior; the normal `LoadPreviewSound(e.SelectedSong)` path therefore resumes the ordinary delayed primary-chart preview.
+- while `_isProjectingPreparedSelection`, do not invalidate prepared state and skip normal automatic preview loading;
+- otherwise, if the row moves away from the prepared row, clear prepared state first and continue today's normal row-selection preview path.
 
 `OnDifficultyChanged`:
 
-- while `_isProjectingPreparedSelection` is true, do not invalidate preparation;
-- otherwise, when `e.NewDifficulty` differs from the prepared slot on the same row, clear the prepared state;
-- after clearing, explicitly call the existing `LoadPreviewSound(e.Song)` path so the row returns to the same primary-chart delayed preview behavior normal Song Select uses after a row selection.
+- while `_isProjectingPreparedSelection`, do not invalidate;
+- otherwise, if difficulty moves away from the prepared slot, clear prepared state;
+- after this prepared-mode exit, reload the row through the existing `LoadPreviewSound(e.Song)` path so normal delayed primary-chart preview behavior resumes;
+- leave ordinary difficulty changes unchanged when there is no preparation.
 
-The difficulty-change reload is only an exit from prepared mode. Normal interactive difficulty changes when no prepared chart exists remain unchanged.
+Cleanup remains idempotent.
 
-### 7. Activation observes the debounce gate before consuming preparation
+### 7. Activation separates eligibility from transition start
 
-Current `SelectSong` silently returns when `_game.CanPerformStageTransition()` is false. Prepared activation cannot clear state first and then call that method because the API could report success while no transition started.
+Current `SelectSong` silently returns if `_game.CanPerformStageTransition()` is false. Prepared activation must observe this rather than reporting success after a no-op.
 
-Keep one shared transition path, but separate **eligibility** from **transition start** inside `SongSelectionStage`:
+Factor the existing method into one small eligibility gate and one shared start body, e.g.:
 
 ```text
 CanStartSongSelection(node)
-- valid Score node
-- StageManager available
-- _game.CanPerformStageTransition() == true
-
 StartSongSelection(node)
-- _game.MarkStageTransition()
-- build selectedSong / selectedDifficulty / songId shared data
-- StageManager.ChangeStage(SongTransition, ...)
 ```
 
-The existing player `SelectSong` path calls these two helpers and may ignore the returned bool.
+Eligibility checks:
+
+- valid Score node;
+- `StageManager` available;
+- `_game.CanPerformStageTransition()`.
+
+The start body remains the sole owner of:
+
+```text
+_game.MarkStageTransition()
+selectedSong / selectedDifficulty / songId
+StageManager.ChangeStage(StageType.SongTransition, ...)
+```
 
 `activatePreparedChart`:
 
-1. Require a current preparation.
-2. Require `_selectedSong` / `_currentDifficulty` still match it.
-3. Evaluate the same transition-eligibility gate.
-4. If debounce or stage-manager availability blocks the transition, return `success=false` and **leave the preparation and preview intact**.
-5. Once eligibility succeeds, stop/dispose the prepared preview and clear prepared state.
-6. Immediately call the shared transition-start body on the same update-thread action.
+1. Require the prepared row/difficulty still match current selection.
+2. Check the shared transition eligibility.
+3. If blocked, return `success=false` and leave prepared state/preview intact.
+4. If eligible, stop/dispose the preview and clear prepared state.
+5. Immediately execute the shared transition-start body on the same update-thread action.
+6. Return success only after the normal stage change has been invoked.
 
-Do not wait 0.5 seconds inside the game and do not duplicate the transition shared-data construction. A successful result means the normal `SongTransitionStage` change was actually started.
+Do not wait 0.5 seconds inside the game.
 
-### 8. Game API commands queue and await the update-thread result
+### 8. Result contract stays narrow and intentionally untyped
 
-Extend `IGameApi` / `GameApiImplementation` with four explicit methods. Keep the result contract narrow, for example:
+Use:
 
 ```text
 PreparedChartCommandResult
@@ -277,52 +258,38 @@ PreparedChartCommandResult
 - string? Error
 ```
 
-`GameApiImplementation` should use one private helper that:
+Do **not** add a cross-assembly error-code enum in HPA-510. The only planned consumer, HPA-503, treats any command failure as a failed recording run. Its activation occurs only after at least 10 seconds of prepared preview playback, far beyond the 0.5-second global transition debounce, so it has no required retry branch that needs to distinguish `TransitionBlocked` from fatal prepare errors.
 
-- creates a `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously`;
-- queues an action through `IGameContext.QueueMainThreadAction`;
-- inside the queued action, verifies the current stage is `SongSelectionStage` and executes the requested stage command;
-- completes the task with the command result.
+Keeping preparation intact on a blocked activation is local correctness and preserves diagnostics/manual retry capability; it is not a new recorder retry protocol. Add structured error codes only when a real caller needs programmatic recovery.
 
-The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not copy `ChangeStageAsync`'s fire-and-forget semantics and do not add a general main-thread dispatcher abstraction.
+### 9. Game API and JSON-RPC queue and await real results
 
-### 9. JSON-RPC stays explicit and authenticated
+Add four explicit `IGameApi` methods and one private `GameApiImplementation` queue helper:
 
-Add four cases/handlers to `JsonRpcServer`:
+- create `TaskCompletionSource` with asynchronous continuations;
+- queue through `IGameContext.QueueMainThreadAction`;
+- verify current stage is `SongSelectionStage` inside the queued action;
+- execute the stage command;
+- complete with its actual result.
+
+Do not copy `ChangeStageAsync`'s fire-and-forget semantics and do not create a generic dispatcher.
+
+`JsonRpcServer` adds only:
 
 ```text
-prepareVideoChart   params: { chartPath: string }
+prepareVideoChart { chartPath }
 startPreparedPreview
 activatePreparedChart
 cancelPreparedChart
 ```
 
-The existing server-level API-key check already protects them.
+Existing API-key authentication protects them. Domain failures return `{ success:false, error:"..." }` without a new JSON-RPC error taxonomy.
 
-Validate JSON shape in the server. Stage/domain failures may be returned as a normal command result (`success=false`, sanitized `error`) so callers receive useful failure text without adding a new JSON-RPC error taxonomy.
+`DTXMania.Automation.JsonRpcGameClient` adds four public wrappers over private `SendAsync`; `success=false` throws `InvalidOperationException` with the safe server message.
 
-Do not expose any method that accepts arbitrary stage/action names or mutation payloads.
+### 10. Telemetry keeps all three accepted fields
 
-### 10. Automation exposes the same four narrow operations
-
-Extend `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs` with public methods for the four commands. Reuse its private `SendAsync` transport and one small command-result parser.
-
-HPA-503 should be able to call:
-
-```text
-PrepareVideoChartAsync(path)
-StartPreparedPreviewAsync()
-ActivatePreparedChartAsync()
-CancelPreparedChartAsync()
-```
-
-without accessing generic JSON-RPC.
-
-A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message. In particular, a debounce-blocked activation is an observable failed command rather than a silent no-op.
-
-### 11. Telemetry adds only recorder-required fields and locks the wire names
-
-Extend `GameTelemetrySnapshot` with:
+Producer fields:
 
 ```text
 PreparedChartIdentity
@@ -330,7 +297,7 @@ PreparedPreviewState
 PreparedPreviewElapsedMs
 ```
 
-Because `JsonRpcServer` serializes DTOs with `JsonNamingPolicy.CamelCase`, the wire contract is exactly:
+Wire names are exactly:
 
 ```text
 preparedChartIdentity
@@ -338,94 +305,78 @@ preparedPreviewState
 preparedPreviewElapsedMs
 ```
 
-`SongSelectionStage.PopulateTelemetry` supplies the producer values from stage-owned prepared state.
+Identity policy remains exact-chart-specific and non-absolute:
 
-Identity policy:
+- `chart:<SongChart.Id>` when the resolved chart has a stable non-zero database ID;
+- otherwise a normalized root-relative chart path.
 
-- prefer `chart:<SongChart.Id>` when the indexed chart has a stable non-zero database ID;
-- otherwise use a root-relative normalized path, never the absolute song-root prefix.
+Do not use `GetStableSelectionIdentity`: it often returns `song:<id>` and therefore cannot identify which chart/difficulty inside a multi-chart row was prepared. Do not expose the absolute requested path; HPA-510 explicitly requires a stable database/chart identity or redacted root-relative path.
 
-Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with read-only accessors for those exact camelCase keys.
+Extend `GameStateSnapshot` with accessors for all three keys, and extend `AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` with non-default producer values and assertions for all three consumer accessors.
 
-The existing `DTXMania.E2E/AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` test **must** be extended with all three producer values and assertions against all three Automation accessors. This is a required producer/consumer contract gate, not an optional extra test.
+### 11. Validation uses the existing E2E harness, not a manual checklist
 
-Screenshot remains the render barrier: after prepare returns, HPA-503 calls the existing screenshot operation and successful image completion proves Song Select completed a Draw pass.
+Retain focused unit/contract tests, then add one live `Category=E2E` prepared-chart smoke using existing `E2EFixtureBuilder`, `E2EGameLaunch`, `JsonRpcGameClient`, and `Eventually`.
 
-## Failure Semantics
+Minimal fixture change: add a `#PREVIEW` line referencing the already-generated `autoplay-tone.wav`.
 
-Preparation fails without leaving active prepared state for:
+Live flow:
 
-- blank or non-absolute path;
+1. Launch the existing isolated fixture and enter Song Select.
+2. `prepareVideoChart(fixture.ChartPath)`.
+3. Take a screenshot as the render barrier.
+4. Wait past the normal automatic preview delay and assert prepared state remains `Prepared` with elapsed `0`.
+5. `startPreparedPreview()`.
+6. Poll until state is `Playing` and `PreparedPreviewElapsedMs >= 10_000`.
+7. `activatePreparedChart()`.
+8. Assert SongTransition is observed before Performance.
+
+This reuses the existing Windows E2E job; it does not add an E2E framework, fake OBS server, or recorder harness.
+
+## Failure semantics
+
+Preparation returns failure and leaves no prepared state for:
+
+- blank/non-absolute path;
 - library not ready;
-- path outside every active root;
-- no exact indexed chart match;
-- ambiguous indexed match;
-- no unique visible difficulty slot after the DRUMS tie-break and existing path-helper fallback;
+- path outside active roots;
+- unindexed path;
+- ambiguous node/chart match;
+- unresolved/ambiguous difficulty slot;
 - missing preview declaration/file;
-- unreadable or unsupported preview resource.
+- preview load failure.
 
-Start fails for no prepared chart/resource or playback creation failure.
+Start fails for missing preparation/resource or sound-instance/playback failure.
 
-Activation fails if preparation is absent, the prepared selection is no longer active, the stage manager is unavailable, or the global transition debounce is active. Debounce/stage-manager failure leaves the preparation intact for retry.
+Activation fails if preparation is absent, current row/difficulty no longer matches it, or transition eligibility is blocked. A blocked transition preserves the preparation.
 
-Cancellation is idempotent success.
+Cancel is idempotent success.
 
-Errors should describe the category without publishing an absolute path into telemetry/log snapshots intended for recorder diagnostics.
+## Risks and mitigations
 
-## Testing Strategy
+### Projection side effects — primary risk
 
-Add focused tests rather than a second end-to-end framework.
+Repeated `NavigateIntoBox -> PopulateSongList -> CurrentList` would repeatedly select row 0 and trigger preview/BGM side effects during prepare. Mitigate by using `RestoreNavigationPaths`, one `RefreshSongListForActiveTab`, one atomic `SetSelection`, and one suppression scope around the entire projection.
 
-### Song Select
+### Exact-chart vs row identity
 
-Cover:
+Existing row identity can collapse a multi-chart row to `song:<id>`. Keep resolver/telemetry identity tied to the resolved `SongChart` instead.
 
-- root-level exact path resolution;
-- nested BOX resolution and browse context;
-- multi-chart/SET row resolves the exact requested chart and correct difficulty slot;
-- ordinary one-file multi-instrument row where DRUMS/GUITAR/BASS slots share one ChartId resolves the unique DRUMS slot;
-- duplicate titles resolve by path;
-- outside-root and unindexed failures;
-- resolved chart preview is used even when it differs from the node's primary chart preview;
-- missing/unreadable/unsupported preview failure;
-- prepare leaves preview loaded but stopped and suppresses automatic timer playback;
-- prepare projection does not invalidate itself through `SelectionChanged`/`DifficultyChanged`;
-- repeated start creates only one instance;
-- elapsed time advances only while the instance reports Playing;
-- row navigation away clears prepared state and resumes normal row preview behavior;
-- difficulty navigation away clears prepared state and resumes the normal primary-chart delayed preview;
-- cancel, replacement, user navigation, and Deactivate clean up exactly once;
-- activation while debounce is blocked returns failure, starts no transition, and preserves prepared state/preview;
-- activation after the gate is available clears preview and reuses the existing transition data path;
-- normal interactive preview delay/loop/BGM behavior remains unchanged with no prepared chart.
+### Preview auto-start leakage
 
-### Game API / JSON-RPC
+`TryLoadPreviewSoundFile` activates the normal delay timer on successful load. Prepared load must explicitly clear `_isPreviewDelayActive` before returning success.
 
-Cover:
+### Activation no-op
 
-- command action is queued to the main thread and the returned task completes after execution;
-- command rejects non-SongSelect current stage;
-- `prepareVideoChart` parameter validation;
-- authenticated JSON-RPC routing and success/failure result shape;
-- debounce-blocked activation propagates `success=false` instead of returning a queued-success result.
+Global transition debounce currently fails silently in `SelectSong`. Surface the eligibility result before consuming preparation.
 
-### Automation contract
+## Expected scope
 
-Cover:
+Still one implementation PR, approximately 2–3 engineer days:
 
-- each new public client method sends the expected method/params;
-- command failure text is propagated;
-- `AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` includes `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs` and proves the Automation accessors read them.
+1. exact resolver + side-effect-free browse projection;
+2. prepared preview lifecycle + activation + telemetry;
+3. explicit Game API/JSON-RPC/Automation wiring + contract tests;
+4. focused regression tests + one existing-harness live E2E smoke.
 
-Use existing unit-test seams and mocks. No real MonoGame window, OBS server, or recorder CLI is required for HPA-510 unit coverage.
-
-## Expected Scope
-
-This remains one implementation PR, approximately 2–3 engineer days:
-
-- exact resolver + browse projection;
-- prepared preview lifecycle + navigation/debounce-safe activation + telemetry;
-- explicit Game API/JSON-RPC/Automation wiring;
-- focused regression/contract tests.
-
-If implementation starts producing a generic automation framework, recorder session object, or alternate Song Select data model, reduce scope back to the stage-owned four-command contract above.
+If implementation starts producing a session framework, database repository, generic mutation dispatcher, alternate navigation model, or separate preview abstraction, reduce scope back to the four-command stage-owned design.

--- a/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
+++ b/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
 **Date:** 2026-08-11  
-**Status:** Draft for implementation review
+**Status:** Revised after implementation review
 
 ## Context
 
@@ -24,14 +24,15 @@ This design deliberately keeps recording preparation inside `SongSelectionStage`
 ## Goals
 
 - Resolve one caller-supplied **absolute chart path** to the exact chart already present in the active Song Select library.
-- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, and duplicate titles.
+- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, ordinary single-file multi-instrument rows, and duplicate titles.
 - Project the resolved chart through the existing Song Select presentation path so status, preview image, play history, selected row, difficulty, and breadcrumb are normal UI state.
 - Load the preview declared by the **resolved chart**, not merely the node's primary chart.
 - Keep the prepared preview stopped until explicitly started.
 - Reuse the existing preview sound resource, volume, looping, and BGM fade behavior.
 - Keep all stage mutations on the game update thread.
-- Activate through the existing `SongSelectionStage.SelectSong` transition path.
+- Activate through the existing Song Select transition construction and report a real success/failure result when the global transition debounce rejects activation.
 - Expose only the prepared identity/state/elapsed telemetry required by HPA-503.
+- Lock the game-to-Automation telemetry contract to the existing camelCase JSON wire format.
 - Extend `DTXMania.Automation` with the four explicit client calls so HPA-503 never needs access to the private generic JSON-RPC transport.
 
 ## Non-goals
@@ -43,6 +44,7 @@ This design deliberately keeps recording preparation inside `SongSelectionStage`
 - OBS, process launch, app-data sandboxing, Result hold timing, or video artifact handling.
 - Changing the normal interactive preview delay or primary-chart preview behavior when no prepared chart is active.
 - Restoring a pre-command filter/tab/breadcrumb after cancellation. The recorder runs in disposable app data; snapshot/restore machinery is unnecessary for MVP.
+- Waiting inside the game for the stage-transition debounce window. A blocked activation returns `success=false`; the preparation remains available for a bounded caller retry.
 - Direct transition to Performance.
 
 ## Current Reuse Survey
@@ -52,15 +54,18 @@ The required building blocks already exist:
 - `SongSelectionStage` owns selection, BOX navigation, status/history/preview UI, preview sound lifecycle, BGM fading, and the player activation path.
 - `SongSelectionStage` already retains the coherent applied `SongLibrarySnapshot`, including `RootSongs` and canonical `ActiveRoots`.
 - `SongSelectionStage.GetNodeChartPaths` already understands that a visible row can represent the primary `DatabaseChart` plus additional `DatabaseSong.Charts`.
-- `SongPathIdentity` already owns path normalization and root containment semantics.
+- `SongPathIdentity` already owns path normalization and root-containment primitives.
 - `SongListNode.Scores` carries difficulty slots; persisted multi-chart rows carry `SongScore.ChartId`.
+- `SongListNode.CreateSongNode` can legitimately assign the same `SongChart.Id` to DRUMS, GUITAR, and BASS score slots for one physical DTX file, so `ChartId` alone is not always a unique slot identity.
 - `SongChartHelper.GetCurrentDifficultyChart` is the existing runtime fallback from a visible difficulty slot to its chart and is useful for legacy/SET rows where a direct `ChartId` match is unavailable.
 - `SongListDisplay` already owns row index, difficulty, selection events, scroll target, and normal Song Select presentation updates.
 - `SongSelectionStage.LoadPreviewSound` / `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` already implement the preview resource and playback behavior.
-- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API.
-- `JsonRpcServer` already authenticates every JSON-RPC request and has explicit method routing.
+- `SongSelectionStage.SelectSong` owns the normal transition data but silently returns while `_game.CanPerformStageTransition()` is false, so prepared activation must surface that gate rather than clearing state first.
+- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API. `BaseGame.CaptureScreenshotAsync` demonstrates the existing `TaskCompletionSource(...RunContinuationsAsynchronously)` pattern for an awaited game-thread result.
+- `JsonRpcServer` already authenticates every JSON-RPC request and serializes public DTOs with camelCase property names.
 - `GameTelemetrySnapshot` plus `IStageTelemetryProvider` is the existing producer telemetry seam.
-- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` now owns the consumer JSON-RPC transport and keeps `SendAsync` private.
+- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` owns the consumer JSON-RPC transport and keeps `SendAsync` private.
+- `DTXMania.E2E/AutomationContractTests.cs` already performs the producer-to-`GameStateSnapshot` camelCase contract round trip and is the required place to lock the three new telemetry fields.
 
 The design should extend these seams rather than create parallel infrastructure.
 
@@ -103,6 +108,7 @@ Keep only the additional runtime fields needed for preview control:
 ```text
 PreparedPreviewState: None | Prepared | Playing | Failed
 PreparedPreviewElapsedMs: double
+_isProjectingPreparedSelection: bool
 ```
 
 No lock is required for this state because every command mutation and elapsed-time update runs on the game update thread. Game telemetry reads the same fields through the existing stage telemetry provider.
@@ -111,9 +117,12 @@ A preparation is cleared by:
 
 - `cancelPreparedChart`;
 - preparing a replacement chart;
-- normal interactive row/difficulty navigation away from the prepared selection;
-- activation;
+- normal interactive row navigation away from the prepared row;
+- normal interactive difficulty navigation away from the prepared slot;
+- successful activation after the transition gate has accepted the request;
 - stage deactivation.
+
+`_isProjectingPreparedSelection` suppresses invalidation while `prepareVideoChart` itself projects the target row/difficulty. It also suppresses the normal automatic preview load during that projection; the exact resolved chart preview is loaded explicitly afterward.
 
 Cleanup remains idempotent. `StopCurrentPreview` already nulls disposed resources, so repeated cleanup must never stop/dispose one instance twice.
 
@@ -128,14 +137,17 @@ On the update thread:
 3. Require it to be under one of `snapshot.ActiveRoots`.
 4. Recursively walk `snapshot.RootSongs` and BOX children.
 5. For each Score node, inspect the node's primary `DatabaseChart` and every chart in `DatabaseSong.Charts`.
-6. Match by normalized path using current-platform path identity rules. Never use title/artist text.
+6. Match by normalized path using the existing platform path-identity semantics. Never use title/artist text.
 7. Require exactly one visible node/chart match.
-8. Resolve the visible difficulty slot:
-   - first match the resolved `SongChart.Id` against non-zero `SongListNode.Scores[i].ChartId`;
-   - when that is unavailable, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching its normalized `FilePath` to the requested path;
-   - fail rather than guess if no unique slot can be established.
+8. Resolve the visible difficulty slot using the following precedence:
+   - collect non-null score slots whose non-zero `SongScore.ChartId` equals the resolved `SongChart.Id`;
+   - if exactly one slot matches, use it;
+   - if multiple slots share that ChartId, use the **unique DRUMS slot** when exactly one candidate has `Instrument == EInstrumentPart.DRUMS`; this is the normal one-file multi-instrument case and matches CX's drum-gameplay path;
+   - if ChartId did not establish a slot, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching that chart's normalized `FilePath` to the requested path;
+   - use the fallback only when it yields one slot; fail rather than guess if ambiguity remains.
+9. Retain the ancestor BOX chain needed to reproduce the normal browse context.
 
-The recursive walk should also retain the ancestor BOX chain needed to reproduce the normal browse context.
+The DRUMS tie-break is required because one physical DTX file can legitimately populate DRUMS/GUITAR/BASS slots with the same `SongChart.Id`. Requiring ChartId uniqueness would reject normal indexed content.
 
 This handles duplicate titles naturally because title never participates in identity. It also reuses the current SET/multi-chart mapping instead of introducing a second difficulty-order algorithm.
 
@@ -160,7 +172,7 @@ It should atomically set row + difficulty, reset the scroll target consistently,
 
 This is an internal UI convenience, not a remote navigation API.
 
-During the synchronous prepare projection, set a stage-local suppression flag so normal `OnSongSelectionChanged` presentation still runs but automatic preview loading/playback is skipped. After the target selection is established, load the resolved chart's preview explicitly.
+During prepare projection, `_isProjectingPreparedSelection` lets normal status/history/image/breadcrumb presentation update while skipping prepared-state invalidation and automatic preview loading. The flag is cleared in `finally` so a projection failure cannot leave normal Song Select behavior suppressed.
 
 ### 4. Prepared preview uses the resolved `SongChart`
 
@@ -207,26 +219,55 @@ In `SongSelectionStage.OnUpdate`, increment `PreparedPreviewElapsedMs` from `Gam
 
 If an explicitly-started instance unexpectedly stops, mark the prepared preview `Failed` rather than silently starting another source. HPA-503 will observe the state/elapsed telemetry and fail its bounded wait.
 
-### 6. Cancellation and activation reuse existing cleanup/transition paths
+### 6. Navigation invalidation returns cleanly to interactive preview behavior
 
-`cancelPreparedChart`:
+Prepared state must not survive when the visible selection no longer represents the prepared chart.
 
-- stops/disposes the current preview through existing cleanup;
-- releases the preview sound reference;
-- clears prepared identity/state/elapsed;
-- allows the normal Song Select BGM fade-in behavior to resume.
+`OnSongSelectionChanged`:
+
+- while `_isProjectingPreparedSelection` is true, do not invalidate preparation and skip its normal automatic preview load;
+- otherwise, when the selected row differs from the prepared row, clear the prepared state first, then continue the handler's existing row-selection behavior; the normal `LoadPreviewSound(e.SelectedSong)` path therefore resumes the ordinary delayed primary-chart preview.
+
+`OnDifficultyChanged`:
+
+- while `_isProjectingPreparedSelection` is true, do not invalidate preparation;
+- otherwise, when `e.NewDifficulty` differs from the prepared slot on the same row, clear the prepared state;
+- after clearing, explicitly call the existing `LoadPreviewSound(e.Song)` path so the row returns to the same primary-chart delayed preview behavior normal Song Select uses after a row selection.
+
+The difficulty-change reload is only an exit from prepared mode. Normal interactive difficulty changes when no prepared chart exists remain unchanged.
+
+### 7. Activation observes the debounce gate before consuming preparation
+
+Current `SelectSong` silently returns when `_game.CanPerformStageTransition()` is false. Prepared activation cannot clear state first and then call that method because the API could report success while no transition started.
+
+Keep one shared transition path, but separate **eligibility** from **transition start** inside `SongSelectionStage`:
+
+```text
+CanStartSongSelection(node)
+- valid Score node
+- StageManager available
+- _game.CanPerformStageTransition() == true
+
+StartSongSelection(node)
+- _game.MarkStageTransition()
+- build selectedSong / selectedDifficulty / songId shared data
+- StageManager.ChangeStage(SongTransition, ...)
+```
+
+The existing player `SelectSong` path calls these two helpers and may ignore the returned bool.
 
 `activatePreparedChart`:
 
 1. Require a current preparation.
-2. Capture the prepared node/difficulty locally.
-3. Stop/dispose the prepared preview and clear prepared state before transition audio can bleed.
-4. Ensure `_selectedSong` / `_currentDifficulty` still match the prepared selection.
-5. Call the existing `SelectSong(node)` method.
+2. Require `_selectedSong` / `_currentDifficulty` still match it.
+3. Evaluate the same transition-eligibility gate.
+4. If debounce or stage-manager availability blocks the transition, return `success=false` and **leave the preparation and preview intact**.
+5. Once eligibility succeeds, stop/dispose the prepared preview and clear prepared state.
+6. Immediately call the shared transition-start body on the same update-thread action.
 
-Do not reproduce its shared-data construction. The existing path remains the sole owner of `selectedSong`, `selectedDifficulty`, `songId`, and the transition to `SongTransitionStage`.
+Do not wait 0.5 seconds inside the game and do not duplicate the transition shared-data construction. A successful result means the normal `SongTransitionStage` change was actually started.
 
-### 7. Game API commands queue and await the update-thread result
+### 8. Game API commands queue and await the update-thread result
 
 Extend `IGameApi` / `GameApiImplementation` with four explicit methods. Keep the result contract narrow, for example:
 
@@ -238,14 +279,14 @@ PreparedChartCommandResult
 
 `GameApiImplementation` should use one private helper that:
 
-- creates a `TaskCompletionSource` with asynchronous continuations;
+- creates a `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously`;
 - queues an action through `IGameContext.QueueMainThreadAction`;
 - inside the queued action, verifies the current stage is `SongSelectionStage` and executes the requested stage command;
 - completes the task with the command result.
 
-The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not add a general main-thread dispatcher abstraction.
+The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not copy `ChangeStageAsync`'s fire-and-forget semantics and do not add a general main-thread dispatcher abstraction.
 
-### 8. JSON-RPC stays explicit and authenticated
+### 9. JSON-RPC stays explicit and authenticated
 
 Add four cases/handlers to `JsonRpcServer`:
 
@@ -262,7 +303,7 @@ Validate JSON shape in the server. Stage/domain failures may be returned as a no
 
 Do not expose any method that accepts arbitrary stage/action names or mutation payloads.
 
-### 9. Automation exposes the same four narrow operations
+### 10. Automation exposes the same four narrow operations
 
 Extend `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs` with public methods for the four commands. Reuse its private `SendAsync` transport and one small command-result parser.
 
@@ -277,9 +318,9 @@ CancelPreparedChartAsync()
 
 without accessing generic JSON-RPC.
 
-A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message.
+A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message. In particular, a debounce-blocked activation is an observable failed command rather than a silent no-op.
 
-### 10. Telemetry adds only recorder-required fields
+### 11. Telemetry adds only recorder-required fields and locks the wire names
 
 Extend `GameTelemetrySnapshot` with:
 
@@ -289,14 +330,24 @@ PreparedPreviewState
 PreparedPreviewElapsedMs
 ```
 
-`SongSelectionStage.PopulateTelemetry` supplies them only from stage-owned prepared state.
+Because `JsonRpcServer` serializes DTOs with `JsonNamingPolicy.CamelCase`, the wire contract is exactly:
+
+```text
+preparedChartIdentity
+preparedPreviewState
+preparedPreviewElapsedMs
+```
+
+`SongSelectionStage.PopulateTelemetry` supplies the producer values from stage-owned prepared state.
 
 Identity policy:
 
 - prefer `chart:<SongChart.Id>` when the indexed chart has a stable non-zero database ID;
 - otherwise use a root-relative normalized path, never the absolute song-root prefix.
 
-Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with corresponding read-only accessors. Do not expose the absolute requested path in telemetry.
+Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with read-only accessors for those exact camelCase keys.
+
+The existing `DTXMania.E2E/AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` test **must** be extended with all three producer values and assertions against all three Automation accessors. This is a required producer/consumer contract gate, not an optional extra test.
 
 Screenshot remains the render barrier: after prepare returns, HPA-503 calls the existing screenshot operation and successful image completion proves Song Select completed a Draw pass.
 
@@ -309,13 +360,13 @@ Preparation fails without leaving active prepared state for:
 - path outside every active root;
 - no exact indexed chart match;
 - ambiguous indexed match;
-- no unique visible difficulty slot;
+- no unique visible difficulty slot after the DRUMS tie-break and existing path-helper fallback;
 - missing preview declaration/file;
 - unreadable or unsupported preview resource.
 
 Start fails for no prepared chart/resource or playback creation failure.
 
-Activation fails if preparation is absent or the prepared selection is no longer the active Song Select selection.
+Activation fails if preparation is absent, the prepared selection is no longer active, the stage manager is unavailable, or the global transition debounce is active. Debounce/stage-manager failure leaves the preparation intact for retry.
 
 Cancellation is idempotent success.
 
@@ -332,15 +383,20 @@ Cover:
 - root-level exact path resolution;
 - nested BOX resolution and browse context;
 - multi-chart/SET row resolves the exact requested chart and correct difficulty slot;
+- ordinary one-file multi-instrument row where DRUMS/GUITAR/BASS slots share one ChartId resolves the unique DRUMS slot;
 - duplicate titles resolve by path;
 - outside-root and unindexed failures;
 - resolved chart preview is used even when it differs from the node's primary chart preview;
 - missing/unreadable/unsupported preview failure;
 - prepare leaves preview loaded but stopped and suppresses automatic timer playback;
+- prepare projection does not invalidate itself through `SelectionChanged`/`DifficultyChanged`;
 - repeated start creates only one instance;
 - elapsed time advances only while the instance reports Playing;
+- row navigation away clears prepared state and resumes normal row preview behavior;
+- difficulty navigation away clears prepared state and resumes the normal primary-chart delayed preview;
 - cancel, replacement, user navigation, and Deactivate clean up exactly once;
-- activation stops preview before reusing `SelectSong`;
+- activation while debounce is blocked returns failure, starts no transition, and preserves prepared state/preview;
+- activation after the gate is available clears preview and reuses the existing transition data path;
 - normal interactive preview delay/loop/BGM behavior remains unchanged with no prepared chart.
 
 ### Game API / JSON-RPC
@@ -350,7 +406,8 @@ Cover:
 - command action is queued to the main thread and the returned task completes after execution;
 - command rejects non-SongSelect current stage;
 - `prepareVideoChart` parameter validation;
-- authenticated JSON-RPC routing and success/failure result shape.
+- authenticated JSON-RPC routing and success/failure result shape;
+- debounce-blocked activation propagates `success=false` instead of returning a queued-success result.
 
 ### Automation contract
 
@@ -358,16 +415,16 @@ Cover:
 
 - each new public client method sends the expected method/params;
 - command failure text is propagated;
-- prepared telemetry accessors deserialize from game JSON.
+- `AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` includes `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs` and proves the Automation accessors read them.
 
 Use existing unit-test seams and mocks. No real MonoGame window, OBS server, or recorder CLI is required for HPA-510 unit coverage.
 
 ## Expected Scope
 
-This should remain one implementation PR, approximately 2–3 engineer days:
+This remains one implementation PR, approximately 2–3 engineer days:
 
 - exact resolver + browse projection;
-- prepared preview lifecycle + telemetry;
+- prepared preview lifecycle + navigation/debounce-safe activation + telemetry;
 - explicit Game API/JSON-RPC/Automation wiring;
 - focused regression/contract tests.
 

--- a/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
+++ b/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
@@ -1,0 +1,374 @@
+# HPA-510 Prepared Chart Recording Commands Design
+
+**Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
+**Date:** 2026-08-11  
+**Status:** Draft for implementation review
+
+## Context
+
+HPA-501 has landed on `main`, so the reusable `DTXMania.Automation` process and JSON-RPC foundation is available. HPA-510 is now the only code prerequisite blocking HPA-503, the Windows recording vertical slice.
+
+The recorder does not need general remote control of the game. It needs four narrow operations while Song Select is active:
+
+```text
+prepareVideoChart(chartPath)
+startPreparedPreview()
+activatePreparedChart()
+cancelPreparedChart()
+```
+
+The implementation should make one exact indexed chart visible through the normal Song Select UI, hold its declared preview audio ready but stopped, play that preview under explicit recorder control, and then activate the chart through the same path a player uses.
+
+This design deliberately keeps recording preparation inside `SongSelectionStage`. It does not add a game-wide capture session, generic mutation API, recorder state machine, database query layer, or synthetic input navigation.
+
+## Goals
+
+- Resolve one caller-supplied **absolute chart path** to the exact chart already present in the active Song Select library.
+- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, and duplicate titles.
+- Project the resolved chart through the existing Song Select presentation path so status, preview image, play history, selected row, difficulty, and breadcrumb are normal UI state.
+- Load the preview declared by the **resolved chart**, not merely the node's primary chart.
+- Keep the prepared preview stopped until explicitly started.
+- Reuse the existing preview sound resource, volume, looping, and BGM fade behavior.
+- Keep all stage mutations on the game update thread.
+- Activate through the existing `SongSelectionStage.SelectSong` transition path.
+- Expose only the prepared identity/state/elapsed telemetry required by HPA-503.
+- Extend `DTXMania.Automation` with the four explicit client calls so HPA-503 never needs access to the private generic JSON-RPC transport.
+
+## Non-goals
+
+- A general Song Select remote-navigation API.
+- A generic command dispatcher or arbitrary main-thread mutation endpoint.
+- A game-wide recording/capture coordinator or immutable recording session ID.
+- A separate render-generation/readiness state machine. Screenshot completion remains the presentation barrier.
+- OBS, process launch, app-data sandboxing, Result hold timing, or video artifact handling.
+- Changing the normal interactive preview delay or primary-chart preview behavior when no prepared chart is active.
+- Restoring a pre-command filter/tab/breadcrumb after cancellation. The recorder runs in disposable app data; snapshot/restore machinery is unnecessary for MVP.
+- Direct transition to Performance.
+
+## Current Reuse Survey
+
+The required building blocks already exist:
+
+- `SongSelectionStage` owns selection, BOX navigation, status/history/preview UI, preview sound lifecycle, BGM fading, and the player activation path.
+- `SongSelectionStage` already retains the coherent applied `SongLibrarySnapshot`, including `RootSongs` and canonical `ActiveRoots`.
+- `SongSelectionStage.GetNodeChartPaths` already understands that a visible row can represent the primary `DatabaseChart` plus additional `DatabaseSong.Charts`.
+- `SongPathIdentity` already owns path normalization and root containment semantics.
+- `SongListNode.Scores` carries difficulty slots; persisted multi-chart rows carry `SongScore.ChartId`.
+- `SongChartHelper.GetCurrentDifficultyChart` is the existing runtime fallback from a visible difficulty slot to its chart and is useful for legacy/SET rows where a direct `ChartId` match is unavailable.
+- `SongListDisplay` already owns row index, difficulty, selection events, scroll target, and normal Song Select presentation updates.
+- `SongSelectionStage.LoadPreviewSound` / `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` already implement the preview resource and playback behavior.
+- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API.
+- `JsonRpcServer` already authenticates every JSON-RPC request and has explicit method routing.
+- `GameTelemetrySnapshot` plus `IStageTelemetryProvider` is the existing producer telemetry seam.
+- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` now owns the consumer JSON-RPC transport and keeps `SendAsync` private.
+
+The design should extend these seams rather than create parallel infrastructure.
+
+## Approaches Considered
+
+### 1. Stage-owned prepared state plus four explicit commands — selected
+
+Add a small amount of state and four command methods to `SongSelectionStage`, expose them through explicit Game API / JSON-RPC handlers, and add matching methods to `DTXMania.Automation`.
+
+This gives HPA-503 exactly what it needs while preserving the normal Song Select and transition paths.
+
+### 2. Recorder drives Song Select with repeated key input — rejected
+
+This is already the failure mode HPA-510 exists to remove. It is slow, fragile with nested boxes/filter state, and cannot safely disambiguate duplicate titles.
+
+### 3. Add a general game automation/session coordinator — rejected
+
+HPA-503 owns orchestration. A second lifecycle/session abstraction inside the game would duplicate ownership before a second use case proves it useful.
+
+### 4. Resolve chart paths through a new database repository/service — rejected
+
+The active `SongLibrarySnapshot` is already the authoritative, coherent view used by Song Select. A second DB query path could disagree with the rendered hierarchy and would add unnecessary synchronization.
+
+## Chosen Architecture
+
+### 1. Prepared state is update-thread-owned by `SongSelectionStage`
+
+Keep a minimal stage-local record for the current preparation, for example:
+
+```text
+PreparedChartSelection
+- SongListNode node
+- SongChart chart
+- int difficultyIndex
+- string telemetryIdentity
+```
+
+Keep only the additional runtime fields needed for preview control:
+
+```text
+PreparedPreviewState: None | Prepared | Playing | Failed
+PreparedPreviewElapsedMs: double
+```
+
+No lock is required for this state because every command mutation and elapsed-time update runs on the game update thread. Game telemetry reads the same fields through the existing stage telemetry provider.
+
+A preparation is cleared by:
+
+- `cancelPreparedChart`;
+- preparing a replacement chart;
+- normal interactive row/difficulty navigation away from the prepared selection;
+- activation;
+- stage deactivation.
+
+Cleanup remains idempotent. `StopCurrentPreview` already nulls disposed resources, so repeated cleanup must never stop/dispose one instance twice.
+
+### 2. Exact chart resolution uses the applied library snapshot
+
+`prepareVideoChart` accepts only a non-empty, fully-qualified path.
+
+On the update thread:
+
+1. Require Song Select to have an applied `SongLibrarySnapshot`.
+2. Normalize the requested chart path with `SongPathIdentity`.
+3. Require it to be under one of `snapshot.ActiveRoots`.
+4. Recursively walk `snapshot.RootSongs` and BOX children.
+5. For each Score node, inspect the node's primary `DatabaseChart` and every chart in `DatabaseSong.Charts`.
+6. Match by normalized path using current-platform path identity rules. Never use title/artist text.
+7. Require exactly one visible node/chart match.
+8. Resolve the visible difficulty slot:
+   - first match the resolved `SongChart.Id` against non-zero `SongListNode.Scores[i].ChartId`;
+   - when that is unavailable, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching its normalized `FilePath` to the requested path;
+   - fail rather than guess if no unique slot can be established.
+
+The recursive walk should also retain the ancestor BOX chain needed to reproduce the normal browse context.
+
+This handles duplicate titles naturally because title never participates in identity. It also reuses the current SET/multi-chart mapping instead of introducing a second difficulty-order algorithm.
+
+### 3. Reuse normal browse navigation, but do not synthesize input
+
+Preparation must leave Song Select in a normal browse context with the target row visible.
+
+Use existing stage behavior:
+
+1. Switch to the All Songs projection and clear the active search/filter projection for this recorder operation.
+2. Return to the root browse list and clear the navigation stack.
+3. Reuse `NavigateIntoBox` for each resolved ancestor BOX so the normal breadcrumb/current-list state is rebuilt.
+4. Select the target row and difficulty through `SongListDisplay`.
+
+Add one narrow programmatic selection method to `SongListDisplay`, such as:
+
+```text
+SetSelection(index, difficulty)
+```
+
+It should atomically set row + difficulty, reset the scroll target consistently, and raise the existing `SelectionChanged` path once. This avoids the current property-order problem where `CurrentList` can temporarily select row 0 and load the wrong preview before the final index is applied.
+
+This is an internal UI convenience, not a remote navigation API.
+
+During the synchronous prepare projection, set a stage-local suppression flag so normal `OnSongSelectionChanged` presentation still runs but automatic preview loading/playback is skipped. After the target selection is established, load the resolved chart's preview explicitly.
+
+### 4. Prepared preview uses the resolved `SongChart`
+
+This is the one place where blindly reusing current interactive preview loading is incorrect: `LoadPreviewSound(SongListNode)` reads `selectedNode.DatabaseChart`, which is the row's primary chart and may not be the chart selected by the recorder.
+
+Extract/reuse the existing path/load primitives so prepared loading can accept the exact resolved `SongChart`:
+
+```text
+SongChart.FilePath directory
++ SongChart.PreviewFile
+-> absolute preview path
+-> existing TryLoadPreviewSoundFile
+```
+
+Prepare fails clearly when:
+
+- `PreviewFile` is absent;
+- the resolved preview file does not exist;
+- the resource manager reports a load failure or unsupported asset.
+
+After successful load:
+
+- `_previewSound` is retained exactly as today;
+- automatic preview delay is disabled while a prepared chart exists;
+- no preview instance is created;
+- preview state becomes `Prepared`;
+- elapsed time is zero.
+
+Normal interactive preview behavior remains unchanged when no preparation exists.
+
+### 5. Explicit start owns exactly one looped preview instance
+
+`startPreparedPreview` requires a prepared chart and loaded preview resource.
+
+Reuse `CreatePreviewSoundInstance`, `SongSelectionUILayout.Audio.PreviewSoundVolume`, looping, `Play()`, and `StartBGMFade(true)`.
+
+Behavior:
+
+- first successful start creates one instance, sets volume/looping, plays, resets elapsed to zero, and reports `Playing`;
+- a repeated start while already playing is idempotent success and does not create another instance;
+- creation/playback failure disposes any partial instance, reports `Failed`, and never substitutes Song Select BGM or full-song audio.
+
+In `SongSelectionStage.OnUpdate`, increment `PreparedPreviewElapsedMs` from `GameTime.ElapsedGameTime` only when prepared state is `Playing` **and** the sound instance currently reports `SoundState.Playing`.
+
+If an explicitly-started instance unexpectedly stops, mark the prepared preview `Failed` rather than silently starting another source. HPA-503 will observe the state/elapsed telemetry and fail its bounded wait.
+
+### 6. Cancellation and activation reuse existing cleanup/transition paths
+
+`cancelPreparedChart`:
+
+- stops/disposes the current preview through existing cleanup;
+- releases the preview sound reference;
+- clears prepared identity/state/elapsed;
+- allows the normal Song Select BGM fade-in behavior to resume.
+
+`activatePreparedChart`:
+
+1. Require a current preparation.
+2. Capture the prepared node/difficulty locally.
+3. Stop/dispose the prepared preview and clear prepared state before transition audio can bleed.
+4. Ensure `_selectedSong` / `_currentDifficulty` still match the prepared selection.
+5. Call the existing `SelectSong(node)` method.
+
+Do not reproduce its shared-data construction. The existing path remains the sole owner of `selectedSong`, `selectedDifficulty`, `songId`, and the transition to `SongTransitionStage`.
+
+### 7. Game API commands queue and await the update-thread result
+
+Extend `IGameApi` / `GameApiImplementation` with four explicit methods. Keep the result contract narrow, for example:
+
+```text
+PreparedChartCommandResult
+- bool Success
+- string? Error
+```
+
+`GameApiImplementation` should use one private helper that:
+
+- creates a `TaskCompletionSource` with asynchronous continuations;
+- queues an action through `IGameContext.QueueMainThreadAction`;
+- inside the queued action, verifies the current stage is `SongSelectionStage` and executes the requested stage command;
+- completes the task with the command result.
+
+The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not add a general main-thread dispatcher abstraction.
+
+### 8. JSON-RPC stays explicit and authenticated
+
+Add four cases/handlers to `JsonRpcServer`:
+
+```text
+prepareVideoChart   params: { chartPath: string }
+startPreparedPreview
+activatePreparedChart
+cancelPreparedChart
+```
+
+The existing server-level API-key check already protects them.
+
+Validate JSON shape in the server. Stage/domain failures may be returned as a normal command result (`success=false`, sanitized `error`) so callers receive useful failure text without adding a new JSON-RPC error taxonomy.
+
+Do not expose any method that accepts arbitrary stage/action names or mutation payloads.
+
+### 9. Automation exposes the same four narrow operations
+
+Extend `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs` with public methods for the four commands. Reuse its private `SendAsync` transport and one small command-result parser.
+
+HPA-503 should be able to call:
+
+```text
+PrepareVideoChartAsync(path)
+StartPreparedPreviewAsync()
+ActivatePreparedChartAsync()
+CancelPreparedChartAsync()
+```
+
+without accessing generic JSON-RPC.
+
+A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message.
+
+### 10. Telemetry adds only recorder-required fields
+
+Extend `GameTelemetrySnapshot` with:
+
+```text
+PreparedChartIdentity
+PreparedPreviewState
+PreparedPreviewElapsedMs
+```
+
+`SongSelectionStage.PopulateTelemetry` supplies them only from stage-owned prepared state.
+
+Identity policy:
+
+- prefer `chart:<SongChart.Id>` when the indexed chart has a stable non-zero database ID;
+- otherwise use a root-relative normalized path, never the absolute song-root prefix.
+
+Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with corresponding read-only accessors. Do not expose the absolute requested path in telemetry.
+
+Screenshot remains the render barrier: after prepare returns, HPA-503 calls the existing screenshot operation and successful image completion proves Song Select completed a Draw pass.
+
+## Failure Semantics
+
+Preparation fails without leaving active prepared state for:
+
+- blank or non-absolute path;
+- library not ready;
+- path outside every active root;
+- no exact indexed chart match;
+- ambiguous indexed match;
+- no unique visible difficulty slot;
+- missing preview declaration/file;
+- unreadable or unsupported preview resource.
+
+Start fails for no prepared chart/resource or playback creation failure.
+
+Activation fails if preparation is absent or the prepared selection is no longer the active Song Select selection.
+
+Cancellation is idempotent success.
+
+Errors should describe the category without publishing an absolute path into telemetry/log snapshots intended for recorder diagnostics.
+
+## Testing Strategy
+
+Add focused tests rather than a second end-to-end framework.
+
+### Song Select
+
+Cover:
+
+- root-level exact path resolution;
+- nested BOX resolution and browse context;
+- multi-chart/SET row resolves the exact requested chart and correct difficulty slot;
+- duplicate titles resolve by path;
+- outside-root and unindexed failures;
+- resolved chart preview is used even when it differs from the node's primary chart preview;
+- missing/unreadable/unsupported preview failure;
+- prepare leaves preview loaded but stopped and suppresses automatic timer playback;
+- repeated start creates only one instance;
+- elapsed time advances only while the instance reports Playing;
+- cancel, replacement, user navigation, and Deactivate clean up exactly once;
+- activation stops preview before reusing `SelectSong`;
+- normal interactive preview delay/loop/BGM behavior remains unchanged with no prepared chart.
+
+### Game API / JSON-RPC
+
+Cover:
+
+- command action is queued to the main thread and the returned task completes after execution;
+- command rejects non-SongSelect current stage;
+- `prepareVideoChart` parameter validation;
+- authenticated JSON-RPC routing and success/failure result shape.
+
+### Automation contract
+
+Cover:
+
+- each new public client method sends the expected method/params;
+- command failure text is propagated;
+- prepared telemetry accessors deserialize from game JSON.
+
+Use existing unit-test seams and mocks. No real MonoGame window, OBS server, or recorder CLI is required for HPA-510 unit coverage.
+
+## Expected Scope
+
+This should remain one implementation PR, approximately 2–3 engineer days:
+
+- exact resolver + browse projection;
+- prepared preview lifecycle + telemetry;
+- explicit Game API/JSON-RPC/Automation wiring;
+- focused regression/contract tests.
+
+If implementation starts producing a generic automation framework, recorder session object, or alternate Song Select data model, reduce scope back to the stage-owned four-command contract above.


### PR DESCRIPTION
## Summary

Planning-only PR for HPA-510: **Add minimal prepared-chart recording commands in Song Select**.

HPA-501 is now merged, which leaves HPA-510 as the remaining prerequisite for HPA-503's Windows recorder vertical slice.

This PR adds:

- `docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md`
- `docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md`

## Design direction

- Keep prepared-chart state owned by `SongSelectionStage`.
- Add only four explicit commands: prepare, start preview, activate, cancel.
- Resolve exact indexed charts from the applied `SongLibrarySnapshot` by normalized path; never by title.
- Reuse existing BOX navigation, difficulty mapping, preview sound lifecycle, BGM fades, main-thread action queue, `SelectSong -> SongTransitionStage`, telemetry, and HPA-501 Automation JSON-RPC transport.
- Add no recorder session/state-machine abstraction, DB query layer, generic mutation API, or synthetic-input navigation.
- Load the preview from the exact resolved `SongChart`, which matters for multi-chart/SET rows where the node's primary chart may differ from the requested difficulty.
- Treat screenshot completion as the render barrier; no extra render-ready generation state.

## Implementation shape

The plan keeps the implementation to one 2–3 engineer-day PR:

1. Exact active-library resolver + normal Song Select browse projection.
2. Prepared preview lifecycle + activation + three telemetry fields.
3. Explicit Game API / JSON-RPC / `DTXMania.Automation` wrappers.
4. Focused regression/contract validation.

## Validation

Docs-only change. Compared against `main`: two added planning documents, no production files changed.

No tests run because this PR contains documentation only.

Linear: https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select

This planning PR does not close HPA-510; the follow-up implementation PR will execute the approved plan.