### PR TITLE
feat: add prepared chart recording commands

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,6 +163,13 @@ jobs:
     - name: Run Automation tests on macOS
       run: dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug --verbosity normal --logger trx --results-directory ./TestResults/Automation
 
+    - name: Run prepared-chart audio E2E on macOS
+      env:
+        ALSOFT_DRIVERS: 'null'
+        DTXMANIA_E2E_GAME_PROJECT: DTXMania.Game/DTXMania.Game.Mac.csproj
+        DTXMANIA_E2E_ARTIFACT_ROOT: TestResults/e2e-audio
+      run: dotnet test DTXMania.E2E/DTXMania.E2E.csproj --configuration Debug --verbosity normal --logger trx --results-directory ./TestResults/e2e-audio --filter "Category=AudioE2E"
+
     - name: Locate coverage report on macOS
       if: always()
       shell: bash

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-2-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-2-report.md
@@ -58,3 +58,37 @@ After the minimal stage and telemetry implementation (and the final three lifecy
 - Verification ran on the macOS-safe .NET test project. Windows build and out-of-process E2E execution remain for the stacked branch's integration verification.
 - A successful real MonoGame `SoundEffectInstance` start cannot be fully unit-tested without an audio device because the underlying type is sealed; tests cover instance-creation failure, idempotent existing playback, cleanup, elapsed-state transitions, and the full normal-path state machine. Task 3/native E2E should provide the real-audio acceptance evidence.
 - The focused rebuild still surfaces the repository's existing 539 compiler/analyzer warnings; the clean no-build focused, regression, and full-suite evidence is warning-free, and no Task 2 warning was introduced.
+
+## Fix Round 1 — preserve ordinary preview ownership on no-op commands
+
+### What changed
+
+- Added `ClearPreparedPreviewStateIfOwned`, keyed by the non-null prepared selection identity. `CancelPreparedChart` now succeeds as an idempotent no-op when Song Select has only its ordinary primary-chart preview, and invalid `PrepareVideoChart` input no longer tears down that ordinary preview before validation.
+- Prepared replacement still uses the existing cleanup path when a prepared selection is actually owned. Deactivation and navigation retain their existing regular preview teardown behavior.
+
+### Tests
+
+- Updated `DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs` with focused tests proving cancel-without-preparation and invalid-prepare-without-preparation preserve the preview sound, instance, delay timer, fade state, and disposal/reference counts.
+- Changed production code only in `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`; this report was appended as required.
+
+### TDD RED
+
+After adding the two tests before the production guard:
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-restore -v:minimal`
+
+Result: **14 passed, 2 failed**. Both new tests observed `_previewSound` cleared (`Expected: Mock<ISound>.Object; Actual: null`), demonstrating the unconditional cleanup defect. The rebuild emitted **539 repository-pre-existing warnings**; no warning referenced the new tests or guard.
+
+### TDD GREEN
+
+After the ownership guard:
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-build --no-restore -v:minimal`
+
+Result: **16 tests passed, 0 warnings**.
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStage|FullyQualifiedName~SongListDisplay" --no-build --no-restore -v:minimal`
+
+Result: **668 tests passed, 0 warnings**.
+
+The only warning-bearing command was the required rebuild above; its 539 warnings match the pre-existing repository warning inventory from the Task 2 baseline and none point to this fix.

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-2-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-2-report.md
@@ -92,3 +92,41 @@ Result: **16 tests passed, 0 warnings**.
 Result: **668 tests passed, 0 warnings**.
 
 The only warning-bearing command was the required rebuild above; its 539 warnings match the pre-existing repository warning inventory from the Task 2 baseline and none point to this fix.
+
+## Fix Round 2 — stop ordinary preview before validated prepared replacement
+
+### What changed
+
+- Added a focused first-time prepare test that starts with an ordinary interactive preview sound and playing instance, then verifies the old instance is stopped/disposed exactly once, the old sound reference is released, and the newly prepared sound remains stopped in `Prepared` state.
+- After chart resolution, preview declaration/path validation, and file existence checks succeed, `PrepareVideoChart` now tears down any ordinary preview resource/instance before projection and `TryLoadPreviewSoundFile` can replace the sound. Invalid input still returns before teardown and preserves ordinary preview ownership.
+
+### Tests
+
+- Updated `DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs` with `PrepareVideoChart_WhenReplacingPlayingInteractivePreview_StopsOldInstanceBeforePublishingPrepared`.
+- Changed production code only in `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`; this report was appended as required.
+
+### TDD RED
+
+After adding the valid first-prepare test before the ordering fix:
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-restore -v:minimal`
+
+Result: **16 passed, 1 failed**. The new test observed zero calls to the ordinary instance's `Stop()` (`Expected invocation once ... x => x.Stop(); Performed invocations: none`), proving the first valid prepare left the prior preview playing. This rebuild printed **539 pre-existing warnings**; no warning referenced the new test or changed production lines.
+
+### TDD GREEN
+
+After moving ordinary-preview teardown after successful chart/path validation and before projection/sound replacement:
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-restore -v:minimal`
+
+Result: **17 tests passed, 139 warnings**. The warning inventory is unchanged repository noise and contains no changed Task 2 lines: `CS8632=54`, `CS8625=52`, `EF1002=6`, `CS8603=9`, `CS8618=7`, `CS8602=8`, `CS8524=1`, `CS8601=1`, `CS8604=1` (139 total).
+
+Clean GREEN evidence:
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-build --no-restore -v:minimal`
+
+Result: **17 tests passed, 0 warnings**.
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStage|FullyQualifiedName~SongListDisplay" --no-build --no-restore -v:minimal`
+
+Result: **669 tests passed, 0 warnings**.

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-2-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-2-report.md
@@ -1,0 +1,60 @@
+# Task 2 report — prepared preview lifecycle, activation, and telemetry
+
+## Implementation summary
+
+- Added stage-owned prepared selection, preview state, and elapsed-time fields. `PrepareVideoChart` resolves the exact Task 1 chart, loads its declared preview file, projects the row/difficulty, explicitly disables the ordinary preview delay, and publishes `Prepared` only after every step succeeds.
+- Added synchronous stage seams `PrepareVideoChart`, `StartPreparedPreview`, `ActivatePreparedChart`, and `CancelPreparedChart`, returning `(bool Success, string Error)` for Task 3 to map into its API result type.
+- Added idempotent start/cancel/replace/deactivate cleanup through the existing stop, dispose, reference-release, and BGM-fade paths. Prepared playback is looped at the existing preview volume, starts only on command, does not auto-restart or substitute the primary preview, and marks itself `Failed` after an unexpected stop.
+- Added navigation invalidation: projection suppresses teardown/loading; leaving the prepared row clears state and resumes ordinary preview behavior; leaving the prepared difficulty clears state and reloads the normal primary-chart preview.
+- Refactored normal and prepared activation through one eligibility gate and one SongTransition start body. Blocked activation preserves the prepared resource/state for retry.
+- Added producer telemetry for exact chart identity, prepared preview state, and actual-playing elapsed milliseconds. Chart IDs use `chart:<id>`; zero-ID charts use an active-root-relative normalized path, never an absolute path.
+
+## Files changed
+
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+- `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
+- `DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs`
+
+## Tests and outputs
+
+- Focused rebuild and test:
+  `rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-restore -v:minimal`
+  Result: **14 tests passed**. The rebuild printed **539 warnings**, all pre-existing outside the Task 2 additions; no warning referenced the new lifecycle test, telemetry fields, or lifecycle implementation region. Warning-code counts: `CS8625=177`, `CS8602=114`, `CS8632=54`, `CS8604=47`, `CS8600=23`, `CS0067=24`, `CS8603=13`, `CS8618=8`, `xUnit2013=14`, `xUnit1012=9`, `CS8620=6`, `EF1002=6`, `xUnit1031=6`, `xUnit1026=5`, `xUnit2031=4`, `SYSLIB0050=3`, `xUnit2000=3`, `CS8601=3`, `CA1416=2`, `CS0219=2`, `CS0649=2`, `xUnit2009=2`, `xUnit2012=7`, `xUnit2017=2`, `CS8605=1`, `CS8524=1`, `CS8123=1` (539 total).
+- Clean focused GREEN evidence:
+  `rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-build --no-restore -v:minimal`
+  Result: **14 tests passed, 0 warnings**.
+- Song Select/display regression:
+  `rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStage|FullyQualifiedName~SongListDisplay" --no-build --no-restore -v:minimal`
+  Result: **666 tests passed, 0 warnings**.
+- Full host-appropriate Mac-safe suite:
+  `rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --no-build --no-restore -v:minimal`
+  Result: **8,185 tests passed, 0 warnings**.
+- `rtk git diff --check` passed.
+
+## TDD RED command/output and why expected
+
+After writing the lifecycle/activation/telemetry tests first, before adding the Task 2 production state and seams:
+
+`rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreparedChartLifecycleTests" --no-build --no-restore -v:minimal`
+
+Result: **0 passed, 11 failed**. The tests intentionally exercised the not-yet-present `PrepareVideoChart`, `StartPreparedPreview`, `CancelPreparedChart`, and `ActivatePreparedChart` seams plus `_preparedChartSelection`/`_preparedPreviewState`; the expected reflection/member failures demonstrated the missing lifecycle behavior before production implementation.
+
+## TDD GREEN command/output
+
+After the minimal stage and telemetry implementation (and the final three lifecycle coverage tests), the clean no-build command above passed **14 tests with 0 warnings**. The Song Select/display regression and full Mac-safe suite also passed with 0 warnings.
+
+## Self-review
+
+- Preparation failure clears old resources/state and publishes no active preparation. The normal delay timer is explicitly reset after the helper succeeds, so waiting cannot start prepared audio.
+- Start is idempotent while the actual instance reports `Playing`; elapsed time advances only in that state, and an unexpected stop becomes `Failed` without fallback playback.
+- One cleanup path is shared by cancellation, replacement, row/difficulty invalidation, blocked-success boundary, activation, and deactivation; repeated calls release each mock resource once.
+- `_isProjectingPreparedSelection` covers the complete projection, preserving the exact preview and suppressing normal selection stop/load cycles. Outside prepared mode, existing delayed primary-chart preview behavior remains covered by regression tests.
+- Activation checks row/difficulty identity, stage-manager availability, and transition debounce before cleanup; successful activation reuses the existing shared data and `InstantTransition` SongTransition construction.
+- Telemetry exposes only the chart identity policy and actual prepared state/timing; no absolute filesystem path is published.
+- No `DTXManiaNX` files were modified.
+
+## Concerns
+
+- Verification ran on the macOS-safe .NET test project. Windows build and out-of-process E2E execution remain for the stacked branch's integration verification.
+- A successful real MonoGame `SoundEffectInstance` start cannot be fully unit-tested without an audio device because the underlying type is sealed; tests cover instance-creation failure, idempotent existing playback, cleanup, elapsed-state transitions, and the full normal-path state machine. Task 3/native E2E should provide the real-audio acceptance evidence.
+- The focused rebuild still surfaces the repository's existing 539 compiler/analyzer warnings; the clean no-build focused, regression, and full-suite evidence is warning-free, and no Task 2 warning was introduced.

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-3-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-3-report.md
@@ -66,3 +66,29 @@ The final full Mac-safe suite passed after all test additions: `8,203 tests pass
 ## Concerns
 
 Unexpected exceptions in queueing or stage execution resolve to the deliberately generic safe message `The prepared chart command could not be completed.`; no structured error taxonomy was introduced because this ticket has no branching caller.
+
+## Fix Round 1 — cross-platform JSON-RPC test paths
+
+Changed only the two JSON-RPC test files. The production handler already enforces the intended fully-qualified-path contract, so the Windows-only failure could not be reproduced honestly on this macOS host. Each valid-path fixture now uses one `Path.GetFullPath(Path.Combine("safe", "chart.dtx"))` value for mock setup, serialized request, and verification, with an explicit `Path.IsPathFullyQualified` assertion.
+
+Focused verification:
+
+```text
+rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerInternalTests.HandlePrepareVideoChart" --no-restore
+  2 tests passed, 0 warnings
+
+rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerInternalTests.RouteMethodCall_PreparedChartCommands" --no-restore
+  3 tests passed, 0 warnings
+
+rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerValidationTests.PreparedChart" --no-restore
+  2 tests passed, 0 warnings
+
+rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerValidationTests.PrepareVideoChart_InvalidParams" --no-restore
+  4 tests passed, 0 warnings
+
+Total exact JSON-RPC focus: 11 tests passed, 0 warnings.
+rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --no-restore --no-build
+  8,203 tests passed, 0 warnings
+```
+
+No production files changed in this fix round; the platform-qualified fixture now reaches the mocked API on both Unix and Windows path implementations.

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-3-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-3-report.md
@@ -74,20 +74,20 @@ Changed only the two JSON-RPC test files. The production handler already enforce
 Focused verification:
 
 ```text
-rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerInternalTests.HandlePrepareVideoChart" --no-restore
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerInternalTests.HandlePrepareVideoChart" --no-restore
   2 tests passed, 0 warnings
 
-rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerInternalTests.RouteMethodCall_PreparedChartCommands" --no-restore
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerInternalTests.RouteMethodCall_PreparedChartCommands" --no-restore
   3 tests passed, 0 warnings
 
-rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerValidationTests.PreparedChart" --no-restore
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerValidationTests.PreparedChart" --no-restore
   2 tests passed, 0 warnings
 
-rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerValidationTests.PrepareVideoChart_InvalidParams" --no-restore
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~JsonRpcServerValidationTests.PrepareVideoChart_InvalidParams" --no-restore
   4 tests passed, 0 warnings
 
 Total exact JSON-RPC focus: 11 tests passed, 0 warnings.
-rtk dotnet test DTXmania.Test/DTXmania.Test.Mac.csproj --no-restore --no-build
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --no-restore --no-build
   8,203 tests passed, 0 warnings
 ```
 

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-3-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-3-report.md
@@ -1,0 +1,68 @@
+# Task 3 report — explicit Game API, JSON-RPC, Automation, and telemetry
+
+## Implementation
+
+Committed as `feat: expose prepared chart automation commands`.
+
+Added the four `IGameApi` prepared-chart operations and `PreparedChartCommandResult`. `GameApiImplementation` now queues each operation to the game update thread, verifies that the current stage is `SongSelectionStage`, awaits the real stage result with `TaskCompletionSource` configured with `RunContinuationsAsynchronously`, and returns safe failure text for wrong-stage/queue failures.
+
+Added explicit authenticated JSON-RPC routes for `prepareVideoChart`, `startPreparedPreview`, `activatePreparedChart`, and `cancelPreparedChart`. Prepare parameters require a non-blank fully qualified `chartPath`; domain failures remain `{ success, error }` results in the existing JSON-RPC envelope.
+
+Added four `JsonRpcGameClient` wrappers over the existing private `SendAsync`, one command-result parser that throws `InvalidOperationException` with the server error text, and the three `GameStateSnapshot` telemetry accessors. Extended the producer/consumer camelCase round-trip contract with non-default prepared-chart values.
+
+Changed files:
+
+- `DTXMania.Game/Lib/GameApi.cs`
+- `DTXMania.Game/Lib/GameApiImplementation.cs`
+- `DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs`
+- `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
+- `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
+- `DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs`
+- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs`
+- `DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs`
+- `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs`
+- `DTXMania.E2E/AutomationContractTests.cs`
+
+## TDD evidence
+
+RED was observed before implementation:
+
+```text
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~GameApiPreparedChartCommandTests" --no-restore
+```
+
+The build failed with the expected missing-contract errors (`GameApiImplementation` had no `Prepare/Start/Activate/Cancel...Async`, `IGameApi` had no corresponding methods, and `PreparedChartCommandResult` was undefined); 0 tests ran.
+
+GREEN focused runs:
+
+```text
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~GameApiPreparedChartCommandTests" --no-restore
+  4 tests passed (existing project warnings only)
+
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~JsonRpcServerValidationTests.PreparedChart|FullyQualifiedName~JsonRpcServerInternalTests.HandlePrepareVideoChart|FullyQualifiedName~JsonRpcServerInternalTests.RouteMethodCall_PreparedChartCommands" --no-restore
+  11 tests passed (existing project warnings only)
+
+rtk dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --no-restore
+  64 tests passed, 0 warnings
+
+rtk dotnet test DTXMania.E2E/DTXMania.E2E.csproj \
+  --filter "FullyQualifiedName~AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip" --no-restore
+  1 test passed, 0 warnings
+```
+
+The final full Mac-safe suite passed after all test additions: `8,203 tests passed, 539 existing warnings` (no new warning or error was reported for this change).
+
+## Self-review
+
+- Update-thread ownership is preserved: all four commands mutate only inside the queued action, and the returned task remains incomplete until that action runs.
+- Wrong-stage, stage-domain, and debounce failures return `Success=false` with safe text; the actual stage result is not replaced by queued-success.
+- The existing JSON-RPC authentication and envelope remain in force. No generic dispatcher, session abstraction, error-code enum, or unrelated route was added.
+- RPC method names, `chartPath`, `success`, `error`, and the three telemetry camelCase names are covered by focused tests and the producer/consumer round trip.
+- Telemetry identity remains the stage-provided non-absolute chart identity; command failures do not echo chart paths.
+
+## Concerns
+
+Unexpected exceptions in queueing or stage execution resolve to the deliberately generic safe message `The prepared chart command could not be completed.`; no structured error taxonomy was introduced because this ticket has no branching caller.

--- a/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-4-report.md
+++ b/.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-4-report.md
@@ -1,0 +1,126 @@
+# Task 4 report — prepared-chart regression suite and live smoke
+
+## Status
+
+Implemented and verified the HPA-510 fixture contract plus one narrow prepared-chart `Category=E2E` smoke. The test uses the existing fixture builder, game launch bundle, JSON-RPC client, `Eventually`, and artifact writer; it does not add a recorder, fake OBS service, persistence assertions, or a second E2E harness.
+
+## Implementation and files
+
+- `DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs`
+  - Declares the existing generated `autoplay-tone.wav` as `#PREVIEW` in the generated chart.
+- `DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs`
+  - Asserts the generated chart contains the `#PREVIEW` declaration using `E2EFixtureBuilder.AudioFileName`.
+- `DTXMania.E2E/PreparedChartRecordingSmokeTests.cs`
+  - Launches an isolated fixture and enters Song Select through the normal Title → SongSelect path.
+  - Prepares the exact absolute chart path, requires and saves a non-empty screenshot, waits beyond the one-second automatic preview delay, and asserts `Prepared` with elapsed `0`.
+  - Starts the prepared preview and polls until `Playing` with elapsed `>= 10,000` ms.
+  - Activates the chart and observes `SongTransition` before `Performance`.
+  - Writes prepared/playing/transition/performance state, fixture, stdout/stderr, and failure artifacts through existing seams.
+- `.superpowers/sdd/2026-08-11-hpa-510-prepared-chart-recording/task-4-report.md`
+  - This report.
+
+## TDD RED/GREEN evidence
+
+RED (before fixture implementation):
+
+```text
+rtk dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~E2EFixtureBuilderTests.Build_ShouldWriteConfigAndGeneratedChart" --logger "console;verbosity=normal"
+```
+
+The focused test failed as intended at the new assertion: `Assert.Contains() Failure`, not found `#PREVIEW: autoplay-tone.wav` (0 passed, 1 failed).
+
+GREEN (after the one-line `BuildChart()` implementation):
+
+```text
+rtk dotnet test DTXMania.E2E/DTXMania.E2E.csproj --no-restore --filter "FullyQualifiedName~E2EFixtureBuilderTests.Build_ShouldWriteConfigAndGeneratedChart" --logger "console;verbosity=normal"
+```
+
+Result: 1 test passed, 0 warnings.
+
+## Verification commands and results
+
+All .NET test commands below were run with the host test-runner permissions required for VSTest localhost communication.
+
+```text
+DTXMANIA_E2E_GAME_PROJECT=DTXMania.Game/DTXMania.Game.Mac.csproj rtk dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~PreparedChartRecordingSmokeTests" --logger "console;verbosity=normal"
+```
+
+Result: 1 test passed, 0 warnings, 25.0 s. This is the documented Mac live run; no platform/audio blocker prevented the HPA-510 flow.
+
+```text
+DTXMANIA_E2E_GAME_PROJECT=DTXMania.Game/DTXMania.Game.Mac.csproj rtk dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~GameplayAutoPlaySmokeTests" --logger "console;verbosity=minimal"
+```
+
+Result: 1 existing autoplay smoke passed in 78.4 s (139 existing nullable warnings), confirming the shared fixture `#PREVIEW` declaration did not regress the score-bucket flow.
+
+```text
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~PreparedChart" --logger "console;verbosity=normal"
+```
+
+Result: 38 tests passed (existing nullable warnings: 400).
+
+```text
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~SongSelectionStagePreviewAndBgm|FullyQualifiedName~SongSelectionStageFilter|FullyQualifiedName~SongSelectionStageRootFilterAdditional|FullyQualifiedName~SongSelectionStageBreadcrumb|FullyQualifiedName~SongSelectionStageTab|FullyQualifiedName~SongSelectionStageNavigation|FullyQualifiedName~SongTransitionStage" --logger "console;verbosity=normal"
+```
+
+Result: 260 tests passed, 0 warnings.
+
+```text
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~GameApi|FullyQualifiedName~JsonRpcServer" --logger "console;verbosity=normal"
+```
+
+Result: 374 tests passed, 0 warnings.
+
+```text
+rtk dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --logger "console;verbosity=normal"
+```
+
+Result: 64 tests passed, 0 warnings.
+
+```text
+rtk dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "Category=E2E-Support" --logger "console;verbosity=normal"
+```
+
+Result: 16 tests passed, 0 warnings.
+
+```text
+rtk dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --logger "console;verbosity=minimal"
+```
+
+Result: 8,203 tests passed, 0 warnings.
+
+```text
+rtk git diff --check
+```
+
+Result: clean.
+
+## Live-run evidence
+
+The successful Mac run left artifacts under:
+
+`/var/folders/_k/lkrpcd8516s5x5szmkq1mbvc0000gn/T/dtxmaniacx-e2e-prepared-chart-6f090ea38b5347e5a7e525d8678886a5/TestResults/e2e/`
+
+- `prepared-song-select.png` is non-empty (104 KiB).
+- `prepared-state.json`: `stageType=SongSelect`, `preparedChartIdentity=chart:1`, `preparedPreviewState=Prepared`, `preparedPreviewElapsedMs=0`.
+- `playing-state.json`: `preparedPreviewState=Playing`, `preparedPreviewElapsedMs=10083.353499999941`.
+- `song-transition-state.json` records `stageType=SongTransition`.
+- `performance-state.json` records `stageType=Performance`.
+- `game-stderr.log` contains only 3 bytes; stdout records the expected SongSelect → SongTransition → Performance lifecycle.
+
+Windows native gameplay E2E was not available on this Mac host; the existing Windows `Category=E2E` workflow remains the authoritative native/CI run.
+
+## Self-review
+
+- The fixture uses a unique temp run root and an OS-selected API port, so chart/audio/config state is isolated per test.
+- The smoke waits for the generated song title before preparing, uses the exact absolute fixture chart path, and never navigates by title or index.
+- The two-second wait is longer than the normal one-second automatic preview delay; `Prepared` plus exact zero elapsed catches accidental auto-start.
+- The preview poll requires actual `Playing` state and at least 10 seconds of measured elapsed time before activation.
+- Activation observes `SongTransition` with a 100 ms poll before waiting for `Performance`, avoiding a stage-observation race while keeping the assertion narrow.
+- The test stops at `Performance`; it does not run to `Result`, inspect score persistence, involve OBS, or duplicate the autoplay score-bucket flow.
+- `git diff --check` is clean and no unrelated production files were changed.
+
+## Concerns
+
+- The Mac game stdout includes the existing `PerformanceError` fallback (`AudioLoader: Cannot create SongTimer - no audio loaded`) after the transition. It does not affect this smoke, which intentionally stops at Performance; Windows CI should remain the authoritative native audio check.
+- The Windows live run and CI result are not observable from this host and must be confirmed by the existing workflow.

--- a/DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs
+++ b/DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs
@@ -276,6 +276,80 @@ public sealed class JsonRpcGameClientTests
     }
 
     [Fact]
+    public async Task PrepareVideoChartAsync_ShouldSendExactMethodAndChartPath()
+    {
+        using var handler = new FakeHandler(req => EchoJsonRpcResponseAsync(req, "{\"success\":true}"));
+        using var httpClient = CreateHttpClient(handler);
+        var client = CreateClient(httpClient);
+
+        await client.PrepareVideoChartAsync("/safe/chart.dtx", CancellationToken.None);
+
+        using var request = JsonDocument.Parse(handler.RequestBodies.Single());
+        var root = request.RootElement;
+        Assert.Equal("prepareVideoChart", root.GetProperty("method").GetString());
+        Assert.Equal("/safe/chart.dtx", root.GetProperty("params").GetProperty("chartPath").GetString());
+    }
+
+    [Theory]
+    [InlineData("startPreparedPreview")]
+    [InlineData("activatePreparedChart")]
+    [InlineData("cancelPreparedChart")]
+    public async Task PreparedChartCommandAsync_ShouldSendExactMethodWithoutParameters(string method)
+    {
+        using var handler = new FakeHandler(req => EchoJsonRpcResponseAsync(req, "{\"success\":true}"));
+        using var httpClient = CreateHttpClient(handler);
+        var client = CreateClient(httpClient);
+
+        switch (method)
+        {
+            case "startPreparedPreview":
+                await client.StartPreparedPreviewAsync(CancellationToken.None);
+                break;
+            case "activatePreparedChart":
+                await client.ActivatePreparedChartAsync(CancellationToken.None);
+                break;
+            case "cancelPreparedChart":
+                await client.CancelPreparedChartAsync(CancellationToken.None);
+                break;
+        }
+
+        using var request = JsonDocument.Parse(handler.RequestBodies.Single());
+        var root = request.RootElement;
+        Assert.Equal(method, root.GetProperty("method").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("params").ValueKind);
+    }
+
+    [Theory]
+    [InlineData("prepareVideoChart")]
+    [InlineData("startPreparedPreview")]
+    [InlineData("activatePreparedChart")]
+    [InlineData("cancelPreparedChart")]
+    public async Task PreparedChartCommandAsync_WhenServerRejects_ShouldThrowSafeErrorText(string method)
+    {
+        const string safeError = "The prepared chart preview could not be started.";
+        using var handler = new FakeHandler(req => EchoJsonRpcResponseAsync(
+            req,
+            $"{{\"success\":false,\"error\":{JsonSerializer.Serialize(safeError)}}}"));
+        using var httpClient = CreateHttpClient(handler);
+        var client = CreateClient(httpClient);
+
+        var exception = method switch
+        {
+            "prepareVideoChart" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.PrepareVideoChartAsync("/safe/chart.dtx", CancellationToken.None)),
+            "startPreparedPreview" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.StartPreparedPreviewAsync(CancellationToken.None)),
+            "activatePreparedChart" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.ActivatePreparedChartAsync(CancellationToken.None)),
+            "cancelPreparedChart" => await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                client.CancelPreparedChartAsync(CancellationToken.None)),
+            _ => throw new InvalidOperationException("unreachable")
+        };
+
+        Assert.Equal(safeError, exception.Message);
+    }
+
+    [Fact]
     public async Task ChangeStageAsync_HttpFailure_ShouldIncludeMethodStatusAndBody()
     {
         using var handler = new FakeHandler(_ => Task.FromResult(

--- a/DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs
+++ b/DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs
@@ -138,6 +138,34 @@ public sealed class JsonRpcGameClient
         await SendAsync("changeStage", new { stageName }, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task PrepareVideoChartAsync(string chartPath, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(chartPath);
+        var result = await SendAsync(
+            "prepareVideoChart",
+            new { chartPath },
+            cancellationToken).ConfigureAwait(false);
+        EnsurePreparedChartCommandSucceeded("prepareVideoChart", result);
+    }
+
+    public async Task StartPreparedPreviewAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await SendAsync("startPreparedPreview", null, cancellationToken).ConfigureAwait(false);
+        EnsurePreparedChartCommandSucceeded("startPreparedPreview", result);
+    }
+
+    public async Task ActivatePreparedChartAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await SendAsync("activatePreparedChart", null, cancellationToken).ConfigureAwait(false);
+        EnsurePreparedChartCommandSucceeded("activatePreparedChart", result);
+    }
+
+    public async Task CancelPreparedChartAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await SendAsync("cancelPreparedChart", null, cancellationToken).ConfigureAwait(false);
+        EnsurePreparedChartCommandSucceeded("cancelPreparedChart", result);
+    }
+
     public async Task<string?> TakeScreenshotBase64Async(CancellationToken cancellationToken)
     {
         var result = await SendAsync("takeScreenshot", null, cancellationToken).ConfigureAwait(false);
@@ -163,6 +191,23 @@ public sealed class JsonRpcGameClient
             throw new InvalidOperationException(
                 $"sendInput type {(int)type} was not accepted by the game.");
         }
+    }
+
+    private static void EnsurePreparedChartCommandSucceeded(string method, JsonElement result)
+    {
+        if (result.TryGetProperty("success", out var success)
+            && success.ValueKind == JsonValueKind.True)
+        {
+            return;
+        }
+
+        var error = result.TryGetProperty("error", out var errorElement)
+            && errorElement.ValueKind == JsonValueKind.String
+            ? errorElement.GetString()
+            : null;
+
+        throw new InvalidOperationException(
+            error ?? $"JSON-RPC {method} command failed.");
     }
 
     private async Task SendReleaseOnCleanupPath(GameApiInputType type, object data)

--- a/DTXMania.Automation/Telemetry/GameStateSnapshot.cs
+++ b/DTXMania.Automation/Telemetry/GameStateSnapshot.cs
@@ -60,6 +60,12 @@ public sealed class GameStateSnapshot
 
     public long PreparedAudioBytes => GetTelemetryLong("preparedAudioBytes") ?? 0L;
 
+    public string? PreparedChartIdentity => GetTelemetryString("preparedChartIdentity");
+
+    public string? PreparedPreviewState => GetTelemetryString("preparedPreviewState");
+
+    public double PreparedPreviewElapsedMs => GetTelemetryDouble("preparedPreviewElapsedMs") ?? 0.0;
+
     public bool AutoPlayEnabled => GetTelemetryBool("autoPlayEnabled") ?? false;
 
     public double CurrentSongTimeMs => GetTelemetryDouble("currentSongTimeMs") ?? 0.0;

--- a/DTXMania.E2E/AutomationContractTests.cs
+++ b/DTXMania.E2E/AutomationContractTests.cs
@@ -169,6 +169,9 @@ public sealed class AutomationContractTests
             AudioPreparationTotal = 2,
             AudioPreparationCacheHits = 1,
             PreparedAudioBytes = 4096,
+            PreparedChartIdentity = "chart:510",
+            PreparedPreviewState = "Playing",
+            PreparedPreviewElapsedMs = 4321.5,
             AutoPlayEnabled = true,
             CurrentSongTimeMs = 1234.5,
             Score = 95000,
@@ -218,6 +221,9 @@ public sealed class AutomationContractTests
         Assert.Equal(2, state.AudioPreparationTotal);
         Assert.Equal(1, state.AudioPreparationCacheHits);
         Assert.Equal(4096L, state.PreparedAudioBytes);
+        Assert.Equal("chart:510", state.PreparedChartIdentity);
+        Assert.Equal("Playing", state.PreparedPreviewState);
+        Assert.Equal(4321.5, state.PreparedPreviewElapsedMs);
         Assert.True(state.AutoPlayEnabled);
         Assert.Equal(1234.5, state.CurrentSongTimeMs);
         Assert.Equal(95000, state.Score);

--- a/DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs
+++ b/DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs
@@ -8,6 +8,7 @@ public static class E2EFixtureBuilder
     public const string ApiKey = "e2e-autoplay-smoke-key";
     public const string SongTitle = "E2E AutoPlay Smoke";
     public const string AudioFileName = "autoplay-tone.wav";
+    public const string PreviewAudioFileName = "preview-tone.wav";
     public const string ArtifactRootEnvironmentVariable = "DTXMANIA_E2E_ARTIFACT_ROOT";
 
     // Minimal valid 8x32 white PNG shipped into the sandbox skin so it mirrors the
@@ -48,7 +49,11 @@ public static class E2EFixtureBuilder
             Encoding.UTF8);
         File.WriteAllText(paths.ChartPath, BuildChart(), Encoding.UTF8);
         var audioPath = Path.Combine(paths.SongDirectory, AudioFileName);
-        WriteDeterministicWave(audioPath);
+        WriteDeterministicWave(audioPath, durationSeconds: 1.0);
+        var previewAudioPath = Path.Combine(paths.SongDirectory, PreviewAudioFileName);
+        // The prepared-chart recording smoke verifies ten seconds of continuous preview.
+        // Keep that preview long without changing the short gameplay tone used by other E2E cases.
+        WriteDeterministicWave(previewAudioPath, durationSeconds: 12.0);
         // Ship hit_fx.png so the sandbox skin matches the bundled System skin.
         File.WriteAllBytes(
             Path.Combine(paths.SkinRoot, "Graphics", "hit_fx.png"),
@@ -145,7 +150,7 @@ public static class E2EFixtureBuilder
             "#BPM: 120",
             "#DLEVEL: 10",
             $"#WAV01: {AudioFileName}",
-            $"#PREVIEW: {AudioFileName}",
+            $"#PREVIEW: {PreviewAudioFileName}",
             string.Empty,
             "; Short deterministic AutoPlay pattern with generated local audio.",
             "#00001: 0100000000000000",
@@ -159,13 +164,12 @@ public static class E2EFixtureBuilder
         });
     }
 
-    private static void WriteDeterministicWave(string path)
+    private static void WriteDeterministicWave(string path, double durationSeconds)
     {
         const int sampleRate = 44_100;
         const short channelCount = 1;
         const short bitsPerSample = 16;
         const double frequencyHz = 440.0;
-        const double durationSeconds = 1.0;
         var sampleCount = (int)(sampleRate * durationSeconds);
         var bytesPerSample = bitsPerSample / 8;
         var dataLength = sampleCount * channelCount * bytesPerSample;

--- a/DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs
+++ b/DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs
@@ -145,6 +145,7 @@ public static class E2EFixtureBuilder
             "#BPM: 120",
             "#DLEVEL: 10",
             $"#WAV01: {AudioFileName}",
+            $"#PREVIEW: {AudioFileName}",
             string.Empty,
             "; Short deterministic AutoPlay pattern with generated local audio.",
             "#00001: 0100000000000000",

--- a/DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs
+++ b/DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs
@@ -8,7 +8,6 @@ public static class E2EFixtureBuilder
     public const string ApiKey = "e2e-autoplay-smoke-key";
     public const string SongTitle = "E2E AutoPlay Smoke";
     public const string AudioFileName = "autoplay-tone.wav";
-    public const string PreviewAudioFileName = "preview-tone.wav";
     public const string ArtifactRootEnvironmentVariable = "DTXMANIA_E2E_ARTIFACT_ROOT";
 
     // Minimal valid 8x32 white PNG shipped into the sandbox skin so it mirrors the
@@ -49,11 +48,7 @@ public static class E2EFixtureBuilder
             Encoding.UTF8);
         File.WriteAllText(paths.ChartPath, BuildChart(), Encoding.UTF8);
         var audioPath = Path.Combine(paths.SongDirectory, AudioFileName);
-        WriteDeterministicWave(audioPath, durationSeconds: 1.0);
-        var previewAudioPath = Path.Combine(paths.SongDirectory, PreviewAudioFileName);
-        // The prepared-chart recording smoke verifies ten seconds of continuous preview.
-        // Keep that preview long without changing the short gameplay tone used by other E2E cases.
-        WriteDeterministicWave(previewAudioPath, durationSeconds: 12.0);
+        WriteDeterministicWave(audioPath);
         // Ship hit_fx.png so the sandbox skin matches the bundled System skin.
         File.WriteAllBytes(
             Path.Combine(paths.SkinRoot, "Graphics", "hit_fx.png"),
@@ -150,7 +145,7 @@ public static class E2EFixtureBuilder
             "#BPM: 120",
             "#DLEVEL: 10",
             $"#WAV01: {AudioFileName}",
-            $"#PREVIEW: {PreviewAudioFileName}",
+            $"#PREVIEW: {AudioFileName}",
             string.Empty,
             "; Short deterministic AutoPlay pattern with generated local audio.",
             "#00001: 0100000000000000",
@@ -164,12 +159,13 @@ public static class E2EFixtureBuilder
         });
     }
 
-    private static void WriteDeterministicWave(string path, double durationSeconds)
+    private static void WriteDeterministicWave(string path)
     {
         const int sampleRate = 44_100;
         const short channelCount = 1;
         const short bitsPerSample = 16;
         const double frequencyHz = 440.0;
+        const double durationSeconds = 1.0;
         var sampleCount = (int)(sampleRate * durationSeconds);
         var bytesPerSample = bitsPerSample / 8;
         var dataLength = sampleCount * channelCount * bytesPerSample;

--- a/DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs
+++ b/DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs
@@ -16,9 +16,6 @@ public sealed class E2EFixtureBuilderTests
         try
         {
             var fixture = E2EFixtureBuilder.Build(root, repoRoot, apiPort: 18080);
-            var previewAudioPath = Path.Combine(
-                fixture.SongDirectory,
-                E2EFixtureBuilder.PreviewAudioFileName);
 
             Assert.Equal(Path.GetFullPath(root), fixture.RunRoot);
             Assert.Equal(Path.Combine(fixture.RunRoot, "appdata"), fixture.AppDataRoot);
@@ -42,7 +39,6 @@ public sealed class E2EFixtureBuilderTests
             Assert.True(File.Exists(fixture.ConfigPath));
             Assert.True(File.Exists(fixture.ChartPath));
             Assert.True(File.Exists(fixture.AudioPath));
-            Assert.True(File.Exists(previewAudioPath));
 
             // The sandbox skin must ship a valid hit_fx.png so it mirrors the bundled
             // System skin (validated by DefaultSkinAssetsTests).
@@ -74,7 +70,7 @@ public sealed class E2EFixtureBuilderTests
             Assert.Contains("#TITLE: E2E AutoPlay Smoke", chart);
             Assert.Contains("#BPM: 120", chart);
             Assert.Contains($"#WAV01: {E2EFixtureBuilder.AudioFileName}", chart);
-            Assert.Contains($"#PREVIEW: {E2EFixtureBuilder.PreviewAudioFileName}", chart);
+            Assert.Contains($"#PREVIEW: {E2EFixtureBuilder.AudioFileName}", chart);
             Assert.Contains("#00001:", chart);
             Assert.Contains("#00011:", chart);
 
@@ -82,11 +78,6 @@ public sealed class E2EFixtureBuilderTests
             Assert.True(audioBytes.Length > 44);
             Assert.Equal("RIFF", System.Text.Encoding.ASCII.GetString(audioBytes, 0, 4));
             Assert.Equal("WAVE", System.Text.Encoding.ASCII.GetString(audioBytes, 8, 4));
-
-            var previewAudioBytes = File.ReadAllBytes(previewAudioPath);
-            Assert.True(previewAudioBytes.Length > audioBytes.Length);
-            Assert.Equal("RIFF", System.Text.Encoding.ASCII.GetString(previewAudioBytes, 0, 4));
-            Assert.Equal("WAVE", System.Text.Encoding.ASCII.GetString(previewAudioBytes, 8, 4));
 
             var configManager = new ConfigManager();
             configManager.LoadConfig(fixture.ConfigPath);

--- a/DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs
+++ b/DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs
@@ -70,6 +70,7 @@ public sealed class E2EFixtureBuilderTests
             Assert.Contains("#TITLE: E2E AutoPlay Smoke", chart);
             Assert.Contains("#BPM: 120", chart);
             Assert.Contains($"#WAV01: {E2EFixtureBuilder.AudioFileName}", chart);
+            Assert.Contains($"#PREVIEW: {E2EFixtureBuilder.AudioFileName}", chart);
             Assert.Contains("#00001:", chart);
             Assert.Contains("#00011:", chart);
 

--- a/DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs
+++ b/DTXMania.E2E/Fixtures/E2EFixtureBuilderTests.cs
@@ -16,6 +16,9 @@ public sealed class E2EFixtureBuilderTests
         try
         {
             var fixture = E2EFixtureBuilder.Build(root, repoRoot, apiPort: 18080);
+            var previewAudioPath = Path.Combine(
+                fixture.SongDirectory,
+                E2EFixtureBuilder.PreviewAudioFileName);
 
             Assert.Equal(Path.GetFullPath(root), fixture.RunRoot);
             Assert.Equal(Path.Combine(fixture.RunRoot, "appdata"), fixture.AppDataRoot);
@@ -39,6 +42,7 @@ public sealed class E2EFixtureBuilderTests
             Assert.True(File.Exists(fixture.ConfigPath));
             Assert.True(File.Exists(fixture.ChartPath));
             Assert.True(File.Exists(fixture.AudioPath));
+            Assert.True(File.Exists(previewAudioPath));
 
             // The sandbox skin must ship a valid hit_fx.png so it mirrors the bundled
             // System skin (validated by DefaultSkinAssetsTests).
@@ -70,7 +74,7 @@ public sealed class E2EFixtureBuilderTests
             Assert.Contains("#TITLE: E2E AutoPlay Smoke", chart);
             Assert.Contains("#BPM: 120", chart);
             Assert.Contains($"#WAV01: {E2EFixtureBuilder.AudioFileName}", chart);
-            Assert.Contains($"#PREVIEW: {E2EFixtureBuilder.AudioFileName}", chart);
+            Assert.Contains($"#PREVIEW: {E2EFixtureBuilder.PreviewAudioFileName}", chart);
             Assert.Contains("#00001:", chart);
             Assert.Contains("#00011:", chart);
 
@@ -78,6 +82,11 @@ public sealed class E2EFixtureBuilderTests
             Assert.True(audioBytes.Length > 44);
             Assert.Equal("RIFF", System.Text.Encoding.ASCII.GetString(audioBytes, 0, 4));
             Assert.Equal("WAVE", System.Text.Encoding.ASCII.GetString(audioBytes, 8, 4));
+
+            var previewAudioBytes = File.ReadAllBytes(previewAudioPath);
+            Assert.True(previewAudioBytes.Length > audioBytes.Length);
+            Assert.Equal("RIFF", System.Text.Encoding.ASCII.GetString(previewAudioBytes, 0, 4));
+            Assert.Equal("WAVE", System.Text.Encoding.ASCII.GetString(previewAudioBytes, 8, 4));
 
             var configManager = new ConfigManager();
             configManager.LoadConfig(fixture.ConfigPath);

--- a/DTXMania.E2E/PreparedChartRecordingSmokeTests.cs
+++ b/DTXMania.E2E/PreparedChartRecordingSmokeTests.cs
@@ -7,7 +7,7 @@ using DTXMania.E2E.Support;
 
 namespace DTXMania.E2E;
 
-[Trait("Category", "E2E")]
+[Trait("Category", "AudioE2E")]
 public sealed class PreparedChartRecordingSmokeTests
 {
     [Fact(Timeout = 180_000)]
@@ -54,103 +54,145 @@ public sealed class PreparedChartRecordingSmokeTests
 
             await client.PrepareVideoChartAsync(fixture.ChartPath, cancellation.Token);
 
-            var screenshotBase64 = await client.TakeScreenshotBase64Async(cancellation.Token);
-            Assert.False(
-                string.IsNullOrWhiteSpace(screenshotBase64),
-                "Prepared SongSelect screenshot should contain image data.");
-            var screenshotBytes = Convert.FromBase64String(screenshotBase64!);
-            Assert.NotEmpty(screenshotBytes);
-            Directory.CreateDirectory(fixture.ArtifactRoot);
-            await File.WriteAllBytesAsync(
-                Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png"),
-                screenshotBytes,
-                cancellation.Token);
-
-            // The generated fixture uses the normal one-second automatic preview delay.
-            // Waiting past it proves preparation does not arm the interactive auto-start path.
-            await Task.Delay(TimeSpan.FromSeconds(2), cancellation.Token);
             var prepared = await Eventually.UntilAsync(
                 token => client.GetGameStateAsync(token),
-                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
+                state => !string.IsNullOrWhiteSpace(state.PreparedChartIdentity)
                     && string.Equals(state.PreparedPreviewState, "Prepared", StringComparison.Ordinal)
                     && state.PreparedPreviewElapsedMs == 0.0,
-                TimeSpan.FromSeconds(10),
-                TimeSpan.FromMilliseconds(250),
-                "prepared preview remains stopped",
+                TimeSpan.FromSeconds(20),
+                TimeSpan.FromMilliseconds(100),
+                "prepared chart state",
                 cancellation.Token);
-            Assert.Equal("Prepared", prepared.PreparedPreviewState);
-            Assert.Equal(0.0, prepared.PreparedPreviewElapsedMs);
-            Assert.False(string.IsNullOrWhiteSpace(prepared.PreparedChartIdentity));
-            Assert.DoesNotContain(
-                Path.GetFullPath(fixture.ChartPath),
-                prepared.PreparedChartIdentity,
-                StringComparison.OrdinalIgnoreCase);
-            await E2EArtifactWriter.WriteJsonAsync(fixture, "prepared-state.json", prepared);
+            await SaveStateAsync(
+                Path.Combine(fixture.ArtifactRoot, "prepared-state.json"),
+                prepared,
+                cancellation.Token);
+
+            await client.CaptureScreenshotAsync(
+                Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png"),
+                cancellation.Token);
+            Assert.True(new FileInfo(Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png")).Length > 0);
+
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellation.Token);
+            var stillPrepared = await client.GetGameStateAsync(cancellation.Token);
+            Assert.Equal("Prepared", stillPrepared.PreparedPreviewState);
+            Assert.Equal(0.0, stillPrepared.PreparedPreviewElapsedMs);
 
             await client.StartPreparedPreviewAsync(cancellation.Token);
+
             var playing = await Eventually.UntilAsync(
                 token => client.GetGameStateAsync(token),
-                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
-                    && string.Equals(state.PreparedPreviewState, "Playing", StringComparison.Ordinal)
+                state => string.Equals(state.PreparedPreviewState, "Playing", StringComparison.Ordinal)
                     && state.PreparedPreviewElapsedMs >= 10_000.0,
                 TimeSpan.FromSeconds(30),
-                TimeSpan.FromMilliseconds(250),
+                TimeSpan.FromMilliseconds(100),
                 "prepared preview reaches ten seconds",
                 cancellation.Token);
-            Assert.Equal("Playing", playing.PreparedPreviewState);
-            Assert.True(playing.PreparedPreviewElapsedMs >= 10_000.0);
-            await E2EArtifactWriter.WriteJsonAsync(fixture, "playing-state.json", playing);
+            await SaveStateAsync(
+                Path.Combine(fixture.ArtifactRoot, "playing-state.json"),
+                playing,
+                cancellation.Token);
 
             await client.ActivatePreparedChartAsync(cancellation.Token);
-            var transition = await WaitForStageAsync(
-                client,
-                "SongTransition",
-                TimeSpan.FromSeconds(5),
-                cancellation.Token);
-            Assert.Equal("SongTransition", transition.StageType);
-            await E2EArtifactWriter.WriteJsonAsync(fixture, "song-transition-state.json", transition);
 
-            var performance = await WaitForStageAsync(
-                client,
-                "Performance",
-                TimeSpan.FromSeconds(15),
+            var transition = await Eventually.UntilAsync(
+                token => client.GetGameStateAsync(token),
+                state => string.Equals(state.StageType, "SongTransition", StringComparison.Ordinal),
+                TimeSpan.FromSeconds(20),
+                TimeSpan.FromMilliseconds(100),
+                "SongTransition after prepared activation",
                 cancellation.Token);
-            Assert.Equal("Performance", performance.StageType);
-            await E2EArtifactWriter.WriteJsonAsync(fixture, "performance-state.json", performance);
+            await SaveStateAsync(
+                Path.Combine(fixture.ArtifactRoot, "song-transition-state.json"),
+                transition,
+                cancellation.Token);
+
+            var performance = await Eventually.UntilAsync(
+                token => client.GetGameStateAsync(token),
+                state => string.Equals(state.StageType, "Performance", StringComparison.Ordinal),
+                TimeSpan.FromSeconds(45),
+                TimeSpan.FromMilliseconds(250),
+                "Performance after prepared activation",
+                cancellation.Token);
+            await SaveStateAsync(
+                Path.Combine(fixture.ArtifactRoot, "performance-state.json"),
+                performance,
+                cancellation.Token);
         }
-        catch (Exception exception)
+        catch (Exception ex)
         {
-            await E2EArtifactWriter.WriteTextAsync(fixture, "failure.txt", exception.ToString());
+            await E2EArtifactWriter.WriteTextAsync(
+                Path.Combine(fixture.ArtifactRoot, "failure.txt"),
+                ex.ToString(),
+                cancellation.Token);
+
             try
             {
-                var failureState = await client.GetGameStateAsync(CancellationToken.None);
-                await E2EArtifactWriter.WriteJsonAsync(fixture, "failure-state.json", failureState);
+                var failureState = await client.GetGameStateAsync(cancellation.Token);
+                await SaveStateAsync(
+                    Path.Combine(fixture.ArtifactRoot, "failure-state.json"),
+                    failureState,
+                    cancellation.Token);
             }
             catch
             {
-                // Preserve the original failure if the game has already exited.
+                // Preserve the primary failure when telemetry is no longer available.
             }
 
             throw;
         }
         finally
         {
-            E2EArtifactWriter.CopyFixtureFiles(fixture);
-            await E2EArtifactWriter.WriteTextAsync(fixture, "game-stdout.log", process.StandardOutput);
-            await E2EArtifactWriter.WriteTextAsync(fixture, "game-stderr.log", process.StandardError);
+            try
+            {
+                await process.StopAsync(TimeSpan.FromSeconds(5), CancellationToken.None);
+            }
+            finally
+            {
+                await E2EArtifactWriter.CopyIfExistsAsync(
+                    fixture.ConfigPath,
+                    Path.Combine(fixture.ArtifactRoot, "config.ini"),
+                    CancellationToken.None);
+                await E2EArtifactWriter.CopyIfExistsAsync(
+                    fixture.ChartPath,
+                    Path.Combine(fixture.ArtifactRoot, "autoplay-smoke.dtx"),
+                    CancellationToken.None);
+                await E2EArtifactWriter.CopyIfExistsAsync(
+                    fixture.AudioPath,
+                    Path.Combine(fixture.ArtifactRoot, E2EFixtureBuilder.AudioFileName),
+                    CancellationToken.None);
+                await E2EArtifactWriter.CopyIfExistsAsync(
+                    process.StandardOutputPath,
+                    Path.Combine(fixture.ArtifactRoot, "game-stdout.log"),
+                    CancellationToken.None);
+                await E2EArtifactWriter.CopyIfExistsAsync(
+                    process.StandardErrorPath,
+                    Path.Combine(fixture.ArtifactRoot, "game-stderr.log"),
+                    CancellationToken.None);
+            }
         }
     }
 
     private static Task<GameStateSnapshot> WaitForStageAsync(
         JsonRpcGameClient client,
-        string expectedStageType,
+        string stageType,
         TimeSpan timeout,
-        CancellationToken cancellationToken) =>
-        Eventually.UntilAsync(
+        CancellationToken cancellationToken)
+    {
+        return Eventually.UntilAsync(
             token => client.GetGameStateAsync(token),
-            state => string.Equals(state.StageType, expectedStageType, StringComparison.Ordinal),
+            state => string.Equals(state.StageType, stageType, StringComparison.Ordinal),
             timeout,
-            TimeSpan.FromMilliseconds(100),
-            expectedStageType,
+            TimeSpan.FromMilliseconds(250),
+            $"stage {stageType}",
             cancellationToken);
+    }
+
+    private static Task SaveStateAsync(
+        string path,
+        GameStateSnapshot state,
+        CancellationToken cancellationToken)
+    {
+        return E2EArtifactWriter.WriteJsonAsync(path, state, cancellationToken);
+    }
 }

--- a/DTXMania.E2E/PreparedChartRecordingSmokeTests.cs
+++ b/DTXMania.E2E/PreparedChartRecordingSmokeTests.cs
@@ -1,0 +1,156 @@
+using DTXMania.Automation.JsonRpc;
+using DTXMania.Automation.Process;
+using DTXMania.Automation.Support;
+using DTXMania.Automation.Telemetry;
+using DTXMania.E2E.Fixtures;
+using DTXMania.E2E.Support;
+
+namespace DTXMania.E2E;
+
+[Trait("Category", "E2E")]
+public sealed class PreparedChartRecordingSmokeTests
+{
+    [Fact(Timeout = 180_000)]
+    public async Task PreparedChartRecording_ShouldHoldPreviewUntilStartedAndActivateThroughSongTransition()
+    {
+        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(165));
+        var repoRoot = E2EGameLaunch.ResolveRepoRoot();
+        var runRoot = Path.Combine(
+            Path.GetTempPath(),
+            "dtxmaniacx-e2e-prepared-chart-" + Guid.NewGuid().ToString("N"));
+        var fixture = E2EFixtureBuilder.Build(
+            runRoot,
+            repoRoot,
+            E2EGameLaunch.ResolveApiPort());
+
+        await using var bundle = E2EGameLaunch.CreateClientBundle(fixture);
+        var process = bundle.Process;
+        var client = bundle.Client;
+
+        try
+        {
+            process.Start(E2EGameLaunch.CreateOptions(fixture));
+            await process.WaitForStartupAsync(
+                client.GetHealthAsync,
+                TimeSpan.FromSeconds(60),
+                TimeSpan.FromMilliseconds(500),
+                cancellation.Token);
+
+            await WaitForStageAsync(client, "Title", TimeSpan.FromSeconds(45), cancellation.Token);
+            await client.SendKeyAsync("Enter", TimeSpan.FromMilliseconds(50), cancellation.Token);
+
+            var songSelect = await Eventually.UntilAsync(
+                token => client.GetGameStateAsync(token),
+                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
+                    && string.Equals(
+                        state.SelectedSongTitle,
+                        E2EFixtureBuilder.SongTitle,
+                        StringComparison.Ordinal),
+                TimeSpan.FromSeconds(45),
+                TimeSpan.FromMilliseconds(250),
+                "SongSelect fixture chart",
+                cancellation.Token);
+            Assert.Equal(E2EFixtureBuilder.SongTitle, songSelect.SelectedSongTitle);
+
+            await client.PrepareVideoChartAsync(fixture.ChartPath, cancellation.Token);
+
+            var screenshotBase64 = await client.TakeScreenshotBase64Async(cancellation.Token);
+            Assert.False(
+                string.IsNullOrWhiteSpace(screenshotBase64),
+                "Prepared SongSelect screenshot should contain image data.");
+            var screenshotBytes = Convert.FromBase64String(screenshotBase64!);
+            Assert.NotEmpty(screenshotBytes);
+            Directory.CreateDirectory(fixture.ArtifactRoot);
+            await File.WriteAllBytesAsync(
+                Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png"),
+                screenshotBytes,
+                cancellation.Token);
+
+            // The generated fixture uses the normal one-second automatic preview delay.
+            // Waiting past it proves preparation does not arm the interactive auto-start path.
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellation.Token);
+            var prepared = await Eventually.UntilAsync(
+                token => client.GetGameStateAsync(token),
+                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
+                    && string.Equals(state.PreparedPreviewState, "Prepared", StringComparison.Ordinal)
+                    && state.PreparedPreviewElapsedMs == 0.0,
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromMilliseconds(250),
+                "prepared preview remains stopped",
+                cancellation.Token);
+            Assert.Equal("Prepared", prepared.PreparedPreviewState);
+            Assert.Equal(0.0, prepared.PreparedPreviewElapsedMs);
+            Assert.False(string.IsNullOrWhiteSpace(prepared.PreparedChartIdentity));
+            Assert.DoesNotContain(
+                Path.GetFullPath(fixture.ChartPath),
+                prepared.PreparedChartIdentity,
+                StringComparison.OrdinalIgnoreCase);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "prepared-state.json", prepared);
+
+            await client.StartPreparedPreviewAsync(cancellation.Token);
+            var playing = await Eventually.UntilAsync(
+                token => client.GetGameStateAsync(token),
+                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
+                    && string.Equals(state.PreparedPreviewState, "Playing", StringComparison.Ordinal)
+                    && state.PreparedPreviewElapsedMs >= 10_000.0,
+                TimeSpan.FromSeconds(30),
+                TimeSpan.FromMilliseconds(250),
+                "prepared preview reaches ten seconds",
+                cancellation.Token);
+            Assert.Equal("Playing", playing.PreparedPreviewState);
+            Assert.True(playing.PreparedPreviewElapsedMs >= 10_000.0);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "playing-state.json", playing);
+
+            await client.ActivatePreparedChartAsync(cancellation.Token);
+            var transition = await WaitForStageAsync(
+                client,
+                "SongTransition",
+                TimeSpan.FromSeconds(5),
+                cancellation.Token);
+            Assert.Equal("SongTransition", transition.StageType);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "song-transition-state.json", transition);
+
+            var performance = await WaitForStageAsync(
+                client,
+                "Performance",
+                TimeSpan.FromSeconds(15),
+                cancellation.Token);
+            Assert.Equal("Performance", performance.StageType);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "performance-state.json", performance);
+        }
+        catch (Exception exception)
+        {
+            await E2EArtifactWriter.WriteTextAsync(fixture, "failure.txt", exception.ToString());
+            try
+            {
+                var failureState = await client.GetGameStateAsync(CancellationToken.None);
+                await E2EArtifactWriter.WriteJsonAsync(fixture, "failure-state.json", failureState);
+            }
+            catch
+            {
+                // Preserve the original failure if the game has already exited.
+            }
+
+            throw;
+        }
+        finally
+        {
+            E2EArtifactWriter.CopyFixtureFiles(fixture);
+            await E2EArtifactWriter.WriteTextAsync(fixture, "game-stdout.log", process.StandardOutput);
+            await E2EArtifactWriter.WriteTextAsync(fixture, "game-stderr.log", process.StandardError);
+        }
+    }
+
+    private static Task<GameStateSnapshot> WaitForStageAsync(
+        JsonRpcGameClient client,
+        string expectedStageType,
+        TimeSpan timeout,
+        CancellationToken cancellationToken) =>
+        Eventually.UntilAsync(
+            token => client.GetGameStateAsync(token),
+            state => string.Equals(state.StageType, expectedStageType, StringComparison.Ordinal),
+            timeout,
+            TimeSpan.FromMilliseconds(100),
+            expectedStageType,
+            cancellationToken);
+}

--- a/DTXMania.E2E/PreparedChartRecordingSmokeTests.cs
+++ b/DTXMania.E2E/PreparedChartRecordingSmokeTests.cs
@@ -54,145 +54,103 @@ public sealed class PreparedChartRecordingSmokeTests
 
             await client.PrepareVideoChartAsync(fixture.ChartPath, cancellation.Token);
 
+            var screenshotBase64 = await client.TakeScreenshotBase64Async(cancellation.Token);
+            Assert.False(
+                string.IsNullOrWhiteSpace(screenshotBase64),
+                "Prepared SongSelect screenshot should contain image data.");
+            var screenshotBytes = Convert.FromBase64String(screenshotBase64!);
+            Assert.NotEmpty(screenshotBytes);
+            Directory.CreateDirectory(fixture.ArtifactRoot);
+            await File.WriteAllBytesAsync(
+                Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png"),
+                screenshotBytes,
+                cancellation.Token);
+
+            // The generated fixture uses the normal one-second automatic preview delay.
+            // Waiting past it proves preparation does not arm the interactive auto-start path.
+            await Task.Delay(TimeSpan.FromSeconds(2), cancellation.Token);
             var prepared = await Eventually.UntilAsync(
                 token => client.GetGameStateAsync(token),
-                state => !string.IsNullOrWhiteSpace(state.PreparedChartIdentity)
+                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
                     && string.Equals(state.PreparedPreviewState, "Prepared", StringComparison.Ordinal)
                     && state.PreparedPreviewElapsedMs == 0.0,
-                TimeSpan.FromSeconds(20),
-                TimeSpan.FromMilliseconds(100),
-                "prepared chart state",
+                TimeSpan.FromSeconds(10),
+                TimeSpan.FromMilliseconds(250),
+                "prepared preview remains stopped",
                 cancellation.Token);
-            await SaveStateAsync(
-                Path.Combine(fixture.ArtifactRoot, "prepared-state.json"),
-                prepared,
-                cancellation.Token);
-
-            await client.CaptureScreenshotAsync(
-                Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png"),
-                cancellation.Token);
-            Assert.True(new FileInfo(Path.Combine(fixture.ArtifactRoot, "prepared-song-select.png")).Length > 0);
-
-            await Task.Delay(TimeSpan.FromSeconds(2), cancellation.Token);
-            var stillPrepared = await client.GetGameStateAsync(cancellation.Token);
-            Assert.Equal("Prepared", stillPrepared.PreparedPreviewState);
-            Assert.Equal(0.0, stillPrepared.PreparedPreviewElapsedMs);
+            Assert.Equal("Prepared", prepared.PreparedPreviewState);
+            Assert.Equal(0.0, prepared.PreparedPreviewElapsedMs);
+            Assert.False(string.IsNullOrWhiteSpace(prepared.PreparedChartIdentity));
+            Assert.DoesNotContain(
+                Path.GetFullPath(fixture.ChartPath),
+                prepared.PreparedChartIdentity,
+                StringComparison.OrdinalIgnoreCase);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "prepared-state.json", prepared);
 
             await client.StartPreparedPreviewAsync(cancellation.Token);
-
             var playing = await Eventually.UntilAsync(
                 token => client.GetGameStateAsync(token),
-                state => string.Equals(state.PreparedPreviewState, "Playing", StringComparison.Ordinal)
+                state => string.Equals(state.StageType, "SongSelect", StringComparison.Ordinal)
+                    && string.Equals(state.PreparedPreviewState, "Playing", StringComparison.Ordinal)
                     && state.PreparedPreviewElapsedMs >= 10_000.0,
                 TimeSpan.FromSeconds(30),
-                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(250),
                 "prepared preview reaches ten seconds",
                 cancellation.Token);
-            await SaveStateAsync(
-                Path.Combine(fixture.ArtifactRoot, "playing-state.json"),
-                playing,
-                cancellation.Token);
+            Assert.Equal("Playing", playing.PreparedPreviewState);
+            Assert.True(playing.PreparedPreviewElapsedMs >= 10_000.0);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "playing-state.json", playing);
 
             await client.ActivatePreparedChartAsync(cancellation.Token);
+            var transition = await WaitForStageAsync(
+                client,
+                "SongTransition",
+                TimeSpan.FromSeconds(5),
+                cancellation.Token);
+            Assert.Equal("SongTransition", transition.StageType);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "song-transition-state.json", transition);
 
-            var transition = await Eventually.UntilAsync(
-                token => client.GetGameStateAsync(token),
-                state => string.Equals(state.StageType, "SongTransition", StringComparison.Ordinal),
-                TimeSpan.FromSeconds(20),
-                TimeSpan.FromMilliseconds(100),
-                "SongTransition after prepared activation",
+            var performance = await WaitForStageAsync(
+                client,
+                "Performance",
+                TimeSpan.FromSeconds(15),
                 cancellation.Token);
-            await SaveStateAsync(
-                Path.Combine(fixture.ArtifactRoot, "song-transition-state.json"),
-                transition,
-                cancellation.Token);
-
-            var performance = await Eventually.UntilAsync(
-                token => client.GetGameStateAsync(token),
-                state => string.Equals(state.StageType, "Performance", StringComparison.Ordinal),
-                TimeSpan.FromSeconds(45),
-                TimeSpan.FromMilliseconds(250),
-                "Performance after prepared activation",
-                cancellation.Token);
-            await SaveStateAsync(
-                Path.Combine(fixture.ArtifactRoot, "performance-state.json"),
-                performance,
-                cancellation.Token);
+            Assert.Equal("Performance", performance.StageType);
+            await E2EArtifactWriter.WriteJsonAsync(fixture, "performance-state.json", performance);
         }
-        catch (Exception ex)
+        catch (Exception exception)
         {
-            await E2EArtifactWriter.WriteTextAsync(
-                Path.Combine(fixture.ArtifactRoot, "failure.txt"),
-                ex.ToString(),
-                cancellation.Token);
-
+            await E2EArtifactWriter.WriteTextAsync(fixture, "failure.txt", exception.ToString());
             try
             {
-                var failureState = await client.GetGameStateAsync(cancellation.Token);
-                await SaveStateAsync(
-                    Path.Combine(fixture.ArtifactRoot, "failure-state.json"),
-                    failureState,
-                    cancellation.Token);
+                var failureState = await client.GetGameStateAsync(CancellationToken.None);
+                await E2EArtifactWriter.WriteJsonAsync(fixture, "failure-state.json", failureState);
             }
             catch
             {
-                // Preserve the primary failure when telemetry is no longer available.
+                // Preserve the original failure if the game has already exited.
             }
 
             throw;
         }
         finally
         {
-            try
-            {
-                await process.StopAsync(TimeSpan.FromSeconds(5), CancellationToken.None);
-            }
-            finally
-            {
-                await E2EArtifactWriter.CopyIfExistsAsync(
-                    fixture.ConfigPath,
-                    Path.Combine(fixture.ArtifactRoot, "config.ini"),
-                    CancellationToken.None);
-                await E2EArtifactWriter.CopyIfExistsAsync(
-                    fixture.ChartPath,
-                    Path.Combine(fixture.ArtifactRoot, "autoplay-smoke.dtx"),
-                    CancellationToken.None);
-                await E2EArtifactWriter.CopyIfExistsAsync(
-                    fixture.AudioPath,
-                    Path.Combine(fixture.ArtifactRoot, E2EFixtureBuilder.AudioFileName),
-                    CancellationToken.None);
-                await E2EArtifactWriter.CopyIfExistsAsync(
-                    process.StandardOutputPath,
-                    Path.Combine(fixture.ArtifactRoot, "game-stdout.log"),
-                    CancellationToken.None);
-                await E2EArtifactWriter.CopyIfExistsAsync(
-                    process.StandardErrorPath,
-                    Path.Combine(fixture.ArtifactRoot, "game-stderr.log"),
-                    CancellationToken.None);
-            }
+            E2EArtifactWriter.CopyFixtureFiles(fixture);
+            await E2EArtifactWriter.WriteTextAsync(fixture, "game-stdout.log", process.StandardOutput);
+            await E2EArtifactWriter.WriteTextAsync(fixture, "game-stderr.log", process.StandardError);
         }
     }
 
     private static Task<GameStateSnapshot> WaitForStageAsync(
         JsonRpcGameClient client,
-        string stageType,
+        string expectedStageType,
         TimeSpan timeout,
-        CancellationToken cancellationToken)
-    {
-        return Eventually.UntilAsync(
+        CancellationToken cancellationToken) =>
+        Eventually.UntilAsync(
             token => client.GetGameStateAsync(token),
-            state => string.Equals(state.StageType, stageType, StringComparison.Ordinal),
+            state => string.Equals(state.StageType, expectedStageType, StringComparison.Ordinal),
             timeout,
-            TimeSpan.FromMilliseconds(250),
-            $"stage {stageType}",
+            TimeSpan.FromMilliseconds(100),
+            expectedStageType,
             cancellationToken);
-    }
-
-    private static Task SaveStateAsync(
-        string path,
-        GameStateSnapshot state,
-        CancellationToken cancellationToken)
-    {
-        return E2EArtifactWriter.WriteJsonAsync(path, state, cancellationToken);
-    }
 }

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -952,6 +952,11 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
         // Unsubscribe from Game.Exiting to avoid double-flush during normal shutdown
         Exiting -= OnGameExiting;
 
+        // Cancel and complete any prepared-chart commands before stage resources begin
+        // disposing. Queued update delegates observe the same lifecycle token and become
+        // no-ops if they are drained after shutdown starts.
+        _gameApiImplementation?.Dispose();
+
         // Dispose StageManager first to properly cleanup all stages
         if (StageManager != null)
         {

--- a/DTXMania.Game/Lib/GameApi.cs
+++ b/DTXMania.Game/Lib/GameApi.cs
@@ -44,35 +44,32 @@ public interface IGameApi
     /// <summary>
     /// Prepares a chart preview on the Song Select update thread.
     /// </summary>
-    Task<PreparedChartCommandResult> PrepareVideoChartAsync(string chartPath);
-
+    /// <param name="chartPath">Fully qualified path to the chart file.</param>
+    /// <param name="cancellationToken">Optional token to cancel the queued command.</param>
     Task<PreparedChartCommandResult> PrepareVideoChartAsync(
         string chartPath,
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Starts the prepared chart preview on the Song Select update thread.
     /// </summary>
-    Task<PreparedChartCommandResult> StartPreparedPreviewAsync();
-
+    /// <param name="cancellationToken">Optional token to cancel the queued command.</param>
     Task<PreparedChartCommandResult> StartPreparedPreviewAsync(
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Activates the prepared chart on the Song Select update thread.
     /// </summary>
-    Task<PreparedChartCommandResult> ActivatePreparedChartAsync();
-
+    /// <param name="cancellationToken">Optional token to cancel the queued command.</param>
     Task<PreparedChartCommandResult> ActivatePreparedChartAsync(
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Cancels the prepared chart preview on the Song Select update thread.
     /// </summary>
-    Task<PreparedChartCommandResult> CancelPreparedChartAsync();
-
+    /// <param name="cancellationToken">Optional token to cancel the queued command.</param>
     Task<PreparedChartCommandResult> CancelPreparedChartAsync(
-        CancellationToken cancellationToken);
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Check if game is running

--- a/DTXMania.Game/Lib/GameApi.cs
+++ b/DTXMania.Game/Lib/GameApi.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DTXMania.Game.Lib;
@@ -45,20 +46,33 @@ public interface IGameApi
     /// </summary>
     Task<PreparedChartCommandResult> PrepareVideoChartAsync(string chartPath);
 
+    Task<PreparedChartCommandResult> PrepareVideoChartAsync(
+        string chartPath,
+        CancellationToken cancellationToken);
+
     /// <summary>
     /// Starts the prepared chart preview on the Song Select update thread.
     /// </summary>
     Task<PreparedChartCommandResult> StartPreparedPreviewAsync();
+
+    Task<PreparedChartCommandResult> StartPreparedPreviewAsync(
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Activates the prepared chart on the Song Select update thread.
     /// </summary>
     Task<PreparedChartCommandResult> ActivatePreparedChartAsync();
 
+    Task<PreparedChartCommandResult> ActivatePreparedChartAsync(
+        CancellationToken cancellationToken);
+
     /// <summary>
     /// Cancels the prepared chart preview on the Song Select update thread.
     /// </summary>
     Task<PreparedChartCommandResult> CancelPreparedChartAsync();
+
+    Task<PreparedChartCommandResult> CancelPreparedChartAsync(
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Check if game is running

--- a/DTXMania.Game/Lib/GameApi.cs
+++ b/DTXMania.Game/Lib/GameApi.cs
@@ -41,10 +41,35 @@ public interface IGameApi
     Task<bool> ChangeStageAsync(string stageName);
 
     /// <summary>
+    /// Prepares a chart preview on the Song Select update thread.
+    /// </summary>
+    Task<PreparedChartCommandResult> PrepareVideoChartAsync(string chartPath);
+
+    /// <summary>
+    /// Starts the prepared chart preview on the Song Select update thread.
+    /// </summary>
+    Task<PreparedChartCommandResult> StartPreparedPreviewAsync();
+
+    /// <summary>
+    /// Activates the prepared chart on the Song Select update thread.
+    /// </summary>
+    Task<PreparedChartCommandResult> ActivatePreparedChartAsync();
+
+    /// <summary>
+    /// Cancels the prepared chart preview on the Song Select update thread.
+    /// </summary>
+    Task<PreparedChartCommandResult> CancelPreparedChartAsync();
+
+    /// <summary>
     /// Check if game is running
     /// </summary>
     bool IsRunning { get; }
 }
+
+/// <summary>
+/// Result returned by an explicit prepared-chart command.
+/// </summary>
+public readonly record struct PreparedChartCommandResult(bool Success, string? Error);
 
 /// <summary>
 /// Represents the current state of the game

--- a/DTXMania.Game/Lib/GameApiImplementation.cs
+++ b/DTXMania.Game/Lib/GameApiImplementation.cs
@@ -327,6 +327,73 @@ public class GameApiImplementation : IGameApi
         return Task.FromResult(true);
     }
 
+    public Task<PreparedChartCommandResult> PrepareVideoChartAsync(string chartPath)
+    {
+        return QueuePreparedChartCommandAsync(stage => stage.PrepareVideoChart(chartPath));
+    }
+
+    public Task<PreparedChartCommandResult> StartPreparedPreviewAsync()
+    {
+        return QueuePreparedChartCommandAsync(stage => stage.StartPreparedPreview());
+    }
+
+    public Task<PreparedChartCommandResult> ActivatePreparedChartAsync()
+    {
+        return QueuePreparedChartCommandAsync(stage => stage.ActivatePreparedChart());
+    }
+
+    public Task<PreparedChartCommandResult> CancelPreparedChartAsync()
+    {
+        return QueuePreparedChartCommandAsync(stage => stage.CancelPreparedChart());
+    }
+
+    private Task<PreparedChartCommandResult> QueuePreparedChartCommandAsync(
+        Func<SongSelectionStage, (bool Success, string? Error)> command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var completion = new TaskCompletionSource<PreparedChartCommandResult>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void CompleteFailure(Exception exception, string logMessage)
+        {
+            _logger?.LogError(exception, logMessage);
+            completion.TrySetResult(new PreparedChartCommandResult(
+                false,
+                "The prepared chart command could not be completed."));
+        }
+
+        try
+        {
+            _game.QueueMainThreadAction(() =>
+            {
+                try
+                {
+                    if (_game.StageManager?.CurrentStage is not SongSelectionStage songSelectionStage)
+                    {
+                        completion.TrySetResult(new PreparedChartCommandResult(
+                            false,
+                            "Prepared chart commands require the Song Select stage."));
+                        return;
+                    }
+
+                    var result = command(songSelectionStage);
+                    completion.TrySetResult(new PreparedChartCommandResult(result.Success, result.Error));
+                }
+                catch (Exception exception)
+                {
+                    CompleteFailure(exception, "Game API: Prepared chart command failed on the update thread");
+                }
+            });
+        }
+        catch (Exception exception)
+        {
+            CompleteFailure(exception, "Game API: Could not queue prepared chart command");
+        }
+
+        return completion.Task;
+    }
+
     private GameWindowInfo GetWindowInfoSafe()
     {
         lock (_lock)

--- a/DTXMania.Game/Lib/GameApiImplementation.cs
+++ b/DTXMania.Game/Lib/GameApiImplementation.cs
@@ -341,53 +341,33 @@ public class GameApiImplementation : IGameApi, IDisposable
         return Task.FromResult(true);
     }
 
-    public Task<PreparedChartCommandResult> PrepareVideoChartAsync(string chartPath)
-    {
-        return PrepareVideoChartAsync(chartPath, CancellationToken.None);
-    }
-
     public Task<PreparedChartCommandResult> PrepareVideoChartAsync(
         string chartPath,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         return QueuePreparedChartCommandAsync(
             stage => stage.PrepareVideoChart(chartPath),
             cancellationToken);
     }
 
-    public Task<PreparedChartCommandResult> StartPreparedPreviewAsync()
-    {
-        return StartPreparedPreviewAsync(CancellationToken.None);
-    }
-
     public Task<PreparedChartCommandResult> StartPreparedPreviewAsync(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         return QueuePreparedChartCommandAsync(
             stage => stage.StartPreparedPreview(),
             cancellationToken);
     }
 
-    public Task<PreparedChartCommandResult> ActivatePreparedChartAsync()
-    {
-        return ActivatePreparedChartAsync(CancellationToken.None);
-    }
-
     public Task<PreparedChartCommandResult> ActivatePreparedChartAsync(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         return QueuePreparedChartCommandAsync(
             stage => stage.ActivatePreparedChart(),
             cancellationToken);
     }
 
-    public Task<PreparedChartCommandResult> CancelPreparedChartAsync()
-    {
-        return CancelPreparedChartAsync(CancellationToken.None);
-    }
-
     public Task<PreparedChartCommandResult> CancelPreparedChartAsync(
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken = default)
     {
         return QueuePreparedChartCommandAsync(
             stage => stage.CancelPreparedChart(),

--- a/DTXMania.Game/Lib/GameApiImplementation.cs
+++ b/DTXMania.Game/Lib/GameApiImplementation.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Xna.Framework;
@@ -36,11 +38,16 @@ public interface IGameContext
 /// <summary>
 /// Implementation of IGameApi for the DTXMania game
 /// </summary>
-public class GameApiImplementation : IGameApi
+public class GameApiImplementation : IGameApi, IDisposable
 {
     private readonly IGameContext _game;
     private readonly object _lock = new object();
     private readonly ILogger<GameApiImplementation>? _logger;
+    private readonly CancellationTokenSource _lifecycleCancellation = new();
+    private readonly HashSet<PendingPreparedChartCommand> _pendingPreparedCommands = new();
+    private bool _disposed;
+
+    private const string PreparedCommandCanceledError = "The prepared chart command was canceled.";
 
     public GameApiImplementation(IGameContext game, ILogger<GameApiImplementation>? logger = null)
     {
@@ -48,7 +55,14 @@ public class GameApiImplementation : IGameApi
         _logger = logger;
     }
 
-    public bool IsRunning => true; // Game is running if this instance exists
+    public bool IsRunning
+    {
+        get
+        {
+            lock (_lock)
+                return !_disposed;
+        }
+    }
 
     public async Task<GameState> GetGameStateAsync()
     {
@@ -329,69 +343,267 @@ public class GameApiImplementation : IGameApi
 
     public Task<PreparedChartCommandResult> PrepareVideoChartAsync(string chartPath)
     {
-        return QueuePreparedChartCommandAsync(stage => stage.PrepareVideoChart(chartPath));
+        return PrepareVideoChartAsync(chartPath, CancellationToken.None);
+    }
+
+    public Task<PreparedChartCommandResult> PrepareVideoChartAsync(
+        string chartPath,
+        CancellationToken cancellationToken)
+    {
+        return QueuePreparedChartCommandAsync(
+            stage => stage.PrepareVideoChart(chartPath),
+            cancellationToken);
     }
 
     public Task<PreparedChartCommandResult> StartPreparedPreviewAsync()
     {
-        return QueuePreparedChartCommandAsync(stage => stage.StartPreparedPreview());
+        return StartPreparedPreviewAsync(CancellationToken.None);
+    }
+
+    public Task<PreparedChartCommandResult> StartPreparedPreviewAsync(
+        CancellationToken cancellationToken)
+    {
+        return QueuePreparedChartCommandAsync(
+            stage => stage.StartPreparedPreview(),
+            cancellationToken);
     }
 
     public Task<PreparedChartCommandResult> ActivatePreparedChartAsync()
     {
-        return QueuePreparedChartCommandAsync(stage => stage.ActivatePreparedChart());
+        return ActivatePreparedChartAsync(CancellationToken.None);
+    }
+
+    public Task<PreparedChartCommandResult> ActivatePreparedChartAsync(
+        CancellationToken cancellationToken)
+    {
+        return QueuePreparedChartCommandAsync(
+            stage => stage.ActivatePreparedChart(),
+            cancellationToken);
     }
 
     public Task<PreparedChartCommandResult> CancelPreparedChartAsync()
     {
-        return QueuePreparedChartCommandAsync(stage => stage.CancelPreparedChart());
+        return CancelPreparedChartAsync(CancellationToken.None);
+    }
+
+    public Task<PreparedChartCommandResult> CancelPreparedChartAsync(
+        CancellationToken cancellationToken)
+    {
+        return QueuePreparedChartCommandAsync(
+            stage => stage.CancelPreparedChart(),
+            cancellationToken);
     }
 
     private Task<PreparedChartCommandResult> QueuePreparedChartCommandAsync(
-        Func<SongSelectionStage, (bool Success, string? Error)> command)
+        Func<SongSelectionStage, (bool Success, string? Error)> command,
+        CancellationToken requestCancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        var completion = new TaskCompletionSource<PreparedChartCommandResult>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-
-        void CompleteFailure(Exception exception, string logMessage)
+        PendingPreparedChartCommand pending;
+        lock (_lock)
         {
-            _logger?.LogError(exception, logMessage);
-            completion.TrySetResult(new PreparedChartCommandResult(
-                false,
-                "The prepared chart command could not be completed."));
+            if (_disposed)
+            {
+                return Task.FromResult(new PreparedChartCommandResult(
+                    false,
+                    PreparedCommandCanceledError));
+            }
+
+            var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                requestCancellationToken,
+                _lifecycleCancellation.Token);
+            pending = new PendingPreparedChartCommand(linkedCancellation);
+            _pendingPreparedCommands.Add(pending);
+        }
+
+        pending.SetCancellationRegistration(
+            pending.CancellationToken.Register(() =>
+                CompletePreparedCommand(
+                    pending,
+                    new PreparedChartCommandResult(false, PreparedCommandCanceledError))));
+
+        if (pending.CancellationToken.IsCancellationRequested)
+        {
+            CompletePreparedCommand(
+                pending,
+                new PreparedChartCommandResult(false, PreparedCommandCanceledError));
+            return pending.Completion.Task;
         }
 
         try
         {
             _game.QueueMainThreadAction(() =>
             {
-                try
-                {
-                    if (_game.StageManager?.CurrentStage is not SongSelectionStage songSelectionStage)
-                    {
-                        completion.TrySetResult(new PreparedChartCommandResult(
-                            false,
-                            "Prepared chart commands require the Song Select stage."));
-                        return;
-                    }
+                if (!pending.TryBeginExecution())
+                    return;
 
-                    var result = command(songSelectionStage);
-                    completion.TrySetResult(new PreparedChartCommandResult(result.Success, result.Error));
-                }
-                catch (Exception exception)
+                PreparedChartCommandResult result;
+                if (pending.CancellationToken.IsCancellationRequested)
                 {
-                    CompleteFailure(exception, "Game API: Prepared chart command failed on the update thread");
+                    result = new PreparedChartCommandResult(
+                        false,
+                        PreparedCommandCanceledError);
                 }
+                else
+                {
+                    try
+                    {
+                        if (_game.StageManager?.CurrentStage is not SongSelectionStage songSelectionStage)
+                        {
+                            result = new PreparedChartCommandResult(
+                                false,
+                                "Prepared chart commands require the Song Select stage.");
+                        }
+                        else
+                        {
+                            var commandResult = command(songSelectionStage);
+                            result = new PreparedChartCommandResult(
+                                commandResult.Success,
+                                commandResult.Error);
+                        }
+                    }
+                    catch (Exception exception)
+                    {
+                        _logger?.LogError(
+                            exception,
+                            "Game API: Prepared chart command failed on the update thread");
+                        result = new PreparedChartCommandResult(
+                            false,
+                            "The prepared chart command could not be completed.");
+                    }
+                }
+
+                pending.TryComplete(result);
+                RemovePreparedCommand(pending);
             });
         }
         catch (Exception exception)
         {
-            CompleteFailure(exception, "Game API: Could not queue prepared chart command");
+            _logger?.LogError(exception, "Game API: Could not queue prepared chart command");
+            CompletePreparedCommand(
+                pending,
+                new PreparedChartCommandResult(
+                    false,
+                    "The prepared chart command could not be completed."));
         }
 
-        return completion.Task;
+        return pending.Completion.Task;
+    }
+
+    private void CompletePreparedCommand(
+        PendingPreparedChartCommand pending,
+        PreparedChartCommandResult result)
+    {
+        pending.TryComplete(result);
+        RemovePreparedCommand(pending);
+    }
+
+    private void RemovePreparedCommand(PendingPreparedChartCommand pending)
+    {
+        lock (_lock)
+            _pendingPreparedCommands.Remove(pending);
+
+        pending.DisposeCancellation();
+    }
+
+    public void Dispose()
+    {
+        PendingPreparedChartCommand[] pendingCommands;
+        lock (_lock)
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            pendingCommands = _pendingPreparedCommands.ToArray();
+        }
+
+        try
+        {
+            _lifecycleCancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+
+        foreach (var pending in pendingCommands)
+        {
+            CompletePreparedCommand(
+                pending,
+                new PreparedChartCommandResult(false, PreparedCommandCanceledError));
+        }
+
+        _lifecycleCancellation.Dispose();
+    }
+
+    private sealed class PendingPreparedChartCommand
+    {
+        private int _completed;
+        private int _executionStarted;
+        private int _registrationReady;
+        private int _disposeRequested;
+        private int _resourcesDisposed;
+        private CancellationTokenRegistration _cancellationRegistration;
+
+        public PendingPreparedChartCommand(CancellationTokenSource cancellationSource)
+        {
+            CancellationSource = cancellationSource;
+            CancellationToken = cancellationSource.Token;
+            Completion = new TaskCompletionSource<PreparedChartCommandResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        public TaskCompletionSource<PreparedChartCommandResult> Completion { get; }
+        public CancellationTokenSource CancellationSource { get; }
+        public CancellationToken CancellationToken { get; }
+        public bool IsCompleted => Volatile.Read(ref _completed) != 0;
+
+        public bool TryBeginExecution()
+        {
+            if (IsCompleted
+                || Interlocked.CompareExchange(ref _executionStarted, 1, 0) != 0)
+            {
+                return false;
+            }
+
+            return !IsCompleted;
+        }
+
+        public bool TryComplete(PreparedChartCommandResult result)
+        {
+            if (Interlocked.Exchange(ref _completed, 1) != 0)
+                return false;
+
+            Completion.TrySetResult(result);
+            return true;
+        }
+
+        public void SetCancellationRegistration(CancellationTokenRegistration registration)
+        {
+            _cancellationRegistration = registration;
+            Volatile.Write(ref _registrationReady, 1);
+            DisposeCancellationIfRequested();
+        }
+
+        public void DisposeCancellation()
+        {
+            Volatile.Write(ref _disposeRequested, 1);
+            DisposeCancellationIfRequested();
+        }
+
+        private void DisposeCancellationIfRequested()
+        {
+            if (Volatile.Read(ref _disposeRequested) == 0
+                || Volatile.Read(ref _registrationReady) == 0
+                || Interlocked.Exchange(ref _resourcesDisposed, 1) != 0)
+            {
+                return;
+            }
+
+            _cancellationRegistration.Dispose();
+            CancellationSource.Dispose();
+        }
     }
 
     private GameWindowInfo GetWindowInfoSafe()

--- a/DTXMania.Game/Lib/GameApiImplementation.cs
+++ b/DTXMania.Game/Lib/GameApiImplementation.cs
@@ -475,8 +475,11 @@ public class GameApiImplementation : IGameApi, IDisposable
         PendingPreparedChartCommand pending,
         PreparedChartCommandResult result)
     {
-        pending.TryComplete(result);
-        RemovePreparedCommand(pending);
+        // Cancellation/lifecycle completion may only win while the command is
+        // still Queued. If execution has already started, the main-thread
+        // execution path owns completion and this is a no-op.
+        if (pending.TryCompleteFromCancellation(result))
+            RemovePreparedCommand(pending);
     }
 
     private void RemovePreparedCommand(PendingPreparedChartCommand pending)
@@ -519,8 +522,16 @@ public class GameApiImplementation : IGameApi, IDisposable
 
     private sealed class PendingPreparedChartCommand
     {
-        private int _completed;
-        private int _executionStarted;
+        // Single atomic lifecycle: Queued → Executing → Completed.
+        // Cancellation may only complete the command while still Queued; once the
+        // main thread claims Executing, that execution owns completion. This
+        // prevents a cancellation callback from reporting failure after the
+        // command has already begun mutating game state.
+        private const int StateQueued = 0;
+        private const int StateExecuting = 1;
+        private const int StateCompleted = 2;
+
+        private int _state = StateQueued;
         private int _registrationReady;
         private int _disposeRequested;
         private int _resourcesDisposed;
@@ -537,22 +548,38 @@ public class GameApiImplementation : IGameApi, IDisposable
         public TaskCompletionSource<PreparedChartCommandResult> Completion { get; }
         public CancellationTokenSource CancellationSource { get; }
         public CancellationToken CancellationToken { get; }
-        public bool IsCompleted => Volatile.Read(ref _completed) != 0;
+        public bool IsCompleted => Volatile.Read(ref _state) == StateCompleted;
 
+        /// <summary>
+        /// Atomically transitions from Queued to Executing. Returns false if the
+        /// command was already canceled (Queued → Completed) or already claimed.
+        /// </summary>
         public bool TryBeginExecution()
         {
-            if (IsCompleted
-                || Interlocked.CompareExchange(ref _executionStarted, 1, 0) != 0)
-            {
-                return false;
-            }
-
-            return !IsCompleted;
+            return Interlocked.CompareExchange(ref _state, StateExecuting, StateQueued) == StateQueued;
         }
 
+        /// <summary>
+        /// Execution-path completion: transitions from Executing to Completed.
+        /// The main thread owns completion once it has claimed Executing.
+        /// </summary>
         public bool TryComplete(PreparedChartCommandResult result)
         {
-            if (Interlocked.Exchange(ref _completed, 1) != 0)
+            if (Interlocked.CompareExchange(ref _state, StateCompleted, StateExecuting) != StateExecuting)
+                return false;
+
+            Completion.TrySetResult(result);
+            return true;
+        }
+
+        /// <summary>
+        /// Cancellation/lifecycle completion: may only win while still Queued.
+        /// Once execution has started (Executing), the execution path owns
+        /// completion and this returns false.
+        /// </summary>
+        public bool TryCompleteFromCancellation(PreparedChartCommandResult result)
+        {
+            if (Interlocked.CompareExchange(ref _state, StateCompleted, StateQueued) != StateQueued)
                 return false;
 
             Completion.TrySetResult(result);

--- a/DTXMania.Game/Lib/GameTelemetrySnapshot.cs
+++ b/DTXMania.Game/Lib/GameTelemetrySnapshot.cs
@@ -25,6 +25,9 @@ public sealed class GameTelemetrySnapshot
     public int? AudioPreparationTotal { get; set; }
     public int? AudioPreparationCacheHits { get; set; }
     public long? PreparedAudioBytes { get; set; }
+    public string? PreparedChartIdentity { get; set; }
+    public string? PreparedPreviewState { get; set; }
+    public double? PreparedPreviewElapsedMs { get; set; }
     public bool? AutoPlayEnabled { get; set; }
     public bool? StageCompleted { get; set; }
     public double? CurrentSongTimeMs { get; set; }

--- a/DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs
+++ b/DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs
@@ -297,6 +297,18 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
                 case "changeStage":
                     return await HandleChangeStage(request);
 
+                case "prepareVideoChart":
+                    return await HandlePrepareVideoChart(request);
+
+                case "startPreparedPreview":
+                    return await HandleStartPreparedPreview(request);
+
+                case "activatePreparedChart":
+                    return await HandleActivatePreparedChart(request);
+
+                case "cancelPreparedChart":
+                    return await HandleCancelPreparedChart(request);
+
                 case "ping":
                     return CreateSuccessResponse(request.Id, new { pong = true, timestamp = DateTime.UtcNow });
 
@@ -484,6 +496,107 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
         }
 
         return CreateSuccessResponse(request.Id, new { success = true, stageName });
+    }
+
+    private async Task<JsonRpcResponse> HandlePrepareVideoChart(JsonRpcRequest request)
+    {
+        if (!_gameApi.IsRunning)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.GameNotRunning,
+                "Game is not running");
+        }
+
+        if (request.Params is not JsonElement paramsElement)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.InvalidParams,
+                "chartPath parameter is required");
+        }
+
+        if (paramsElement.ValueKind != JsonValueKind.Object)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.InvalidParams,
+                "params must be an object");
+        }
+
+        if (!paramsElement.TryGetProperty("chartPath", out var chartPathElement))
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.InvalidParams,
+                "chartPath must be a non-empty string");
+        }
+
+        if (chartPathElement.ValueKind != JsonValueKind.String)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.InvalidParams,
+                "chartPath must be a string");
+        }
+
+        var chartPath = chartPathElement.GetString();
+        if (string.IsNullOrWhiteSpace(chartPath))
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.InvalidParams,
+                "chartPath must be a non-empty string");
+        }
+
+        if (!Path.IsPathFullyQualified(chartPath))
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.InvalidParams,
+                "chartPath must be a fully-qualified path");
+        }
+
+        var commandResult = await _gameApi.PrepareVideoChartAsync(chartPath);
+        return CreateSuccessResponse(request.Id, new
+        {
+            success = commandResult.Success,
+            error = commandResult.Error
+        });
+    }
+
+    private async Task<JsonRpcResponse> HandleStartPreparedPreview(JsonRpcRequest request)
+    {
+        if (!_gameApi.IsRunning)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.GameNotRunning,
+                "Game is not running");
+        }
+
+        var commandResult = await _gameApi.StartPreparedPreviewAsync();
+        return CreateSuccessResponse(request.Id, new
+        {
+            success = commandResult.Success,
+            error = commandResult.Error
+        });
+    }
+
+    private async Task<JsonRpcResponse> HandleActivatePreparedChart(JsonRpcRequest request)
+    {
+        if (!_gameApi.IsRunning)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.GameNotRunning,
+                "Game is not running");
+        }
+
+        var commandResult = await _gameApi.ActivatePreparedChartAsync();
+        return CreateSuccessResponse(request.Id, new
+        {
+            success = commandResult.Success,
+            error = commandResult.Error
+        });
+    }
+
+    private async Task<JsonRpcResponse> HandleCancelPreparedChart(JsonRpcRequest request)
+    {
+        if (!_gameApi.IsRunning)
+        {
+            return CreateErrorResponse(request.Id, JsonRpcErrorCodes.GameNotRunning,
+                "Game is not running");
+        }
+
+        var commandResult = await _gameApi.CancelPreparedChartAsync();
+        return CreateSuccessResponse(request.Id, new
+        {
+            success = commandResult.Success,
+            error = commandResult.Error
+        });
     }
 
     /// <summary>

--- a/DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs
+++ b/DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs
@@ -249,7 +249,7 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
             }
 
             // Route the method call
-            response = await RouteMethodCall(request);
+            response = await RouteMethodCallWithCancellation(request, context.RequestAborted);
 
             // Don't send response for notifications
             if (!request.IsNotification)
@@ -276,7 +276,17 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
     /// <summary>
     /// Route method calls to appropriate handlers
     /// </summary>
-    private async Task<JsonRpcResponse> RouteMethodCall(JsonRpcRequest request)
+    private Task<JsonRpcResponse> RouteMethodCall(JsonRpcRequest request)
+        => RouteMethodCallCore(request, null);
+
+    private Task<JsonRpcResponse> RouteMethodCallWithCancellation(
+        JsonRpcRequest request,
+        CancellationToken cancellationToken)
+        => RouteMethodCallCore(request, cancellationToken);
+
+    private async Task<JsonRpcResponse> RouteMethodCallCore(
+        JsonRpcRequest request,
+        CancellationToken? cancellationToken)
     {
         try
         {
@@ -298,16 +308,24 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
                     return await HandleChangeStage(request);
 
                 case "prepareVideoChart":
-                    return await HandlePrepareVideoChart(request);
+                    return cancellationToken.HasValue
+                        ? await HandlePrepareVideoChartWithCancellation(request, cancellationToken.Value)
+                        : await HandlePrepareVideoChart(request);
 
                 case "startPreparedPreview":
-                    return await HandleStartPreparedPreview(request);
+                    return cancellationToken.HasValue
+                        ? await HandleStartPreparedPreviewWithCancellation(request, cancellationToken.Value)
+                        : await HandleStartPreparedPreview(request);
 
                 case "activatePreparedChart":
-                    return await HandleActivatePreparedChart(request);
+                    return cancellationToken.HasValue
+                        ? await HandleActivatePreparedChartWithCancellation(request, cancellationToken.Value)
+                        : await HandleActivatePreparedChart(request);
 
                 case "cancelPreparedChart":
-                    return await HandleCancelPreparedChart(request);
+                    return cancellationToken.HasValue
+                        ? await HandleCancelPreparedChartWithCancellation(request, cancellationToken.Value)
+                        : await HandleCancelPreparedChart(request);
 
                 case "ping":
                     return CreateSuccessResponse(request.Id, new { pong = true, timestamp = DateTime.UtcNow });
@@ -498,7 +516,17 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
         return CreateSuccessResponse(request.Id, new { success = true, stageName });
     }
 
-    private async Task<JsonRpcResponse> HandlePrepareVideoChart(JsonRpcRequest request)
+    private Task<JsonRpcResponse> HandlePrepareVideoChart(JsonRpcRequest request)
+        => HandlePrepareVideoChartCore(request, null);
+
+    private Task<JsonRpcResponse> HandlePrepareVideoChartWithCancellation(
+        JsonRpcRequest request,
+        CancellationToken cancellationToken)
+        => HandlePrepareVideoChartCore(request, cancellationToken);
+
+    private async Task<JsonRpcResponse> HandlePrepareVideoChartCore(
+        JsonRpcRequest request,
+        CancellationToken? cancellationToken)
     {
         if (!_gameApi.IsRunning)
         {
@@ -543,7 +571,9 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
                 "chartPath must be a fully-qualified path");
         }
 
-        var commandResult = await _gameApi.PrepareVideoChartAsync(chartPath);
+        var commandResult = cancellationToken.HasValue
+            ? await _gameApi.PrepareVideoChartAsync(chartPath, cancellationToken.Value)
+            : await _gameApi.PrepareVideoChartAsync(chartPath);
         return CreateSuccessResponse(request.Id, new
         {
             success = commandResult.Success,
@@ -551,7 +581,17 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
         });
     }
 
-    private async Task<JsonRpcResponse> HandleStartPreparedPreview(JsonRpcRequest request)
+    private Task<JsonRpcResponse> HandleStartPreparedPreview(JsonRpcRequest request)
+        => HandleStartPreparedPreviewCore(request, null);
+
+    private Task<JsonRpcResponse> HandleStartPreparedPreviewWithCancellation(
+        JsonRpcRequest request,
+        CancellationToken cancellationToken)
+        => HandleStartPreparedPreviewCore(request, cancellationToken);
+
+    private async Task<JsonRpcResponse> HandleStartPreparedPreviewCore(
+        JsonRpcRequest request,
+        CancellationToken? cancellationToken)
     {
         if (!_gameApi.IsRunning)
         {
@@ -559,7 +599,9 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
                 "Game is not running");
         }
 
-        var commandResult = await _gameApi.StartPreparedPreviewAsync();
+        var commandResult = cancellationToken.HasValue
+            ? await _gameApi.StartPreparedPreviewAsync(cancellationToken.Value)
+            : await _gameApi.StartPreparedPreviewAsync();
         return CreateSuccessResponse(request.Id, new
         {
             success = commandResult.Success,
@@ -567,7 +609,17 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
         });
     }
 
-    private async Task<JsonRpcResponse> HandleActivatePreparedChart(JsonRpcRequest request)
+    private Task<JsonRpcResponse> HandleActivatePreparedChart(JsonRpcRequest request)
+        => HandleActivatePreparedChartCore(request, null);
+
+    private Task<JsonRpcResponse> HandleActivatePreparedChartWithCancellation(
+        JsonRpcRequest request,
+        CancellationToken cancellationToken)
+        => HandleActivatePreparedChartCore(request, cancellationToken);
+
+    private async Task<JsonRpcResponse> HandleActivatePreparedChartCore(
+        JsonRpcRequest request,
+        CancellationToken? cancellationToken)
     {
         if (!_gameApi.IsRunning)
         {
@@ -575,7 +627,9 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
                 "Game is not running");
         }
 
-        var commandResult = await _gameApi.ActivatePreparedChartAsync();
+        var commandResult = cancellationToken.HasValue
+            ? await _gameApi.ActivatePreparedChartAsync(cancellationToken.Value)
+            : await _gameApi.ActivatePreparedChartAsync();
         return CreateSuccessResponse(request.Id, new
         {
             success = commandResult.Success,
@@ -583,7 +637,17 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
         });
     }
 
-    private async Task<JsonRpcResponse> HandleCancelPreparedChart(JsonRpcRequest request)
+    private Task<JsonRpcResponse> HandleCancelPreparedChart(JsonRpcRequest request)
+        => HandleCancelPreparedChartCore(request, null);
+
+    private Task<JsonRpcResponse> HandleCancelPreparedChartWithCancellation(
+        JsonRpcRequest request,
+        CancellationToken cancellationToken)
+        => HandleCancelPreparedChartCore(request, cancellationToken);
+
+    private async Task<JsonRpcResponse> HandleCancelPreparedChartCore(
+        JsonRpcRequest request,
+        CancellationToken? cancellationToken)
     {
         if (!_gameApi.IsRunning)
         {
@@ -591,7 +655,9 @@ public class JsonRpcServer : IDisposable, IAsyncDisposable
                 "Game is not running");
         }
 
-        var commandResult = await _gameApi.CancelPreparedChartAsync();
+        var commandResult = cancellationToken.HasValue
+            ? await _gameApi.CancelPreparedChartAsync(cancellationToken.Value)
+            : await _gameApi.CancelPreparedChartAsync();
         return CreateSuccessResponse(request.Id, new
         {
             success = commandResult.Success,

--- a/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
+++ b/DTXMania.Game/Lib/Song/Components/SongListDisplay.cs
@@ -362,6 +362,32 @@ namespace DTXMania.Game.Lib.Song.Components
         }
 
         /// <summary>
+        /// Applies a validated row and difficulty selection as one UI operation.
+        /// Prepared-chart projection uses this instead of setting the two values
+        /// independently, which would briefly expose an intermediate selection.
+        /// </summary>
+        internal void SetSelection(int index, int difficulty)
+        {
+            if (_currentList == null
+                || _currentList.Count == 0
+                || index < 0
+                || index >= _currentList.Count)
+            {
+                return;
+            }
+
+            _selectedIndex = index;
+            _currentDifficulty = Math.Clamp(difficulty, 0, 4);
+
+            // The projection is already at its final row, so keep the current and
+            // target counters aligned and report a scroll-complete selection event.
+            _targetScrollCounter = index * SCROLL_UNIT;
+            _currentScrollCounter = _targetScrollCounter;
+
+            UpdateSelectionCore(forceSelectionEvent: true);
+        }
+
+        /// <summary>
         /// Cycle through available difficulties
         /// </summary>
         public void CycleDifficulty()
@@ -1381,6 +1407,11 @@ namespace DTXMania.Game.Lib.Song.Components
 
         private void UpdateSelection()
         {
+            UpdateSelectionCore(forceSelectionEvent: false);
+        }
+
+        private void UpdateSelectionCore(bool forceSelectionEvent)
+        {
             var previousSong = SelectedSong;
 
             // Update logical selection with infinite looping support
@@ -1406,6 +1437,10 @@ namespace DTXMania.Game.Lib.Song.Components
                 // Pre-generate textures for adjacent songs (±5 from current selection - increased per senior engineer feedback)
                 PreGenerateAdjacentSongTextures();
 
+            }
+
+            if (SelectedSong != previousSong || forceSelectionEvent)
+            {
                 SelectionChanged?.Invoke(this, new SongSelectionChangedEventArgs(SelectedSong, _currentDifficulty, IsScrollComplete));
             }
         }        /// <summary>

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1547,6 +1547,12 @@ namespace DTXMania.Game.Lib.Stage
             if (!File.Exists(previewPath))
                 return PreparedFailure("The requested chart preview file was not found.");
 
+            // The ordinary preview path is not owned by prepared state on a first prepare.
+            // Tear it down only after chart/path validation succeeds and before replacing its
+            // sound resource, so invalid commands preserve interactive preview ownership.
+            if (_previewSound != null || _previewSoundInstance != null)
+                StopCurrentPreview();
+
             // Project through the normal Song Select hierarchy before publishing prepared
             // state. The projection itself suppresses the intermediate selection events so
             // they cannot stop or replace this exact-chart preview.

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -166,6 +166,9 @@ namespace DTXMania.Game.Lib.Stage
         private Stack<SongListNode> _navigationStack;
         private string _currentBreadcrumb = "";
         private bool _isProjectingPreparedSelection;
+        private PreparedChartSelection _preparedChartSelection;
+        private PreparedPreviewState _preparedPreviewState = PreparedPreviewState.None;
+        private double _preparedPreviewElapsedMs;
 
         // Status panel navigation state
         private bool _isInStatusPanel = false;
@@ -248,6 +251,20 @@ namespace DTXMania.Game.Lib.Stage
             long Generation,
             SongLibrarySnapshot? Snapshot,
             IReadOnlyList<SongListNode> SongList);
+
+        private sealed record PreparedChartSelection(
+            SongListNode Node,
+            SongChart Chart,
+            int DifficultyIndex,
+            string TelemetryIdentity);
+
+        private enum PreparedPreviewState
+        {
+            None,
+            Prepared,
+            Playing,
+            Failed
+        }
 
         private sealed record PreparedChartResolution(
             SongListNode Node,
@@ -528,7 +545,7 @@ namespace DTXMania.Game.Lib.Stage
             _footerPanelTexture?.RemoveReference();
 
             // Clean up preview sound resources
-            StopCurrentPreview();
+            ClearPreparedPreviewState();
             _backgroundMusicInstance?.Dispose();
             _backgroundMusicInstance = null;
             _backgroundMusic?.RemoveReference();
@@ -1513,6 +1530,190 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        internal (bool Success, string Error) PrepareVideoChart(string chartPath)
+        {
+            ClearPreparedPreviewState();
+
+            if (string.IsNullOrWhiteSpace(chartPath))
+                return PreparedFailure("A chart path is required.");
+
+            var resolution = ResolvePreparedChart(chartPath);
+            if (resolution == null)
+                return PreparedFailure("The requested chart is not available in the active song library.");
+
+            if (!TryGetChartPreviewPath(resolution.Chart, out var previewPath))
+                return PreparedFailure("The requested chart does not declare a preview file.");
+
+            if (!File.Exists(previewPath))
+                return PreparedFailure("The requested chart preview file was not found.");
+
+            // Project through the normal Song Select hierarchy before publishing prepared
+            // state. The projection itself suppresses the intermediate selection events so
+            // they cannot stop or replace this exact-chart preview.
+            if (!ProjectPreparedChartSelection(resolution))
+                return PreparedFailure("The requested chart could not be selected.");
+
+            if (_resourceManager == null || !TryLoadPreviewSoundFile(previewPath))
+                return PreparedFailure("The requested chart preview could not be loaded.");
+
+            // TryLoadPreviewSoundFile intentionally arms the ordinary delayed preview path.
+            // Prepared playback must remain stopped until StartPreparedPreview is called.
+            _previewPlayDelay = 0.0;
+            _isPreviewDelayActive = false;
+
+            _preparedChartSelection = new PreparedChartSelection(
+                resolution.Node,
+                resolution.Chart,
+                resolution.DifficultyIndex,
+                BuildPreparedChartTelemetryIdentity(resolution.Chart));
+            _preparedPreviewState = PreparedPreviewState.Prepared;
+            _preparedPreviewElapsedMs = 0.0;
+            return PreparedSuccess();
+        }
+
+        internal (bool Success, string Error) StartPreparedPreview()
+        {
+            if (_preparedChartSelection == null || _previewSound == null)
+                return PreparedFailure("No prepared chart preview is available.");
+
+            if (_preparedPreviewState == PreparedPreviewState.Playing)
+            {
+                if (_previewSoundInstance?.State == SoundState.Playing)
+                    return PreparedSuccess();
+
+                _preparedPreviewState = PreparedPreviewState.Failed;
+                return PreparedFailure("The prepared preview stopped unexpectedly.");
+            }
+
+            if (_preparedPreviewState != PreparedPreviewState.Prepared)
+                return PreparedFailure("The prepared chart preview is not ready to play.");
+
+            try
+            {
+                if (_previewSoundInstance != null)
+                    DisposePreviewInstance();
+
+                _previewSoundInstance = CreatePreviewSoundInstance(_previewSound);
+                if (_previewSoundInstance == null)
+                    return MarkPreparedPreviewFailed("The prepared chart preview instance could not be created.");
+
+                _previewSoundInstance.Volume = SongSelectionUILayout.Audio.PreviewSoundVolume;
+                _previewSoundInstance.IsLooped = true;
+                _previewSoundInstance.Play();
+                StartBGMFade(true);
+                _preparedPreviewElapsedMs = 0.0;
+                _preparedPreviewState = PreparedPreviewState.Playing;
+                return PreparedSuccess();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongSelectionStage: Failed to start prepared preview: {ex.Message}");
+                DisposePreviewInstance();
+                return MarkPreparedPreviewFailed("The prepared chart preview could not be started.");
+            }
+        }
+
+        internal (bool Success, string Error) CancelPreparedChart()
+        {
+            ClearPreparedPreviewState();
+            return PreparedSuccess();
+        }
+
+        internal (bool Success, string Error) ActivatePreparedChart()
+        {
+            var prepared = _preparedChartSelection;
+            if (prepared == null)
+                return PreparedFailure("No prepared chart is available.");
+
+            var selectedSong = _selectedSong ?? _songListDisplay?.SelectedSong;
+            if (!ReferenceEquals(selectedSong, prepared.Node)
+                || _currentDifficulty != prepared.DifficultyIndex)
+            {
+                return PreparedFailure("The prepared chart is no longer selected.");
+            }
+
+            if (!CanStartSongSelection(prepared.Node, out var eligibilityError))
+                return PreparedFailure(eligibilityError);
+
+            // Eligibility is checked before cleanup so a debounce-blocked activation can be
+            // retried without losing the stopped/playing prepared preview.
+            ClearPreparedPreviewState();
+            StartSongSelection(prepared.Node);
+            return PreparedSuccess();
+        }
+
+        private static (bool Success, string Error) PreparedSuccess() => (true, null);
+
+        private static (bool Success, string Error) PreparedFailure(string error) =>
+            (false, error);
+
+        private (bool Success, string Error) MarkPreparedPreviewFailed(string error)
+        {
+            _preparedPreviewState = PreparedPreviewState.Failed;
+            return PreparedFailure(error);
+        }
+
+        private void ClearPreparedPreviewState()
+        {
+            StopCurrentPreview();
+            _preparedChartSelection = null;
+            _preparedPreviewState = PreparedPreviewState.None;
+            _preparedPreviewElapsedMs = 0.0;
+        }
+
+        private static bool TryGetChartPreviewPath(SongChart chart, out string previewPath)
+        {
+            previewPath = null;
+            if (chart == null
+                || string.IsNullOrWhiteSpace(chart.FilePath)
+                || string.IsNullOrWhiteSpace(chart.PreviewFile))
+            {
+                return false;
+            }
+
+            try
+            {
+                var chartDirectory = Path.GetDirectoryName(chart.FilePath);
+                if (string.IsNullOrWhiteSpace(chartDirectory))
+                    return false;
+
+                previewPath = Path.GetFullPath(Path.Combine(chartDirectory, chart.PreviewFile));
+                return true;
+            }
+            catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException)
+            {
+                previewPath = null;
+                return false;
+            }
+        }
+
+        private string BuildPreparedChartTelemetryIdentity(SongChart chart)
+        {
+            if (chart.Id != 0)
+                return $"chart:{chart.Id}";
+
+            if (!SongPathIdentity.TryNormalize(chart.FilePath, out var normalizedChartPath)
+                || _appliedLibrarySnapshot == null)
+            {
+                return "";
+            }
+
+            foreach (var activeRoot in _appliedLibrarySnapshot.ActiveRoots)
+            {
+                if (!SongPathIdentity.TryNormalize(activeRoot, out var normalizedRoot)
+                    || !SongPathIdentity.IsUnderNormalizedRoot(normalizedChartPath, normalizedRoot))
+                {
+                    continue;
+                }
+
+                var relativePath = Path.GetRelativePath(normalizedRoot, normalizedChartPath);
+                return relativePath.Replace(Path.DirectorySeparatorChar, '/');
+            }
+
+            return "";
+        }
+
         private SongListNode? FindVisibleSongByIdentity(string? identity)
         {
             if (string.IsNullOrEmpty(identity))
@@ -1801,6 +2002,9 @@ namespace DTXMania.Game.Lib.Stage
         private void OnSongSelectionChanged(object sender, SongSelectionChangedEventArgs e)
         {
             int playSpeedPercent = SynchronizeActivePlaySpeed();
+            var preparedSelection = _preparedChartSelection;
+            var leavingPreparedRow = preparedSelection != null
+                && !ReferenceEquals(preparedSelection.Node, e.SelectedSong);
             _selectedSong = e.SelectedSong;
             _currentDifficulty = e.CurrentDifficulty;
             _playHistoryPanel?.UpdateSongInfo(
@@ -1811,7 +2015,16 @@ namespace DTXMania.Game.Lib.Stage
             // Prepared projection raises the normal selection event while the row is
             // being rebuilt. Keep presentation updates, but suppress preview teardown
             // and automatic loading until the entire projection has completed.
-            if (!_isProjectingPreparedSelection)
+            var clearedPreparedPreview = false;
+            if (!_isProjectingPreparedSelection && leavingPreparedRow)
+            {
+                ClearPreparedPreviewState();
+                clearedPreparedPreview = true;
+            }
+
+            if (!_isProjectingPreparedSelection
+                && !clearedPreparedPreview
+                && (preparedSelection == null || leavingPreparedRow))
                 StopCurrentPreview();
 
             // Auto-manage status panel visibility and navigation mode based on selected item type
@@ -1829,7 +2042,7 @@ namespace DTXMania.Game.Lib.Stage
                 // Start preview sound loading - load immediately but delay playback.
                 // The prepared projection owns its preview resource and must not be
                 // replaced by the normal primary-chart preview path.
-                if (!_isProjectingPreparedSelection)
+                if (!_isProjectingPreparedSelection && (preparedSelection == null || leavingPreparedRow))
                     LoadPreviewSound(e.SelectedSong);
             }
             else
@@ -1895,6 +2108,17 @@ namespace DTXMania.Game.Lib.Stage
             _currentDifficulty = e.NewDifficulty;
             int playSpeedPercent = SynchronizeActivePlaySpeed();
 
+            var preparedSelection = _preparedChartSelection;
+            var leavingPreparedDifficulty = preparedSelection != null
+                && (!ReferenceEquals(preparedSelection.Node, e.Song)
+                    || preparedSelection.DifficultyIndex != e.NewDifficulty);
+            if (!_isProjectingPreparedSelection && leavingPreparedDifficulty)
+            {
+                ClearPreparedPreviewState();
+                if (e.Song?.Type == NodeType.Score)
+                    LoadPreviewSound(e.Song);
+            }
+
             // Update status panel
             _statusPanel.UpdateSongInfo(e.Song, e.NewDifficulty, playSpeedPercent);
             _playHistoryPanel?.UpdateSongInfo(e.Song, e.NewDifficulty, playSpeedPercent);
@@ -1957,13 +2181,39 @@ namespace DTXMania.Game.Lib.Stage
 
         private void SelectSong(SongListNode songNode)
         {
-            if (songNode == null || songNode.Type != NodeType.Score)
-                return;
-            
-            // Debounce stage transitions to prevent accidental double selections
-            if (!_game.CanPerformStageTransition())
+            if (!CanStartSongSelection(songNode, out _))
                 return;
 
+            StartSongSelection(songNode);
+        }
+
+        private bool CanStartSongSelection(SongListNode songNode, out string error)
+        {
+            if (songNode == null || songNode.Type != NodeType.Score)
+            {
+                error = "The selected item is not a playable song.";
+                return false;
+            }
+
+            if (StageManager == null)
+            {
+                error = "The song transition manager is unavailable.";
+                return false;
+            }
+
+            // Debounce stage transitions to prevent accidental double selections.
+            if (!_game.CanPerformStageTransition())
+            {
+                error = "The song transition is currently blocked.";
+                return false;
+            }
+
+            error = null;
+            return true;
+        }
+
+        private void StartSongSelection(SongListNode songNode)
+        {
             _game.MarkStageTransition();
             
             // Create shared data to pass song information to the transition stage
@@ -1975,7 +2225,7 @@ namespace DTXMania.Game.Lib.Stage
             };
             
             // Transition immediately to SongTransitionStage
-            StageManager?.ChangeStage(StageType.SongTransition, new InstantTransition(), sharedData);
+            StageManager.ChangeStage(StageType.SongTransition, new InstantTransition(), sharedData);
         }
 
         private void SelectRandomSong()
@@ -2958,8 +3208,23 @@ namespace DTXMania.Game.Lib.Stage
         /// </summary>
         private void UpdatePreviewSoundTimers(double deltaTime)
         {
+            if (_preparedPreviewState == PreparedPreviewState.Playing)
+            {
+                if (_previewSoundInstance?.State == SoundState.Playing)
+                {
+                    _preparedPreviewElapsedMs += Math.Max(0.0, deltaTime) * 1000.0;
+                }
+                else
+                {
+                    // Explicitly-started prepared previews never restart themselves or fall
+                    // back to the ordinary delayed primary-chart preview after an unexpected
+                    // stop. Keep the prepared identity available for diagnostics/retry.
+                    _preparedPreviewState = PreparedPreviewState.Failed;
+                }
+            }
+
             // Update preview play delay timer
-            if (_isPreviewDelayActive)
+            if (_preparedChartSelection == null && _isPreviewDelayActive)
             {
                 _previewPlayDelay += deltaTime;
                 
@@ -3180,8 +3445,7 @@ namespace DTXMania.Game.Lib.Stage
                 }
                 finally
                 {
-                    _previewSoundInstance.Dispose();
-                    _previewSoundInstance = null;
+                    DisposePreviewInstance();
                 }
             }
 
@@ -3194,6 +3458,26 @@ namespace DTXMania.Game.Lib.Stage
             
             // Start BGM fade in
             StartBGMFade(false);
+        }
+
+        private void DisposePreviewInstance()
+        {
+            if (_previewSoundInstance == null)
+                return;
+
+            try
+            {
+                _previewSoundInstance.Dispose();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"SongSelectionStage: Error disposing preview sound: {ex.Message}");
+            }
+            finally
+            {
+                _previewSoundInstance = null;
+            }
         }
 
         private static void ReleaseManagedSound(ref ISound sound)
@@ -3719,6 +4003,9 @@ namespace DTXMania.Game.Lib.Stage
             telemetry.PitchSemitones = PitchRange.SnapAndClamp(
                 config?.PitchSemitones ?? PitchRange.Default);
             telemetry.PlaybackProfileFrozen = false;
+            telemetry.PreparedChartIdentity = _preparedChartSelection?.TelemetryIdentity;
+            telemetry.PreparedPreviewState = _preparedPreviewState.ToString();
+            telemetry.PreparedPreviewElapsedMs = _preparedPreviewElapsedMs;
         }
 
         #endregion

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -17,6 +17,7 @@ using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.UI.Components;
 using DTXMania.Game.Lib.UI.Layout;
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.Input;
 using DTXMania.Game.Lib.Config;
@@ -164,6 +165,7 @@ namespace DTXMania.Game.Lib.Stage
         // Navigation state
         private Stack<SongListNode> _navigationStack;
         private string _currentBreadcrumb = "";
+        private bool _isProjectingPreparedSelection;
 
         // Status panel navigation state
         private bool _isInStatusPanel = false;
@@ -246,6 +248,12 @@ namespace DTXMania.Game.Lib.Stage
             long Generation,
             SongLibrarySnapshot? Snapshot,
             IReadOnlyList<SongListNode> SongList);
+
+        private sealed record PreparedChartResolution(
+            SongListNode Node,
+            SongChart Chart,
+            int DifficultyIndex,
+            IReadOnlyList<string> AncestorBoxPaths);
 
         #endregion
 
@@ -1313,6 +1321,198 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        private PreparedChartResolution? ResolvePreparedChart(string requestedChartPath)
+        {
+            if (string.IsNullOrWhiteSpace(requestedChartPath)
+                || !Path.IsPathFullyQualified(requestedChartPath)
+                || _appliedLibrarySnapshot == null
+                || !SongPathIdentity.TryNormalize(requestedChartPath, out var normalizedRequestedPath))
+            {
+                return null;
+            }
+
+            var normalizedActiveRoots = new List<string>();
+            foreach (var activeRoot in _appliedLibrarySnapshot.ActiveRoots)
+            {
+                if (SongPathIdentity.TryNormalize(activeRoot, out var normalizedRoot))
+                    normalizedActiveRoots.Add(normalizedRoot);
+            }
+
+            if (!normalizedActiveRoots.Any(root =>
+                    SongPathIdentity.IsUnderNormalizedRoot(normalizedRequestedPath, root)))
+            {
+                return null;
+            }
+
+            var matches = new List<(SongListNode Node, SongChart Chart, IReadOnlyList<string> AncestorBoxPaths)>();
+            VisitPreparedChartNodes(
+                _appliedLibrarySnapshot.RootSongs,
+                Array.Empty<string>(),
+                normalizedRequestedPath,
+                matches);
+
+            if (matches.Count != 1)
+                return null;
+
+            var match = matches[0];
+            if (!TryResolvePreparedDifficulty(
+                    match.Node,
+                    match.Chart,
+                    normalizedRequestedPath,
+                    out var difficultyIndex))
+            {
+                return null;
+            }
+
+            return new PreparedChartResolution(
+                match.Node,
+                match.Chart,
+                difficultyIndex,
+                match.AncestorBoxPaths);
+        }
+
+        private static void VisitPreparedChartNodes(
+            IEnumerable<SongListNode> nodes,
+            IReadOnlyList<string> ancestorBoxPaths,
+            string normalizedRequestedPath,
+            List<(SongListNode Node, SongChart Chart, IReadOnlyList<string> AncestorBoxPaths)> matches)
+        {
+            foreach (var node in nodes ?? Enumerable.Empty<SongListNode>())
+            {
+                if (node == null)
+                    continue;
+
+                if (node.Type == NodeType.Score)
+                {
+                    foreach (var chart in EnumerateNodeCharts(node))
+                    {
+                        if (!SongPathIdentity.TryNormalize(chart.FilePath, out var normalizedChartPath)
+                            || !StringComparer.Ordinal.Equals(normalizedChartPath, normalizedRequestedPath))
+                        {
+                            continue;
+                        }
+
+                        matches.Add((node, chart, ancestorBoxPaths));
+                    }
+                }
+
+                if (node.Type != NodeType.Box || node.Children == null)
+                    continue;
+
+                var boxPath = GetStableBoxPath(node);
+                if (boxPath == null)
+                    continue;
+
+                VisitPreparedChartNodes(
+                    node.Children,
+                    ancestorBoxPaths.Concat(new[] { boxPath }).ToArray(),
+                    normalizedRequestedPath,
+                    matches);
+            }
+        }
+
+        private static IEnumerable<SongChart> EnumerateNodeCharts(SongListNode node)
+        {
+            var seen = new HashSet<SongChart>();
+            if (node.DatabaseChart != null && seen.Add(node.DatabaseChart))
+                yield return node.DatabaseChart;
+
+            foreach (var chart in node.DatabaseSong?.Charts ?? Enumerable.Empty<SongChart>())
+            {
+                if (chart != null && seen.Add(chart))
+                    yield return chart;
+            }
+        }
+
+        private static bool TryResolvePreparedDifficulty(
+            SongListNode node,
+            SongChart chart,
+            string normalizedChartPath,
+            out int difficultyIndex)
+        {
+            difficultyIndex = -1;
+            var scores = node.Scores ?? Array.Empty<SongScore>();
+            var matchingChartIdSlots = chart.Id != 0
+                ? scores
+                    .Select((score, index) => (score, index))
+                    .Where(value => value.score != null
+                        && value.score.ChartId != 0
+                        && value.score.ChartId == chart.Id)
+                    .ToList()
+                : new List<(SongScore score, int index)>();
+
+            if (matchingChartIdSlots.Count == 1)
+            {
+                difficultyIndex = matchingChartIdSlots[0].index;
+                return true;
+            }
+
+            if (matchingChartIdSlots.Count > 1)
+            {
+                var drumSlots = matchingChartIdSlots
+                    .Where(value => value.score.Instrument == EInstrumentPart.DRUMS)
+                    .ToList();
+                if (drumSlots.Count == 1)
+                {
+                    difficultyIndex = drumSlots[0].index;
+                    return true;
+                }
+            }
+
+            var exactFallbackSlots = scores
+                .Select((score, index) => (score, index))
+                .Where(value => value.score != null)
+                .Where(value =>
+                {
+                    var fallbackChart = node.GetCurrentDifficultyChart(value.index);
+                    return fallbackChart != null
+                        && SongPathIdentity.TryNormalize(fallbackChart.FilePath, out var fallbackPath)
+                        && StringComparer.Ordinal.Equals(fallbackPath, normalizedChartPath);
+                })
+                .Select(value => value.index)
+                .ToList();
+
+            if (exactFallbackSlots.Count == 1)
+            {
+                difficultyIndex = exactFallbackSlots[0];
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool ProjectPreparedChartSelection(PreparedChartResolution resolution)
+        {
+            if (resolution == null || _appliedLibrarySnapshot == null || _songListDisplay == null)
+                return false;
+
+            _isProjectingPreparedSelection = true;
+            try
+            {
+                _activeTab = SongSelectionTab.AllSongs;
+                _filterCriteria = SongFilterCriteria.Default;
+                _filteredView = null;
+                _showEmptyFilterMessage = false;
+
+                RestoreNavigationPaths(resolution.AncestorBoxPaths, _appliedLibrarySnapshot);
+                RefreshSongListForActiveTab();
+
+                var targetIndex = _songListDisplay.CurrentList.FindIndex(node =>
+                    ReferenceEquals(node, resolution.Node));
+                if (targetIndex < 0)
+                    return false;
+
+                _songListDisplay.SetSelection(targetIndex, resolution.DifficultyIndex);
+                UpdateBreadcrumb();
+                UpdateStatusPanelFolderHint();
+                return true;
+            }
+            finally
+            {
+                _isProjectingPreparedSelection = false;
+            }
+        }
+
         private SongListNode? FindVisibleSongByIdentity(string? identity)
         {
             if (string.IsNullOrEmpty(identity))
@@ -1608,8 +1808,11 @@ namespace DTXMania.Game.Lib.Stage
                 e.CurrentDifficulty,
                 playSpeedPercent);
 
-            // Handle preview sound on selection change
-            StopCurrentPreview();
+            // Prepared projection raises the normal selection event while the row is
+            // being rebuilt. Keep presentation updates, but suppress preview teardown
+            // and automatic loading until the entire projection has completed.
+            if (!_isProjectingPreparedSelection)
+                StopCurrentPreview();
 
             // Auto-manage status panel visibility and navigation mode based on selected item type
             if (e.SelectedSong != null && e.SelectedSong.Type == NodeType.Score)
@@ -1623,9 +1826,11 @@ namespace DTXMania.Game.Lib.Stage
                 // Update preview image panel immediately for songs so it knows about the new song
                 _previewImagePanel?.UpdateSelectedSong(e.SelectedSong);
 
-                // Start preview sound loading - load immediately but delay playback
-                // Always load the preview sound - the delay timer will handle when to play it
-                LoadPreviewSound(e.SelectedSong);
+                // Start preview sound loading - load immediately but delay playback.
+                // The prepared projection owns its preview resource and must not be
+                // replaced by the normal primary-chart preview path.
+                if (!_isProjectingPreparedSelection)
+                    LoadPreviewSound(e.SelectedSong);
             }
             else
             {

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1503,6 +1503,14 @@ namespace DTXMania.Game.Lib.Stage
             if (resolution == null || _appliedLibrarySnapshot == null || _songListDisplay == null)
                 return false;
 
+            var previousTab = _activeTab;
+            var previousFilterCriteria = _filterCriteria;
+            var previousFilteredView = _filteredView;
+            var previousShowEmptyFilterMessage = _showEmptyFilterMessage;
+            var previousSongList = _currentSongList;
+            var previousBreadcrumb = _currentBreadcrumb;
+            var previousNavigation = new List<SongListNode>(_navigationStack);
+
             _isProjectingPreparedSelection = true;
             try
             {
@@ -1517,7 +1525,17 @@ namespace DTXMania.Game.Lib.Stage
                 var targetIndex = _songListDisplay.CurrentList.FindIndex(node =>
                     ReferenceEquals(node, resolution.Node));
                 if (targetIndex < 0)
+                {
+                    RestoreBrowseState(
+                        previousTab,
+                        previousFilterCriteria,
+                        previousFilteredView,
+                        previousShowEmptyFilterMessage,
+                        previousSongList,
+                        previousBreadcrumb,
+                        previousNavigation);
                     return false;
+                }
 
                 _songListDisplay.SetSelection(targetIndex, resolution.DifficultyIndex);
                 UpdateBreadcrumb();
@@ -1530,10 +1548,31 @@ namespace DTXMania.Game.Lib.Stage
             }
         }
 
+        private void RestoreBrowseState(
+            SongSelectionTab tab,
+            SongFilterCriteria filterCriteria,
+            System.Collections.Generic.IReadOnlyList<FilteredSongResult>? filteredView,
+            bool showEmptyFilterMessage,
+            List<SongListNode> songList,
+            string breadcrumb,
+            List<SongListNode> navigation)
+        {
+            _activeTab = tab;
+            _filterCriteria = filterCriteria;
+            _filteredView = filteredView;
+            _showEmptyFilterMessage = showEmptyFilterMessage;
+            _currentSongList = songList;
+            _currentBreadcrumb = breadcrumb;
+
+            _navigationStack.Clear();
+            for (var i = navigation.Count - 1; i >= 0; i--)
+                _navigationStack.Push(navigation[i]);
+
+            RefreshSongListForActiveTab();
+        }
+
         internal (bool Success, string Error) PrepareVideoChart(string chartPath)
         {
-            ClearPreparedPreviewStateIfOwned();
-
             if (string.IsNullOrWhiteSpace(chartPath))
                 return PreparedFailure("A chart path is required.");
 
@@ -1547,9 +1586,10 @@ namespace DTXMania.Game.Lib.Stage
             if (!File.Exists(previewPath))
                 return PreparedFailure("The requested chart preview file was not found.");
 
-            // The ordinary preview path is not owned by prepared state on a first prepare.
-            // Tear it down only after chart/path validation succeeds and before replacing its
-            // sound resource, so invalid commands preserve interactive preview ownership.
+            // Tear down any existing prepared state and the ordinary interactive preview only
+            // after all validation succeeds, so a rejected request preserves the current
+            // prepared selection and loaded preview.
+            ClearPreparedPreviewStateIfOwned();
             if (_previewSound != null || _previewSoundInstance != null)
                 StopCurrentPreview();
 

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1532,7 +1532,7 @@ namespace DTXMania.Game.Lib.Stage
 
         internal (bool Success, string Error) PrepareVideoChart(string chartPath)
         {
-            ClearPreparedPreviewState();
+            ClearPreparedPreviewStateIfOwned();
 
             if (string.IsNullOrWhiteSpace(chartPath))
                 return PreparedFailure("A chart path is required.");
@@ -1616,7 +1616,7 @@ namespace DTXMania.Game.Lib.Stage
 
         internal (bool Success, string Error) CancelPreparedChart()
         {
-            ClearPreparedPreviewState();
+            ClearPreparedPreviewStateIfOwned();
             return PreparedSuccess();
         }
 
@@ -1660,6 +1660,14 @@ namespace DTXMania.Game.Lib.Stage
             _preparedChartSelection = null;
             _preparedPreviewState = PreparedPreviewState.None;
             _preparedPreviewElapsedMs = 0.0;
+        }
+
+        private void ClearPreparedPreviewStateIfOwned()
+        {
+            if (_preparedChartSelection == null)
+                return;
+
+            ClearPreparedPreviewState();
         }
 
         private static bool TryGetChartPreviewPath(SongChart chart, out string previewPath)

--- a/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
+++ b/DTXMania.Game/Lib/Stage/SongSelectionStage.cs
@@ -1557,10 +1557,16 @@ namespace DTXMania.Game.Lib.Stage
             // state. The projection itself suppresses the intermediate selection events so
             // they cannot stop or replace this exact-chart preview.
             if (!ProjectPreparedChartSelection(resolution))
+            {
+                ResumeOrdinaryPreviewAfterPrepareFailure(resolution.Node);
                 return PreparedFailure("The requested chart could not be selected.");
+            }
 
             if (_resourceManager == null || !TryLoadPreviewSoundFile(previewPath))
+            {
+                ResumeOrdinaryPreviewAfterPrepareFailure(resolution.Node);
                 return PreparedFailure("The requested chart preview could not be loaded.");
+            }
 
             // TryLoadPreviewSoundFile intentionally arms the ordinary delayed preview path.
             // Prepared playback must remain stopped until StartPreparedPreview is called.
@@ -1674,6 +1680,13 @@ namespace DTXMania.Game.Lib.Stage
                 return;
 
             ClearPreparedPreviewState();
+        }
+
+        private void ResumeOrdinaryPreviewAfterPrepareFailure(SongListNode fallbackNode)
+        {
+            var selectedNode = _selectedSong ?? _songListDisplay?.SelectedSong ?? fallbackNode;
+            if (selectedNode?.Type == NodeType.Score)
+                LoadPreviewSound(selectedNode);
         }
 
         private static bool TryGetChartPreviewPath(SongChart chart, out string previewPath)
@@ -2212,6 +2225,12 @@ namespace DTXMania.Game.Lib.Stage
             if (StageManager == null)
             {
                 error = "The song transition manager is unavailable.";
+                return false;
+            }
+
+            if (StageManager.IsTransitioning)
+            {
+                error = "The song transition is currently blocked.";
                 return false;
             }
 

--- a/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
+++ b/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
@@ -409,6 +409,84 @@ public sealed class GameApiPreparedChartCommandTests
         }
     }
 
+    [Fact]
+    public async Task ActivatePreparedChartAsync_WhenRequestCancelsMidExecution_ShouldLetExecutionOwnCompletion()
+    {
+        // Reproduces the race in [P2]: cancellation fires after TryBeginExecution
+        // succeeds but before the command finishes. The execution path must own
+        // completion — the caller should see the command's real result, not
+        // "canceled", and the stage transition must have happened.
+        var game = ReflectionHelpers.CreateGame(totalGameTime: 1.0, lastStageTransitionTime: 0d);
+        var stage = SongSelectionStageTestFactory.CreateStage(game);
+        var node = CreateNode();
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stageManager.SetupGet(manager => manager.IsTransitioning).Returns(false);
+        ReflectionHelpers.SetPrivateField(stage, "_selectedSong", node);
+        ReflectionHelpers.SetPrivateField(stage, "_currentDifficulty", 0);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_preparedChartSelection",
+            CreatePreparedSelection(stage, node));
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_preparedPreviewState",
+            Enum.Parse(
+                ReflectionHelpers.GetField(typeof(SongSelectionStage), "_preparedPreviewState")!.FieldType,
+                "Prepared"));
+
+        var enteredChangeStage = new ManualResetEventSlim(initialState: false);
+        var releaseChangeStage = new ManualResetEventSlim(initialState: false);
+        stageManager.Setup(
+                manager => manager.ChangeStage(
+                    It.IsAny<StageType>(),
+                    It.IsAny<IStageTransition>(),
+                    It.IsAny<Dictionary<string, object>>()))
+            .Callback<StageType, IStageTransition, Dictionary<string, object>>((_, _, _) =>
+            {
+                enteredChangeStage.Set();
+                releaseChangeStage.Wait(TimeSpan.FromSeconds(5));
+            });
+
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(gameContext => gameContext.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        using var requestCancellation = new CancellationTokenSource();
+        var commandTask = api.ActivatePreparedChartAsync(requestCancellation.Token);
+        Assert.Single(queuedActions);
+
+        // Run the queued action on a background thread so we can cancel while
+        // the command is blocked inside StageManager.ChangeStage.
+        var executionTask = Task.Run(queuedActions[0]);
+
+        Assert.True(enteredChangeStage.Wait(TimeSpan.FromSeconds(5)),
+            "ChangeStage was not entered within the timeout.");
+
+        // Cancellation fires while the command is executing (state == Executing).
+        requestCancellation.Cancel();
+
+        // Let the command finish. The execution path should own completion.
+        releaseChangeStage.Set();
+        var result = await commandTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await executionTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(result.Success);
+        Assert.Null(result.Error);
+        stageManager.Verify(
+            manager => manager.ChangeStage(
+                It.Is<StageType>(t => t == StageType.SongTransition),
+                It.IsAny<IStageTransition>(),
+                It.IsAny<Dictionary<string, object>>()),
+            Times.Once);
+    }
+
     private static BlockedActivationFixture CreateBlockedActivationFixture()
     {
         var game = ReflectionHelpers.CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0d);

--- a/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
+++ b/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using DTXMania.Game;
+using DTXMania.Game.Lib;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using DTXMania.Test.Stage;
+using DTXMania.Test.TestData;
+using Moq;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.GameApi;
+
+[Trait("Category", "Unit")]
+public sealed class GameApiPreparedChartCommandTests
+{
+    [Fact]
+    public async Task PrepareVideoChartAsync_WhenStageCommandFails_ShouldPropagateSafeErrorText()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stage.StageManager = stageManager.Object;
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        var commandTask = api.PrepareVideoChartAsync(" ");
+
+        Assert.False(commandTask.IsCompleted);
+        Assert.Single(queuedActions);
+        queuedActions[0]();
+
+        var result = await commandTask;
+
+        Assert.False(result.Success);
+        Assert.Equal("A chart path is required.", result.Error);
+    }
+
+    [Fact]
+    public async Task ActivatePreparedChartAsync_ShouldNotMutateOrCompleteBeforeQueuedActionRuns()
+    {
+        var fixture = CreateBlockedActivationFixture();
+        var queuedActions = new List<Action>();
+        fixture.Context
+            .Setup(context => context.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(fixture.Context.Object);
+
+        var commandTask = api.ActivatePreparedChartAsync();
+
+        Assert.False(commandTask.IsCompleted);
+        Assert.NotNull(ReflectionHelpers.GetPrivateField<object>(fixture.Stage, "_preparedChartSelection"));
+        Assert.Single(queuedActions);
+        fixture.StageManager.Verify(
+            manager => manager.ChangeStage(
+                It.IsAny<StageType>(),
+                It.IsAny<IStageTransition>(),
+                It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+
+        queuedActions[0]();
+        var result = await commandTask;
+
+        Assert.False(result.Success);
+        Assert.Equal("The song transition is currently blocked.", result.Error);
+        Assert.NotNull(ReflectionHelpers.GetPrivateField<object>(fixture.Stage, "_preparedChartSelection"));
+        fixture.StageManager.Verify(
+            manager => manager.ChangeStage(
+                It.IsAny<StageType>(),
+                It.IsAny<IStageTransition>(),
+                It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task StartPreparedPreviewAsync_WhenStageCommandFails_ShouldPropagateSafeErrorText()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stage.StageManager = stageManager.Object;
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        var commandTask = api.StartPreparedPreviewAsync();
+
+        Assert.False(commandTask.IsCompleted);
+        Assert.Single(queuedActions);
+
+        queuedActions[0]();
+        var result = await commandTask;
+
+        Assert.False(result.Success);
+        Assert.Equal("No prepared chart preview is available.", result.Error);
+    }
+
+    [Fact]
+    public async Task CancelPreparedChartAsync_WhenCurrentStageIsNotSongSelect_ShouldReturnFailure()
+    {
+        var currentStage = new Mock<IStage>();
+        currentStage.SetupGet(stage => stage.Type).Returns(StageType.Title);
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(currentStage.Object);
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        var commandTask = api.CancelPreparedChartAsync();
+
+        Assert.False(commandTask.IsCompleted);
+        queuedActions[0]();
+        var result = await commandTask;
+
+        Assert.False(result.Success);
+        Assert.Equal("Prepared chart commands require the Song Select stage.", result.Error);
+    }
+
+    private static BlockedActivationFixture CreateBlockedActivationFixture()
+    {
+        var game = ReflectionHelpers.CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0d);
+        var stage = SongSelectionStageTestFactory.CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        var node = CreateNode();
+        stage.StageManager = stageManager.Object;
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        ReflectionHelpers.SetPrivateField(stage, "_selectedSong", node);
+        ReflectionHelpers.SetPrivateField(stage, "_currentDifficulty", 0);
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_preparedChartSelection",
+            CreatePreparedSelection(stage, node));
+        ReflectionHelpers.SetPrivateField(
+            stage,
+            "_preparedPreviewState",
+            Enum.Parse(
+                ReflectionHelpers.GetField(typeof(SongSelectionStage), "_preparedPreviewState")!.FieldType,
+                "Prepared"));
+
+        var context = new Mock<IGameContext>();
+        context.SetupGet(gameContext => gameContext.StageManager).Returns(stageManager.Object);
+        return new BlockedActivationFixture(stage, stageManager, context);
+    }
+
+    private static object CreatePreparedSelection(SongSelectionStage stage, SongListNode node)
+    {
+        var field = ReflectionHelpers.GetField(typeof(SongSelectionStage), "_preparedChartSelection");
+        var chart = node.DatabaseChart!;
+        return Activator.CreateInstance(
+            field!.FieldType,
+            node,
+            chart,
+            0,
+            $"chart:{chart.Id}")!;
+    }
+
+    private static SongListNode CreateNode()
+    {
+        var chartPath = Path.Combine(Path.GetTempPath(), "hpa510-api-command.dtx");
+        var chart = new SongChart
+        {
+            Id = 901,
+            FilePath = chartPath,
+            HasDrumChart = true,
+            DrumLevel = 5
+        };
+        var song = new SongEntity { Id = 901, Title = "prepared", Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        chart.SongId = song.Id;
+        return new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = song.Title,
+            DatabaseSongId = song.Id,
+            DatabaseSong = song,
+            DatabaseChart = chart,
+        };
+    }
+
+    private sealed record BlockedActivationFixture(
+        SongSelectionStage Stage,
+        Mock<IStageManager> StageManager,
+        Mock<IGameContext> Context);
+}

--- a/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
+++ b/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
 using DTXMania.Game.Lib;
@@ -130,6 +132,85 @@ public sealed class GameApiPreparedChartCommandTests
 
         Assert.False(result.Success);
         Assert.Equal("Prepared chart commands require the Song Select stage.", result.Error);
+    }
+
+    [Fact]
+    public async Task Dispose_CompletesPendingPreparedCommand_AndQueuedDelegateBecomesNoOp()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        var commandTask = api.StartPreparedPreviewAsync();
+        Assert.False(commandTask.IsCompleted);
+        Assert.Single(queuedActions);
+
+        var dispose = typeof(GameApiImplementation).GetMethod(
+            nameof(IDisposable.Dispose),
+            BindingFlags.Instance | BindingFlags.Public);
+        Assert.NotNull(dispose);
+        dispose!.Invoke(api, null);
+
+        var result = await commandTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command was canceled.", result.Error);
+
+        queuedActions[0]();
+        Assert.Equal("The prepared chart command was canceled.", result.Error);
+        stageManager.Verify(
+            manager => manager.ChangeStage(
+                It.IsAny<StageType>(),
+                It.IsAny<IStageTransition>(),
+                It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PreparedCommand_WhenRequestCancellationIsSignaled_CompletesAndQueuedDelegateBecomesNoOp()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        using var requestCancellation = new CancellationTokenSource();
+        var commandMethod = typeof(GameApiImplementation).GetMethod(
+            nameof(GameApiImplementation.StartPreparedPreviewAsync),
+            BindingFlags.Instance | BindingFlags.Public,
+            binder: null,
+            types: new[] { typeof(CancellationToken) },
+            modifiers: null);
+        Assert.NotNull(commandMethod);
+        var commandTask = (Task<PreparedChartCommandResult>)commandMethod!.Invoke(
+            api,
+            new object[] { requestCancellation.Token })!;
+
+        requestCancellation.Cancel();
+
+        var result = await commandTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command was canceled.", result.Error);
+
+        queuedActions[0]();
+        stageManager.Verify(
+            manager => manager.ChangeStage(
+                It.IsAny<StageType>(),
+                It.IsAny<IStageTransition>(),
+                It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
     }
 
     private static BlockedActivationFixture CreateBlockedActivationFixture()

--- a/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
+++ b/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
@@ -5,7 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
 using DTXMania.Game.Lib;
+using DTXMania.Game.Lib.Resources;
 using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Song.Entities;
 using DTXMania.Game.Lib.Stage;
 using DTXMania.Test.Stage;
@@ -197,6 +199,214 @@ public sealed class GameApiPreparedChartCommandTests
                 It.IsAny<IStageTransition>(),
                 It.IsAny<Dictionary<string, object>>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task PreparedCommand_WhenAlreadyDisposed_ShouldReturnCanceledWithoutQueuing()
+    {
+        var context = new Mock<IGameContext>();
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(action => action());
+        var api = new GameApiImplementation(context.Object);
+
+        api.Dispose();
+
+        var result = await api.CancelPreparedChartAsync();
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command was canceled.", result.Error);
+        context.Verify(game => game.QueueMainThreadAction(It.IsAny<Action>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PreparedCommand_WithPreCanceledToken_ShouldReturnCanceledWithoutExecutingCommand()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stage.StageManager = stageManager.Object;
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        using var preCanceled = new CancellationTokenSource();
+        preCanceled.Cancel();
+
+        var commandTask = api.StartPreparedPreviewAsync(preCanceled.Token);
+
+        var result = await commandTask.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command was canceled.", result.Error);
+        // The queued action may or may not be present, but if it is, it must be a no-op.
+        foreach (var action in queuedActions)
+            action();
+        stageManager.Verify(
+            manager => manager.ChangeStage(
+                It.IsAny<StageType>(),
+                It.IsAny<IStageTransition>(),
+                It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task PreparedCommand_WhenQueueMainThreadActionThrows_ShouldReturnFailure()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stage.StageManager = stageManager.Object;
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Throws(new InvalidOperationException("queue unavailable"));
+        var api = new GameApiImplementation(context.Object);
+
+        var result = await api.CancelPreparedChartAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command could not be completed.", result.Error);
+    }
+
+    [Fact]
+    public async Task CancelPreparedChartAsync_WhenStageIsSongSelect_ShouldReturnSuccess()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stage.StageManager = stageManager.Object;
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        var commandTask = api.CancelPreparedChartAsync();
+        Assert.Single(queuedActions);
+        queuedActions[0]();
+
+        var result = await commandTask;
+        Assert.True(result.Success);
+        Assert.Null(result.Error);
+    }
+
+    [Fact]
+    public async Task PreparedCommand_WhenStageManagerIsNull_ShouldReturnRequiresSongSelectStage()
+    {
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns((IStageManager?)null);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        var commandTask = api.CancelPreparedChartAsync();
+        Assert.Single(queuedActions);
+        queuedActions[0]();
+
+        var result = await commandTask;
+        Assert.False(result.Success);
+        Assert.Equal("Prepared chart commands require the Song Select stage.", result.Error);
+    }
+
+    [Fact]
+    public async Task Dispose_CalledTwice_ShouldBeIdempotent()
+    {
+        var context = new Mock<IGameContext>();
+        var api = new GameApiImplementation(context.Object);
+
+        api.Dispose();
+        api.Dispose();
+
+        var result = await api.CancelPreparedChartAsync();
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command was canceled.", result.Error);
+    }
+
+    [Fact]
+    public async Task PreparedCommand_WhenCommandThrowsOnUpdateThread_ShouldReturnSafeError()
+    {
+        var stage = SongSelectionStageTestFactory.CreateStage();
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
+        stage.StageManager = stageManager.Object;
+        var queuedActions = new List<Action>();
+        var context = new Mock<IGameContext>();
+        context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
+        context
+            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Callback<Action>(queuedActions.Add);
+        var api = new GameApiImplementation(context.Object);
+
+        // Set up a prepared selection with a node whose DatabaseChart is null, causing
+        // BuildPreparedChartTelemetryIdentity to throw NullReferenceException when
+        // PrepareVideoChart tries to build the telemetry identity after a successful
+        // resolution. This exercises the catch block in QueuePreparedChartCommandAsync.
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-command-throws");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        var previewPath = Path.Combine(root, "preview.wav");
+        File.WriteAllText(chartPath, "chart");
+        File.WriteAllText(previewPath, "preview");
+
+        try
+        {
+            var chart = new SongChart
+            {
+                Id = 0,
+                FilePath = chartPath,
+                PreviewFile = "preview.wav",
+                HasDrumChart = true,
+                DrumLevel = 5
+            };
+            var song = new SongEntity { Id = 0, Title = "throws", Charts = new List<SongChart> { chart } };
+            chart.Song = song;
+            chart.SongId = 0;
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "throws",
+                DatabaseSongId = 0,
+                DatabaseSong = song,
+                DatabaseChart = chart,
+                Scores = new[] { new SongScore { ChartId = 0, Instrument = EInstrumentPart.DRUMS } }
+            };
+            var resourceManager = new Mock<IResourceManager>();
+            var loadedSound = new Mock<ISound>();
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(loadedSound.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            ReflectionHelpers.SetPrivateField(stage, "_appliedLibrarySnapshot", new SongLibrarySnapshot(
+                version: 1,
+                rootSongs: new[] { node },
+                activeRoots: new[] { Path.GetFullPath(root) },
+                enumeratedFileCount: 1,
+                discoveredScoreCount: 1));
+            var display = new SongListDisplay { CurrentList = new List<SongListNode> { node } };
+            ReflectionHelpers.SetPrivateField(stage, "_songListDisplay", display);
+            ReflectionHelpers.SetPrivateField(stage, "_currentSongList", new List<SongListNode> { node });
+
+            var commandTask = api.PrepareVideoChartAsync(chartPath);
+            Assert.Single(queuedActions);
+            queuedActions[0]();
+
+            var result = await commandTask;
+            // The command should either succeed (if BuildPreparedChartTelemetryIdentity handles
+            // the null chart gracefully) or return a safe error (if it throws and is caught).
+            // Either way, it must not throw to the caller.
+            Assert.True(result.Success || result.Error != null);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
     }
 
     private static BlockedActivationFixture CreateBlockedActivationFixture()

--- a/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
+++ b/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using DTXMania.Game;
@@ -135,7 +134,7 @@ public sealed class GameApiPreparedChartCommandTests
     }
 
     [Fact]
-    public async Task Dispose_CompletesPendingPreparedCommand_AndQueuedDelegateBecomesNoOp()
+    public async Task         Dispose_ShouldCompletePendingPreparedCommandAndLeaveQueuedDelegateAsNoOp()
     {
         var stage = SongSelectionStageTestFactory.CreateStage();
         var stageManager = new Mock<IStageManager>();
@@ -152,11 +151,7 @@ public sealed class GameApiPreparedChartCommandTests
         Assert.False(commandTask.IsCompleted);
         Assert.Single(queuedActions);
 
-        var dispose = typeof(GameApiImplementation).GetMethod(
-            nameof(IDisposable.Dispose),
-            BindingFlags.Instance | BindingFlags.Public);
-        Assert.NotNull(dispose);
-        dispose!.Invoke(api, null);
+        api.Dispose();
 
         var result = await commandTask.WaitAsync(TimeSpan.FromSeconds(1));
         Assert.False(result.Success);
@@ -173,7 +168,7 @@ public sealed class GameApiPreparedChartCommandTests
     }
 
     [Fact]
-    public async Task PreparedCommand_WhenRequestCancellationIsSignaled_CompletesAndQueuedDelegateBecomesNoOp()
+    public async Task         PreparedCommand_WhenRequestCancellationIsSignaled_ShouldCompleteAndLeaveQueuedDelegateAsNoOp()
     {
         var stage = SongSelectionStageTestFactory.CreateStage();
         var stageManager = new Mock<IStageManager>();
@@ -187,16 +182,7 @@ public sealed class GameApiPreparedChartCommandTests
         var api = new GameApiImplementation(context.Object);
 
         using var requestCancellation = new CancellationTokenSource();
-        var commandMethod = typeof(GameApiImplementation).GetMethod(
-            nameof(GameApiImplementation.StartPreparedPreviewAsync),
-            BindingFlags.Instance | BindingFlags.Public,
-            binder: null,
-            types: new[] { typeof(CancellationToken) },
-            modifiers: null);
-        Assert.NotNull(commandMethod);
-        var commandTask = (Task<PreparedChartCommandResult>)commandMethod!.Invoke(
-            api,
-            new object[] { requestCancellation.Token })!;
+        var commandTask = api.StartPreparedPreviewAsync(requestCancellation.Token);
 
         requestCancellation.Cancel();
 

--- a/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
+++ b/DTXMania.Test/GameApi/GameApiPreparedChartCommandTests.cs
@@ -334,10 +334,18 @@ public sealed class GameApiPreparedChartCommandTests
     [Fact]
     public async Task PreparedCommand_WhenCommandThrowsOnUpdateThread_ShouldReturnSafeError()
     {
-        var stage = SongSelectionStageTestFactory.CreateStage();
+        // QueuePreparedChartCommandAsync wraps the update-thread command in a
+        // try/catch so an unexpected exception surfaces as a safe error result
+        // instead of propagating to the caller. The previous fixture relied on
+        // BuildPreparedChartTelemetryIdentity throwing on a null DatabaseChart,
+        // but that path is fully defensive (Try-pattern + catch-all) and never
+        // actually threw — the command succeeded and the loose assertion hid it.
+        // We now force the throw deterministically by having StageManager.CurrentStage
+        // raise on access, which is the first dereference inside the inner try.
         var stageManager = new Mock<IStageManager>();
-        stageManager.SetupGet(manager => manager.CurrentStage).Returns(stage);
-        stage.StageManager = stageManager.Object;
+        stageManager
+            .SetupGet(manager => manager.CurrentStage)
+            .Throws(new InvalidOperationException("Stage access failed on the update thread."));
         var queuedActions = new List<Action>();
         var context = new Mock<IGameContext>();
         context.SetupGet(game => game.StageManager).Returns(stageManager.Object);
@@ -346,67 +354,14 @@ public sealed class GameApiPreparedChartCommandTests
             .Callback<Action>(queuedActions.Add);
         var api = new GameApiImplementation(context.Object);
 
-        // Set up a prepared selection with a node whose DatabaseChart is null, causing
-        // BuildPreparedChartTelemetryIdentity to throw NullReferenceException when
-        // PrepareVideoChart tries to build the telemetry identity after a successful
-        // resolution. This exercises the catch block in QueuePreparedChartCommandAsync.
-        var root = Path.Combine(Path.GetTempPath(), "hpa510-command-throws");
-        Directory.CreateDirectory(root);
-        var chartPath = Path.Combine(root, "chart.dtx");
-        var previewPath = Path.Combine(root, "preview.wav");
-        File.WriteAllText(chartPath, "chart");
-        File.WriteAllText(previewPath, "preview");
+        var commandTask = api.PrepareVideoChartAsync(
+            Path.Combine(Path.GetTempPath(), "hpa510-throw.dtx"));
+        Assert.Single(queuedActions);
+        queuedActions[0]();
 
-        try
-        {
-            var chart = new SongChart
-            {
-                Id = 0,
-                FilePath = chartPath,
-                PreviewFile = "preview.wav",
-                HasDrumChart = true,
-                DrumLevel = 5
-            };
-            var song = new SongEntity { Id = 0, Title = "throws", Charts = new List<SongChart> { chart } };
-            chart.Song = song;
-            chart.SongId = 0;
-            var node = new SongListNode
-            {
-                Type = NodeType.Score,
-                Title = "throws",
-                DatabaseSongId = 0,
-                DatabaseSong = song,
-                DatabaseChart = chart,
-                Scores = new[] { new SongScore { ChartId = 0, Instrument = EInstrumentPart.DRUMS } }
-            };
-            var resourceManager = new Mock<IResourceManager>();
-            var loadedSound = new Mock<ISound>();
-            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(loadedSound.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_resourceManager", resourceManager.Object);
-            ReflectionHelpers.SetPrivateField(stage, "_appliedLibrarySnapshot", new SongLibrarySnapshot(
-                version: 1,
-                rootSongs: new[] { node },
-                activeRoots: new[] { Path.GetFullPath(root) },
-                enumeratedFileCount: 1,
-                discoveredScoreCount: 1));
-            var display = new SongListDisplay { CurrentList = new List<SongListNode> { node } };
-            ReflectionHelpers.SetPrivateField(stage, "_songListDisplay", display);
-            ReflectionHelpers.SetPrivateField(stage, "_currentSongList", new List<SongListNode> { node });
-
-            var commandTask = api.PrepareVideoChartAsync(chartPath);
-            Assert.Single(queuedActions);
-            queuedActions[0]();
-
-            var result = await commandTask;
-            // The command should either succeed (if BuildPreparedChartTelemetryIdentity handles
-            // the null chart gracefully) or return a safe error (if it throws and is caught).
-            // Either way, it must not throw to the caller.
-            Assert.True(result.Success || result.Error != null);
-        }
-        finally
-        {
-            try { Directory.Delete(root, recursive: true); } catch { }
-        }
+        var result = await commandTask;
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart command could not be completed.", result.Error);
     }
 
     [Fact]
@@ -453,7 +408,7 @@ public sealed class GameApiPreparedChartCommandTests
         var context = new Mock<IGameContext>();
         context.SetupGet(gameContext => gameContext.StageManager).Returns(stageManager.Object);
         context
-            .Setup(game => game.QueueMainThreadAction(It.IsAny<Action>()))
+            .Setup(gameContext => gameContext.QueueMainThreadAction(It.IsAny<Action>()))
             .Callback<Action>(queuedActions.Add);
         var api = new GameApiImplementation(context.Object);
 

--- a/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -164,12 +165,15 @@ public class JsonRpcServerInternalTests
     [Fact]
     public async Task HandlePrepareVideoChart_WithValidParams_ShouldReturnCommandResult()
     {
+        var chartPath = Path.GetFullPath(Path.Combine("safe", "chart.dtx"));
+        Assert.True(Path.IsPathFullyQualified(chartPath));
         var gameApi = CreateGameApi();
         gameApi
-            .Setup(api => api.PrepareVideoChartAsync("/safe/chart.dtx"))
+            .Setup(api => api.PrepareVideoChartAsync(chartPath))
             .ReturnsAsync(new PreparedChartCommandResult(false, "The requested chart preview file was not found."));
         var server = new JsonRpcServer(gameApi.Object);
-        using var paramsDocument = JsonDocument.Parse("{\"chartPath\":\"/safe/chart.dtx\"}");
+        using var paramsDocument = JsonDocument.Parse(
+            JsonSerializer.Serialize(new { chartPath }));
 
         var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
             server,
@@ -184,7 +188,7 @@ public class JsonRpcServerInternalTests
         Assert.Null(response!.Error);
         Assert.Contains("\"success\":false", JsonSerializer.Serialize(response.Result));
         Assert.Contains("The requested chart preview file was not found.", JsonSerializer.Serialize(response.Result));
-        gameApi.Verify(api => api.PrepareVideoChartAsync("/safe/chart.dtx"), Times.Once);
+        gameApi.Verify(api => api.PrepareVideoChartAsync(chartPath), Times.Once);
     }
 
     [Theory]

--- a/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
@@ -169,7 +169,7 @@ public class JsonRpcServerInternalTests
         Assert.True(Path.IsPathFullyQualified(chartPath));
         var gameApi = CreateGameApi();
         gameApi
-            .Setup(api => api.PrepareVideoChartAsync(chartPath))
+            .Setup(api => api.PrepareVideoChartAsync(chartPath, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PreparedChartCommandResult(false, "The requested chart preview file was not found."));
         var server = new JsonRpcServer(gameApi.Object);
         using var paramsDocument = JsonDocument.Parse(
@@ -188,7 +188,7 @@ public class JsonRpcServerInternalTests
         Assert.Null(response!.Error);
         Assert.Contains("\"success\":false", JsonSerializer.Serialize(response.Result));
         Assert.Contains("The requested chart preview file was not found.", JsonSerializer.Serialize(response.Result));
-        gameApi.Verify(api => api.PrepareVideoChartAsync(chartPath), Times.Once);
+        gameApi.Verify(api => api.PrepareVideoChartAsync(chartPath, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -226,11 +226,11 @@ public class JsonRpcServerInternalTests
     public async Task RouteMethodCall_PreparedChartCommands_ShouldUseExplicitRoutes(string method)
     {
         var gameApi = CreateGameApi();
-        gameApi.Setup(api => api.StartPreparedPreviewAsync())
+        gameApi.Setup(api => api.StartPreparedPreviewAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PreparedChartCommandResult(true, null));
-        gameApi.Setup(api => api.ActivatePreparedChartAsync())
+        gameApi.Setup(api => api.ActivatePreparedChartAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PreparedChartCommandResult(true, null));
-        gameApi.Setup(api => api.CancelPreparedChartAsync())
+        gameApi.Setup(api => api.CancelPreparedChartAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PreparedChartCommandResult(true, null));
         var server = new JsonRpcServer(gameApi.Object);
 
@@ -244,13 +244,13 @@ public class JsonRpcServerInternalTests
         switch (method)
         {
             case "startPreparedPreview":
-                gameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Once);
+                gameApi.Verify(api => api.StartPreparedPreviewAsync(It.IsAny<CancellationToken>()), Times.Once);
                 break;
             case "activatePreparedChart":
-                gameApi.Verify(api => api.ActivatePreparedChartAsync(), Times.Once);
+                gameApi.Verify(api => api.ActivatePreparedChartAsync(It.IsAny<CancellationToken>()), Times.Once);
                 break;
             case "cancelPreparedChart":
-                gameApi.Verify(api => api.CancelPreparedChartAsync(), Times.Once);
+                gameApi.Verify(api => api.CancelPreparedChartAsync(It.IsAny<CancellationToken>()), Times.Once);
                 break;
         }
     }

--- a/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
@@ -255,6 +255,134 @@ public class JsonRpcServerInternalTests
         }
     }
 
+    [Theory]
+    [InlineData("HandleStartPreparedPreviewWithCancellation", "startPreparedPreview")]
+    [InlineData("HandleActivatePreparedChartWithCancellation", "activatePreparedChart")]
+    [InlineData("HandleCancelPreparedChartWithCancellation", "cancelPreparedChart")]
+    public async Task PreparedChartCancellationHandlers_ShouldForwardCancellationToken(string handlerMethod, string apiMethod)
+    {
+        using var cancellation = new CancellationTokenSource();
+        var gameApi = CreateGameApi();
+        var expectedResult = new PreparedChartCommandResult(true, null);
+        if (apiMethod == "startPreparedPreview")
+            gameApi.Setup(api => api.StartPreparedPreviewAsync(cancellation.Token)).ReturnsAsync(expectedResult);
+        else if (apiMethod == "activatePreparedChart")
+            gameApi.Setup(api => api.ActivatePreparedChartAsync(cancellation.Token)).ReturnsAsync(expectedResult);
+        else
+            gameApi.Setup(api => api.CancelPreparedChartAsync(cancellation.Token)).ReturnsAsync(expectedResult);
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            handlerMethod,
+            new JsonRpcRequest { Id = 30, Method = apiMethod },
+            cancellation.Token);
+
+        Assert.Null(response!.Error);
+        Assert.Contains("\"success\":true", JsonSerializer.Serialize(response.Result));
+    }
+
+    [Theory]
+    [InlineData("HandleStartPreparedPreview")]
+    [InlineData("HandleActivatePreparedChart")]
+    [InlineData("HandleCancelPreparedChart")]
+    [InlineData("HandlePrepareVideoChart")]
+    public async Task PreparedChartHandlers_WhenGameNotRunning_ShouldReturnGameNotRunningError(string handlerMethod)
+    {
+        var gameApi = new Mock<IGameApi>();
+        gameApi.SetupGet(api => api.IsRunning).Returns(false);
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            handlerMethod,
+            new JsonRpcRequest { Id = 31, Method = "test" });
+
+        Assert.Equal(JsonRpcErrorCodes.GameNotRunning, response!.Error!.Code);
+        Assert.Contains("Game is not running", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandlePrepareVideoChart_WhenParamsIsNotObject_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        using var paramsDocument = JsonDocument.Parse("\"just-a-string\"");
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChart",
+            new JsonRpcRequest
+            {
+                Id = 32,
+                Method = "prepareVideoChart",
+                Params = paramsDocument.RootElement.Clone()
+            });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("params must be an object", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandlePrepareVideoChart_WhenChartPathIsRelative_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        using var paramsDocument = JsonDocument.Parse(
+            JsonSerializer.Serialize(new { chartPath = "relative/chart.dtx" }));
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChart",
+            new JsonRpcRequest
+            {
+                Id = 33,
+                Method = "prepareVideoChart",
+                Params = paramsDocument.RootElement.Clone()
+            });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("chartPath must be a fully-qualified path", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandlePrepareVideoChart_WhenParamsIsNumber_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        using var paramsDocument = JsonDocument.Parse("42");
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChart",
+            new JsonRpcRequest
+            {
+                Id = 34,
+                Method = "prepareVideoChart",
+                Params = paramsDocument.RootElement.Clone()
+            });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("params must be an object", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandlePrepareVideoChart_WhenChartPathIsNotString_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+        using var paramsDocument = JsonDocument.Parse("{\"chartPath\":true}");
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChart",
+            new JsonRpcRequest
+            {
+                Id = 35,
+                Method = "prepareVideoChart",
+                Params = paramsDocument.RootElement.Clone()
+            });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("chartPath must be a string", response.Error.Message);
+    }
+
     [Fact]
     public async Task RouteMethodCall_WhenMethodIsPing_ShouldReturnPong()
     {

--- a/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
@@ -148,6 +148,82 @@ public class JsonRpcServerInternalTests
     }
 
     [Fact]
+    public async Task HandlePrepareVideoChart_WhenParamsAreMissing_ShouldReturnInvalidParams()
+    {
+        var server = new JsonRpcServer(CreateGameApi().Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChart",
+            new JsonRpcRequest { Id = 21, Method = "prepareVideoChart" });
+
+        Assert.Equal(JsonRpcErrorCodes.InvalidParams, response!.Error!.Code);
+        Assert.Equal("chartPath parameter is required", response.Error.Message);
+    }
+
+    [Fact]
+    public async Task HandlePrepareVideoChart_WithValidParams_ShouldReturnCommandResult()
+    {
+        var gameApi = CreateGameApi();
+        gameApi
+            .Setup(api => api.PrepareVideoChartAsync("/safe/chart.dtx"))
+            .ReturnsAsync(new PreparedChartCommandResult(false, "The requested chart preview file was not found."));
+        var server = new JsonRpcServer(gameApi.Object);
+        using var paramsDocument = JsonDocument.Parse("{\"chartPath\":\"/safe/chart.dtx\"}");
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChart",
+            new JsonRpcRequest
+            {
+                Id = 22,
+                Method = "prepareVideoChart",
+                Params = paramsDocument.RootElement.Clone()
+            });
+
+        Assert.Null(response!.Error);
+        Assert.Contains("\"success\":false", JsonSerializer.Serialize(response.Result));
+        Assert.Contains("The requested chart preview file was not found.", JsonSerializer.Serialize(response.Result));
+        gameApi.Verify(api => api.PrepareVideoChartAsync("/safe/chart.dtx"), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("startPreparedPreview")]
+    [InlineData("activatePreparedChart")]
+    [InlineData("cancelPreparedChart")]
+    public async Task RouteMethodCall_PreparedChartCommands_ShouldUseExplicitRoutes(string method)
+    {
+        var gameApi = CreateGameApi();
+        gameApi.Setup(api => api.StartPreparedPreviewAsync())
+            .ReturnsAsync(new PreparedChartCommandResult(true, null));
+        gameApi.Setup(api => api.ActivatePreparedChartAsync())
+            .ReturnsAsync(new PreparedChartCommandResult(true, null));
+        gameApi.Setup(api => api.CancelPreparedChartAsync())
+            .ReturnsAsync(new PreparedChartCommandResult(true, null));
+        var server = new JsonRpcServer(gameApi.Object);
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "RouteMethodCall",
+            new JsonRpcRequest { Id = 23, Method = method });
+
+        Assert.Null(response!.Error);
+        Assert.Contains("\"success\":true", JsonSerializer.Serialize(response.Result));
+        switch (method)
+        {
+            case "startPreparedPreview":
+                gameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Once);
+                break;
+            case "activatePreparedChart":
+                gameApi.Verify(api => api.ActivatePreparedChartAsync(), Times.Once);
+                break;
+            case "cancelPreparedChart":
+                gameApi.Verify(api => api.CancelPreparedChartAsync(), Times.Once);
+                break;
+        }
+    }
+
+    [Fact]
     public async Task RouteMethodCall_WhenMethodIsPing_ShouldReturnPong()
     {
         var server = new JsonRpcServer(CreateGameApi().Object);

--- a/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs
@@ -191,6 +191,34 @@ public class JsonRpcServerInternalTests
         gameApi.Verify(api => api.PrepareVideoChartAsync(chartPath), Times.Once);
     }
 
+    [Fact]
+    public async Task HandlePrepareVideoChart_WithRequestCancellation_ForwardsCancellationToken()
+    {
+        var chartPath = Path.GetFullPath(Path.Combine("safe", "chart.dtx"));
+        using var cancellation = new CancellationTokenSource();
+        var gameApi = CreateGameApi();
+        gameApi
+            .Setup(api => api.PrepareVideoChartAsync(chartPath, cancellation.Token))
+            .ReturnsAsync(new PreparedChartCommandResult(false, "The prepared chart command was canceled."));
+        var server = new JsonRpcServer(gameApi.Object);
+        using var paramsDocument = JsonDocument.Parse(
+            JsonSerializer.Serialize(new { chartPath }));
+
+        var response = await ReflectionHelpers.InvokePrivateMethodAsync<JsonRpcResponse>(
+            server,
+            "HandlePrepareVideoChartWithCancellation",
+            new JsonRpcRequest
+            {
+                Id = 24,
+                Method = "prepareVideoChart",
+                Params = paramsDocument.RootElement.Clone()
+            },
+            cancellation.Token);
+
+        Assert.Null(response!.Error);
+        gameApi.Verify(api => api.PrepareVideoChartAsync(chartPath, cancellation.Token), Times.Once);
+    }
+
     [Theory]
     [InlineData("startPreparedPreview")]
     [InlineData("activatePreparedChart")]

--- a/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
@@ -327,7 +327,7 @@ namespace DTXMania.Test.JsonRpc
             var body = await response.Content.ReadAsStringAsync();
 
             Assert.Contains("-32602", body);
-            _mockGameApi.Verify(api => api.PrepareVideoChartAsync(It.IsAny<string>()), Times.Never);
+            _mockGameApi.Verify(api => api.PrepareVideoChartAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Fact]
@@ -377,7 +377,7 @@ namespace DTXMania.Test.JsonRpc
             using var response = await client.PostAsync("/jsonrpc", RawRpcBody(requestJson));
 
             Assert.Equal(401, (int)response.StatusCode);
-            _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Never);
+            _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(It.IsAny<CancellationToken>()), Times.Never);
         }
 
         #endregion

--- a/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -334,13 +335,13 @@ namespace DTXMania.Test.JsonRpc
         {
             var chartPath = Path.GetFullPath(Path.Combine("safe", "chart.dtx"));
             Assert.True(Path.IsPathFullyQualified(chartPath));
-            _mockGameApi.Setup(api => api.PrepareVideoChartAsync(chartPath))
+            _mockGameApi.Setup(api => api.PrepareVideoChartAsync(chartPath, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new PreparedChartCommandResult(true, null));
-            _mockGameApi.Setup(api => api.StartPreparedPreviewAsync())
+            _mockGameApi.Setup(api => api.StartPreparedPreviewAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new PreparedChartCommandResult(false, "No prepared chart preview is available."));
-            _mockGameApi.Setup(api => api.ActivatePreparedChartAsync())
+            _mockGameApi.Setup(api => api.ActivatePreparedChartAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new PreparedChartCommandResult(true, null));
-            _mockGameApi.Setup(api => api.CancelPreparedChartAsync())
+            _mockGameApi.Setup(api => api.CancelPreparedChartAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new PreparedChartCommandResult(true, null));
             using var client = await StartServerAsync(NextPort());
 
@@ -361,10 +362,10 @@ namespace DTXMania.Test.JsonRpc
                 Assert.Contains("\"error\":", body);
             }
 
-            _mockGameApi.Verify(api => api.PrepareVideoChartAsync(chartPath), Times.Once);
-            _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Once);
-            _mockGameApi.Verify(api => api.ActivatePreparedChartAsync(), Times.Once);
-            _mockGameApi.Verify(api => api.CancelPreparedChartAsync(), Times.Once);
+            _mockGameApi.Verify(api => api.PrepareVideoChartAsync(chartPath, It.IsAny<CancellationToken>()), Times.Once);
+            _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _mockGameApi.Verify(api => api.ActivatePreparedChartAsync(It.IsAny<CancellationToken>()), Times.Once);
+            _mockGameApi.Verify(api => api.CancelPreparedChartAsync(It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]

--- a/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
@@ -3,6 +3,7 @@ using DTXMania.Game.Lib.JsonRpc;
 using Moq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
@@ -331,7 +332,9 @@ namespace DTXMania.Test.JsonRpc
         [Fact]
         public async Task PreparedChartCommandRoutes_ShouldReturnSuccessAndErrorFields()
         {
-            _mockGameApi.Setup(api => api.PrepareVideoChartAsync("/safe/chart.dtx"))
+            var chartPath = Path.GetFullPath(Path.Combine("safe", "chart.dtx"));
+            Assert.True(Path.IsPathFullyQualified(chartPath));
+            _mockGameApi.Setup(api => api.PrepareVideoChartAsync(chartPath))
                 .ReturnsAsync(new PreparedChartCommandResult(true, null));
             _mockGameApi.Setup(api => api.StartPreparedPreviewAsync())
                 .ReturnsAsync(new PreparedChartCommandResult(false, "No prepared chart preview is available."));
@@ -343,7 +346,7 @@ namespace DTXMania.Test.JsonRpc
 
             var requests = new[]
             {
-                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prepareVideoChart\",\"params\":{\"chartPath\":\"/safe/chart.dtx\"}}",
+                $"{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prepareVideoChart\",\"params\":{{\"chartPath\":{JsonSerializer.Serialize(chartPath)}}}}}",
                 "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"startPreparedPreview\"}",
                 "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"activatePreparedChart\"}",
                 "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"cancelPreparedChart\"}",
@@ -358,7 +361,7 @@ namespace DTXMania.Test.JsonRpc
                 Assert.Contains("\"error\":", body);
             }
 
-            _mockGameApi.Verify(api => api.PrepareVideoChartAsync("/safe/chart.dtx"), Times.Once);
+            _mockGameApi.Verify(api => api.PrepareVideoChartAsync(chartPath), Times.Once);
             _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Once);
             _mockGameApi.Verify(api => api.ActivatePreparedChartAsync(), Times.Once);
             _mockGameApi.Verify(api => api.CancelPreparedChartAsync(), Times.Once);

--- a/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
+++ b/DTXMania.Test/JsonRpc/JsonRpcServerValidationTests.cs
@@ -310,6 +310,74 @@ namespace DTXMania.Test.JsonRpc
 
         #endregion
 
+        #region Prepared Chart Command Routes
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("{}")]
+        [InlineData("{\"chartPath\":\"   \"}")]
+        [InlineData("{\"chartPath\":123}")]
+        public async Task PrepareVideoChart_InvalidParams_ShouldReturnInvalidParams(string paramsJson)
+        {
+            using var client = await StartServerAsync(NextPort());
+            var requestJson = $"{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prepareVideoChart\",\"params\":{paramsJson}}}";
+            using var response = await client.PostAsync("/jsonrpc", RawRpcBody(requestJson));
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.Contains("-32602", body);
+            _mockGameApi.Verify(api => api.PrepareVideoChartAsync(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task PreparedChartCommandRoutes_ShouldReturnSuccessAndErrorFields()
+        {
+            _mockGameApi.Setup(api => api.PrepareVideoChartAsync("/safe/chart.dtx"))
+                .ReturnsAsync(new PreparedChartCommandResult(true, null));
+            _mockGameApi.Setup(api => api.StartPreparedPreviewAsync())
+                .ReturnsAsync(new PreparedChartCommandResult(false, "No prepared chart preview is available."));
+            _mockGameApi.Setup(api => api.ActivatePreparedChartAsync())
+                .ReturnsAsync(new PreparedChartCommandResult(true, null));
+            _mockGameApi.Setup(api => api.CancelPreparedChartAsync())
+                .ReturnsAsync(new PreparedChartCommandResult(true, null));
+            using var client = await StartServerAsync(NextPort());
+
+            var requests = new[]
+            {
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"prepareVideoChart\",\"params\":{\"chartPath\":\"/safe/chart.dtx\"}}",
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"startPreparedPreview\"}",
+                "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"activatePreparedChart\"}",
+                "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"cancelPreparedChart\"}",
+            };
+
+            foreach (var requestJson in requests)
+            {
+                using var response = await client.PostAsync("/jsonrpc", RawRpcBody(requestJson));
+                var body = await response.Content.ReadAsStringAsync();
+                Assert.True(response.IsSuccessStatusCode);
+                Assert.Contains("\"success\":", body);
+                Assert.Contains("\"error\":", body);
+            }
+
+            _mockGameApi.Verify(api => api.PrepareVideoChartAsync("/safe/chart.dtx"), Times.Once);
+            _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Once);
+            _mockGameApi.Verify(api => api.ActivatePreparedChartAsync(), Times.Once);
+            _mockGameApi.Verify(api => api.CancelPreparedChartAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task PreparedChartRoutes_WithApiKeyConfigured_ShouldRequireAuthentication()
+        {
+            using var client = await StartServerAsync(NextPort(), apiKey: "secret");
+            var requestJson = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"startPreparedPreview\"}";
+
+            using var response = await client.PostAsync("/jsonrpc", RawRpcBody(requestJson));
+
+            Assert.Equal(401, (int)response.StatusCode);
+            _mockGameApi.Verify(api => api.StartPreparedPreviewAsync(), Times.Never);
+        }
+
+        #endregion
+
         #region GetWindowInfo Game Not Running
 
         [Fact]

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
@@ -72,6 +72,46 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
+    public void PrepareVideoChart_WhenReplacingPlayingInteractivePreview_StopsOldInstanceBeforePublishingPrepared()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-replace-interactive");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        var previewPath = Path.Combine(root, "prepared.wav");
+        File.WriteAllText(chartPath, "chart");
+        File.WriteAllText(previewPath, "preview");
+
+        try
+        {
+            var node = CreateNode("prepared", chartPath, previewFile: "prepared.wav");
+            var resourceManager = new Mock<IResourceManager>();
+            var preparedSound = new Mock<ISound>();
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(preparedSound.Object);
+            var stage = CreatePreparedStage(root, node, resourceManager.Object);
+            var interactiveSound = new Mock<ISound>();
+            var interactiveInstance = new Mock<ISoundInstance>();
+            interactiveInstance.SetupGet(x => x.State).Returns(SoundState.Playing);
+            SetPrivateField(stage, "_previewSound", interactiveSound.Object);
+            SetPrivateField(stage, "_previewSoundInstance", interactiveInstance.Object);
+
+            var result = InvokeCommand(stage, "PrepareVideoChart", chartPath);
+
+            Assert.True(result.Success);
+            interactiveInstance.Verify(x => x.Stop(), Times.Once);
+            interactiveInstance.Verify(x => x.Dispose(), Times.Once);
+            interactiveSound.Verify(x => x.RemoveReference(), Times.Once);
+            Assert.Same(preparedSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+            Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+            preparedSound.Verify(x => x.CreateInstance(), Times.Never);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void PrepareVideoChart_WhenDeclarationFileOrLoadIsInvalid_ClearsPreparation()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-failures");

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
@@ -22,7 +22,7 @@ namespace DTXMania.Test.Stage;
 public sealed class SongSelectionStagePreparedChartLifecycleTests
 {
     [Fact]
-    public void PrepareVideoChart_UsesResolvedChartPreviewAndLeavesPreviewStopped()
+    public void PrepareVideoChart_ShouldUseResolvedChartPreviewAndLeavePreviewStopped()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-exact");
         Directory.CreateDirectory(root);
@@ -72,7 +72,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void PrepareVideoChart_WhenReplacingPlayingInteractivePreview_StopsOldInstanceBeforePublishingPrepared()
+    public void PrepareVideoChart_WhenReplacingPlayingInteractivePreview_ShouldStopOldInstanceBeforePublishingPrepared()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-replace-interactive");
         Directory.CreateDirectory(root);
@@ -112,7 +112,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void PrepareVideoChart_WhenDeclarationFileOrLoadIsInvalid_ClearsPreparation()
+    public void PrepareVideoChart_WhenDeclarationFileOrLoadIsInvalid_ShouldClearPreparation()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-failures");
         Directory.CreateDirectory(root);
@@ -155,7 +155,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void PrepareVideoChart_WhenRequestedPreviewLoadFails_RestoresPrimaryDelayedPreviewWithoutPreparation()
+    public void PrepareVideoChart_WhenRequestedPreviewLoadFails_ShouldRestorePrimaryDelayedPreviewWithoutPreparation()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-fallback-primary");
         Directory.CreateDirectory(root);
@@ -208,7 +208,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void PreparedPreview_DoesNotAutoStartAfterNormalDelay()
+    public void PreparedPreview_ShouldNotAutoStartAfterNormalDelay()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-delay");
         Directory.CreateDirectory(root);
@@ -238,7 +238,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void StartPreparedPreview_WhenAlreadyPlaying_IsIdempotent()
+    public void StartPreparedPreview_WhenAlreadyPlaying_ShouldBeIdempotent()
     {
         var stage = CreateStage();
         var sound = new Mock<ISound>();
@@ -258,7 +258,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void StartPreparedPreview_WhenInstanceCannotBeCreated_MarksPreviewFailed()
+    public void StartPreparedPreview_WhenInstanceCannotBeCreated_ShouldMarkPreviewFailed()
     {
         var stage = CreateStage();
         var sound = new Mock<ISound>();
@@ -277,7 +277,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void UpdatePreparedPreview_WhenPlaying_AccumulatesOnlyActualPlaybackAndFailsOnStop()
+    public void UpdatePreparedPreview_WhenPlaying_ShouldAccumulateOnlyActualPlaybackAndFailOnStop()
     {
         var stage = CreateStage();
         var instance = new Mock<ISoundInstance>();
@@ -298,7 +298,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void CancelPreparedChart_IsIdempotentAndReleasesPreviewExactlyOnce()
+    public void CancelPreparedChart_ShouldBeIdempotentAndReleasePreviewExactlyOnce()
     {
         var stage = CreateStage();
         var sound = new Mock<ISound>();
@@ -323,7 +323,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void CancelPreparedChart_WhenNoPreparationPreservesInteractivePreview()
+    public void CancelPreparedChart_WhenNoPreparation_ShouldPreserveInteractivePreview()
     {
         var stage = CreateStage();
         var sound = new Mock<ISound>();
@@ -351,7 +351,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void PrepareVideoChart_WhenInvalidAndNoPreparationPreservesInteractivePreview()
+    public void PrepareVideoChart_WhenInvalidAndNoPreparation_ShouldPreserveInteractivePreview()
     {
         var stage = CreateStage();
         var sound = new Mock<ISound>();
@@ -379,7 +379,32 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void Deactivate_CleansPreparedPreviewExactlyOnceAcrossRepeatedCalls()
+    public void PrepareVideoChart_WhenInvalidAndPreparationExists_ShouldPreserveExistingPreparation()
+    {
+        var stage = CreateStage();
+        var preparedSound = new Mock<ISound>();
+        var preparedInstance = new Mock<ISoundInstance>();
+        preparedInstance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSound", preparedSound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", preparedInstance.Object);
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-existing.dtx"));
+        var existingSelection = MakePreparedSelection(node, 0);
+        SetPrivateField(stage, "_preparedChartSelection", existingSelection);
+        SetPreparedState(stage, "Playing");
+        SetPrivateField(stage, "_preparedPreviewElapsedMs", 750d);
+
+        var result = InvokeCommand(stage, "PrepareVideoChart", " ");
+
+        Assert.False(result.Success);
+        Assert.Same(existingSelection, GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("Playing", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        Assert.Same(preparedSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+        Assert.Same(preparedInstance.Object, GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+        Assert.Equal(750d, GetPrivateField<double>(stage, "_preparedPreviewElapsedMs"));
+    }
+
+    [Fact]
+    public void Deactivate_ShouldCleanPreparedPreviewExactlyOnceAcrossRepeatedCalls()
     {
         var stage = CreateStage();
         var sound = new Mock<ISound>();
@@ -402,7 +427,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void OnSongSelectionChanged_WhenLeavingPreparedRow_ClearsPreparation()
+    public void OnSongSelectionChanged_WhenLeavingPreparedRow_ShouldClearPreparation()
     {
         var stage = CreateStage();
         var prepared = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared.dtx"));
@@ -425,7 +450,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void OnSongSelectionChanged_WhenProjectingPreparedSelection_PreservesPreparation()
+    public void OnSongSelectionChanged_WhenProjectingPreparedSelection_ShouldPreservePreparation()
     {
         var stage = CreateStage();
         var prepared = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-projecting.dtx"));
@@ -448,7 +473,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void OnDifficultyChanged_WhenLeavingPreparedDifficulty_ClearsAndLoadsNormalPreview()
+    public void OnDifficultyChanged_WhenLeavingPreparedDifficulty_ShouldClearAndLoadNormalPreview()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-difficulty");
         Directory.CreateDirectory(root);
@@ -484,7 +509,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void ActivatePreparedChart_WhenTransitionBlocked_PreservesPreparation()
+    public void ActivatePreparedChart_WhenTransitionBlocked_ShouldPreservePreparation()
     {
         var game = CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0d);
         var stage = CreateStage(game);
@@ -504,7 +529,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void ActivatePreparedChart_WhenStageManagerIsTransitioning_PreservesPreparation()
+    public void ActivatePreparedChart_WhenStageManagerIsTransitioning_ShouldPreservePreparation()
     {
         var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
         var stage = CreateStage(game);
@@ -526,7 +551,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void ActivatePreparedChart_WhenEligible_CleansPreparationAndUsesSongTransition()
+    public void ActivatePreparedChart_WhenEligible_ShouldCleanPreparationAndUseSongTransition()
     {
         var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
         var stage = CreateStage(game);
@@ -554,7 +579,7 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
-    public void PopulateTelemetry_ReportsPreparedIdentityStateAndElapsedWithoutAbsolutePath()
+    public void PopulateTelemetry_ShouldReportPreparedIdentityStateAndElapsedWithoutAbsolutePath()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-telemetry");
         var chartPath = Path.Combine(root, "telemetry.dtx");

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
@@ -155,6 +155,59 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
+    public void PrepareVideoChart_WhenRequestedPreviewLoadFails_RestoresPrimaryDelayedPreviewWithoutPreparation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-fallback-primary");
+        Directory.CreateDirectory(root);
+        var primaryPath = Path.Combine(root, "primary.dtx");
+        var requestedPath = Path.Combine(root, "requested.dtx");
+        var primaryPreviewPath = Path.Combine(root, "primary.wav");
+        var requestedPreviewPath = Path.Combine(root, "requested.wav");
+        File.WriteAllText(primaryPath, "chart");
+        File.WriteAllText(requestedPath, "chart");
+        File.WriteAllText(primaryPreviewPath, "preview");
+        File.WriteAllText(requestedPreviewPath, "preview");
+
+        try
+        {
+            var primary = new SongChart { Id = 601, FilePath = primaryPath, PreviewFile = "primary.wav" };
+            var requested = new SongChart { Id = 602, FilePath = requestedPath, PreviewFile = "requested.wav" };
+            var song = new SongEntity { Id = 601, Title = "multi-chart", Charts = new List<SongChart> { primary, requested } };
+            primary.Song = song;
+            requested.Song = song;
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = song.Title,
+                DatabaseSong = song,
+                DatabaseSongId = song.Id,
+                DatabaseChart = primary,
+                Scores = new[] { new SongScore { ChartId = requested.Id, Instrument = EInstrumentPart.DRUMS } }
+            };
+            var resourceManager = new Mock<IResourceManager>();
+            var primarySound = new Mock<ISound>();
+            resourceManager.Setup(x => x.LoadSound(requestedPreviewPath))
+                .Throws(new InvalidDataException("requested preview is invalid"));
+            resourceManager.Setup(x => x.LoadSound(primaryPreviewPath)).Returns(primarySound.Object);
+            var stage = CreatePreparedStage(root, node, resourceManager.Object);
+
+            var result = InvokeCommand(stage, "PrepareVideoChart", requestedPath);
+
+            Assert.False(result.Success);
+            resourceManager.Verify(x => x.LoadSound(requestedPreviewPath), Times.Once);
+            resourceManager.Verify(x => x.LoadSound(primaryPreviewPath), Times.Once);
+            Assert.Same(primarySound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+            Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+            Assert.Equal("None", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void PreparedPreview_DoesNotAutoStartAfterNormalDelay()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-delay");
@@ -447,6 +500,28 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
 
         Assert.False(result.Success);
         Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        stageManager.Verify(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Never);
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenStageManagerIsTransitioning_PreservesPreparation()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stageManager.SetupGet(manager => manager.IsTransitioning).Returns(true);
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-activation-transitioning.dtx"));
+        stage.StageManager = stageManager.Object;
+        SetPrivateField(stage, "_selectedSong", node);
+        SetPrivateField(stage, "_currentDifficulty", 0);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.False(result.Success);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
         stageManager.Verify(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Never);
     }
 

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
@@ -230,6 +230,62 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
+    public void CancelPreparedChart_WhenNoPreparationPreservesInteractivePreview()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPrivateField(stage, "_previewPlayDelay", 1.5d);
+        SetPrivateField(stage, "_isPreviewDelayActive", true);
+        SetPrivateField(stage, "_isBgmFadingOut", true);
+        SetPrivateField(stage, "_isBgmFadingIn", false);
+
+        var result = InvokeCommand(stage, "CancelPreparedChart");
+
+        Assert.True(result.Success);
+        Assert.Same(sound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+        Assert.Same(instance.Object, GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+        Assert.Equal(1.5d, GetPrivateField<double>(stage, "_previewPlayDelay"));
+        Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        sound.Verify(x => x.RemoveReference(), Times.Never);
+        instance.Verify(x => x.Stop(), Times.Never);
+        instance.Verify(x => x.Dispose(), Times.Never);
+    }
+
+    [Fact]
+    public void PrepareVideoChart_WhenInvalidAndNoPreparationPreservesInteractivePreview()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPrivateField(stage, "_previewPlayDelay", 2.5d);
+        SetPrivateField(stage, "_isPreviewDelayActive", true);
+        SetPrivateField(stage, "_isBgmFadingOut", true);
+        SetPrivateField(stage, "_isBgmFadingIn", false);
+
+        var result = InvokeCommand(stage, "PrepareVideoChart", " ");
+
+        Assert.False(result.Success);
+        Assert.Same(sound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+        Assert.Same(instance.Object, GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+        Assert.Equal(2.5d, GetPrivateField<double>(stage, "_previewPlayDelay"));
+        Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        Assert.True(GetPrivateField<bool>(stage, "_isBgmFadingOut"));
+        Assert.False(GetPrivateField<bool>(stage, "_isBgmFadingIn"));
+        sound.Verify(x => x.RemoveReference(), Times.Never);
+        instance.Verify(x => x.Stop(), Times.Never);
+        instance.Verify(x => x.Dispose(), Times.Never);
+    }
+
+    [Fact]
     public void Deactivate_CleansPreparedPreviewExactlyOnceAcrossRepeatedCalls()
     {
         var stage = CreateStage();

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
@@ -579,6 +579,527 @@ public sealed class SongSelectionStagePreparedChartLifecycleTests
     }
 
     [Fact]
+    public void StartPreparedPreview_WhenPlayingButInstanceStopped_ShouldMarkFailed()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Stopped);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPreparedState(stage, "Playing");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-stopped.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared preview stopped unexpectedly.", result.Error);
+        Assert.Equal("Failed", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        sound.Verify(x => x.CreateInstance(), Times.Never);
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenStateIsNone_ShouldReturnNotReady()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPreparedState(stage, "None");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-none.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart preview is not ready to play.", result.Error);
+        sound.Verify(x => x.CreateInstance(), Times.Never);
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenStateIsFailed_ShouldReturnNotReady()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPreparedState(stage, "Failed");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-failed.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart preview is not ready to play.", result.Error);
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenPreparedSelectionIsNull_ShouldReturnNoPreview()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        Assert.Equal("No prepared chart preview is available.", result.Error);
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenPreviewSoundIsNull_ShouldReturnNoPreview()
+    {
+        var stage = CreateStage();
+        SetPreparedState(stage, "Prepared");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-no-sound.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        Assert.Equal("No prepared chart preview is available.", result.Error);
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenExistingInstancePresent_ShouldDisposeBeforeCreatingNew()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        sound.Setup(x => x.CreateInstance()).Returns((SoundEffectInstance)null!);
+        var existingInstance = new Mock<ISoundInstance>();
+        existingInstance.SetupGet(x => x.State).Returns(SoundState.Stopped);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", existingInstance.Object);
+        SetPreparedState(stage, "Prepared");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-dispose-existing.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        existingInstance.Verify(x => x.Dispose(), Times.Once);
+        Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenCreateInstanceThrows_ShouldMarkFailedAndDispose()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        sound.Setup(x => x.CreateInstance()).Throws(new InvalidOperationException("device lost"));
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPreparedState(stage, "Prepared");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-throw.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart preview could not be started.", result.Error);
+        Assert.Equal("Failed", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenNoPreparation_ShouldReturnNoChartAvailable()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.False(result.Success);
+        Assert.Equal("No prepared chart is available.", result.Error);
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenSelectedSongDiffersFromPreparedNode_ShouldReturnNoLongerSelected()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var preparedNode = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-node.dtx"));
+        var otherNode = CreateNode("other", Path.Combine(Path.GetTempPath(), "other-node.dtx"));
+        SetPrivateField(stage, "_selectedSong", otherNode);
+        SetPrivateField(stage, "_currentDifficulty", 0);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(preparedNode, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart is no longer selected.", result.Error);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenDifficultyDiffersFromPrepared_ShouldReturnNoLongerSelected()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-diff.dtx"));
+        SetPrivateField(stage, "_selectedSong", node);
+        SetPrivateField(stage, "_currentDifficulty", 3);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.False(result.Success);
+        Assert.Equal("The prepared chart is no longer selected.", result.Error);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenStageManagerIsNull_ShouldReturnTransitionUnavailable()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        stage.StageManager = null;
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-no-sm.dtx"));
+        SetPrivateField(stage, "_selectedSong", node);
+        SetPrivateField(stage, "_currentDifficulty", 0);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.False(result.Success);
+        Assert.Equal("The song transition manager is unavailable.", result.Error);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenSelectedSongFromDisplayMatches_ShouldSucceed()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-display.dtx"), songId: 904);
+        var display = new SongListDisplay { CurrentList = new List<SongListNode> { node } };
+        display.SetSelection(0, 0);
+        SetPrivateField(stage, "_songListDisplay", display);
+        SetPrivateField(stage, "_selectedSong", null);
+        SetPrivateField(stage, "_currentDifficulty", 0);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.True(result.Success);
+        Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        stageManager.Verify(
+            x => x.ChangeStage(StageType.SongTransition, It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void PopulateTelemetry_WhenChartIdIsZero_ShouldReportRelativePathIdentity()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-telemetry-relative");
+        var chartPath = Path.Combine(root, "sub", "telemetry.dtx");
+        var stage = CreateStage();
+        var chart = new SongChart
+        {
+            Id = 0,
+            FilePath = chartPath,
+            PreviewFile = "preview.wav",
+            HasDrumChart = true,
+            DrumLevel = 5
+        };
+        var song = new SongEntity { Id = 0, Title = "telemetry", Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        chart.SongId = 0;
+        var node = new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "telemetry",
+            DatabaseSongId = 0,
+            DatabaseSong = song,
+            DatabaseChart = chart,
+            Scores = new[] { new SongScore { ChartId = 0, Instrument = EInstrumentPart.DRUMS } }
+        };
+        SetPrivateField(stage, "_appliedLibrarySnapshot", new SongLibrarySnapshot(
+            version: 1,
+            rootSongs: new[] { node },
+            activeRoots: new[] { Path.GetFullPath(root) },
+            enumeratedFileCount: 1,
+            discoveredScoreCount: 1));
+        var identity = (string)InvokePrivateMethod(stage, "BuildPreparedChartTelemetryIdentity", chart)!;
+
+        Assert.Equal("sub/telemetry.dtx", identity);
+        Assert.DoesNotContain(Path.GetFullPath(chartPath), identity, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PopulateTelemetry_WhenChartIdIsZeroAndNoActiveRootMatch_ShouldReportEmptyIdentity()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-telemetry-no-root");
+        var otherRoot = Path.Combine(Path.GetTempPath(), "hpa510-telemetry-other-root");
+        var chartPath = Path.Combine(otherRoot, "telemetry.dtx");
+        var stage = CreateStage();
+        var chart = new SongChart
+        {
+            Id = 0,
+            FilePath = chartPath,
+            PreviewFile = "preview.wav",
+            HasDrumChart = true,
+            DrumLevel = 5
+        };
+        var song = new SongEntity { Id = 0, Title = "telemetry", Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        var node = new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "telemetry",
+            DatabaseSong = song,
+            DatabaseChart = chart,
+        };
+        SetPrivateField(stage, "_appliedLibrarySnapshot", new SongLibrarySnapshot(
+            version: 1,
+            rootSongs: new[] { node },
+            activeRoots: new[] { Path.GetFullPath(root) },
+            enumeratedFileCount: 1,
+            discoveredScoreCount: 1));
+        var identity = (string)InvokePrivateMethod(stage, "BuildPreparedChartTelemetryIdentity", chart)!;
+
+        Assert.Equal("", identity);
+    }
+
+    [Fact]
+    public void PopulateTelemetry_WhenChartIdIsZeroAndNoSnapshot_ShouldReportEmptyIdentity()
+    {
+        var stage = CreateStage();
+        var chart = new SongChart
+        {
+            Id = 0,
+            FilePath = Path.Combine(Path.GetTempPath(), "telemetry.dtx"),
+            PreviewFile = "preview.wav",
+        };
+
+        var identity = (string)InvokePrivateMethod(stage, "BuildPreparedChartTelemetryIdentity", chart)!;
+
+        Assert.Equal("", identity);
+    }
+
+    [Fact]
+    public void PrepareVideoChart_WhenPreviewPathContainsInvalidChars_ShouldReturnPreviewNotFound()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-invalid-chars");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        File.WriteAllText(chartPath, "chart");
+
+        try
+        {
+            var chart = new SongChart
+            {
+                Id = 701,
+                FilePath = chartPath,
+                PreviewFile = "pre\0view.wav",
+                HasDrumChart = true,
+                DrumLevel = 5
+            };
+            var song = new SongEntity { Id = 701, Title = "invalid", Charts = new List<SongChart> { chart } };
+            chart.Song = song;
+            chart.SongId = 701;
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "invalid",
+                DatabaseSongId = 701,
+                DatabaseSong = song,
+                DatabaseChart = chart,
+                Scores = new[] { new SongScore { ChartId = 701, Instrument = EInstrumentPart.DRUMS } }
+            };
+            var stage = CreatePreparedStage(root, node, new Mock<IResourceManager>().Object);
+
+            var result = InvokeCommand(stage, "PrepareVideoChart", chartPath);
+
+            Assert.False(result.Success);
+            Assert.Equal("The requested chart does not declare a preview file.", result.Error);
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void DisposePreviewInstance_WhenDisposeThrows_ShouldSwallowExceptionAndClearInstance()
+    {
+        var stage = CreateStage();
+        var instance = new Mock<ISoundInstance>();
+        instance.Setup(x => x.Dispose()).Throws(new InvalidOperationException("disposed twice"));
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+
+        InvokePrivateMethod(stage, "DisposePreviewInstance");
+
+        Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+        instance.Verify(x => x.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public void DisposePreviewInstance_WhenInstanceIsNull_ShouldBeNoOp()
+    {
+        var stage = CreateStage();
+        SetPrivateField(stage, "_previewSoundInstance", null);
+
+        InvokePrivateMethod(stage, "DisposePreviewInstance");
+
+        Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+    }
+
+    [Fact]
+    public void OnSongSelectionChanged_WhenStayingOnPreparedRow_ShouldPreservePreparationAndNotLoadPreview()
+    {
+        var stage = CreateStage();
+        var prepared = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-stay.dtx"));
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(prepared, 0));
+        SetPreparedState(stage, "Prepared");
+        AttachCoreUi(stage, display: new SongListDisplay());
+
+        InvokePrivateMethod(
+            stage,
+            "OnSongSelectionChanged",
+            GetPrivateField<SongListDisplay>(stage, "_songListDisplay")!,
+            new SongSelectionChangedEventArgs(prepared, 0, true));
+
+        sound.Verify(x => x.RemoveReference(), Times.Never);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+    }
+
+    [Fact]
+    public void OnDifficultyChanged_WhenStayingOnPreparedDifficulty_ShouldPreservePreparation()
+    {
+        var stage = CreateStage();
+        var prepared = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-diff-stay.dtx"));
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(prepared, 0));
+        SetPreparedState(stage, "Prepared");
+        AttachCoreUi(stage, display: new SongListDisplay(), statusPanel: new SongStatusPanel());
+
+        InvokePrivateMethod(stage, "OnDifficultyChanged", stage, new DifficultyChangedEventArgs(prepared, 0));
+
+        sound.Verify(x => x.RemoveReference(), Times.Never);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+    }
+
+    [Fact]
+    public void UpdatePreviewSoundTimers_WhenPlayingWithNegativeDelta_ShouldClampToZero()
+    {
+        var stage = CreateStage();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPreparedState(stage, "Playing");
+        SetPrivateField(stage, "_preparedPreviewElapsedMs", 100d);
+
+        InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", -0.5d);
+
+        Assert.Equal(100d, GetPrivateField<double>(stage, "_preparedPreviewElapsedMs"));
+    }
+
+    [Fact]
+    public void SelectSong_WhenSongNodeIsNull_ShouldNotTransition()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+
+        InvokePrivateMethod(stage, "SelectSong", (SongListNode?)null);
+
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void SelectSong_WhenSongNodeIsBox_ShouldNotTransition()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        stage.StageManager = stageManager.Object;
+        var box = new SongListNode { Type = NodeType.Box, Title = "box" };
+
+        InvokePrivateMethod(stage, "SelectSong", box);
+
+        stageManager.Verify(
+            x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void SelectSong_WhenStageManagerIsNull_ShouldNotTransition()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        stage.StageManager = null;
+        var node = CreateNode("song", Path.Combine(Path.GetTempPath(), "select-no-sm.dtx"));
+
+        var exception = Record.Exception(() => InvokePrivateMethod(stage, "SelectSong", node));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void OnSongSelectionChanged_WhenNoPreparationAndScoreSelected_ShouldStopAndLoadPreview()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-no-prep");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        var previewPath = Path.Combine(root, "preview.wav");
+        File.WriteAllText(chartPath, "chart");
+        File.WriteAllText(previewPath, "preview");
+
+        try
+        {
+            var node = CreateNode("song", chartPath, previewFile: "preview.wav");
+            var resourceManager = new Mock<IResourceManager>();
+            var sound = new Mock<ISound>();
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(sound.Object);
+            var stage = CreateStage();
+            SetPrivateField(stage, "_resourceManager", resourceManager.Object);
+            SetPrivateField(stage, "_preparedChartSelection", null);
+            SetPreparedState(stage, "None");
+            AttachCoreUi(stage, display: new SongListDisplay(), statusPanel: new SongStatusPanel());
+
+            InvokePrivateMethod(
+                stage,
+                "OnSongSelectionChanged",
+                GetPrivateField<SongListDisplay>(stage, "_songListDisplay")!,
+                new SongSelectionChangedEventArgs(node, 0, true));
+
+            // With no prepared selection, the normal path should load the preview sound
+            resourceManager.Verify(x => x.LoadSound(previewPath), Times.Once);
+            Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
     public void PopulateTelemetry_ShouldReportPreparedIdentityStateAndElapsedWithoutAbsolutePath()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-telemetry");

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartLifecycleTests.cs
@@ -1,0 +1,485 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using DTXMania.Game.Lib;
+using DTXMania.Game.Lib.Resources;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using Microsoft.Xna.Framework.Audio;
+using Moq;
+using Xunit;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage;
+
+[Collection("SongManager")]
+[Trait("Category", "Unit")]
+public sealed class SongSelectionStagePreparedChartLifecycleTests
+{
+    [Fact]
+    public void PrepareVideoChart_UsesResolvedChartPreviewAndLeavesPreviewStopped()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-exact");
+        Directory.CreateDirectory(root);
+        var primaryPath = Path.Combine(root, "primary.dtx");
+        var preparedPath = Path.Combine(root, "prepared.dtx");
+        var primaryPreview = Path.Combine(root, "primary.wav");
+        var preparedPreview = Path.Combine(root, "prepared.wav");
+        File.WriteAllText(preparedPath, "chart");
+        File.WriteAllText(preparedPreview, "preview");
+
+        try
+        {
+            var primary = new SongChart { Id = 501, FilePath = primaryPath, PreviewFile = "primary.wav" };
+            var prepared = new SongChart { Id = 502, FilePath = preparedPath, PreviewFile = "prepared.wav" };
+            var song = new SongEntity { Id = 501, Title = "set", Charts = new List<SongChart> { primary, prepared } };
+            primary.Song = song;
+            prepared.Song = song;
+            var node = new SongListNode
+            {
+                Type = NodeType.Score,
+                Title = "set",
+                DatabaseSong = song,
+                DatabaseSongId = song.Id,
+                DatabaseChart = primary,
+                Scores = new[] { new SongScore { ChartId = prepared.Id, Instrument = EInstrumentPart.DRUMS } }
+            };
+            var resourceManager = new Mock<IResourceManager>();
+            var loadedSound = new Mock<ISound>();
+            resourceManager.Setup(x => x.LoadSound(preparedPreview)).Returns(loadedSound.Object);
+            var stage = CreatePreparedStage(root, node, resourceManager.Object);
+
+            var result = InvokeCommand(stage, "PrepareVideoChart", preparedPath);
+
+            Assert.True(result.Success);
+            resourceManager.Verify(x => x.LoadSound(preparedPreview), Times.Once);
+            resourceManager.Verify(x => x.LoadSound(primaryPreview), Times.Never);
+            Assert.Same(loadedSound.Object, GetPrivateField<ISound>(stage, "_previewSound"));
+            Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+            Assert.Equal(0d, GetPrivateField<double>(stage, "_preparedPreviewElapsedMs"));
+            Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void PrepareVideoChart_WhenDeclarationFileOrLoadIsInvalid_ClearsPreparation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-failures");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        var previewPath = Path.Combine(root, "preview.wav");
+        File.WriteAllText(chartPath, "chart");
+
+        try
+        {
+            var noDeclaration = CreateNode("none", chartPath, previewFile: "");
+            var missingFile = CreateNode("missing", chartPath, previewFile: "missing.wav");
+            var loadFailure = CreateNode("load", chartPath, previewFile: "preview.wav");
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Throws(new InvalidDataException("bad preview"));
+
+            var noDeclarationResult = InvokeCommand(
+                CreatePreparedStage(root, noDeclaration, resourceManager.Object),
+                "PrepareVideoChart",
+                chartPath);
+            var missingFileResult = InvokeCommand(
+                CreatePreparedStage(root, missingFile, resourceManager.Object),
+                "PrepareVideoChart",
+                chartPath);
+
+            File.WriteAllText(previewPath, "preview");
+            var loadFailureStage = CreatePreparedStage(root, loadFailure, resourceManager.Object);
+            var loadFailureResult = InvokeCommand(loadFailureStage, "PrepareVideoChart", chartPath);
+
+            Assert.False(noDeclarationResult.Success);
+            Assert.False(missingFileResult.Success);
+            Assert.False(loadFailureResult.Success);
+            Assert.Equal("None", GetPrivateField<object>(loadFailureStage, "_preparedPreviewState")?.ToString());
+            Assert.Null(GetPrivateField<object>(loadFailureStage, "_preparedChartSelection"));
+            Assert.Null(GetPrivateField<ISound>(loadFailureStage, "_previewSound"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void PreparedPreview_DoesNotAutoStartAfterNormalDelay()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-delay");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        var previewPath = Path.Combine(root, "preview.wav");
+        File.WriteAllText(chartPath, "chart");
+        File.WriteAllText(previewPath, "preview");
+
+        try
+        {
+            var resourceManager = new Mock<IResourceManager>();
+            var sound = new Mock<ISound>();
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(sound.Object);
+            var stage = CreatePreparedStage(root, CreateNode("song", chartPath, previewFile: "preview.wav"), resourceManager.Object);
+
+            Assert.True(InvokeCommand(stage, "PrepareVideoChart", chartPath).Success);
+            InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 10d);
+
+            sound.Verify(x => x.CreateInstance(), Times.Never);
+            Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+            Assert.False(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenAlreadyPlaying_IsIdempotent()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPreparedState(stage, "Playing");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-start.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.True(result.Success);
+        sound.Verify(x => x.CreateInstance(), Times.Never);
+        instance.Verify(x => x.Play(), Times.Never);
+    }
+
+    [Fact]
+    public void StartPreparedPreview_WhenInstanceCannotBeCreated_MarksPreviewFailed()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        sound.Setup(x => x.CreateInstance()).Returns((SoundEffectInstance)null!);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPreparedState(stage, "Prepared");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-start-failed.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        var result = InvokeCommand(stage, "StartPreparedPreview");
+
+        Assert.False(result.Success);
+        sound.Verify(x => x.CreateInstance(), Times.Once);
+        Assert.Equal("Failed", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        Assert.Null(GetPrivateField<ISoundInstance>(stage, "_previewSoundInstance"));
+    }
+
+    [Fact]
+    public void UpdatePreparedPreview_WhenPlaying_AccumulatesOnlyActualPlaybackAndFailsOnStop()
+    {
+        var stage = CreateStage();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPreparedState(stage, "Playing");
+        SetPrivateField(stage, "_preparedPreviewElapsedMs", 100d);
+
+        InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 0.5d);
+
+        Assert.Equal(600d, GetPrivateField<double>(stage, "_preparedPreviewElapsedMs"));
+
+        instance.SetupGet(x => x.State).Returns(SoundState.Stopped);
+        InvokePrivateMethod(stage, "UpdatePreviewSoundTimers", 1d);
+
+        Assert.Equal(600d, GetPrivateField<double>(stage, "_preparedPreviewElapsedMs"));
+        Assert.Equal("Failed", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+    }
+
+    [Fact]
+    public void CancelPreparedChart_IsIdempotentAndReleasesPreviewExactlyOnce()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPreparedState(stage, "Playing");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-cancel.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPrivateField(stage, "_preparedPreviewElapsedMs", 500d);
+
+        Assert.True(InvokeCommand(stage, "CancelPreparedChart").Success);
+        Assert.True(InvokeCommand(stage, "CancelPreparedChart").Success);
+
+        sound.Verify(x => x.RemoveReference(), Times.Once);
+        instance.Verify(x => x.Stop(), Times.Once);
+        instance.Verify(x => x.Dispose(), Times.Once);
+        Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("None", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+        Assert.Equal(0d, GetPrivateField<double>(stage, "_preparedPreviewElapsedMs"));
+    }
+
+    [Fact]
+    public void Deactivate_CleansPreparedPreviewExactlyOnceAcrossRepeatedCalls()
+    {
+        var stage = CreateStage();
+        var sound = new Mock<ISound>();
+        var instance = new Mock<ISoundInstance>();
+        instance.SetupGet(x => x.State).Returns(SoundState.Playing);
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_previewSoundInstance", instance.Object);
+        SetPreparedState(stage, "Playing");
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-deactivate.dtx"));
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+
+        stage.Deactivate();
+        stage.Deactivate();
+
+        sound.Verify(x => x.RemoveReference(), Times.Once);
+        instance.Verify(x => x.Stop(), Times.Once);
+        instance.Verify(x => x.Dispose(), Times.Once);
+        Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("None", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+    }
+
+    [Fact]
+    public void OnSongSelectionChanged_WhenLeavingPreparedRow_ClearsPreparation()
+    {
+        var stage = CreateStage();
+        var prepared = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared.dtx"));
+        var other = CreateNode("other", Path.Combine(Path.GetTempPath(), "other.dtx"));
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(prepared, 0));
+        SetPreparedState(stage, "Prepared");
+        AttachCoreUi(stage, display: new SongListDisplay());
+
+        InvokePrivateMethod(
+            stage,
+            "OnSongSelectionChanged",
+            GetPrivateField<SongListDisplay>(stage, "_songListDisplay")!,
+            new SongSelectionChangedEventArgs(other, 0, true));
+
+        sound.Verify(x => x.RemoveReference(), Times.Once);
+        Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("None", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+    }
+
+    [Fact]
+    public void OnSongSelectionChanged_WhenProjectingPreparedSelection_PreservesPreparation()
+    {
+        var stage = CreateStage();
+        var prepared = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-projecting.dtx"));
+        var sound = new Mock<ISound>();
+        SetPrivateField(stage, "_previewSound", sound.Object);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(prepared, 0));
+        SetPreparedState(stage, "Prepared");
+        SetPrivateField(stage, "_isProjectingPreparedSelection", true);
+        AttachCoreUi(stage, display: new SongListDisplay());
+
+        InvokePrivateMethod(
+            stage,
+            "OnSongSelectionChanged",
+            GetPrivateField<SongListDisplay>(stage, "_songListDisplay")!,
+            new SongSelectionChangedEventArgs(prepared, 0, true));
+
+        sound.Verify(x => x.RemoveReference(), Times.Never);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        Assert.Equal("Prepared", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+    }
+
+    [Fact]
+    public void OnDifficultyChanged_WhenLeavingPreparedDifficulty_ClearsAndLoadsNormalPreview()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-lifecycle-difficulty");
+        Directory.CreateDirectory(root);
+        var chartPath = Path.Combine(root, "chart.dtx");
+        var previewPath = Path.Combine(root, "preview.wav");
+        File.WriteAllText(chartPath, "chart");
+        File.WriteAllText(previewPath, "preview");
+
+        try
+        {
+            var node = CreateNode("prepared", chartPath, previewFile: "preview.wav");
+            var resourceManager = new Mock<IResourceManager>();
+            resourceManager.Setup(x => x.LoadSound(previewPath)).Returns(new Mock<ISound>().Object);
+            var stage = CreatePreparedStage(root, node, resourceManager.Object);
+            var preparedSound = new Mock<ISound>();
+            SetPrivateField(stage, "_previewSound", preparedSound.Object);
+            SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+            SetPreparedState(stage, "Prepared");
+            AttachCoreUi(stage, display: new SongListDisplay(), statusPanel: new SongStatusPanel());
+
+            InvokePrivateMethod(stage, "OnDifficultyChanged", stage, new DifficultyChangedEventArgs(node, 1));
+
+            preparedSound.Verify(x => x.RemoveReference(), Times.Once);
+            resourceManager.Verify(x => x.LoadSound(previewPath), Times.Once);
+            Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+            Assert.Equal("None", GetPrivateField<object>(stage, "_preparedPreviewState")?.ToString());
+            Assert.True(GetPrivateField<bool>(stage, "_isPreviewDelayActive"));
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenTransitionBlocked_PreservesPreparation()
+    {
+        var game = CreateGame(totalGameTime: 0.1, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-activation-blocked.dtx"));
+        stage.StageManager = stageManager.Object;
+        SetPrivateField(stage, "_selectedSong", node);
+        SetPrivateField(stage, "_currentDifficulty", 0);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.False(result.Success);
+        Assert.NotNull(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        stageManager.Verify(x => x.ChangeStage(It.IsAny<StageType>(), It.IsAny<IStageTransition>(), It.IsAny<Dictionary<string, object>>()), Times.Never);
+    }
+
+    [Fact]
+    public void ActivatePreparedChart_WhenEligible_CleansPreparationAndUsesSongTransition()
+    {
+        var game = CreateGame(totalGameTime: 2d, lastStageTransitionTime: 0d);
+        var stage = CreateStage(game);
+        var stageManager = new Mock<IStageManager>();
+        var node = CreateNode("prepared", Path.Combine(Path.GetTempPath(), "prepared-activation.dtx"), songId: 902);
+        stage.StageManager = stageManager.Object;
+        SetPrivateField(stage, "_selectedSong", node);
+        SetPrivateField(stage, "_currentDifficulty", 0);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Prepared");
+
+        var result = InvokeCommand(stage, "ActivatePreparedChart");
+
+        Assert.True(result.Success);
+        Assert.Null(GetPrivateField<object>(stage, "_preparedChartSelection"));
+        stageManager.Verify(
+            x => x.ChangeStage(
+                StageType.SongTransition,
+                It.Is<IStageTransition>(transition => transition is InstantTransition),
+                It.Is<Dictionary<string, object>>(data =>
+                    ReferenceEquals(data["selectedSong"], node)
+                    && (int)data["selectedDifficulty"] == 0
+                    && (int)data["songId"] == 902)),
+            Times.Once);
+    }
+
+    [Fact]
+    public void PopulateTelemetry_ReportsPreparedIdentityStateAndElapsedWithoutAbsolutePath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-telemetry");
+        var chartPath = Path.Combine(root, "telemetry.dtx");
+        var stage = CreateStage();
+        var node = CreateNode("telemetry", chartPath, songId: 903);
+        SetPrivateField(stage, "_preparedChartSelection", MakePreparedSelection(node, 0));
+        SetPreparedState(stage, "Playing");
+        SetPrivateField(stage, "_preparedPreviewElapsedMs", 1234.5d);
+        var telemetry = new GameTelemetrySnapshot();
+
+        stage.PopulateTelemetry(telemetry);
+
+        Assert.Equal("chart:903", GetTelemetryProperty<string>(telemetry, "PreparedChartIdentity"));
+        Assert.Equal("Playing", GetTelemetryProperty<string>(telemetry, "PreparedPreviewState"));
+        Assert.Equal(1234.5d, GetTelemetryProperty<double?>(telemetry, "PreparedPreviewElapsedMs"));
+        Assert.DoesNotContain(Path.GetFullPath(chartPath), GetTelemetryProperty<string>(telemetry, "PreparedChartIdentity") ?? "", StringComparison.Ordinal);
+    }
+
+    private static SongSelectionStage CreatePreparedStage(string root, SongListNode node, IResourceManager resourceManager)
+    {
+        var stage = CreateStage(CreateGame(totalGameTime: 2d));
+        AttachCoreUi(stage, display: new SongListDisplay { CurrentList = new List<SongListNode> { node } });
+        SetPrivateField(stage, "_resourceManager", resourceManager);
+        SetPrivateField(stage, "_currentSongList", new List<SongListNode> { node });
+        SetPrivateField(stage, "_appliedLibrarySnapshot", new SongLibrarySnapshot(
+            version: 1,
+            rootSongs: new[] { node },
+            activeRoots: new[] { Path.GetFullPath(root) },
+            enumeratedFileCount: 1,
+            discoveredScoreCount: 1));
+        return stage;
+    }
+
+    private static SongListNode CreateNode(string title, string chartPath, string previewFile = "preview.wav", int songId = 901)
+    {
+        var chart = new SongChart
+        {
+            Id = songId,
+            FilePath = chartPath,
+            PreviewFile = previewFile,
+            HasDrumChart = true,
+            DrumLevel = 5
+        };
+        var song = new SongEntity { Id = songId, Title = title, Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        chart.SongId = songId;
+        return new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = title,
+            DatabaseSongId = songId,
+            DatabaseSong = song,
+            DatabaseChart = chart,
+            Scores = new[] { new SongScore { ChartId = songId, Instrument = EInstrumentPart.DRUMS } }
+        };
+    }
+
+    private static object MakePreparedSelection(SongListNode node, int difficulty)
+    {
+        var field = GetField(typeof(SongSelectionStage), "_preparedChartSelection");
+        Assert.NotNull(field);
+        var selectionType = field!.FieldType;
+        var chart = node.DatabaseChart!;
+        return Activator.CreateInstance(selectionType, node, chart, difficulty, $"chart:{chart.Id}")!;
+    }
+
+    private static void SetPreparedState(SongSelectionStage stage, string state)
+    {
+        var field = GetField(typeof(SongSelectionStage), "_preparedPreviewState");
+        Assert.NotNull(field);
+        SetPrivateField(stage, "_preparedPreviewState", Enum.Parse(field!.FieldType, state));
+    }
+
+    private static (bool Success, string? Error) InvokeCommand(SongSelectionStage stage, string methodName, params object[] args)
+    {
+        var value = InvokePrivateMethod(stage, methodName, args);
+        Assert.NotNull(value);
+        var success = (bool)value!.GetType().GetField("Item1")!.GetValue(value)!;
+        var error = (string?)value.GetType().GetField("Item2")!.GetValue(value);
+        return (success, error);
+    }
+
+    private static T? GetTelemetryProperty<T>(GameTelemetrySnapshot telemetry, string propertyName)
+    {
+        return (T?)typeof(GameTelemetrySnapshot).GetProperty(propertyName)?.GetValue(telemetry);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DTXMania.Game.Lib.Song;
+using DTXMania.Game.Lib.Song.Components;
+using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Stage;
+using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
+using static DTXMania.Test.TestData.ReflectionHelpers;
+using SongEntity = DTXMania.Game.Lib.Song.Entities.Song;
+
+namespace DTXMania.Test.Stage;
+
+[Collection("SongManager")]
+[Trait("Category", "Unit")]
+public sealed class SongSelectionStagePreparedChartTests
+{
+    [Fact]
+    public void ResolvePreparedChart_RootLevelChart_ReturnsExactNodeChartAndDifficulty()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-root");
+        var chartPath = Path.Combine(root, "root.dtx");
+        var node = CreateNode("same title", chartPath, chartId: 11, instrument: EInstrumentPart.DRUMS);
+        var stage = CreateStageWithSnapshot(root, node);
+
+        var resolution = Resolve(stage, chartPath);
+
+        Assert.NotNull(resolution);
+        Assert.Same(node, Property<SongListNode>(resolution!, "Node"));
+        Assert.Same(node.DatabaseChart, Property<SongChart>(resolution!, "Chart"));
+        Assert.Equal(0, Property<int>(resolution!, "DifficultyIndex"));
+        Assert.Empty(Property<IReadOnlyList<string>>(resolution!, "AncestorBoxPaths"));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_NestedBox_ReturnsAncestorPathsInOrder()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-nested");
+        var outerPath = Path.Combine(root, "outer");
+        var innerPath = Path.Combine(outerPath, "inner");
+        var chartPath = Path.Combine(innerPath, "nested.dtx");
+        var node = CreateNode("nested", chartPath, chartId: 12, instrument: EInstrumentPart.DRUMS);
+        var inner = Box("same title", innerPath, node);
+        var outer = Box("same title", outerPath, inner);
+        var stage = CreateStageWithSnapshot(root, outer);
+
+        var resolution = Resolve(stage, chartPath);
+
+        Assert.NotNull(resolution);
+        Assert.Equal(
+            new[] { Path.GetFullPath(outerPath), Path.GetFullPath(innerPath) },
+            Property<IReadOnlyList<string>>(resolution!, "AncestorBoxPaths"));
+        Assert.Same(node, Property<SongListNode>(resolution!, "Node"));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_WhenRequestedChartIsNotDatabaseChart_UsesSongChartsByPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-set");
+        var primaryPath = Path.Combine(root, "primary.dtx");
+        var requestedPath = Path.Combine(root, "requested.dtx");
+        var primary = Chart(21, primaryPath, drums: 2);
+        var requested = Chart(22, requestedPath, drums: 7);
+        var song = new SongEntity { Id = 21, Title = "set", Charts = new List<SongChart> { primary, requested } };
+        primary.Song = song;
+        requested.Song = song;
+        var node = new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = "set",
+            DatabaseSong = song,
+            DatabaseChart = primary,
+            Scores = Scores((22, EInstrumentPart.DRUMS))
+        };
+        var stage = CreateStageWithSnapshot(root, node);
+
+        var resolution = Resolve(stage, requestedPath);
+
+        Assert.NotNull(resolution);
+        Assert.Same(requested, Property<SongChart>(resolution!, "Chart"));
+        Assert.Equal(0, Property<int>(resolution!, "DifficultyIndex"));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_DuplicateTitlesAtDifferentPaths_UsesOnlyRequestedPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-duplicates");
+        var first = CreateNode("duplicate", Path.Combine(root, "one", "chart.dtx"), 31, EInstrumentPart.DRUMS);
+        var second = CreateNode("duplicate", Path.Combine(root, "two", "chart.dtx"), 32, EInstrumentPart.DRUMS);
+        var stage = CreateStageWithSnapshot(root, first, second);
+
+        var resolution = Resolve(stage, second.DatabaseChart!.FilePath);
+
+        Assert.NotNull(resolution);
+        Assert.Same(second, Property<SongListNode>(resolution!, "Node"));
+        Assert.NotSame(first, Property<SongListNode>(resolution!, "Node"));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_OutsideActiveRoot_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-active");
+        var outsidePath = Path.Combine(Path.GetTempPath(), "hpa510-outside", "chart.dtx");
+        var node = CreateNode("outside", outsidePath, 41, EInstrumentPart.DRUMS);
+        var stage = CreateStageWithSnapshot(root, node);
+
+        Assert.Null(Resolve(stage, outsidePath));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_ActiveRootButUnindexedPath_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-unindexed");
+        var requestedPath = Path.Combine(root, "not-indexed.dtx");
+        var indexed = CreateNode("indexed", Path.Combine(root, "indexed.dtx"), 51, EInstrumentPart.DRUMS);
+        var stage = CreateStageWithSnapshot(root, indexed);
+
+        Assert.Null(Resolve(stage, requestedPath));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_OrdinaryMultiInstrumentRowWithSharedChartId_PrefersDrumsSlot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-shared-id");
+        var chartPath = Path.Combine(root, "shared.dtx");
+        var node = CreateNode(
+            "shared",
+            chartPath,
+            chartId: 61,
+            instrument: EInstrumentPart.GUITAR,
+            scores: Scores(
+                (61, EInstrumentPart.GUITAR),
+                (61, EInstrumentPart.DRUMS),
+                (61, EInstrumentPart.BASS)));
+        var stage = CreateStageWithSnapshot(root, node);
+
+        var resolution = Resolve(stage, chartPath);
+
+        Assert.NotNull(resolution);
+        Assert.Equal(1, Property<int>(resolution!, "DifficultyIndex"));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_WhenDifficultyCannotBeDisambiguated_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-ambiguous");
+        var chartPath = Path.Combine(root, "ambiguous.dtx");
+        var node = CreateNode(
+            "ambiguous",
+            chartPath,
+            chartId: 71,
+            instrument: EInstrumentPart.GUITAR,
+            scores: Scores(
+                (71, EInstrumentPart.GUITAR),
+                (71, EInstrumentPart.BASS)));
+        var stage = CreateStageWithSnapshot(root, node);
+
+        Assert.Null(Resolve(stage, chartPath));
+    }
+
+    [Fact]
+    public void ResolvePreparedChart_BlankOrRelativePath_ReturnsNull()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-validation");
+        var node = CreateNode("song", Path.Combine(root, "song.dtx"), 81, EInstrumentPart.DRUMS);
+        var stage = CreateStageWithSnapshot(root, node);
+
+        Assert.Null(Resolve(stage, " "));
+        Assert.Null(Resolve(stage, "relative/song.dtx"));
+    }
+
+    [Fact]
+    public void ProjectPreparedChartSelection_RebuildsHierarchyOnceAndSelectsResolvedRow()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-projection");
+        var boxPath = Path.Combine(root, "box");
+        var chartPath = Path.Combine(boxPath, "prepared.dtx");
+        var node = CreateNode(
+            "prepared",
+            chartPath,
+            chartId: 91,
+            instrument: EInstrumentPart.DRUMS,
+            scores: Scores((91, EInstrumentPart.DRUMS), (91, EInstrumentPart.GUITAR)));
+        var box = Box("box", boxPath, node);
+        var stage = CreateStageWithSnapshot(root, box);
+        var display = new SongListDisplay();
+        AttachCoreUi(stage, display: display);
+        SetPrivateField(stage, "_currentSongList", new List<SongListNode> { box });
+
+        var resolution = Resolve(stage, chartPath);
+        Assert.NotNull(resolution);
+
+        var projected = InvokePrivateMethod<bool>(stage, "ProjectPreparedChartSelection", resolution!);
+
+        Assert.True(projected);
+        Assert.Equal(SongSelectionTab.AllSongs, GetPrivateField<SongSelectionTab>(stage, "_activeTab"));
+        Assert.Null(GetPrivateField<object>(stage, "_filteredView"));
+        Assert.Single(GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!);
+        Assert.Same(node, display.SelectedSong);
+        Assert.Equal(0, display.CurrentDifficulty);
+        Assert.False(GetPrivateField<bool>(stage, "_isProjectingPreparedSelection"));
+    }
+
+    [Fact]
+    public void SetSelection_AppliesRowDifficultyAndRaisesOneSelectionEvent()
+    {
+        var first = new SongListNode { Type = NodeType.Score, Title = "first" };
+        var second = new SongListNode { Type = NodeType.Score, Title = "second" };
+        var display = new SongListDisplay { CurrentList = new List<SongListNode> { first, second } };
+        var events = 0;
+        SongSelectionChangedEventArgs? args = null;
+        display.SelectionChanged += (_, eventArgs) =>
+        {
+            events++;
+            args = eventArgs;
+        };
+
+        InvokePrivateMethod(display, "SetSelection", 1, 99);
+
+        Assert.Equal(1, events);
+        Assert.Same(second, display.SelectedSong);
+        Assert.Equal(1, display.SelectedIndex);
+        Assert.Equal(4, display.CurrentDifficulty);
+        Assert.NotNull(args);
+        Assert.Same(second, args!.SelectedSong);
+        Assert.Equal(4, args.CurrentDifficulty);
+        Assert.True(args.IsScrollComplete);
+        Assert.Equal(
+            GetPrivateField<int>(display, "_targetScrollCounter"),
+            GetPrivateField<int>(display, "_currentScrollCounter"));
+    }
+
+    [Fact]
+    public void SetSelection_InvalidIndex_DoesNotChangeSelectionOrRaiseEvent()
+    {
+        var first = new SongListNode { Type = NodeType.Score, Title = "first" };
+        var display = new SongListDisplay { CurrentList = new List<SongListNode> { first } };
+        var events = 0;
+        display.SelectionChanged += (_, _) => events++;
+
+        InvokePrivateMethod(display, "SetSelection", -1, 2);
+        InvokePrivateMethod(display, "SetSelection", 1, 2);
+
+        Assert.Equal(0, events);
+        Assert.Same(first, display.SelectedSong);
+        Assert.Equal(0, display.SelectedIndex);
+        Assert.Equal(0, display.CurrentDifficulty);
+    }
+
+    private static SongSelectionStage CreateStageWithSnapshot(string activeRoot, params SongListNode[] roots)
+    {
+        var stage = CreateStage();
+        SetPrivateField(stage, "_appliedLibrarySnapshot", new SongLibrarySnapshot(
+            version: 1,
+            rootSongs: roots,
+            activeRoots: new[] { Path.GetFullPath(activeRoot) },
+            enumeratedFileCount: roots.Length,
+            discoveredScoreCount: roots.Length));
+        return stage;
+    }
+
+    private static object? Resolve(SongSelectionStage stage, string path) =>
+        InvokePrivateMethod(stage, "ResolvePreparedChart", path);
+
+    private static T Property<T>(object value, string name) =>
+        (T)value.GetType().GetProperty(name)!.GetValue(value)!;
+
+    private static SongListNode CreateNode(
+        string title,
+        string chartPath,
+        int chartId,
+        EInstrumentPart instrument,
+        SongScore[]? scores = null)
+    {
+        var chart = Chart(chartId, chartPath, drums: instrument == EInstrumentPart.DRUMS ? 5 : 0);
+        var song = new SongEntity { Id = chartId, Title = title, Charts = new List<SongChart> { chart } };
+        chart.Song = song;
+        chart.SongId = song.Id;
+        return new SongListNode
+        {
+            Type = NodeType.Score,
+            Title = title,
+            DatabaseSong = song,
+            DatabaseSongId = song.Id,
+            DatabaseChart = chart,
+            Scores = scores ?? Scores((chartId, instrument))
+        };
+    }
+
+    private static SongChart Chart(int id, string path, int drums) => new()
+    {
+        Id = id,
+        FilePath = path,
+        HasDrumChart = drums > 0,
+        DrumLevel = drums
+    };
+
+    private static SongScore[] Scores(params (int ChartId, EInstrumentPart Instrument)[] values)
+    {
+        var scores = new SongScore[5];
+        for (var index = 0; index < values.Length; index++)
+        {
+            scores[index] = new SongScore
+            {
+                ChartId = values[index].ChartId,
+                Instrument = values[index].Instrument
+            };
+        }
+
+        return scores;
+    }
+}

--- a/DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs
+++ b/DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using DTXMania.Game.Lib.Song;
 using DTXMania.Game.Lib.Song.Components;
 using DTXMania.Game.Lib.Song.Entities;
+using DTXMania.Game.Lib.Song.Filtering;
 using DTXMania.Game.Lib.Stage;
 using static DTXMania.Test.Stage.SongSelectionStageTestFactory;
 using static DTXMania.Test.TestData.ReflectionHelpers;
@@ -17,7 +18,7 @@ namespace DTXMania.Test.Stage;
 public sealed class SongSelectionStagePreparedChartTests
 {
     [Fact]
-    public void ResolvePreparedChart_RootLevelChart_ReturnsExactNodeChartAndDifficulty()
+    public void ResolvePreparedChart_ForRootLevelChart_ShouldReturnExactNodeChartAndDifficulty()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-root");
         var chartPath = Path.Combine(root, "root.dtx");
@@ -34,7 +35,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_NestedBox_ReturnsAncestorPathsInOrder()
+    public void ResolvePreparedChart_ForNestedBox_ShouldReturnAncestorPathsInOrder()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-nested");
         var outerPath = Path.Combine(root, "outer");
@@ -55,7 +56,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_WhenRequestedChartIsNotDatabaseChart_UsesSongChartsByPath()
+    public void ResolvePreparedChart_WhenRequestedChartIsNotDatabaseChart_ShouldUseSongChartsByPath()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-set");
         var primaryPath = Path.Combine(root, "primary.dtx");
@@ -83,7 +84,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_DuplicateTitlesAtDifferentPaths_UsesOnlyRequestedPath()
+    public void ResolvePreparedChart_WithDuplicateTitlesAtDifferentPaths_ShouldUseOnlyRequestedPath()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-duplicates");
         var first = CreateNode("duplicate", Path.Combine(root, "one", "chart.dtx"), 31, EInstrumentPart.DRUMS);
@@ -98,7 +99,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_OutsideActiveRoot_ReturnsNull()
+    public void ResolvePreparedChart_WhenOutsideActiveRoot_ShouldReturnNull()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-active");
         var outsidePath = Path.Combine(Path.GetTempPath(), "hpa510-outside", "chart.dtx");
@@ -109,7 +110,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_ActiveRootButUnindexedPath_ReturnsNull()
+    public void ResolvePreparedChart_WhenActiveRootButUnindexedPath_ShouldReturnNull()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-unindexed");
         var requestedPath = Path.Combine(root, "not-indexed.dtx");
@@ -120,7 +121,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_OrdinaryMultiInstrumentRowWithSharedChartId_PrefersDrumsSlot()
+    public void ResolvePreparedChart_ForOrdinaryMultiInstrumentRowWithSharedChartId_ShouldPreferDrumsSlot()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-shared-id");
         var chartPath = Path.Combine(root, "shared.dtx");
@@ -142,7 +143,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_WhenDifficultyCannotBeDisambiguated_ReturnsNull()
+    public void ResolvePreparedChart_WhenDifficultyCannotBeDisambiguated_ShouldReturnNull()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-ambiguous");
         var chartPath = Path.Combine(root, "ambiguous.dtx");
@@ -160,7 +161,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ResolvePreparedChart_BlankOrRelativePath_ReturnsNull()
+    public void ResolvePreparedChart_ForBlankOrRelativePath_ShouldReturnNull()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-validation");
         var node = CreateNode("song", Path.Combine(root, "song.dtx"), 81, EInstrumentPart.DRUMS);
@@ -171,7 +172,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void ProjectPreparedChartSelection_RebuildsHierarchyOnceAndSelectsResolvedRow()
+    public void ProjectPreparedChartSelection_ShouldRebuildHierarchyOnceAndSelectResolvedRow()
     {
         var root = Path.Combine(Path.GetTempPath(), "hpa510-projection");
         var boxPath = Path.Combine(root, "box");
@@ -203,7 +204,49 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void SetSelection_AppliesRowDifficultyAndRaisesOneSelectionEvent()
+    public void ProjectPreparedChartSelection_WhenTargetNodeIsNotFound_ShouldRestorePreviousBrowseState()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "hpa510-projection-restore");
+        var boxPath = Path.Combine(root, "box");
+        var chartPath = Path.Combine(boxPath, "visible.dtx");
+        var visibleNode = CreateNode("visible", chartPath, 91, EInstrumentPart.DRUMS);
+        var box = Box("box", boxPath, visibleNode);
+        var stage = CreateStageWithSnapshot(root, box);
+        var display = new SongListDisplay();
+        AttachCoreUi(stage, display: display);
+
+        var previousSongList = new List<SongListNode> { visibleNode };
+        SetPrivateField(stage, "_currentSongList", previousSongList);
+        var previousBreadcrumb = "root > box";
+        SetPrivateField(stage, "_currentBreadcrumb", previousBreadcrumb);
+        var navStack = new Stack<SongListNode>();
+        navStack.Push(new SongListNode { Title = "root", Children = new List<SongListNode> { box } });
+        SetPrivateField(stage, "_navigationStack", navStack);
+        var previousFilter = new SongFilterCriteria(
+            "test", null, null, PlayedStatus.All, SongSortCriteria.Title, false);
+        SetPrivateField(stage, "_filterCriteria", previousFilter);
+        var previousFilteredView = new List<FilteredSongResult> { new(visibleNode, "root > box") };
+        SetPrivateField(stage, "_filteredView", previousFilteredView);
+
+        var resolutionType = Resolve(stage, chartPath)!.GetType();
+        var orphanNode = CreateNode("orphan", Path.Combine(root, "orphan.dtx"), 99, EInstrumentPart.DRUMS);
+        var orphanResolution = Activator.CreateInstance(
+            resolutionType, orphanNode, orphanNode.DatabaseChart, 0, Array.Empty<string>())!;
+
+        var projected = InvokePrivateMethod<bool>(stage, "ProjectPreparedChartSelection", orphanResolution);
+
+        Assert.False(projected);
+        Assert.Same(previousSongList, GetPrivateField<List<SongListNode>>(stage, "_currentSongList"));
+        Assert.Equal(previousBreadcrumb, GetPrivateField<string>(stage, "_currentBreadcrumb"));
+        Assert.Equal(previousFilter, GetPrivateField<SongFilterCriteria>(stage, "_filterCriteria"));
+        Assert.Same(previousFilteredView, GetPrivateField<object>(stage, "_filteredView"));
+        var restoredNav = GetPrivateField<Stack<SongListNode>>(stage, "_navigationStack")!;
+        Assert.Single(restoredNav);
+        Assert.False(GetPrivateField<bool>(stage, "_isProjectingPreparedSelection"));
+    }
+
+    [Fact]
+    public void SetSelection_ShouldApplyRowDifficultyAndRaiseOneSelectionEvent()
     {
         var first = new SongListNode { Type = NodeType.Score, Title = "first" };
         var second = new SongListNode { Type = NodeType.Score, Title = "second" };
@@ -232,7 +275,7 @@ public sealed class SongSelectionStagePreparedChartTests
     }
 
     [Fact]
-    public void SetSelection_InvalidIndex_DoesNotChangeSelectionOrRaiseEvent()
+    public void SetSelection_WhenInvalidIndex_ShouldNotChangeSelectionOrRaiseEvent()
     {
         var first = new SongListNode { Type = NodeType.Score, Title = "first" };
         var display = new SongListDisplay { CurrentList = new List<SongListNode> { first } };

--- a/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
+++ b/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
@@ -1,0 +1,356 @@
+# HPA-510 Prepared Chart Recording Commands Implementation Plan
+
+**Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
+**Design:** `docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md`  
+**Target size:** one implementation PR, 2–3 engineer days
+
+## Objective
+
+Add the smallest production API HPA-503 needs to prepare one exact indexed chart in Song Select, explicitly start its declared preview, activate it through the normal player path, and cancel/clean up safely.
+
+Keep the implementation local to existing Song Select, Game API/JSON-RPC, telemetry, and Automation seams. Do not introduce a general automation/session framework.
+
+## File Map
+
+### Game / Song Select
+
+- `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
+  - exact active-library chart resolution;
+  - prepared selection/preview state;
+  - programmatic browse projection;
+  - prepare/start/activate/cancel commands;
+  - elapsed preview telemetry;
+  - cleanup on navigation/deactivation.
+- `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
+  - one narrow atomic row+difficulty programmatic selection method.
+- `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
+  - three prepared-recording telemetry fields.
+
+### Game API / transport
+
+- `DTXMania.Game/Lib/GameApi.cs`
+  - four explicit command methods and narrow command result contract.
+- `DTXMania.Game/Lib/GameApiImplementation.cs`
+  - queue each command through the existing main-thread action queue and await its actual result.
+- `DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs`
+  - four explicit authenticated JSON-RPC routes/handlers.
+
+### Automation consumer
+
+- `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
+  - public wrappers for the four new operations.
+- `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
+  - accessors for prepared identity/state/elapsed time.
+
+### Tests
+
+Prefer one focused new Song Select fixture rather than spreading preparation cases across unrelated files:
+
+- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new.
+- `DTXMania.Test/GameApi/GameApiImplementationTests.cs` — extend.
+- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or existing JSON-RPC integration tests — extend only where current seams fit.
+- `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs` — extend.
+- `DTXMania.E2E/Telemetry/E2EGameStateTests.cs` or the current producer/consumer telemetry contract test — extend only if needed to keep game/Automation field names aligned.
+
+Do not add a new E2E harness or recorder test project in this ticket.
+
+---
+
+## Task 1 — Resolve and project an exact indexed chart
+
+**Goal:** given one absolute chart path, identify exactly one active Song Select row + difficulty and show it through the normal UI without synthetic input.
+
+### 1.1 Write failing focused tests first
+
+In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-library hierarchies covering:
+
+- root-level chart;
+- chart below one or more BOX nodes;
+- multi-chart/SET-style row where the requested chart is not the node's primary chart;
+- duplicate song titles with different file paths;
+- path outside active roots;
+- path under an active root but absent from the indexed snapshot;
+- no unique difficulty mapping.
+
+Assertions should verify the resolved node and difficulty come from path identity only. No title matching is allowed.
+
+### 1.2 Add a stage-private resolver
+
+In `SongSelectionStage.cs`:
+
+- require a fully-qualified non-blank path;
+- use the currently applied `SongLibrarySnapshot` as the authoritative library view;
+- normalize with `SongPathIdentity`;
+- require containment under `snapshot.ActiveRoots`;
+- recursively traverse root/BOX nodes and inspect both `DatabaseChart` and `DatabaseSong.Charts`;
+- require one exact normalized chart match;
+- resolve the visible difficulty slot by `SongScore.ChartId` first;
+- for legacy/SET fallback, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart` rather than recreating chart-order rules;
+- retain the ancestor BOX chain and matched `SongChart` in the resolution result.
+
+Keep this helper inside the game assembly. Do not expose library traversal through Game API.
+
+### 1.3 Add one atomic `SongListDisplay` selection seam
+
+Add a small method such as `SetSelection(int index, int difficulty)` that:
+
+- validates the current list/index;
+- applies row and difficulty together;
+- resets scroll target/counters coherently;
+- calls the existing selection update/event path once.
+
+Do not add arbitrary list mutation or remote-navigation methods.
+
+Add focused component/unit coverage if existing `SongListDisplay` tests do not already cover the required event behavior.
+
+### 1.4 Project through normal Song Select browse state
+
+In the prepare path:
+
+- switch to All Songs and default/no-filter projection for the recorder operation;
+- clear/rebuild normal navigation state;
+- reuse existing BOX navigation helpers for the resolved ancestor chain;
+- select the target row+difficulty through the new atomic component method;
+- suppress only automatic preview loading during this synchronous programmatic projection so status/history/image/breadcrumb still update without briefly playing/loading the wrong row's audio.
+
+**Task 1 acceptance:** exact root/nested/SET/duplicate-title selection is deterministic by path, and the normal Song Select UI state points at the requested row/difficulty.
+
+---
+
+## Task 2 — Add prepared preview lifecycle, activation, and telemetry
+
+**Goal:** load the exact chart's preview stopped, play it only on command, measure only actual playback time, and cleanly reuse existing activation.
+
+### 2.1 Write failing preview lifecycle tests
+
+Add cases for:
+
+- prepare loads the requested `SongChart.PreviewFile`, not the node's primary chart preview;
+- missing preview declaration;
+- missing preview file;
+- resource-load/unsupported failure;
+- successful prepare creates no sound instance and does not auto-play after the normal preview delay;
+- first start creates one looped instance at existing preview volume;
+- repeated start while playing creates no second instance;
+- elapsed ms advances only when `ISoundInstance.State == Playing`;
+- playback creation/start failure reports failed state with no BGM/full-song fallback;
+- cancel is idempotent;
+- replacement preparation stops/disposes the old instance once;
+- normal row/difficulty navigation away clears prepared state;
+- Deactivate clears prepared state and resources;
+- no prepared state leaves existing interactive preview behavior unchanged.
+
+Reuse existing `ISound` / `ISoundInstance` mocks and preview tests.
+
+### 2.2 Add minimal stage-owned prepared state
+
+In `SongSelectionStage.cs`, add only:
+
+- resolved prepared selection (node/chart/difficulty/telemetry identity);
+- preview state (`None`, `Prepared`, `Playing`, `Failed`);
+- elapsed milliseconds;
+- a temporary synchronous flag used only to suppress automatic preview loading while prepare projects the selection.
+
+Do not add locks or a session/generation model; mutations and elapsed updates are update-thread-owned.
+
+### 2.3 Load the exact resolved chart preview
+
+Reuse current preview resource methods, but factor enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
+
+Requirements:
+
+- resolve preview relative to the matched chart's `FilePath` directory;
+- use the existing resource manager/sound type support;
+- keep the loaded `_previewSound` but leave `_previewSoundInstance` null;
+- disable normal delayed auto-start while prepared;
+- state = `Prepared`, elapsed = 0 only after load succeeds;
+- any prepare failure leaves no active prepared state.
+
+Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics outside prepared mode.
+
+### 2.4 Implement explicit start/cancel
+
+`StartPreparedPreview`:
+
+- require a prepared resource;
+- create the instance with the existing helper;
+- apply existing preview volume and looping;
+- call `Play()` once;
+- start the existing BGM fade-out;
+- become `Playing`, elapsed = 0;
+- repeated call while already playing is idempotent success.
+
+`CancelPreparedChart`:
+
+- reuse existing stop/dispose/release behavior;
+- clear prepared state/identity/elapsed;
+- remain idempotent.
+
+During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance actually reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
+
+### 2.5 Activate through the existing player path
+
+`ActivatePreparedChart` must:
+
+- require the prepared row/difficulty still be the selected row/difficulty;
+- capture node/difficulty;
+- stop and clear prepared preview before transition;
+- call existing `SelectSong(node)`.
+
+Do not reconstruct transition shared data or call Performance directly.
+
+Extend existing Song Select activation tests to assert the normal selected-song/difficulty/song-id transition contract remains the one used.
+
+### 2.6 Add three telemetry fields
+
+In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry` add only:
+
+- `PreparedChartIdentity`;
+- `PreparedPreviewState`;
+- `PreparedPreviewElapsedMs`.
+
+Identity:
+
+- `chart:<database-id>` when a non-zero chart ID exists;
+- otherwise a root-relative normalized path with no absolute root prefix.
+
+**Task 2 acceptance:** recorder can prepare a stopped preview, start exactly one loop, wait on elapsed telemetry, activate through normal SongTransition, and all exit/replacement paths clean up.
+
+---
+
+## Task 3 — Wire the explicit Game API, JSON-RPC, and Automation client
+
+**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation or transport APIs.
+
+### 3.1 Add Game API contract and queue/await helper
+
+In `GameApi.cs`, add a narrow prepared-command result and four methods equivalent to:
+
+```text
+PrepareVideoChartAsync(chartPath)
+StartPreparedPreviewAsync()
+ActivatePreparedChartAsync()
+CancelPreparedChartAsync()
+```
+
+In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus `TaskCompletionSource` with asynchronous continuations.
+
+The queued action must perform the current-stage check and execute the Song Select command on the update thread. The returned task completes with the actual command result, not merely after enqueue.
+
+Add tests that capture/execute the queued action and verify:
+
+- no stage mutation occurs before the queued action runs;
+- the task completes after execution;
+- non-SongSelect current stage produces a clear failure;
+- stage failure text propagates.
+
+Do not add a reusable dispatcher class.
+
+### 3.2 Add four explicit JSON-RPC handlers
+
+In `JsonRpcServer.cs`:
+
+- add explicit route cases only for the four method names;
+- validate `prepareVideoChart` has object params and a non-empty string `chartPath`;
+- call the corresponding Game API method;
+- return a small `{ success, error? }` result;
+- rely on the existing server-level API key authentication.
+
+Extend current JSON-RPC tests for method routing, invalid prepare params, and command failure shape.
+
+No generic `executeGameAction` endpoint.
+
+### 3.3 Extend `DTXMania.Automation`
+
+In `JsonRpcGameClient.cs`, add the four public async wrappers using existing private `SendAsync`.
+
+Add one small command-result parser shared by the four methods:
+
+- success=true returns normally;
+- missing/false success throws `InvalidOperationException` with server-provided safe error text.
+
+In `GameStateSnapshot.cs`, add accessors for the three prepared telemetry fields.
+
+Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation. Extend the existing producer/consumer telemetry contract test if one is required to keep camel-case field naming locked between game and Automation.
+
+**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only, and can poll prepared telemetry using the existing `GetGameStateAsync` path.
+
+---
+
+## Task 4 — Regression and acceptance validation
+
+### 4.1 Focused tests
+
+Run the new/focused suites first. Use the repository's current project appropriate to the host, for example:
+
+```bash
+# Song Select / Game API / JSON-RPC focused tests
+# Use the relevant test project for the current OS.
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PreparedChart"
+
+# Reusable Automation contract
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj
+```
+
+On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game test suite.
+
+### 4.2 Full regression suite
+
+Run the full platform-appropriate game unit suite plus Automation tests.
+
+At minimum verify:
+
+- existing Song Select preview/BGM tests stay green;
+- existing Song Select navigation/filter/BOX tests stay green;
+- existing SongTransition tests stay green;
+- Game API/JSON-RPC tests stay green;
+- Automation tests stay green.
+
+HPA-510 does **not** need to add OBS/recorder E2E. HPA-503 is the live Windows recording validation consumer.
+
+### 4.3 Manual/API smoke for implementation PR
+
+Use an indexed test chart with preview audio and the existing Game API:
+
+1. enter Song Select;
+2. call prepare with the exact absolute chart path;
+3. verify telemetry reports Prepared and a redacted identity;
+4. take a screenshot and verify the requested row/difficulty/status UI is rendered;
+5. wait long enough to prove normal preview delay does not auto-play;
+6. call start, then poll until prepared elapsed >= 10,000 ms;
+7. call activate and confirm transition follows SongTransition;
+8. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
+
+This smoke is implementation validation only; do not create a permanent recorder harness in HPA-510.
+
+---
+
+## Scope Guardrails for the Implementing Agent
+
+Stop and simplify if the implementation starts adding any of the following:
+
+- recording session IDs/state machines;
+- generic Game API mutation dispatch;
+- a new song repository/query service;
+- title-based or input-driven navigation;
+- alternate chart/difficulty ordering rules instead of current Song Select helpers;
+- a second preview audio abstraction;
+- OBS/process/FFmpeg concerns;
+- render-ready generation counters.
+
+The desired end state is four explicit commands layered on the existing Song Select state machine, with `DTXMania.Automation` wrappers ready for HPA-503.
+
+## Definition of Done
+
+- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, and duplicate-title cases.
+- Outside-root/unindexed/ambiguous/missing-preview/unsupported-preview cases fail clearly.
+- Prepare leaves the exact chart preview loaded but stopped.
+- Start creates exactly one looped instance using existing preview volume/path behavior.
+- Prepared elapsed telemetry advances only while the instance is actually Playing.
+- Cancel/replacement/navigation/deactivation/activation clean up without audio bleed or double disposal.
+- Activation reuses `SelectSong -> SongTransitionStage` and does not jump directly to Performance.
+- Telemetry exposes only prepared identity/state/elapsed, with no absolute path.
+- JSON-RPC commands are explicit and use existing API-key authentication.
+- `DTXMania.Automation` exposes four typed wrappers; generic JSON-RPC remains private.
+- Existing interactive Song Select behavior is unchanged when no prepared chart is active.
+- Platform-appropriate game unit suite and Automation tests pass.

--- a/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
+++ b/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
@@ -10,6 +10,18 @@ Add the smallest production API HPA-503 needs to prepare one exact indexed chart
 
 Keep the implementation local to existing Song Select, Game API/JSON-RPC, telemetry, and Automation seams. Do not introduce a general automation/session framework.
 
+## Global Constraints
+
+- Prepared state remains owned by `SongSelectionStage`.
+- The external contract remains exactly four commands: prepare, start preview, activate, cancel.
+- Exact chart identity is normalized path, never title.
+- All stage mutations execute on the game update thread and the Game API awaits their real result.
+- Activation must respect the existing global stage-transition debounce and must not consume preparation when the debounce blocks the transition.
+- HPA-510 selects the DRUMS slot when one physical DTX chart populates multiple instrument slots with the same `ChartId`.
+- Screenshot completion remains the Song Select render barrier; add no render-generation state machine.
+- The telemetry wire names are exactly `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs`.
+- No recorder session, DB query path, generic mutation API, synthetic key navigation, OBS, process, or FFmpeg work belongs in this PR.
+
 ## File Map
 
 ### Game / Song Select
@@ -18,9 +30,9 @@ Keep the implementation local to existing Song Select, Game API/JSON-RPC, teleme
   - exact active-library chart resolution;
   - prepared selection/preview state;
   - programmatic browse projection;
-  - prepare/start/activate/cancel commands;
-  - elapsed preview telemetry;
-  - cleanup on navigation/deactivation.
+  - clear-on-row/difficulty navigation rules;
+  - debounce-safe prepare/start/activate/cancel commands;
+  - elapsed preview telemetry.
 - `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
   - one narrow atomic row+difficulty programmatic selection method.
 - `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
@@ -40,17 +52,15 @@ Keep the implementation local to existing Song Select, Game API/JSON-RPC, teleme
 - `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
   - public wrappers for the four new operations.
 - `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
-  - accessors for prepared identity/state/elapsed time.
+  - accessors for the three exact camelCase telemetry keys.
 
 ### Tests
 
-Prefer one focused new Song Select fixture rather than spreading preparation cases across unrelated files:
-
-- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new.
+- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new focused fixture.
 - `DTXMania.Test/GameApi/GameApiImplementationTests.cs` — extend.
-- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or existing JSON-RPC integration tests — extend only where current seams fit.
+- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or the existing JSON-RPC integration fixture — extend only where current seams fit.
 - `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs` — extend.
-- `DTXMania.E2E/Telemetry/E2EGameStateTests.cs` or the current producer/consumer telemetry contract test — extend only if needed to keep game/Automation field names aligned.
+- `DTXMania.E2E/AutomationContractTests.cs` — **mandatory** producer/consumer camelCase telemetry contract update.
 
 Do not add a new E2E harness or recorder test project in this ticket.
 
@@ -58,9 +68,9 @@ Do not add a new E2E harness or recorder test project in this ticket.
 
 ## Task 1 — Resolve and project an exact indexed chart
 
-**Goal:** given one absolute chart path, identify exactly one active Song Select row + difficulty and show it through the normal UI without synthetic input.
+**Goal:** given one absolute chart path, identify exactly one active Song Select row + gameplay difficulty and show it through the normal UI without synthetic input.
 
-### 1.1 Write failing focused tests first
+### 1.1 Write failing focused resolver tests first
 
 In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-library hierarchies covering:
 
@@ -68,60 +78,79 @@ In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-librar
 - chart below one or more BOX nodes;
 - multi-chart/SET-style row where the requested chart is not the node's primary chart;
 - duplicate song titles with different file paths;
+- ordinary one-file multi-instrument chart where DRUMS/GUITAR/BASS score slots all carry the same non-zero `ChartId`;
 - path outside active roots;
 - path under an active root but absent from the indexed snapshot;
-- no unique difficulty mapping.
+- a genuinely ambiguous slot mapping after all supported tie-break/fallback rules.
 
-Assertions should verify the resolved node and difficulty come from path identity only. No title matching is allowed.
+For the shared-ChartId fixture, assert the resolver chooses the unique `EInstrumentPart.DRUMS` slot rather than rejecting the row.
 
-### 1.2 Add a stage-private resolver
+Assertions must prove title never participates in identity.
+
+### 1.2 Add a stage-private exact-path resolver
 
 In `SongSelectionStage.cs`:
 
 - require a fully-qualified non-blank path;
-- use the currently applied `SongLibrarySnapshot` as the authoritative library view;
+- use `_appliedLibrarySnapshot` as the authoritative active library;
 - normalize with `SongPathIdentity`;
 - require containment under `snapshot.ActiveRoots`;
 - recursively traverse root/BOX nodes and inspect both `DatabaseChart` and `DatabaseSong.Charts`;
-- require one exact normalized chart match;
-- resolve the visible difficulty slot by `SongScore.ChartId` first;
-- for legacy/SET fallback, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart` rather than recreating chart-order rules;
+- require one exact normalized node/chart match;
 - retain the ancestor BOX chain and matched `SongChart` in the resolution result.
+
+Resolve the visible gameplay slot in this order:
+
+1. Collect non-null `Scores[i]` with non-zero `ChartId == resolvedChart.Id`.
+2. If exactly one matches, use it.
+3. If multiple match, select the **unique DRUMS** candidate when exactly one has `Instrument == EInstrumentPart.DRUMS`.
+4. If no slot was established, scan valid slots with `SongChartHelper.GetCurrentDifficultyChart(node, i)` and match the helper result's normalized `FilePath` to the resolved chart path.
+5. Use the fallback only when exactly one slot matches; otherwise return an explicit ambiguity failure.
+
+Do not recreate SET/chart ordering rules and do not require `ChartId` uniqueness by itself.
 
 Keep this helper inside the game assembly. Do not expose library traversal through Game API.
 
 ### 1.3 Add one atomic `SongListDisplay` selection seam
 
-Add a small method such as `SetSelection(int index, int difficulty)` that:
+Add a small method such as:
 
-- validates the current list/index;
-- applies row and difficulty together;
-- resets scroll target/counters coherently;
-- calls the existing selection update/event path once.
+```text
+SetSelection(int index, int difficulty)
+```
+
+It must:
+
+- validate the current list/index;
+- apply row and difficulty together;
+- reset scroll target/counters coherently;
+- run the existing selection update/event path once.
 
 Do not add arbitrary list mutation or remote-navigation methods.
 
-Add focused component/unit coverage if existing `SongListDisplay` tests do not already cover the required event behavior.
+Add focused `SongListDisplay` coverage if the current component tests do not prove the one-event behavior.
 
 ### 1.4 Project through normal Song Select browse state
 
-In the prepare path:
+In `PrepareVideoChart`:
 
 - switch to All Songs and default/no-filter projection for the recorder operation;
-- clear/rebuild normal navigation state;
+- return to the root browse list and clear the navigation stack;
 - reuse existing BOX navigation helpers for the resolved ancestor chain;
+- set `_isProjectingPreparedSelection = true` in a `try/finally` around the programmatic selection;
 - select the target row+difficulty through the new atomic component method;
-- suppress only automatic preview loading during this synchronous programmatic projection so status/history/image/breadcrumb still update without briefly playing/loading the wrong row's audio.
+- while the flag is true, let status/history/image/breadcrumb presentation update but suppress prepared-state invalidation and automatic preview loading;
+- always clear the flag in `finally`.
 
-**Task 1 acceptance:** exact root/nested/SET/duplicate-title selection is deterministic by path, and the normal Song Select UI state points at the requested row/difficulty.
+**Task 1 acceptance:** exact root/nested/SET/duplicate-title/single-file-multi-instrument selection is deterministic by path, and normal Song Select UI state points at the requested DRUMS gameplay slot.
 
 ---
 
-## Task 2 — Add prepared preview lifecycle, activation, and telemetry
+## Task 2 — Add prepared preview lifecycle, navigation invalidation, activation, and telemetry
 
-**Goal:** load the exact chart's preview stopped, play it only on command, measure only actual playback time, and cleanly reuse existing activation.
+**Goal:** load the exact chart's preview stopped, play it only on command, measure actual playback time, exit prepared mode cleanly on user navigation, and activate only when the normal transition can really start.
 
-### 2.1 Write failing preview lifecycle tests
+### 2.1 Write failing lifecycle and activation tests
 
 Add cases for:
 
@@ -130,17 +159,21 @@ Add cases for:
 - missing preview file;
 - resource-load/unsupported failure;
 - successful prepare creates no sound instance and does not auto-play after the normal preview delay;
+- prepare projection does not clear itself via selection/difficulty events;
 - first start creates one looped instance at existing preview volume;
 - repeated start while playing creates no second instance;
 - elapsed ms advances only when `ISoundInstance.State == Playing`;
 - playback creation/start failure reports failed state with no BGM/full-song fallback;
 - cancel is idempotent;
-- replacement preparation stops/disposes the old instance once;
-- normal row/difficulty navigation away clears prepared state;
-- Deactivate clears prepared state and resources;
+- replacement preparation stops/disposes the old instance exactly once;
+- row navigation away clears preparation and resumes the row's normal interactive preview path;
+- difficulty navigation away clears preparation and resumes the normal primary-chart delayed preview;
+- Deactivate clears prepared state/resources exactly once;
+- activation while `CanPerformStageTransition()` is false returns failure, starts no transition, and preserves prepared state/preview;
+- activation after the debounce gate is available clears preview and uses the existing `selectedSong` / `selectedDifficulty` / `songId` transition data path;
 - no prepared state leaves existing interactive preview behavior unchanged.
 
-Reuse existing `ISound` / `ISoundInstance` mocks and preview tests.
+Reuse existing `ISound` / `ISoundInstance` mocks and Song Select activation tests.
 
 ### 2.2 Add minimal stage-owned prepared state
 
@@ -149,13 +182,15 @@ In `SongSelectionStage.cs`, add only:
 - resolved prepared selection (node/chart/difficulty/telemetry identity);
 - preview state (`None`, `Prepared`, `Playing`, `Failed`);
 - elapsed milliseconds;
-- a temporary synchronous flag used only to suppress automatic preview loading while prepare projects the selection.
+- `_isProjectingPreparedSelection` for the synchronous prepare projection.
 
-Do not add locks or a session/generation model; mutations and elapsed updates are update-thread-owned.
+Do not add locks, session IDs, or a generation/state-machine framework; mutations and elapsed updates are update-thread-owned.
+
+Provide one idempotent prepared cleanup path so cancel, replacement, navigation, activation, and Deactivate share resource release behavior.
 
 ### 2.3 Load the exact resolved chart preview
 
-Reuse current preview resource methods, but factor enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
+Reuse current preview resource methods, factoring only enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
 
 Requirements:
 
@@ -166,9 +201,9 @@ Requirements:
 - state = `Prepared`, elapsed = 0 only after load succeeds;
 - any prepare failure leaves no active prepared state.
 
-Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics outside prepared mode.
+Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics when no preparation exists.
 
-### 2.4 Implement explicit start/cancel
+### 2.4 Implement explicit start/cancel and elapsed tracking
 
 `StartPreparedPreview`:
 
@@ -186,24 +221,68 @@ Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics outs
 - clear prepared state/identity/elapsed;
 - remain idempotent.
 
-During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance actually reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
+During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
 
-### 2.5 Activate through the existing player path
+### 2.5 Clear preparation on real user navigation, not prepare projection
+
+Wire both selection paths.
+
+`OnSongSelectionChanged`:
+
+- if `_isProjectingPreparedSelection` is true, do not clear preparation and skip automatic preview loading for that projection;
+- otherwise, if a prepared chart exists and the selected row moved away, clear it;
+- continue the handler's existing row-selection preview behavior, so normal delayed `LoadPreviewSound(e.SelectedSong)` resumes.
+
+`OnDifficultyChanged`:
+
+- if `_isProjectingPreparedSelection` is true, do not clear preparation;
+- otherwise, if a prepared chart exists and `e.NewDifficulty` differs from the prepared slot, clear it;
+- after that prepared-mode exit, call the existing `LoadPreviewSound(e.Song)` so interactive Song Select resumes its normal primary-chart delayed preview;
+- when no preparation exists, leave today's difficulty-change behavior untouched.
+
+The cleanup path must remain idempotent so existing `StopCurrentPreview` calls cannot double-dispose an instance.
+
+### 2.6 Make activation return a real transition outcome
+
+Current `SelectSong` silently returns when the global debounce rejects the transition. Factor its logic into a small eligibility gate and one shared transition-start body; names may follow existing style, for example:
+
+```text
+CanStartSongSelection(node)
+StartSongSelection(node)
+```
+
+Eligibility must reject:
+
+- null/non-Score node;
+- unavailable `StageManager`;
+- `_game.CanPerformStageTransition() == false`.
+
+The shared start body remains the sole owner of:
+
+```text
+_game.MarkStageTransition()
+selectedSong
+selectedDifficulty
+songId
+StageManager.ChangeStage(StageType.SongTransition, ...)
+```
+
+Normal interactive `SelectSong` uses the same gate/start helpers.
 
 `ActivatePreparedChart` must:
 
-- require the prepared row/difficulty still be the selected row/difficulty;
-- capture node/difficulty;
-- stop and clear prepared preview before transition;
-- call existing `SelectSong(node)`.
+1. require the prepared row/difficulty still equal `_selectedSong` / `_currentDifficulty`;
+2. evaluate the shared eligibility gate;
+3. when blocked, return `success=false` with a clear category such as transition debounce active and leave prepared state/preview intact;
+4. only after the gate succeeds, stop/dispose the prepared preview and clear prepared state;
+5. immediately execute the shared transition-start body on the same update-thread action;
+6. return success only after `ChangeStage` was invoked.
 
-Do not reconstruct transition shared data or call Performance directly.
+Do not wait inside the game for the 0.5-second debounce and do not duplicate transition shared-data construction.
 
-Extend existing Song Select activation tests to assert the normal selected-song/difficulty/song-id transition contract remains the one used.
+### 2.7 Add three producer telemetry fields
 
-### 2.6 Add three telemetry fields
-
-In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry` add only:
+In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry`, add only:
 
 - `PreparedChartIdentity`;
 - `PreparedPreviewState`;
@@ -214,13 +293,21 @@ Identity:
 - `chart:<database-id>` when a non-zero chart ID exists;
 - otherwise a root-relative normalized path with no absolute root prefix.
 
-**Task 2 acceptance:** recorder can prepare a stopped preview, start exactly one loop, wait on elapsed telemetry, activate through normal SongTransition, and all exit/replacement paths clean up.
+The serialized wire names must be exactly:
+
+```text
+preparedChartIdentity
+preparedPreviewState
+preparedPreviewElapsedMs
+```
+
+**Task 2 acceptance:** recorder can prepare a stopped exact-chart preview, start exactly one loop, wait on elapsed telemetry, retry a debounce-blocked activation without losing preparation, activate through the normal SongTransition path, and all navigation/exit paths clean up correctly.
 
 ---
 
-## Task 3 — Wire the explicit Game API, JSON-RPC, and Automation client
+## Task 3 — Wire the explicit Game API, JSON-RPC, Automation client, and telemetry contract
 
-**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation or transport APIs.
+**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation/transport APIs, and lock producer/consumer wire names.
 
 ### 3.1 Add Game API contract and queue/await helper
 
@@ -233,18 +320,22 @@ ActivatePreparedChartAsync()
 CancelPreparedChartAsync()
 ```
 
-In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus `TaskCompletionSource` with asynchronous continuations.
+In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus:
+
+```text
+TaskCompletionSource(..., TaskCreationOptions.RunContinuationsAsynchronously)
+```
 
 The queued action must perform the current-stage check and execute the Song Select command on the update thread. The returned task completes with the actual command result, not merely after enqueue.
 
 Add tests that capture/execute the queued action and verify:
 
 - no stage mutation occurs before the queued action runs;
-- the task completes after execution;
+- the task completes only after execution;
 - non-SongSelect current stage produces a clear failure;
-- stage failure text propagates.
+- stage failure text, including debounce-blocked activation, propagates.
 
-Do not add a reusable dispatcher class.
+Do not copy `ChangeStageAsync`'s fire-and-forget contract and do not add a reusable dispatcher class.
 
 ### 3.2 Add four explicit JSON-RPC handlers
 
@@ -254,9 +345,9 @@ In `JsonRpcServer.cs`:
 - validate `prepareVideoChart` has object params and a non-empty string `chartPath`;
 - call the corresponding Game API method;
 - return a small `{ success, error? }` result;
-- rely on the existing server-level API key authentication.
+- rely on existing server-level API-key authentication.
 
-Extend current JSON-RPC tests for method routing, invalid prepare params, and command failure shape.
+Extend current JSON-RPC tests for method routing, invalid prepare params, normal failures, and debounce failure shape.
 
 No generic `executeGameAction` endpoint.
 
@@ -266,14 +357,33 @@ In `JsonRpcGameClient.cs`, add the four public async wrappers using existing pri
 
 Add one small command-result parser shared by the four methods:
 
-- success=true returns normally;
+- `success=true` returns normally;
 - missing/false success throws `InvalidOperationException` with server-provided safe error text.
 
-In `GameStateSnapshot.cs`, add accessors for the three prepared telemetry fields.
+In `GameStateSnapshot.cs`, add accessors that read the exact keys:
 
-Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation. Extend the existing producer/consumer telemetry contract test if one is required to keep camel-case field naming locked between game and Automation.
+```text
+preparedChartIdentity
+preparedPreviewState
+preparedPreviewElapsedMs
+```
 
-**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only, and can poll prepared telemetry using the existing `GetGameStateAsync` path.
+Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation.
+
+### 3.4 Mandatory game-to-Automation camelCase contract test
+
+Extend:
+
+```text
+DTXMania.E2E/AutomationContractTests.cs
+GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields
+```
+
+The producer `GameTelemetrySnapshot` fixture must set non-default values for all three fields. Serialize it with the existing camelCase serializer and assert the deserialized `GameStateSnapshot` returns those same values through its new accessors.
+
+This is mandatory. Do not replace it with an Automation-only JSON fixture because the purpose is to catch producer property-name drift as well as consumer accessor drift.
+
+**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only and poll all three prepared telemetry values through the existing `GetGameStateAsync` path with the producer/consumer wire contract locked.
 
 ---
 
@@ -281,18 +391,20 @@ Extend `JsonRpcGameClientTests` to assert exact method names/params and error pr
 
 ### 4.1 Focused tests
 
-Run the new/focused suites first. Use the repository's current project appropriate to the host, for example:
+Run the new/focused suites first. Use the repository's host-appropriate game test project, for example:
 
 ```bash
 # Song Select / Game API / JSON-RPC focused tests
-# Use the relevant test project for the current OS.
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PreparedChart"
 
-# Reusable Automation contract
+# Reusable Automation tests
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj
+
+# Existing producer/consumer contract
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~AutomationContractTests"
 ```
 
-On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game test suite.
+On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game unit suite. Run the E2E-support contract on its supported host configuration; no live gameplay launch is required for this contract test.
 
 ### 4.2 Full regression suite
 
@@ -304,7 +416,8 @@ At minimum verify:
 - existing Song Select navigation/filter/BOX tests stay green;
 - existing SongTransition tests stay green;
 - Game API/JSON-RPC tests stay green;
-- Automation tests stay green.
+- Automation tests stay green;
+- `AutomationContractTests` stays green with the three new telemetry fields.
 
 HPA-510 does **not** need to add OBS/recorder E2E. HPA-503 is the live Windows recording validation consumer.
 
@@ -314,12 +427,14 @@ Use an indexed test chart with preview audio and the existing Game API:
 
 1. enter Song Select;
 2. call prepare with the exact absolute chart path;
-3. verify telemetry reports Prepared and a redacted identity;
+3. verify telemetry reports `Prepared` and a redacted identity;
 4. take a screenshot and verify the requested row/difficulty/status UI is rendered;
 5. wait long enough to prove normal preview delay does not auto-play;
 6. call start, then poll until prepared elapsed >= 10,000 ms;
 7. call activate and confirm transition follows SongTransition;
-8. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
+8. separately exercise a debounce-blocked activation and verify preparation remains available for retry;
+9. exercise user difficulty navigation after prepare and verify prepared state clears and the normal primary-chart delayed preview resumes;
+10. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
 
 This smoke is implementation validation only; do not create a permanent recorder harness in HPA-510.
 
@@ -333,8 +448,9 @@ Stop and simplify if the implementation starts adding any of the following:
 - generic Game API mutation dispatch;
 - a new song repository/query service;
 - title-based or input-driven navigation;
-- alternate chart/difficulty ordering rules instead of current Song Select helpers;
+- alternate chart/difficulty ordering rules instead of current Song Select helpers plus the explicit DRUMS tie-break;
 - a second preview audio abstraction;
+- a game-owned debounce wait/retry loop;
 - OBS/process/FFmpeg concerns;
 - render-ready generation counters.
 
@@ -342,15 +458,18 @@ The desired end state is four explicit commands layered on the existing Song Sel
 
 ## Definition of Done
 
-- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, and duplicate-title cases.
-- Outside-root/unindexed/ambiguous/missing-preview/unsupported-preview cases fail clearly.
-- Prepare leaves the exact chart preview loaded but stopped.
+- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, duplicate-title, and ordinary shared-ChartId multi-instrument cases.
+- Shared ChartId across DRUMS/GUITAR/BASS resolves to the unique DRUMS gameplay slot rather than failing as ambiguous.
+- Outside-root/unindexed/truly-ambiguous/missing-preview/unsupported-preview cases fail clearly.
+- Prepare leaves the exact chart preview loaded but stopped and cannot clear itself through projection events.
 - Start creates exactly one looped instance using existing preview volume/path behavior.
 - Prepared elapsed telemetry advances only while the instance is actually Playing.
+- User row/difficulty navigation clears preparation; difficulty exit restores the normal primary-chart delayed preview.
+- Debounce-blocked activation returns failure and preserves preparation; accepted activation clears audio/state and starts the existing SongTransition path.
 - Cancel/replacement/navigation/deactivation/activation clean up without audio bleed or double disposal.
-- Activation reuses `SelectSong -> SongTransitionStage` and does not jump directly to Performance.
-- Telemetry exposes only prepared identity/state/elapsed, with no absolute path.
+- Telemetry exposes only prepared identity/state/elapsed with exact camelCase wire keys and no absolute path.
+- `AutomationContractTests` proves those producer wire keys reach the Automation accessors.
 - JSON-RPC commands are explicit and use existing API-key authentication.
 - `DTXMania.Automation` exposes four typed wrappers; generic JSON-RPC remains private.
 - Existing interactive Song Select behavior is unchanged when no prepared chart is active.
-- Platform-appropriate game unit suite and Automation tests pass.
+- Platform-appropriate game unit suite, Automation tests, and the existing Automation producer/consumer contract pass.

--- a/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
+++ b/docs/superpowers/plans/2026-08-11-hpa-510-prepared-chart-recording.md
@@ -1,299 +1,306 @@
 # HPA-510 Prepared Chart Recording Commands Implementation Plan
 
+> **For agentic workers:** implement task-by-task and keep the four-command stage-owned scope. Do not introduce a generic automation/session framework.
+
 **Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
 **Design:** `docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md`  
 **Target size:** one implementation PR, 2–3 engineer days
 
-## Objective
+**Goal:** Let HPA-503 prepare one exact indexed chart in Song Select, explicitly play its preview for CX-reported time, and activate it through the normal SongTransition path.
 
-Add the smallest production API HPA-503 needs to prepare one exact indexed chart in Song Select, explicitly start its declared preview, activate it through the normal player path, and cancel/clean up safely.
+**Architecture:** Keep all prepared state in `SongSelectionStage`. Resolve from the applied library snapshot, rebuild the browse projection with existing navigation reconciliation helpers, expose four awaited Game API/JSON-RPC commands, and reuse HPA-501 Automation transport.
 
-Keep the implementation local to existing Song Select, Game API/JSON-RPC, telemetry, and Automation seams. Do not introduce a general automation/session framework.
+**Tech stack:** .NET 8, MonoGame, xUnit, existing Game API/JSON-RPC, `DTXMania.Automation`, existing Windows E2E harness.
 
-## Global Constraints
+## Global constraints
 
-- Prepared state remains owned by `SongSelectionStage`.
-- The external contract remains exactly four commands: prepare, start preview, activate, cancel.
-- Exact chart identity is normalized path, never title.
-- All stage mutations execute on the game update thread and the Game API awaits their real result.
-- Activation must respect the existing global stage-transition debounce and must not consume preparation when the debounce blocks the transition.
-- HPA-510 selects the DRUMS slot when one physical DTX chart populates multiple instrument slots with the same `ChartId`.
-- Screenshot completion remains the Song Select render barrier; add no render-generation state machine.
-- The telemetry wire names are exactly `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs`.
-- No recorder session, DB query path, generic mutation API, synthetic key navigation, OBS, process, or FFmpeg work belongs in this PR.
+- Exactly four commands: prepare, start preview, activate, cancel.
+- All stage mutations run on the game update thread.
+- Resolve by chart path, never title.
+- No DB query/repository layer.
+- No session ID/state-machine abstraction.
+- No generic mutation/dispatch endpoint.
+- Screenshot completion remains the render barrier.
+- Keep all three accepted telemetry values: prepared identity, state, elapsed ms.
+- Do not expose the absolute chart path in telemetry.
+- Existing interactive Song Select preview behavior must remain unchanged outside prepared mode.
 
-## File Map
+---
+
+## File map
 
 ### Game / Song Select
 
 - `DTXMania.Game/Lib/Stage/SongSelectionStage.cs`
-  - exact active-library chart resolution;
-  - prepared selection/preview state;
-  - programmatic browse projection;
-  - clear-on-row/difficulty navigation rules;
-  - debounce-safe prepare/start/activate/cancel commands;
-  - elapsed preview telemetry.
+  - whole-tree exact chart resolver;
+  - stage-owned prepared state;
+  - side-effect-controlled browse projection;
+  - exact-chart preview load/start/cancel;
+  - activation eligibility/start split;
+  - navigation cleanup and telemetry.
 - `DTXMania.Game/Lib/Song/Components/SongListDisplay.cs`
-  - one narrow atomic row+difficulty programmatic selection method.
+  - atomic `SetSelection(index, difficulty)` seam.
 - `DTXMania.Game/Lib/GameTelemetrySnapshot.cs`
-  - three prepared-recording telemetry fields.
+  - three prepared-chart telemetry fields.
 
 ### Game API / transport
 
 - `DTXMania.Game/Lib/GameApi.cs`
-  - four explicit command methods and narrow command result contract.
+  - narrow command result and four methods.
 - `DTXMania.Game/Lib/GameApiImplementation.cs`
-  - queue each command through the existing main-thread action queue and await its actual result.
+  - queue-and-await helper using existing main-thread queue.
 - `DTXMania.Game/Lib/JsonRpc/JsonRpcServer.cs`
-  - four explicit authenticated JSON-RPC routes/handlers.
+  - four explicit authenticated routes.
 
-### Automation consumer
+### Automation
 
 - `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs`
-  - public wrappers for the four new operations.
+  - four public wrappers over private `SendAsync`.
 - `DTXMania.Automation/Telemetry/GameStateSnapshot.cs`
-  - accessors for the three exact camelCase telemetry keys.
+  - three prepared telemetry accessors.
 
 ### Tests
 
-- `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs` — new focused fixture.
-- `DTXMania.Test/GameApi/GameApiImplementationTests.cs` — extend.
-- `DTXMania.Test/JsonRpc/JsonRpcServerInternalTests.cs` and/or the existing JSON-RPC integration fixture — extend only where current seams fit.
-- `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs` — extend.
-- `DTXMania.E2E/AutomationContractTests.cs` — **mandatory** producer/consumer camelCase telemetry contract update.
+- Create `DTXMania.Test/Stage/SongSelectionStagePreparedChartTests.cs`.
+- Extend `DTXMania.Test/GameApi/GameApiImplementationTests.cs`.
+- Extend existing JSON-RPC tests where the current seams fit.
+- Extend `DTXMania.Automation.Tests/JsonRpc/JsonRpcGameClientTests.cs`.
+- Extend `DTXMania.E2E/AutomationContractTests.cs`.
+- Modify `DTXMania.E2E/Fixtures/E2EFixtureBuilder.cs` to declare its generated WAV as `#PREVIEW`.
+- Create `DTXMania.E2E/PreparedChartRecordingSmokeTests.cs` using the existing `Category=E2E` harness.
 
-Do not add a new E2E harness or recorder test project in this ticket.
+Do not create a recorder test project, fake OBS server, or second E2E harness.
 
 ---
 
-## Task 1 — Resolve and project an exact indexed chart
+## Task 1 — Exact resolver and side-effect-free Song Select projection
 
-**Goal:** given one absolute chart path, identify exactly one active Song Select row + gameplay difficulty and show it through the normal UI without synthetic input.
+**Goal:** resolve an exact active-library chart to one row/difficulty and project it once through normal UI state.
 
-### 1.1 Write failing focused resolver tests first
+### 1.1 Add focused failing resolver tests
 
-In `SongSelectionStagePreparedChartTests.cs`, construct minimal published-library hierarchies covering:
+Cover:
 
 - root-level chart;
-- chart below one or more BOX nodes;
-- multi-chart/SET-style row where the requested chart is not the node's primary chart;
-- duplicate song titles with different file paths;
-- ordinary one-file multi-instrument chart where DRUMS/GUITAR/BASS score slots all carry the same non-zero `ChartId`;
-- path outside active roots;
-- path under an active root but absent from the indexed snapshot;
-- a genuinely ambiguous slot mapping after all supported tie-break/fallback rules.
+- nested BOX chart;
+- SET/multi-chart row where requested chart is not `DatabaseChart`;
+- duplicate titles at different paths;
+- outside-root path;
+- active-root but unindexed path;
+- ordinary single-file multi-instrument row where several score slots share one `ChartId`;
+- unresolved ambiguity.
 
-For the shared-ChartId fixture, assert the resolver chooses the unique `EInstrumentPart.DRUMS` slot rather than rejecting the row.
+The test fixture must assert path identity only; title must never select the result.
 
-Assertions must prove title never participates in identity.
-
-### 1.2 Add a stage-private exact-path resolver
+### 1.2 Add a stage-private whole-tree resolver
 
 In `SongSelectionStage.cs`:
 
-- require a fully-qualified non-blank path;
-- use `_appliedLibrarySnapshot` as the authoritative active library;
-- normalize with `SongPathIdentity`;
-- require containment under `snapshot.ActiveRoots`;
-- recursively traverse root/BOX nodes and inspect both `DatabaseChart` and `DatabaseSong.Charts`;
-- require one exact normalized node/chart match;
-- retain the ancestor BOX chain and matched `SongChart` in the resolution result.
+1. require a fully-qualified non-blank path;
+2. use `_appliedLibrarySnapshot` as the authoritative view;
+3. normalize with `SongPathIdentity`;
+4. require containment under `snapshot.ActiveRoots`;
+5. recursively traverse root/BOX nodes;
+6. inspect both `DatabaseChart` and `DatabaseSong.Charts`;
+7. return exactly one `(node, chart, difficultyIndex, ancestorBoxPaths)`.
 
-Resolve the visible gameplay slot in this order:
-
-1. Collect non-null `Scores[i]` with non-zero `ChartId == resolvedChart.Id`.
-2. If exactly one matches, use it.
-3. If multiple match, select the **unique DRUMS** candidate when exactly one has `Instrument == EInstrumentPart.DRUMS`.
-4. If no slot was established, scan valid slots with `SongChartHelper.GetCurrentDifficultyChart(node, i)` and match the helper result's normalized `FilePath` to the resolved chart path.
-5. Use the fallback only when exactly one slot matches; otherwise return an explicit ambiguity failure.
-
-Do not recreate SET/chart ordering rules and do not require `ChartId` uniqueness by itself.
-
-Keep this helper inside the game assembly. Do not expose library traversal through Game API.
-
-### 1.3 Add one atomic `SongListDisplay` selection seam
-
-Add a small method such as:
+Difficulty precedence:
 
 ```text
-SetSelection(int index, int difficulty)
+matching non-zero ChartId
+-> if one candidate: use it
+-> if several: unique DRUMS candidate
+-> otherwise GetCurrentDifficultyChart(slot) + exact path fallback
+-> fail if still ambiguous
 ```
 
-It must:
+Do not add a new chart-ordering algorithm or database query.
 
-- validate the current list/index;
-- apply row and difficulty together;
-- reset scroll target/counters coherently;
-- run the existing selection update/event path once.
+### 1.3 Add atomic `SongListDisplay.SetSelection`
 
-Do not add arbitrary list mutation or remote-navigation methods.
+Add one internal/public-to-game-assembly method equivalent to:
 
-Add focused `SongListDisplay` coverage if the current component tests do not prove the one-event behavior.
-
-### 1.4 Project through normal Song Select browse state
-
-In `PrepareVideoChart`:
-
-- switch to All Songs and default/no-filter projection for the recorder operation;
-- return to the root browse list and clear the navigation stack;
-- reuse existing BOX navigation helpers for the resolved ancestor chain;
-- set `_isProjectingPreparedSelection = true` in a `try/finally` around the programmatic selection;
-- select the target row+difficulty through the new atomic component method;
-- while the flag is true, let status/history/image/breadcrumb presentation update but suppress prepared-state invalidation and automatic preview loading;
-- always clear the flag in `finally`.
-
-**Task 1 acceptance:** exact root/nested/SET/duplicate-title/single-file-multi-instrument selection is deterministic by path, and normal Song Select UI state points at the requested DRUMS gameplay slot.
-
----
-
-## Task 2 — Add prepared preview lifecycle, navigation invalidation, activation, and telemetry
-
-**Goal:** load the exact chart's preview stopped, play it only on command, measure actual playback time, exit prepared mode cleanly on user navigation, and activate only when the normal transition can really start.
-
-### 2.1 Write failing lifecycle and activation tests
-
-Add cases for:
-
-- prepare loads the requested `SongChart.PreviewFile`, not the node's primary chart preview;
-- missing preview declaration;
-- missing preview file;
-- resource-load/unsupported failure;
-- successful prepare creates no sound instance and does not auto-play after the normal preview delay;
-- prepare projection does not clear itself via selection/difficulty events;
-- first start creates one looped instance at existing preview volume;
-- repeated start while playing creates no second instance;
-- elapsed ms advances only when `ISoundInstance.State == Playing`;
-- playback creation/start failure reports failed state with no BGM/full-song fallback;
-- cancel is idempotent;
-- replacement preparation stops/disposes the old instance exactly once;
-- row navigation away clears preparation and resumes the row's normal interactive preview path;
-- difficulty navigation away clears preparation and resumes the normal primary-chart delayed preview;
-- Deactivate clears prepared state/resources exactly once;
-- activation while `CanPerformStageTransition()` is false returns failure, starts no transition, and preserves prepared state/preview;
-- activation after the debounce gate is available clears preview and uses the existing `selectedSong` / `selectedDifficulty` / `songId` transition data path;
-- no prepared state leaves existing interactive preview behavior unchanged.
-
-Reuse existing `ISound` / `ISoundInstance` mocks and Song Select activation tests.
-
-### 2.2 Add minimal stage-owned prepared state
-
-In `SongSelectionStage.cs`, add only:
-
-- resolved prepared selection (node/chart/difficulty/telemetry identity);
-- preview state (`None`, `Prepared`, `Playing`, `Failed`);
-- elapsed milliseconds;
-- `_isProjectingPreparedSelection` for the synchronous prepare projection.
-
-Do not add locks, session IDs, or a generation/state-machine framework; mutations and elapsed updates are update-thread-owned.
-
-Provide one idempotent prepared cleanup path so cancel, replacement, navigation, activation, and Deactivate share resource release behavior.
-
-### 2.3 Load the exact resolved chart preview
-
-Reuse current preview resource methods, factoring only enough path/loading logic so prepared loading can accept the resolved `SongChart` directly.
+```text
+SetSelection(index, difficulty)
+```
 
 Requirements:
 
-- resolve preview relative to the matched chart's `FilePath` directory;
-- use the existing resource manager/sound type support;
-- keep the loaded `_previewSound` but leave `_previewSoundInstance` null;
-- disable normal delayed auto-start while prepared;
-- state = `Prepared`, elapsed = 0 only after load succeeds;
-- any prepare failure leaves no active prepared state.
+- validate current list/index;
+- clamp/validate difficulty using existing semantics;
+- apply row + difficulty as one operation;
+- reset scroll target/counters coherently;
+- invoke the normal selection update/event path exactly once.
 
-Do not change normal interactive `LoadPreviewSound(SongListNode)` semantics when no preparation exists.
+Add focused component coverage for one event and final selected row/difficulty.
 
-### 2.4 Implement explicit start/cancel and elapsed tracking
+### 1.4 Project with existing reconciliation machinery
+
+Do **not** call `NavigateIntoBox` for each ancestor.
+
+Wrap the **entire** prepare projection in `_isProjectingPreparedSelection = true` / `finally false`:
+
+1. switch to All Songs/default recorder browse projection;
+2. clear active filter projection for this operation;
+3. call `RestoreNavigationPaths(ancestorPaths, snapshot)`;
+4. call `RefreshSongListForActiveTab()` once;
+5. find target index in the projected list;
+6. call `SetSelection(targetIndex, difficultyIndex)` once;
+7. update normal breadcrumb/status hints through existing stage paths.
+
+The suppression flag must prevent prepared invalidation and normal automatic preview loading during every projection side effect, including the one final refresh.
+
+**Task 1 acceptance:** nested BOX preparation causes one final list projection/selection, not one stop/load/BGM cycle per ancestor, and the intended row/difficulty is visible.
+
+---
+
+## Task 2 — Prepared preview lifecycle, navigation invalidation, activation, and telemetry
+
+**Goal:** load the exact preview stopped, play exactly one loop, measure actual CX playback, and activate only when the real transition can start.
+
+### 2.1 Add failing lifecycle tests
+
+Cover:
+
+- prepared load uses resolved `SongChart.PreviewFile`, not primary `DatabaseChart`;
+- missing declaration/file/load failure;
+- successful prepare creates no `ISoundInstance`;
+- successful prepared load leaves `_isPreviewDelayActive == false`;
+- waiting beyond the normal preview delay does not auto-start;
+- first start creates one looped instance at existing preview volume;
+- repeated start creates no second instance;
+- elapsed advances only while `State == Playing`;
+- unexpected stop moves state to Failed;
+- replacement/cancel/deactivate clean up exactly once;
+- row navigation away clears prepared state;
+- difficulty navigation away clears prepared state and resumes normal delayed primary-chart preview;
+- `_isProjectingPreparedSelection` prevents prepare from clearing itself;
+- no prepared state preserves today's interactive preview behavior.
+
+Reuse existing `ISound` / `ISoundInstance` mocks.
+
+### 2.2 Add minimal stage-owned prepared state
+
+Add only:
+
+```text
+PreparedChartSelection(node, chart, difficultyIndex, telemetryIdentity)
+PreparedPreviewState
+PreparedPreviewElapsedMs
+_isProjectingPreparedSelection
+```
+
+Use one idempotent prepared cleanup path shared by cancel, replacement, navigation, activation, and Deactivate.
+
+No locks/session/generation framework.
+
+### 2.3 Load the exact preview and explicitly defeat the normal delay timer
+
+Factor only enough path logic to accept a resolved `SongChart` and reuse `TryLoadPreviewSoundFile`.
+
+After `TryLoadPreviewSoundFile` succeeds, explicitly set:
+
+```text
+_previewPlayDelay = 0
+_isPreviewDelayActive = false
+```
+
+This is mandatory because the existing helper sets `_isPreviewDelayActive = true` on every successful load.
+
+Only then publish prepared state:
+
+```text
+_previewSound retained
+_previewSoundInstance == null
+state = Prepared
+elapsed = 0
+```
+
+Any failure leaves no active preparation.
+
+### 2.4 Implement start/cancel and elapsed update
 
 `StartPreparedPreview`:
 
-- require a prepared resource;
-- create the instance with the existing helper;
-- apply existing preview volume and looping;
-- call `Play()` once;
-- start the existing BGM fade-out;
-- become `Playing`, elapsed = 0;
+- require prepared resource;
+- create one instance with existing helper;
+- apply existing volume + looping;
+- `Play()` once;
+- start existing BGM fade-out;
+- state `Playing`, elapsed `0`;
 - repeated call while already playing is idempotent success.
 
 `CancelPreparedChart`:
 
-- reuse existing stop/dispose/release behavior;
-- clear prepared state/identity/elapsed;
-- remain idempotent.
+- reuse existing stop/dispose/release path;
+- clear identity/state/elapsed;
+- idempotent success.
 
-During `OnUpdate`, add elapsed time only when prepared state is Playing and the sound instance reports Playing. If an explicitly-started loop unexpectedly stops, move to Failed and do not auto-restart or substitute another source.
+In `OnUpdate`, add elapsed time only while state is Playing and the instance reports Playing. If it stops unexpectedly, mark Failed and do not substitute another audio source.
 
-### 2.5 Clear preparation on real user navigation, not prepare projection
-
-Wire both selection paths.
+### 2.5 Wire row/difficulty invalidation
 
 `OnSongSelectionChanged`:
 
-- if `_isProjectingPreparedSelection` is true, do not clear preparation and skip automatic preview loading for that projection;
-- otherwise, if a prepared chart exists and the selected row moved away, clear it;
-- continue the handler's existing row-selection preview behavior, so normal delayed `LoadPreviewSound(e.SelectedSong)` resumes.
+- if projecting prepare, skip prepared invalidation and normal auto-preview load;
+- otherwise clear preparation when moving to another row, then continue existing normal selection behavior.
 
 `OnDifficultyChanged`:
 
-- if `_isProjectingPreparedSelection` is true, do not clear preparation;
-- otherwise, if a prepared chart exists and `e.NewDifficulty` differs from the prepared slot, clear it;
-- after that prepared-mode exit, call the existing `LoadPreviewSound(e.Song)` so interactive Song Select resumes its normal primary-chart delayed preview;
-- when no preparation exists, leave today's difficulty-change behavior untouched.
+- if projecting prepare, do not invalidate;
+- otherwise clear when moving away from prepared difficulty;
+- on that prepared-mode exit only, call existing `LoadPreviewSound(e.Song)` to resume normal delayed primary-chart preview;
+- when no prepared chart exists, keep current difficulty behavior unchanged.
 
-The cleanup path must remain idempotent so existing `StopCurrentPreview` calls cannot double-dispose an instance.
+### 2.6 Split transition eligibility from transition start
 
-### 2.6 Make activation return a real transition outcome
+Refactor the existing ~20-line `SelectSong` body into a small shared gate + shared start body.
 
-Current `SelectSong` silently returns when the global debounce rejects the transition. Factor its logic into a small eligibility gate and one shared transition-start body; names may follow existing style, for example:
-
-```text
-CanStartSongSelection(node)
-StartSongSelection(node)
-```
-
-Eligibility must reject:
+Eligibility rejects:
 
 - null/non-Score node;
-- unavailable `StageManager`;
+- missing `StageManager`;
 - `_game.CanPerformStageTransition() == false`.
 
-The shared start body remains the sole owner of:
+The start body remains the only code that performs:
 
 ```text
 _game.MarkStageTransition()
-selectedSong
-selectedDifficulty
-songId
-StageManager.ChangeStage(StageType.SongTransition, ...)
+selectedSong / selectedDifficulty / songId shared data
+StageManager.ChangeStage(SongTransition, ...)
 ```
 
-Normal interactive `SelectSong` uses the same gate/start helpers.
+Normal player `SelectSong` uses the same helpers.
 
-`ActivatePreparedChart` must:
+`ActivatePreparedChart`:
 
-1. require the prepared row/difficulty still equal `_selectedSong` / `_currentDifficulty`;
-2. evaluate the shared eligibility gate;
-3. when blocked, return `success=false` with a clear category such as transition debounce active and leave prepared state/preview intact;
-4. only after the gate succeeds, stop/dispose the prepared preview and clear prepared state;
-5. immediately execute the shared transition-start body on the same update-thread action;
-6. return success only after `ChangeStage` was invoked.
+1. require prepared row/difficulty still matches current selection;
+2. run eligibility;
+3. if blocked, return failure and preserve preparation/preview;
+4. only after eligibility succeeds, clean prepared preview/state;
+5. immediately call shared transition-start body;
+6. return success only after the stage change was invoked.
 
-Do not wait inside the game for the 0.5-second debounce and do not duplicate transition shared-data construction.
+Do not sleep/retry inside the game.
 
-### 2.7 Add three producer telemetry fields
+### 2.7 Add all three producer telemetry fields
 
-In `GameTelemetrySnapshot.cs` and `SongSelectionStage.PopulateTelemetry`, add only:
+Add:
 
-- `PreparedChartIdentity`;
-- `PreparedPreviewState`;
-- `PreparedPreviewElapsedMs`.
+```text
+PreparedChartIdentity
+PreparedPreviewState
+PreparedPreviewElapsedMs
+```
 
-Identity:
+Identity policy:
 
-- `chart:<database-id>` when a non-zero chart ID exists;
-- otherwise a root-relative normalized path with no absolute root prefix.
+- `chart:<SongChart.Id>` when ID is non-zero;
+- otherwise normalized path relative to the matching active root.
 
-The serialized wire names must be exactly:
+Do not use `GetStableSelectionIdentity`; it identifies the row and commonly returns `song:<id>`, which is not sufficient for an exact chart/difficulty preparation.
+
+Wire names must serialize exactly as:
 
 ```text
 preparedChartIdentity
@@ -301,66 +308,77 @@ preparedPreviewState
 preparedPreviewElapsedMs
 ```
 
-**Task 2 acceptance:** recorder can prepare a stopped exact-chart preview, start exactly one loop, wait on elapsed telemetry, retry a debounce-blocked activation without losing preparation, activate through the normal SongTransition path, and all navigation/exit paths clean up correctly.
+**Task 2 acceptance:** prepared preview stays stopped until commanded, reports 10+ seconds of actual playing time, retries are possible after a blocked activation without losing state, and successful activation uses the normal SongTransition construction.
 
 ---
 
-## Task 3 — Wire the explicit Game API, JSON-RPC, Automation client, and telemetry contract
+## Task 3 — Explicit Game API, JSON-RPC, Automation wrappers, and telemetry contract
 
-**Goal:** expose the stage behavior to HPA-503 without exposing generic mutation/transport APIs, and lock producer/consumer wire names.
+**Goal:** expose only the four required operations and lock their game/consumer contract.
 
-### 3.1 Add Game API contract and queue/await helper
+### 3.1 Add Game API contract + queue-and-await helper
 
-In `GameApi.cs`, add a narrow prepared-command result and four methods equivalent to:
+In `GameApi.cs` add:
 
 ```text
+PreparedChartCommandResult
+- bool Success
+- string? Error
+
 PrepareVideoChartAsync(chartPath)
 StartPreparedPreviewAsync()
 ActivatePreparedChartAsync()
 CancelPreparedChartAsync()
 ```
 
-In `GameApiImplementation.cs`, implement one private queue helper using the existing `IGameContext.QueueMainThreadAction` plus:
+Do **not** add an error-code enum in this ticket. HPA-503 has no programmatic recovery branch: all command failures fail the recording run, and activation occurs after 10 seconds of preview, well beyond the 0.5-second transition debounce. Add structured codes only when a real caller needs branching.
+
+In `GameApiImplementation.cs`, add one private helper using:
 
 ```text
-TaskCompletionSource(..., TaskCreationOptions.RunContinuationsAsynchronously)
+IGameContext.QueueMainThreadAction
+TaskCompletionSource(...RunContinuationsAsynchronously)
 ```
 
-The queued action must perform the current-stage check and execute the Song Select command on the update thread. The returned task completes with the actual command result, not merely after enqueue.
+The queued action checks current stage, executes the Song Select command, and completes with the real result.
 
-Add tests that capture/execute the queued action and verify:
+Tests must prove:
 
-- no stage mutation occurs before the queued action runs;
-- the task completes only after execution;
-- non-SongSelect current stage produces a clear failure;
-- stage failure text, including debounce-blocked activation, propagates.
+- no mutation before queued action execution;
+- task not completed before action execution;
+- wrong stage returns failure;
+- stage failure text propagates;
+- debounce-blocked activation returns failure rather than queued-success.
 
-Do not copy `ChangeStageAsync`'s fire-and-forget contract and do not add a reusable dispatcher class.
+### 3.2 Add four authenticated JSON-RPC routes
 
-### 3.2 Add four explicit JSON-RPC handlers
+Add only:
 
-In `JsonRpcServer.cs`:
+```text
+prepareVideoChart { chartPath }
+startPreparedPreview
+activatePreparedChart
+cancelPreparedChart
+```
 
-- add explicit route cases only for the four method names;
-- validate `prepareVideoChart` has object params and a non-empty string `chartPath`;
-- call the corresponding Game API method;
-- return a small `{ success, error? }` result;
-- rely on existing server-level API-key authentication.
+Validate prepare params. Return `{ success, error? }` using the existing server authentication and JSON-RPC envelope.
 
-Extend current JSON-RPC tests for method routing, invalid prepare params, normal failures, and debounce failure shape.
+No `executeGameAction`/generic dispatcher and no new error taxonomy.
 
-No generic `executeGameAction` endpoint.
+### 3.3 Extend Automation wrappers
 
-### 3.3 Extend `DTXMania.Automation`
+In `JsonRpcGameClient` add:
 
-In `JsonRpcGameClient.cs`, add the four public async wrappers using existing private `SendAsync`.
+```text
+PrepareVideoChartAsync(path)
+StartPreparedPreviewAsync()
+ActivatePreparedChartAsync()
+CancelPreparedChartAsync()
+```
 
-Add one small command-result parser shared by the four methods:
+Use private `SendAsync` and one small command-result parser. `success=false` throws `InvalidOperationException` with the server's safe error text.
 
-- `success=true` returns normally;
-- missing/false success throws `InvalidOperationException` with server-provided safe error text.
-
-In `GameStateSnapshot.cs`, add accessors that read the exact keys:
+In `GameStateSnapshot` add accessors for exactly:
 
 ```text
 preparedChartIdentity
@@ -368,9 +386,9 @@ preparedPreviewState
 preparedPreviewElapsedMs
 ```
 
-Extend `JsonRpcGameClientTests` to assert exact method names/params and error propagation.
+Extend client tests for exact method names/params and error propagation.
 
-### 3.4 Mandatory game-to-Automation camelCase contract test
+### 3.4 Mandatory producer/consumer camelCase contract
 
 Extend:
 
@@ -379,97 +397,120 @@ DTXMania.E2E/AutomationContractTests.cs
 GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields
 ```
 
-The producer `GameTelemetrySnapshot` fixture must set non-default values for all three fields. Serialize it with the existing camelCase serializer and assert the deserialized `GameStateSnapshot` returns those same values through its new accessors.
+Set non-default values for the three game producer fields, serialize through the existing camelCase options, deserialize to `GameStateSnapshot`, and assert all three accessors.
 
-This is mandatory. Do not replace it with an Automation-only JSON fixture because the purpose is to catch producer property-name drift as well as consumer accessor drift.
+Do not replace this with an Automation-only JSON fixture; the point is to catch producer and consumer name drift together.
 
-**Task 3 acceptance:** HPA-503 can prepare/start/activate/cancel using `DTXMania.Automation` only and poll all three prepared telemetry values through the existing `GetGameStateAsync` path with the producer/consumer wire contract locked.
+**Task 3 acceptance:** HPA-503 can invoke all four commands and poll all three telemetry values through `DTXMania.Automation` only; generic JSON-RPC remains private.
 
 ---
 
-## Task 4 — Regression and acceptance validation
+## Task 4 — Regression suite plus one live prepared-chart E2E
 
-### 4.1 Focused tests
+**Goal:** replace the one-off manual checklist with repeatable proof using machinery already in CI.
 
-Run the new/focused suites first. Use the repository's host-appropriate game test project, for example:
+### 4.1 Focused unit/contract tests
+
+Run the host-appropriate game test project plus Automation tests. Focus first on:
+
+- prepared-chart Song Select tests;
+- existing Song Select preview/BGM tests;
+- Song Select navigation/filter/BOX tests;
+- SongTransition tests;
+- Game API/JSON-RPC tests;
+- Automation JSON-RPC tests;
+- E2E-Support automation contract test.
+
+Example:
 
 ```bash
-# Song Select / Game API / JSON-RPC focused tests
+# Windows game tests
 dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~PreparedChart"
 
-# Reusable Automation tests
+# macOS game tests
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --filter "FullyQualifiedName~PreparedChart"
+
+# Automation
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj
 
-# Existing producer/consumer contract
-dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "FullyQualifiedName~AutomationContractTests"
+# Producer/consumer contract
+dotnet test DTXMania.E2E/DTXMania.E2E.csproj --filter "Category=E2E-Support"
 ```
 
-On macOS, use `DTXMania.Test/DTXMania.Test.Mac.csproj` for the game unit suite. Run the E2E-support contract on its supported host configuration; no live gameplay launch is required for this contract test.
+### 4.2 Reuse the generated E2E fixture for preview audio
 
-### 4.2 Full regression suite
+In `E2EFixtureBuilder.BuildChart()`, add:
 
-Run the full platform-appropriate game unit suite plus Automation tests.
+```text
+#PREVIEW: autoplay-tone.wav
+```
 
-At minimum verify:
+using the existing `AudioFileName` constant rather than adding another generated asset.
 
-- existing Song Select preview/BGM tests stay green;
-- existing Song Select navigation/filter/BOX tests stay green;
-- existing SongTransition tests stay green;
-- Game API/JSON-RPC tests stay green;
-- Automation tests stay green;
-- `AutomationContractTests` stays green with the three new telemetry fields.
+### 4.3 Add one `Category=E2E` prepared-chart live smoke
 
-HPA-510 does **not** need to add OBS/recorder E2E. HPA-503 is the live Windows recording validation consumer.
+Create `PreparedChartRecordingSmokeTests.cs` using existing:
 
-### 4.3 Manual/API smoke for implementation PR
+- `E2EFixtureBuilder`;
+- `E2EGameLaunch.CreateClientBundle`;
+- `JsonRpcGameClient`;
+- `Eventually.UntilAsync`;
+- current stage waits/artifact helpers where reusable.
 
-Use an indexed test chart with preview audio and the existing Game API:
+Required live flow:
 
-1. enter Song Select;
-2. call prepare with the exact absolute chart path;
-3. verify telemetry reports `Prepared` and a redacted identity;
-4. take a screenshot and verify the requested row/difficulty/status UI is rendered;
-5. wait long enough to prove normal preview delay does not auto-play;
-6. call start, then poll until prepared elapsed >= 10,000 ms;
-7. call activate and confirm transition follows SongTransition;
-8. separately exercise a debounce-blocked activation and verify preparation remains available for retry;
-9. exercise user difficulty navigation after prepare and verify prepared state clears and the normal primary-chart delayed preview resumes;
-10. repeat with cancel/reprepare to confirm no preview audio bleeds across attempts.
+1. build/launch isolated fixture;
+2. enter SongSelect through the existing normal path;
+3. call `PrepareVideoChartAsync(fixture.ChartPath)`;
+4. call screenshot and require non-empty image;
+5. wait longer than the normal automatic preview delay and assert state is `Prepared` with elapsed `0`;
+6. call `StartPreparedPreviewAsync()`;
+7. poll until state is `Playing` and elapsed `>= 10_000`;
+8. call `ActivatePreparedChartAsync()`;
+9. observe `SongTransition` before `Performance`.
 
-This smoke is implementation validation only; do not create a permanent recorder harness in HPA-510.
+Keep this test narrowly about HPA-510. Do not run to Result, inspect persistence, involve OBS, or duplicate `GameplayAutoPlaySmokeTests`' score-bucket purpose.
+
+The existing `.github/workflows/build-and-test.yml` already runs `Category=E2E` on Windows, so no new CI job is required.
+
+### 4.4 Full regression
+
+Run the platform-appropriate full game unit suite and Automation tests. Verify the existing Windows gameplay E2E job remains green.
+
+There is no separate manual smoke checklist after this change; the live E2E is the repeatable acceptance proof.
 
 ---
 
-## Scope Guardrails for the Implementing Agent
+## Primary implementation risks
 
-Stop and simplify if the implementation starts adding any of the following:
+### Projection side effects
 
-- recording session IDs/state machines;
-- generic Game API mutation dispatch;
-- a new song repository/query service;
-- title-based or input-driven navigation;
-- alternate chart/difficulty ordering rules instead of current Song Select helpers plus the explicit DRUMS tie-break;
-- a second preview audio abstraction;
-- a game-owned debounce wait/retry loop;
-- OBS/process/FFmpeg concerns;
-- render-ready generation counters.
+`NavigateIntoBox` repopulates the list at each level, which resets index and fires selection events. Avoid it during prepare projection: use `RestoreNavigationPaths` + one final refresh + one atomic selection under the full suppression scope.
 
-The desired end state is four explicit commands layered on the existing Song Select state machine, with `DTXMania.Automation` wrappers ready for HPA-503.
+### Prepared preview auto-start
 
-## Definition of Done
+`TryLoadPreviewSoundFile` sets `_isPreviewDelayActive = true` on success. Prepared loading must explicitly clear it.
 
-- Exact absolute chart path selects the correct indexed row+difficulty for root, nested, SET/multi-chart, duplicate-title, and ordinary shared-ChartId multi-instrument cases.
-- Shared ChartId across DRUMS/GUITAR/BASS resolves to the unique DRUMS gameplay slot rather than failing as ambiguous.
-- Outside-root/unindexed/truly-ambiguous/missing-preview/unsupported-preview cases fail clearly.
-- Prepare leaves the exact chart preview loaded but stopped and cannot clear itself through projection events.
-- Start creates exactly one looped instance using existing preview volume/path behavior.
-- Prepared elapsed telemetry advances only while the instance is actually Playing.
-- User row/difficulty navigation clears preparation; difficulty exit restores the normal primary-chart delayed preview.
-- Debounce-blocked activation returns failure and preserves preparation; accepted activation clears audio/state and starts the existing SongTransition path.
-- Cancel/replacement/navigation/deactivation/activation clean up without audio bleed or double disposal.
-- Telemetry exposes only prepared identity/state/elapsed with exact camelCase wire keys and no absolute path.
-- `AutomationContractTests` proves those producer wire keys reach the Automation accessors.
-- JSON-RPC commands are explicit and use existing API-key authentication.
-- `DTXMania.Automation` exposes four typed wrappers; generic JSON-RPC remains private.
-- Existing interactive Song Select behavior is unchanged when no prepared chart is active.
-- Platform-appropriate game unit suite, Automation tests, and the existing Automation producer/consumer contract pass.
+### Exact chart identity
+
+`GetStableSelectionIdentity` is row-oriented and can return `song:<id>`. Do not reuse it as exact prepared-chart telemetry identity.
+
+### Activation debounce
+
+`SelectSong` currently no-ops on debounce. Check eligibility before clearing preparation and reuse one shared transition-start body.
+
+---
+
+## Definition of done
+
+- Exact absolute path selects the correct active row/difficulty for root, nested, SET/multi-chart, duplicate-title, and shared-ChartId multi-instrument cases.
+- Prepare projection does not trigger wrong-row preview/BGM cycles while rebuilding BOX hierarchy.
+- Prepare loads the resolved chart preview and explicitly leaves `_isPreviewDelayActive == false`.
+- Start creates exactly one looped preview instance using current volume/BGM behavior.
+- `PreparedPreviewElapsedMs` advances only while the instance reports Playing and reaches at least 10,000 ms in the live smoke.
+- Cancel/replacement/navigation/deactivation clean up without double disposal or audio bleed.
+- Blocked activation returns failure without consuming preparation; successful activation reuses normal SongTransition shared data.
+- Telemetry exposes exactly prepared identity/state/elapsed with no absolute path and passes the mandatory game->Automation camelCase contract test.
+- JSON-RPC exposes only four authenticated commands; generic transport stays private.
+- Focused tests, full unit/Automation regression, and the existing-harness Windows `Category=E2E` prepared-chart smoke pass.
+- No recorder session, generic dispatcher, song repository, fake OBS server, or new E2E framework is introduced.

--- a/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
+++ b/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
@@ -2,13 +2,13 @@
 
 **Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
 **Date:** 2026-08-11  
-**Status:** Revised after implementation review
+**Status:** Revised after second implementation review
 
 ## Context
 
-HPA-501 has landed on `main`, so the reusable `DTXMania.Automation` process and JSON-RPC foundation is available. HPA-510 is now the only code prerequisite blocking HPA-503, the Windows recording vertical slice.
+HPA-501 has landed on `main`, so the reusable `DTXMania.Automation` process and JSON-RPC foundation is available. HPA-510 is the remaining CX-side prerequisite for HPA-503's Windows recording vertical slice.
 
-The recorder does not need general remote control of the game. It needs four narrow operations while Song Select is active:
+The recorder needs exactly four Song Select operations:
 
 ```text
 prepareVideoChart(chartPath)
@@ -17,83 +17,60 @@ activatePreparedChart()
 cancelPreparedChart()
 ```
 
-The implementation should make one exact indexed chart visible through the normal Song Select UI, hold its declared preview audio ready but stopped, play that preview under explicit recorder control, and then activate the chart through the same path a player uses.
+The implementation must prepare one exact indexed chart through normal Song Select state, hold its declared preview audio stopped, play it only on command, and activate it through the same Song Select -> SongTransition path used by a player.
 
-This design deliberately keeps recording preparation inside `SongSelectionStage`. It does not add a game-wide capture session, generic mutation API, recorder state machine, database query layer, or synthetic input navigation.
+Prepared state remains owned by `SongSelectionStage`. Do not add a recorder session, generic mutation endpoint, database query path, or synthetic-input navigation.
 
 ## Goals
 
-- Resolve one caller-supplied **absolute chart path** to the exact chart already present in the active Song Select library.
-- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, ordinary single-file multi-instrument rows, and duplicate titles.
-- Project the resolved chart through the existing Song Select presentation path so status, preview image, play history, selected row, difficulty, and breadcrumb are normal UI state.
-- Load the preview declared by the **resolved chart**, not merely the node's primary chart.
-- Keep the prepared preview stopped until explicitly started.
-- Reuse the existing preview sound resource, volume, looping, and BGM fade behavior.
-- Keep all stage mutations on the game update thread.
-- Activate through the existing Song Select transition construction and report a real success/failure result when the global transition debounce rejects activation.
-- Expose only the prepared identity/state/elapsed telemetry required by HPA-503.
-- Lock the game-to-Automation telemetry contract to the existing camelCase JSON wire format.
-- Extend `DTXMania.Automation` with the four explicit client calls so HPA-503 never needs access to the private generic JSON-RPC transport.
+- Resolve one caller-supplied absolute chart path against the currently applied `SongLibrarySnapshot`.
+- Support root-level charts, nested BOX hierarchy, SET/multi-chart rows, ordinary one-file multi-instrument rows, and duplicate titles.
+- Project the exact row + difficulty through normal Song Select UI state.
+- Load preview audio from the resolved `SongChart`, not merely the row's primary `DatabaseChart`.
+- Keep preview loaded but stopped until `startPreparedPreview`.
+- Reuse current preview volume, loop, BGM fade, sound resource, and cleanup behavior.
+- Keep every stage mutation on the game update thread and await the real command outcome.
+- Reuse the normal `SelectSong` transition construction while surfacing transition-debounce rejection.
+- Expose exactly `PreparedChartIdentity`, `PreparedPreviewState`, and `PreparedPreviewElapsedMs` to HPA-503.
+- Lock the camelCase game -> Automation telemetry contract.
+- Validate the command path once against a live game using the existing E2E fixture/CI machinery.
 
 ## Non-goals
 
-- A general Song Select remote-navigation API.
-- A generic command dispatcher or arbitrary main-thread mutation endpoint.
-- A game-wide recording/capture coordinator or immutable recording session ID.
-- A separate render-generation/readiness state machine. Screenshot completion remains the presentation barrier.
-- OBS, process launch, app-data sandboxing, Result hold timing, or video artifact handling.
-- Changing the normal interactive preview delay or primary-chart preview behavior when no prepared chart is active.
-- Restoring a pre-command filter/tab/breadcrumb after cancellation. The recorder runs in disposable app data; snapshot/restore machinery is unnecessary for MVP.
-- Waiting inside the game for the stage-transition debounce window. A blocked activation returns `success=false`; the preparation remains available for a bounded caller retry.
+- General Song Select remote navigation.
+- Generic game-thread dispatch or arbitrary mutation APIs.
+- A capture/recording session object or state machine.
+- A second song repository/query layer.
+- A new render-readiness state machine; screenshot completion remains the presentation barrier.
+- OBS, process launch, sandbox construction, video finalization, or Result timing.
+- Restoring the pre-command tab/filter/breadcrumb after cancel; HPA-503 uses disposable app data.
+- Changing normal interactive preview behavior when no prepared chart exists.
+- Waiting inside the game for transition debounce to expire.
 - Direct transition to Performance.
 
-## Current Reuse Survey
+## Verified reuse seams
 
-The required building blocks already exist:
+Use the existing code rather than parallel abstractions:
 
-- `SongSelectionStage` owns selection, BOX navigation, status/history/preview UI, preview sound lifecycle, BGM fading, and the player activation path.
-- `SongSelectionStage` already retains the coherent applied `SongLibrarySnapshot`, including `RootSongs` and canonical `ActiveRoots`.
-- `SongSelectionStage.GetNodeChartPaths` already understands that a visible row can represent the primary `DatabaseChart` plus additional `DatabaseSong.Charts`.
-- `SongPathIdentity` already owns path normalization and root-containment primitives.
-- `SongListNode.Scores` carries difficulty slots; persisted multi-chart rows carry `SongScore.ChartId`.
-- `SongListNode.CreateSongNode` can legitimately assign the same `SongChart.Id` to DRUMS, GUITAR, and BASS score slots for one physical DTX file, so `ChartId` alone is not always a unique slot identity.
-- `SongChartHelper.GetCurrentDifficultyChart` is the existing runtime fallback from a visible difficulty slot to its chart and is useful for legacy/SET rows where a direct `ChartId` match is unavailable.
-- `SongListDisplay` already owns row index, difficulty, selection events, scroll target, and normal Song Select presentation updates.
-- `SongSelectionStage.LoadPreviewSound` / `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` already implement the preview resource and playback behavior.
-- `SongSelectionStage.SelectSong` owns the normal transition data but silently returns while `_game.CanPerformStageTransition()` is false, so prepared activation must surface that gate rather than clearing state first.
-- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API. `BaseGame.CaptureScreenshotAsync` demonstrates the existing `TaskCompletionSource(...RunContinuationsAsynchronously)` pattern for an awaited game-thread result.
-- `JsonRpcServer` already authenticates every JSON-RPC request and serializes public DTOs with camelCase property names.
-- `GameTelemetrySnapshot` plus `IStageTelemetryProvider` is the existing producer telemetry seam.
-- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` owns the consumer JSON-RPC transport and keeps `SendAsync` private.
-- `DTXMania.E2E/AutomationContractTests.cs` already performs the producer-to-`GameStateSnapshot` camelCase contract round trip and is the required place to lock the three new telemetry fields.
+- `_appliedLibrarySnapshot`, `GetNodeChartPaths`, and `SongPathIdentity` for exact active-library path resolution.
+- `RestoreNavigationPaths(paths, snapshot)` for rebuilding `_navigationStack`, `_currentSongList`, and `_currentBreadcrumb` without repopulating at every BOX level.
+- `RefreshSongListForActiveTab()` for one final list projection after navigation state is rebuilt.
+- `SongListDisplay` for the final row/difficulty UI selection.
+- `SongListNode.Scores[].ChartId` plus `SongChartHelper.GetCurrentDifficultyChart` for difficulty mapping.
+- `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` for preview lifecycle.
+- `IGameContext.QueueMainThreadAction` plus `TaskCompletionSource(...RunContinuationsAsynchronously)` for awaited game-thread commands.
+- `SelectSong` for normal SongTransition shared-data construction.
+- `JsonRpcServer`'s existing authenticated method switch and `JsonRpcGameClient.SendAsync` for transport.
+- `DTXMania.E2E/AutomationContractTests.cs` for game -> camelCase -> Automation telemetry contract coverage.
+- `E2EFixtureBuilder`, `E2EGameLaunch`, `Eventually`, and the existing Windows `Category=E2E` CI job for one live validation.
 
-The design should extend these seams rather than create parallel infrastructure.
+`GetStableSelectionIdentity` is **not** the prepared-chart telemetry identity seam. It is a row-selection identity: it prefers `song:<DatabaseSongId>` when present and only falls back to the first chart path. HPA-510 must identify the exact resolved chart/difficulty, not merely its row.
 
-## Approaches Considered
+## Chosen architecture
 
-### 1. Stage-owned prepared state plus four explicit commands — selected
+### 1. Minimal stage-owned prepared state
 
-Add a small amount of state and four command methods to `SongSelectionStage`, expose them through explicit Game API / JSON-RPC handlers, and add matching methods to `DTXMania.Automation`.
-
-This gives HPA-503 exactly what it needs while preserving the normal Song Select and transition paths.
-
-### 2. Recorder drives Song Select with repeated key input — rejected
-
-This is already the failure mode HPA-510 exists to remove. It is slow, fragile with nested boxes/filter state, and cannot safely disambiguate duplicate titles.
-
-### 3. Add a general game automation/session coordinator — rejected
-
-HPA-503 owns orchestration. A second lifecycle/session abstraction inside the game would duplicate ownership before a second use case proves it useful.
-
-### 4. Resolve chart paths through a new database repository/service — rejected
-
-The active `SongLibrarySnapshot` is already the authoritative, coherent view used by Song Select. A second DB query path could disagree with the rendered hierarchy and would add unnecessary synchronization.
-
-## Chosen Architecture
-
-### 1. Prepared state is update-thread-owned by `SongSelectionStage`
-
-Keep a minimal stage-local record for the current preparation, for example:
+Keep one update-thread-owned record:
 
 ```text
 PreparedChartSelection
@@ -103,7 +80,7 @@ PreparedChartSelection
 - string telemetryIdentity
 ```
 
-Keep only the additional runtime fields needed for preview control:
+Additional fields:
 
 ```text
 PreparedPreviewState: None | Prepared | Playing | Failed
@@ -111,165 +88,169 @@ PreparedPreviewElapsedMs: double
 _isProjectingPreparedSelection: bool
 ```
 
-No lock is required for this state because every command mutation and elapsed-time update runs on the game update thread. Game telemetry reads the same fields through the existing stage telemetry provider.
+No lock, session ID, generation object, or separate state machine is required.
 
-A preparation is cleared by:
+Prepared state is cleared by:
 
-- `cancelPreparedChart`;
-- preparing a replacement chart;
-- normal interactive row navigation away from the prepared row;
-- normal interactive difficulty navigation away from the prepared slot;
-- successful activation after the transition gate has accepted the request;
+- cancel;
+- replacement prepare;
+- real user row navigation away;
+- real user difficulty navigation away;
+- successful activation after transition eligibility is confirmed;
 - stage deactivation.
 
-`_isProjectingPreparedSelection` suppresses invalidation while `prepareVideoChart` itself projects the target row/difficulty. It also suppresses the normal automatic preview load during that projection; the exact resolved chart preview is loaded explicitly afterward.
+The projection suppression flag is scoped to the **entire prepare projection**, not only the final row selection.
 
-Cleanup remains idempotent. `StopCurrentPreview` already nulls disposed resources, so repeated cleanup must never stop/dispose one instance twice.
+### 2. Exact path resolver over the applied snapshot
 
-### 2. Exact chart resolution uses the applied library snapshot
-
-`prepareVideoChart` accepts only a non-empty, fully-qualified path.
+`prepareVideoChart` accepts only a non-blank fully-qualified chart path.
 
 On the update thread:
 
-1. Require Song Select to have an applied `SongLibrarySnapshot`.
-2. Normalize the requested chart path with `SongPathIdentity`.
-3. Require it to be under one of `snapshot.ActiveRoots`.
+1. Require `_appliedLibrarySnapshot`.
+2. Normalize the requested path with `SongPathIdentity`.
+3. Require containment under one of `snapshot.ActiveRoots`.
 4. Recursively walk `snapshot.RootSongs` and BOX children.
-5. For each Score node, inspect the node's primary `DatabaseChart` and every chart in `DatabaseSong.Charts`.
-6. Match by normalized path using the existing platform path-identity semantics. Never use title/artist text.
-7. Require exactly one visible node/chart match.
-8. Resolve the visible difficulty slot using the following precedence:
-   - collect non-null score slots whose non-zero `SongScore.ChartId` equals the resolved `SongChart.Id`;
-   - if exactly one slot matches, use it;
-   - if multiple slots share that ChartId, use the **unique DRUMS slot** when exactly one candidate has `Instrument == EInstrumentPart.DRUMS`; this is the normal one-file multi-instrument case and matches CX's drum-gameplay path;
-   - if ChartId did not establish a slot, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching that chart's normalized `FilePath` to the requested path;
-   - use the fallback only when it yields one slot; fail rather than guess if ambiguity remains.
-9. Retain the ancestor BOX chain needed to reproduce the normal browse context.
+5. For Score nodes, inspect `DatabaseChart` plus `DatabaseSong.Charts`.
+6. Match normalized chart path only; never title/artist.
+7. Require one exact node/chart match.
+8. Resolve the visible difficulty slot:
+   - collect non-null score slots with matching non-zero `ChartId`;
+   - if exactly one matches, use it;
+   - when several slots share the same ChartId, use the unique DRUMS slot if exactly one candidate is DRUMS;
+   - otherwise scan valid slots through `GetCurrentDifficultyChart(node, index)` and compare the returned chart path to the resolved path;
+   - fail if no unique slot remains.
+9. Return the node, resolved chart, difficulty index, and ancestor BOX paths.
 
-The DRUMS tie-break is required because one physical DTX file can legitimately populate DRUMS/GUITAR/BASS slots with the same `SongChart.Id`. Requiring ChartId uniqueness would reject normal indexed content.
+The DRUMS tie-break is required because a single physical DTX can populate DRUMS/GUITAR/BASS slots with the same `SongChart.Id`.
 
-This handles duplicate titles naturally because title never participates in identity. It also reuses the current SET/multi-chart mapping instead of introducing a second difficulty-order algorithm.
+### 3. Projection uses one existing navigation rebuild and one UI refresh
 
-### 3. Reuse normal browse navigation, but do not synthesize input
+Do **not** call `NavigateIntoBox` once per ancestor. It calls `PopulateSongList()` on each level; `SongListDisplay.CurrentList` resets selection to index 0 and raises `SelectionChanged`, which would repeatedly stop/load the wrong preview during prepare.
 
-Preparation must leave Song Select in a normal browse context with the target row visible.
-
-Use existing stage behavior:
-
-1. Switch to the All Songs projection and clear the active search/filter projection for this recorder operation.
-2. Return to the root browse list and clear the navigation stack.
-3. Reuse `NavigateIntoBox` for each resolved ancestor BOX so the normal breadcrumb/current-list state is rebuilt.
-4. Select the target row and difficulty through `SongListDisplay`.
-
-Add one narrow programmatic selection method to `SongListDisplay`, such as:
+Instead, run the whole projection inside:
 
 ```text
-SetSelection(index, difficulty)
+_isProjectingPreparedSelection = true
+try
+    reset recorder-owned tab/filter projection
+    RestoreNavigationPaths(ancestorPaths, snapshot)
+    RefreshSongListForActiveTab() exactly once
+    SetSelection(targetIndex, difficultyIndex)
+finally
+    _isProjectingPreparedSelection = false
 ```
 
-It should atomically set row + difficulty, reset the scroll target consistently, and raise the existing `SelectionChanged` path once. This avoids the current property-order problem where `CurrentList` can temporarily select row 0 and load the wrong preview before the final index is applied.
+Add one narrow `SongListDisplay.SetSelection(index, difficulty)` method that applies row + difficulty atomically, updates scroll state coherently, and raises the normal selection path once.
 
-This is an internal UI convenience, not a remote navigation API.
+During the suppression scope, normal status/history/image/breadcrumb presentation may update, but prepared-state invalidation and normal automatic preview loading must not run.
 
-During prepare projection, `_isProjectingPreparedSelection` lets normal status/history/image/breadcrumb presentation update while skipping prepared-state invalidation and automatic preview loading. The flag is cleared in `finally` so a projection failure cannot leave normal Song Select behavior suppressed.
+This is an internal UI seam, not a remote navigation API.
 
-### 4. Prepared preview uses the resolved `SongChart`
+### 4. Prepared preview loads the exact resolved chart
 
-This is the one place where blindly reusing current interactive preview loading is incorrect: `LoadPreviewSound(SongListNode)` reads `selectedNode.DatabaseChart`, which is the row's primary chart and may not be the chart selected by the recorder.
-
-Extract/reuse the existing path/load primitives so prepared loading can accept the exact resolved `SongChart`:
+Current `LoadPreviewSound(SongListNode)` hardcodes `selectedNode.DatabaseChart`. Prepared mode must instead resolve:
 
 ```text
-SongChart.FilePath directory
-+ SongChart.PreviewFile
+resolvedChart.FilePath directory
++ resolvedChart.PreviewFile
 -> absolute preview path
--> existing TryLoadPreviewSoundFile
+-> TryLoadPreviewSoundFile
 ```
 
-Prepare fails clearly when:
+Prepare fails for missing declaration, missing file, unreadable/unsupported load, or null sound resource.
 
-- `PreviewFile` is absent;
-- the resolved preview file does not exist;
-- the resource manager reports a load failure or unsupported asset.
+One important existing side effect must be overridden explicitly: successful `TryLoadPreviewSoundFile` sets:
 
-After successful load:
+```text
+_previewPlayDelay = 0
+_isPreviewDelayActive = true
+```
 
-- `_previewSound` is retained exactly as today;
-- automatic preview delay is disabled while a prepared chart exists;
-- no preview instance is created;
-- preview state becomes `Prepared`;
-- elapsed time is zero.
+After the prepared load succeeds, immediately force:
 
-Normal interactive preview behavior remains unchanged when no preparation exists.
+```text
+_previewPlayDelay = 0
+_isPreviewDelayActive = false
+```
 
-### 5. Explicit start owns exactly one looped preview instance
+so the normal one-second timer cannot auto-start the prepared preview.
 
-`startPreparedPreview` requires a prepared chart and loaded preview resource.
+Successful prepare leaves `_previewSound` retained, `_previewSoundInstance == null`, state `Prepared`, and elapsed `0`.
 
-Reuse `CreatePreviewSoundInstance`, `SongSelectionUILayout.Audio.PreviewSoundVolume`, looping, `Play()`, and `StartBGMFade(true)`.
+### 5. Explicit preview start and elapsed telemetry
 
-Behavior:
+`startPreparedPreview`:
 
-- first successful start creates one instance, sets volume/looping, plays, resets elapsed to zero, and reports `Playing`;
-- a repeated start while already playing is idempotent success and does not create another instance;
-- creation/playback failure disposes any partial instance, reports `Failed`, and never substitutes Song Select BGM or full-song audio.
+- requires a prepared chart/resource;
+- creates one instance with the existing helper;
+- applies existing preview volume and `IsLooped = true`;
+- calls `Play()` once;
+- starts the existing BGM fade-out;
+- sets state `Playing` and elapsed `0`;
+- returns idempotent success when already playing without creating a second instance.
 
-In `SongSelectionStage.OnUpdate`, increment `PreparedPreviewElapsedMs` from `GameTime.ElapsedGameTime` only when prepared state is `Playing` **and** the sound instance currently reports `SoundState.Playing`.
+On each Song Select update, increment `PreparedPreviewElapsedMs` only while state is `Playing` **and** the sound instance reports `SoundState.Playing`.
 
-If an explicitly-started instance unexpectedly stops, mark the prepared preview `Failed` rather than silently starting another source. HPA-503 will observe the state/elapsed telemetry and fail its bounded wait.
+If the explicitly-started instance unexpectedly stops, set state `Failed`; do not auto-restart or substitute Song Select BGM/full-song audio.
 
-### 6. Navigation invalidation returns cleanly to interactive preview behavior
+`PreparedPreviewElapsedMs` stays in scope because both HPA-510 and HPA-503 explicitly require CX-reported actual playback time, and HPA-503 polls `>= 10_000`. Caller wall-clock time is not the accepted contract.
 
-Prepared state must not survive when the visible selection no longer represents the prepared chart.
+### 6. User navigation exits prepared mode cleanly
 
 `OnSongSelectionChanged`:
 
-- while `_isProjectingPreparedSelection` is true, do not invalidate preparation and skip its normal automatic preview load;
-- otherwise, when the selected row differs from the prepared row, clear the prepared state first, then continue the handler's existing row-selection behavior; the normal `LoadPreviewSound(e.SelectedSong)` path therefore resumes the ordinary delayed primary-chart preview.
+- while `_isProjectingPreparedSelection`, do not invalidate prepared state and skip normal automatic preview loading;
+- otherwise, if the row moves away from the prepared row, clear prepared state first and continue today's normal row-selection preview path.
 
 `OnDifficultyChanged`:
 
-- while `_isProjectingPreparedSelection` is true, do not invalidate preparation;
-- otherwise, when `e.NewDifficulty` differs from the prepared slot on the same row, clear the prepared state;
-- after clearing, explicitly call the existing `LoadPreviewSound(e.Song)` path so the row returns to the same primary-chart delayed preview behavior normal Song Select uses after a row selection.
+- while `_isProjectingPreparedSelection`, do not invalidate;
+- otherwise, if difficulty moves away from the prepared slot, clear prepared state;
+- after this prepared-mode exit, reload the row through the existing `LoadPreviewSound(e.Song)` path so normal delayed primary-chart preview behavior resumes;
+- leave ordinary difficulty changes unchanged when there is no preparation.
 
-The difficulty-change reload is only an exit from prepared mode. Normal interactive difficulty changes when no prepared chart exists remain unchanged.
+Cleanup remains idempotent.
 
-### 7. Activation observes the debounce gate before consuming preparation
+### 7. Activation separates eligibility from transition start
 
-Current `SelectSong` silently returns when `_game.CanPerformStageTransition()` is false. Prepared activation cannot clear state first and then call that method because the API could report success while no transition started.
+Current `SelectSong` silently returns if `_game.CanPerformStageTransition()` is false. Prepared activation must observe this rather than reporting success after a no-op.
 
-Keep one shared transition path, but separate **eligibility** from **transition start** inside `SongSelectionStage`:
+Factor the existing method into one small eligibility gate and one shared start body, e.g.:
 
 ```text
 CanStartSongSelection(node)
-- valid Score node
-- StageManager available
-- _game.CanPerformStageTransition() == true
-
 StartSongSelection(node)
-- _game.MarkStageTransition()
-- build selectedSong / selectedDifficulty / songId shared data
-- StageManager.ChangeStage(SongTransition, ...)
 ```
 
-The existing player `SelectSong` path calls these two helpers and may ignore the returned bool.
+Eligibility checks:
+
+- valid Score node;
+- `StageManager` available;
+- `_game.CanPerformStageTransition()`.
+
+The start body remains the sole owner of:
+
+```text
+_game.MarkStageTransition()
+selectedSong / selectedDifficulty / songId
+StageManager.ChangeStage(StageType.SongTransition, ...)
+```
 
 `activatePreparedChart`:
 
-1. Require a current preparation.
-2. Require `_selectedSong` / `_currentDifficulty` still match it.
-3. Evaluate the same transition-eligibility gate.
-4. If debounce or stage-manager availability blocks the transition, return `success=false` and **leave the preparation and preview intact**.
-5. Once eligibility succeeds, stop/dispose the prepared preview and clear prepared state.
-6. Immediately call the shared transition-start body on the same update-thread action.
+1. Require the prepared row/difficulty still match current selection.
+2. Check the shared transition eligibility.
+3. If blocked, return `success=false` and leave prepared state/preview intact.
+4. If eligible, stop/dispose the preview and clear prepared state.
+5. Immediately execute the shared transition-start body on the same update-thread action.
+6. Return success only after the normal stage change has been invoked.
 
-Do not wait 0.5 seconds inside the game and do not duplicate the transition shared-data construction. A successful result means the normal `SongTransitionStage` change was actually started.
+Do not wait 0.5 seconds inside the game.
 
-### 8. Game API commands queue and await the update-thread result
+### 8. Result contract stays narrow and intentionally untyped
 
-Extend `IGameApi` / `GameApiImplementation` with four explicit methods. Keep the result contract narrow, for example:
+Use:
 
 ```text
 PreparedChartCommandResult
@@ -277,52 +258,38 @@ PreparedChartCommandResult
 - string? Error
 ```
 
-`GameApiImplementation` should use one private helper that:
+Do **not** add a cross-assembly error-code enum in HPA-510. The only planned consumer, HPA-503, treats any command failure as a failed recording run. Its activation occurs only after at least 10 seconds of prepared preview playback, far beyond the 0.5-second global transition debounce, so it has no required retry branch that needs to distinguish `TransitionBlocked` from fatal prepare errors.
 
-- creates a `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously`;
-- queues an action through `IGameContext.QueueMainThreadAction`;
-- inside the queued action, verifies the current stage is `SongSelectionStage` and executes the requested stage command;
-- completes the task with the command result.
+Keeping preparation intact on a blocked activation is local correctness and preserves diagnostics/manual retry capability; it is not a new recorder retry protocol. Add structured error codes only when a real caller needs programmatic recovery.
 
-The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not copy `ChangeStageAsync`'s fire-and-forget semantics and do not add a general main-thread dispatcher abstraction.
+### 9. Game API and JSON-RPC queue and await real results
 
-### 9. JSON-RPC stays explicit and authenticated
+Add four explicit `IGameApi` methods and one private `GameApiImplementation` queue helper:
 
-Add four cases/handlers to `JsonRpcServer`:
+- create `TaskCompletionSource` with asynchronous continuations;
+- queue through `IGameContext.QueueMainThreadAction`;
+- verify current stage is `SongSelectionStage` inside the queued action;
+- execute the stage command;
+- complete with its actual result.
+
+Do not copy `ChangeStageAsync`'s fire-and-forget semantics and do not create a generic dispatcher.
+
+`JsonRpcServer` adds only:
 
 ```text
-prepareVideoChart   params: { chartPath: string }
+prepareVideoChart { chartPath }
 startPreparedPreview
 activatePreparedChart
 cancelPreparedChart
 ```
 
-The existing server-level API-key check already protects them.
+Existing API-key authentication protects them. Domain failures return `{ success:false, error:"..." }` without a new JSON-RPC error taxonomy.
 
-Validate JSON shape in the server. Stage/domain failures may be returned as a normal command result (`success=false`, sanitized `error`) so callers receive useful failure text without adding a new JSON-RPC error taxonomy.
+`DTXMania.Automation.JsonRpcGameClient` adds four public wrappers over private `SendAsync`; `success=false` throws `InvalidOperationException` with the safe server message.
 
-Do not expose any method that accepts arbitrary stage/action names or mutation payloads.
+### 10. Telemetry keeps all three accepted fields
 
-### 10. Automation exposes the same four narrow operations
-
-Extend `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs` with public methods for the four commands. Reuse its private `SendAsync` transport and one small command-result parser.
-
-HPA-503 should be able to call:
-
-```text
-PrepareVideoChartAsync(path)
-StartPreparedPreviewAsync()
-ActivatePreparedChartAsync()
-CancelPreparedChartAsync()
-```
-
-without accessing generic JSON-RPC.
-
-A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message. In particular, a debounce-blocked activation is an observable failed command rather than a silent no-op.
-
-### 11. Telemetry adds only recorder-required fields and locks the wire names
-
-Extend `GameTelemetrySnapshot` with:
+Producer fields:
 
 ```text
 PreparedChartIdentity
@@ -330,7 +297,7 @@ PreparedPreviewState
 PreparedPreviewElapsedMs
 ```
 
-Because `JsonRpcServer` serializes DTOs with `JsonNamingPolicy.CamelCase`, the wire contract is exactly:
+Wire names are exactly:
 
 ```text
 preparedChartIdentity
@@ -338,94 +305,78 @@ preparedPreviewState
 preparedPreviewElapsedMs
 ```
 
-`SongSelectionStage.PopulateTelemetry` supplies the producer values from stage-owned prepared state.
+Identity policy remains exact-chart-specific and non-absolute:
 
-Identity policy:
+- `chart:<SongChart.Id>` when the resolved chart has a stable non-zero database ID;
+- otherwise a normalized root-relative chart path.
 
-- prefer `chart:<SongChart.Id>` when the indexed chart has a stable non-zero database ID;
-- otherwise use a root-relative normalized path, never the absolute song-root prefix.
+Do not use `GetStableSelectionIdentity`: it often returns `song:<id>` and therefore cannot identify which chart/difficulty inside a multi-chart row was prepared. Do not expose the absolute requested path; HPA-510 explicitly requires a stable database/chart identity or redacted root-relative path.
 
-Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with read-only accessors for those exact camelCase keys.
+Extend `GameStateSnapshot` with accessors for all three keys, and extend `AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` with non-default producer values and assertions for all three consumer accessors.
 
-The existing `DTXMania.E2E/AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` test **must** be extended with all three producer values and assertions against all three Automation accessors. This is a required producer/consumer contract gate, not an optional extra test.
+### 11. Validation uses the existing E2E harness, not a manual checklist
 
-Screenshot remains the render barrier: after prepare returns, HPA-503 calls the existing screenshot operation and successful image completion proves Song Select completed a Draw pass.
+Retain focused unit/contract tests, then add one live `Category=E2E` prepared-chart smoke using existing `E2EFixtureBuilder`, `E2EGameLaunch`, `JsonRpcGameClient`, and `Eventually`.
 
-## Failure Semantics
+Minimal fixture change: add a `#PREVIEW` line referencing the already-generated `autoplay-tone.wav`.
 
-Preparation fails without leaving active prepared state for:
+Live flow:
 
-- blank or non-absolute path;
+1. Launch the existing isolated fixture and enter Song Select.
+2. `prepareVideoChart(fixture.ChartPath)`.
+3. Take a screenshot as the render barrier.
+4. Wait past the normal automatic preview delay and assert prepared state remains `Prepared` with elapsed `0`.
+5. `startPreparedPreview()`.
+6. Poll until state is `Playing` and `PreparedPreviewElapsedMs >= 10_000`.
+7. `activatePreparedChart()`.
+8. Assert SongTransition is observed before Performance.
+
+This reuses the existing Windows E2E job; it does not add an E2E framework, fake OBS server, or recorder harness.
+
+## Failure semantics
+
+Preparation returns failure and leaves no prepared state for:
+
+- blank/non-absolute path;
 - library not ready;
-- path outside every active root;
-- no exact indexed chart match;
-- ambiguous indexed match;
-- no unique visible difficulty slot after the DRUMS tie-break and existing path-helper fallback;
+- path outside active roots;
+- unindexed path;
+- ambiguous node/chart match;
+- unresolved/ambiguous difficulty slot;
 - missing preview declaration/file;
-- unreadable or unsupported preview resource.
+- preview load failure.
 
-Start fails for no prepared chart/resource or playback creation failure.
+Start fails for missing preparation/resource or sound-instance/playback failure.
 
-Activation fails if preparation is absent, the prepared selection is no longer active, the stage manager is unavailable, or the global transition debounce is active. Debounce/stage-manager failure leaves the preparation intact for retry.
+Activation fails if preparation is absent, current row/difficulty no longer matches it, or transition eligibility is blocked. A blocked transition preserves the preparation.
 
-Cancellation is idempotent success.
+Cancel is idempotent success.
 
-Errors should describe the category without publishing an absolute path into telemetry/log snapshots intended for recorder diagnostics.
+## Risks and mitigations
 
-## Testing Strategy
+### Projection side effects — primary risk
 
-Add focused tests rather than a second end-to-end framework.
+Repeated `NavigateIntoBox -> PopulateSongList -> CurrentList` would repeatedly select row 0 and trigger preview/BGM side effects during prepare. Mitigate by using `RestoreNavigationPaths`, one `RefreshSongListForActiveTab`, one atomic `SetSelection`, and one suppression scope around the entire projection.
 
-### Song Select
+### Exact-chart vs row identity
 
-Cover:
+Existing row identity can collapse a multi-chart row to `song:<id>`. Keep resolver/telemetry identity tied to the resolved `SongChart` instead.
 
-- root-level exact path resolution;
-- nested BOX resolution and browse context;
-- multi-chart/SET row resolves the exact requested chart and correct difficulty slot;
-- ordinary one-file multi-instrument row where DRUMS/GUITAR/BASS slots share one ChartId resolves the unique DRUMS slot;
-- duplicate titles resolve by path;
-- outside-root and unindexed failures;
-- resolved chart preview is used even when it differs from the node's primary chart preview;
-- missing/unreadable/unsupported preview failure;
-- prepare leaves preview loaded but stopped and suppresses automatic timer playback;
-- prepare projection does not invalidate itself through `SelectionChanged`/`DifficultyChanged`;
-- repeated start creates only one instance;
-- elapsed time advances only while the instance reports Playing;
-- row navigation away clears prepared state and resumes normal row preview behavior;
-- difficulty navigation away clears prepared state and resumes the normal primary-chart delayed preview;
-- cancel, replacement, user navigation, and Deactivate clean up exactly once;
-- activation while debounce is blocked returns failure, starts no transition, and preserves prepared state/preview;
-- activation after the gate is available clears preview and reuses the existing transition data path;
-- normal interactive preview delay/loop/BGM behavior remains unchanged with no prepared chart.
+### Preview auto-start leakage
 
-### Game API / JSON-RPC
+`TryLoadPreviewSoundFile` activates the normal delay timer on successful load. Prepared load must explicitly clear `_isPreviewDelayActive` before returning success.
 
-Cover:
+### Activation no-op
 
-- command action is queued to the main thread and the returned task completes after execution;
-- command rejects non-SongSelect current stage;
-- `prepareVideoChart` parameter validation;
-- authenticated JSON-RPC routing and success/failure result shape;
-- debounce-blocked activation propagates `success=false` instead of returning a queued-success result.
+Global transition debounce currently fails silently in `SelectSong`. Surface the eligibility result before consuming preparation.
 
-### Automation contract
+## Expected scope
 
-Cover:
+Still one implementation PR, approximately 2–3 engineer days:
 
-- each new public client method sends the expected method/params;
-- command failure text is propagated;
-- `AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` includes `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs` and proves the Automation accessors read them.
+1. exact resolver + side-effect-free browse projection;
+2. prepared preview lifecycle + activation + telemetry;
+3. explicit Game API/JSON-RPC/Automation wiring + contract tests;
+4. focused regression tests + one existing-harness live E2E smoke.
 
-Use existing unit-test seams and mocks. No real MonoGame window, OBS server, or recorder CLI is required for HPA-510 unit coverage.
-
-## Expected Scope
-
-This remains one implementation PR, approximately 2–3 engineer days:
-
-- exact resolver + browse projection;
-- prepared preview lifecycle + navigation/debounce-safe activation + telemetry;
-- explicit Game API/JSON-RPC/Automation wiring;
-- focused regression/contract tests.
-
-If implementation starts producing a generic automation framework, recorder session object, or alternate Song Select data model, reduce scope back to the stage-owned four-command contract above.
+If implementation starts producing a session framework, database repository, generic mutation dispatcher, alternate navigation model, or separate preview abstraction, reduce scope back to the four-command stage-owned design.

--- a/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
+++ b/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
 **Date:** 2026-08-11  
-**Status:** Draft for implementation review
+**Status:** Revised after implementation review
 
 ## Context
 
@@ -24,14 +24,15 @@ This design deliberately keeps recording preparation inside `SongSelectionStage`
 ## Goals
 
 - Resolve one caller-supplied **absolute chart path** to the exact chart already present in the active Song Select library.
-- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, and duplicate titles.
+- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, ordinary single-file multi-instrument rows, and duplicate titles.
 - Project the resolved chart through the existing Song Select presentation path so status, preview image, play history, selected row, difficulty, and breadcrumb are normal UI state.
 - Load the preview declared by the **resolved chart**, not merely the node's primary chart.
 - Keep the prepared preview stopped until explicitly started.
 - Reuse the existing preview sound resource, volume, looping, and BGM fade behavior.
 - Keep all stage mutations on the game update thread.
-- Activate through the existing `SongSelectionStage.SelectSong` transition path.
+- Activate through the existing Song Select transition construction and report a real success/failure result when the global transition debounce rejects activation.
 - Expose only the prepared identity/state/elapsed telemetry required by HPA-503.
+- Lock the game-to-Automation telemetry contract to the existing camelCase JSON wire format.
 - Extend `DTXMania.Automation` with the four explicit client calls so HPA-503 never needs access to the private generic JSON-RPC transport.
 
 ## Non-goals
@@ -43,6 +44,7 @@ This design deliberately keeps recording preparation inside `SongSelectionStage`
 - OBS, process launch, app-data sandboxing, Result hold timing, or video artifact handling.
 - Changing the normal interactive preview delay or primary-chart preview behavior when no prepared chart is active.
 - Restoring a pre-command filter/tab/breadcrumb after cancellation. The recorder runs in disposable app data; snapshot/restore machinery is unnecessary for MVP.
+- Waiting inside the game for the stage-transition debounce window. A blocked activation returns `success=false`; the preparation remains available for a bounded caller retry.
 - Direct transition to Performance.
 
 ## Current Reuse Survey
@@ -52,15 +54,18 @@ The required building blocks already exist:
 - `SongSelectionStage` owns selection, BOX navigation, status/history/preview UI, preview sound lifecycle, BGM fading, and the player activation path.
 - `SongSelectionStage` already retains the coherent applied `SongLibrarySnapshot`, including `RootSongs` and canonical `ActiveRoots`.
 - `SongSelectionStage.GetNodeChartPaths` already understands that a visible row can represent the primary `DatabaseChart` plus additional `DatabaseSong.Charts`.
-- `SongPathIdentity` already owns path normalization and root containment semantics.
+- `SongPathIdentity` already owns path normalization and root-containment primitives.
 - `SongListNode.Scores` carries difficulty slots; persisted multi-chart rows carry `SongScore.ChartId`.
+- `SongListNode.CreateSongNode` can legitimately assign the same `SongChart.Id` to DRUMS, GUITAR, and BASS score slots for one physical DTX file, so `ChartId` alone is not always a unique slot identity.
 - `SongChartHelper.GetCurrentDifficultyChart` is the existing runtime fallback from a visible difficulty slot to its chart and is useful for legacy/SET rows where a direct `ChartId` match is unavailable.
 - `SongListDisplay` already owns row index, difficulty, selection events, scroll target, and normal Song Select presentation updates.
 - `SongSelectionStage.LoadPreviewSound` / `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` already implement the preview resource and playback behavior.
-- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API.
-- `JsonRpcServer` already authenticates every JSON-RPC request and has explicit method routing.
+- `SongSelectionStage.SelectSong` owns the normal transition data but silently returns while `_game.CanPerformStageTransition()` is false, so prepared activation must surface that gate rather than clearing state first.
+- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API. `BaseGame.CaptureScreenshotAsync` demonstrates the existing `TaskCompletionSource(...RunContinuationsAsynchronously)` pattern for an awaited game-thread result.
+- `JsonRpcServer` already authenticates every JSON-RPC request and serializes public DTOs with camelCase property names.
 - `GameTelemetrySnapshot` plus `IStageTelemetryProvider` is the existing producer telemetry seam.
-- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` now owns the consumer JSON-RPC transport and keeps `SendAsync` private.
+- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` owns the consumer JSON-RPC transport and keeps `SendAsync` private.
+- `DTXMania.E2E/AutomationContractTests.cs` already performs the producer-to-`GameStateSnapshot` camelCase contract round trip and is the required place to lock the three new telemetry fields.
 
 The design should extend these seams rather than create parallel infrastructure.
 
@@ -103,6 +108,7 @@ Keep only the additional runtime fields needed for preview control:
 ```text
 PreparedPreviewState: None | Prepared | Playing | Failed
 PreparedPreviewElapsedMs: double
+_isProjectingPreparedSelection: bool
 ```
 
 No lock is required for this state because every command mutation and elapsed-time update runs on the game update thread. Game telemetry reads the same fields through the existing stage telemetry provider.
@@ -111,9 +117,12 @@ A preparation is cleared by:
 
 - `cancelPreparedChart`;
 - preparing a replacement chart;
-- normal interactive row/difficulty navigation away from the prepared selection;
-- activation;
+- normal interactive row navigation away from the prepared row;
+- normal interactive difficulty navigation away from the prepared slot;
+- successful activation after the transition gate has accepted the request;
 - stage deactivation.
+
+`_isProjectingPreparedSelection` suppresses invalidation while `prepareVideoChart` itself projects the target row/difficulty. It also suppresses the normal automatic preview load during that projection; the exact resolved chart preview is loaded explicitly afterward.
 
 Cleanup remains idempotent. `StopCurrentPreview` already nulls disposed resources, so repeated cleanup must never stop/dispose one instance twice.
 
@@ -128,14 +137,17 @@ On the update thread:
 3. Require it to be under one of `snapshot.ActiveRoots`.
 4. Recursively walk `snapshot.RootSongs` and BOX children.
 5. For each Score node, inspect the node's primary `DatabaseChart` and every chart in `DatabaseSong.Charts`.
-6. Match by normalized path using current-platform path identity rules. Never use title/artist text.
+6. Match by normalized path using the existing platform path-identity semantics. Never use title/artist text.
 7. Require exactly one visible node/chart match.
-8. Resolve the visible difficulty slot:
-   - first match the resolved `SongChart.Id` against non-zero `SongListNode.Scores[i].ChartId`;
-   - when that is unavailable, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching its normalized `FilePath` to the requested path;
-   - fail rather than guess if no unique slot can be established.
+8. Resolve the visible difficulty slot using the following precedence:
+   - collect non-null score slots whose non-zero `SongScore.ChartId` equals the resolved `SongChart.Id`;
+   - if exactly one slot matches, use it;
+   - if multiple slots share that ChartId, use the **unique DRUMS slot** when exactly one candidate has `Instrument == EInstrumentPart.DRUMS`; this is the normal one-file multi-instrument case and matches CX's drum-gameplay path;
+   - if ChartId did not establish a slot, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching that chart's normalized `FilePath` to the requested path;
+   - use the fallback only when it yields one slot; fail rather than guess if ambiguity remains.
+9. Retain the ancestor BOX chain needed to reproduce the normal browse context.
 
-The recursive walk should also retain the ancestor BOX chain needed to reproduce the normal browse context.
+The DRUMS tie-break is required because one physical DTX file can legitimately populate DRUMS/GUITAR/BASS slots with the same `SongChart.Id`. Requiring ChartId uniqueness would reject normal indexed content.
 
 This handles duplicate titles naturally because title never participates in identity. It also reuses the current SET/multi-chart mapping instead of introducing a second difficulty-order algorithm.
 
@@ -160,7 +172,7 @@ It should atomically set row + difficulty, reset the scroll target consistently,
 
 This is an internal UI convenience, not a remote navigation API.
 
-During the synchronous prepare projection, set a stage-local suppression flag so normal `OnSongSelectionChanged` presentation still runs but automatic preview loading/playback is skipped. After the target selection is established, load the resolved chart's preview explicitly.
+During prepare projection, `_isProjectingPreparedSelection` lets normal status/history/image/breadcrumb presentation update while skipping prepared-state invalidation and automatic preview loading. The flag is cleared in `finally` so a projection failure cannot leave normal Song Select behavior suppressed.
 
 ### 4. Prepared preview uses the resolved `SongChart`
 
@@ -207,26 +219,55 @@ In `SongSelectionStage.OnUpdate`, increment `PreparedPreviewElapsedMs` from `Gam
 
 If an explicitly-started instance unexpectedly stops, mark the prepared preview `Failed` rather than silently starting another source. HPA-503 will observe the state/elapsed telemetry and fail its bounded wait.
 
-### 6. Cancellation and activation reuse existing cleanup/transition paths
+### 6. Navigation invalidation returns cleanly to interactive preview behavior
 
-`cancelPreparedChart`:
+Prepared state must not survive when the visible selection no longer represents the prepared chart.
 
-- stops/disposes the current preview through existing cleanup;
-- releases the preview sound reference;
-- clears prepared identity/state/elapsed;
-- allows the normal Song Select BGM fade-in behavior to resume.
+`OnSongSelectionChanged`:
+
+- while `_isProjectingPreparedSelection` is true, do not invalidate preparation and skip its normal automatic preview load;
+- otherwise, when the selected row differs from the prepared row, clear the prepared state first, then continue the handler's existing row-selection behavior; the normal `LoadPreviewSound(e.SelectedSong)` path therefore resumes the ordinary delayed primary-chart preview.
+
+`OnDifficultyChanged`:
+
+- while `_isProjectingPreparedSelection` is true, do not invalidate preparation;
+- otherwise, when `e.NewDifficulty` differs from the prepared slot on the same row, clear the prepared state;
+- after clearing, explicitly call the existing `LoadPreviewSound(e.Song)` path so the row returns to the same primary-chart delayed preview behavior normal Song Select uses after a row selection.
+
+The difficulty-change reload is only an exit from prepared mode. Normal interactive difficulty changes when no prepared chart exists remain unchanged.
+
+### 7. Activation observes the debounce gate before consuming preparation
+
+Current `SelectSong` silently returns when `_game.CanPerformStageTransition()` is false. Prepared activation cannot clear state first and then call that method because the API could report success while no transition started.
+
+Keep one shared transition path, but separate **eligibility** from **transition start** inside `SongSelectionStage`:
+
+```text
+CanStartSongSelection(node)
+- valid Score node
+- StageManager available
+- _game.CanPerformStageTransition() == true
+
+StartSongSelection(node)
+- _game.MarkStageTransition()
+- build selectedSong / selectedDifficulty / songId shared data
+- StageManager.ChangeStage(SongTransition, ...)
+```
+
+The existing player `SelectSong` path calls these two helpers and may ignore the returned bool.
 
 `activatePreparedChart`:
 
 1. Require a current preparation.
-2. Capture the prepared node/difficulty locally.
-3. Stop/dispose the prepared preview and clear prepared state before transition audio can bleed.
-4. Ensure `_selectedSong` / `_currentDifficulty` still match the prepared selection.
-5. Call the existing `SelectSong(node)` method.
+2. Require `_selectedSong` / `_currentDifficulty` still match it.
+3. Evaluate the same transition-eligibility gate.
+4. If debounce or stage-manager availability blocks the transition, return `success=false` and **leave the preparation and preview intact**.
+5. Once eligibility succeeds, stop/dispose the prepared preview and clear prepared state.
+6. Immediately call the shared transition-start body on the same update-thread action.
 
-Do not reproduce its shared-data construction. The existing path remains the sole owner of `selectedSong`, `selectedDifficulty`, `songId`, and the transition to `SongTransitionStage`.
+Do not wait 0.5 seconds inside the game and do not duplicate the transition shared-data construction. A successful result means the normal `SongTransitionStage` change was actually started.
 
-### 7. Game API commands queue and await the update-thread result
+### 8. Game API commands queue and await the update-thread result
 
 Extend `IGameApi` / `GameApiImplementation` with four explicit methods. Keep the result contract narrow, for example:
 
@@ -238,14 +279,14 @@ PreparedChartCommandResult
 
 `GameApiImplementation` should use one private helper that:
 
-- creates a `TaskCompletionSource` with asynchronous continuations;
+- creates a `TaskCompletionSource` with `TaskCreationOptions.RunContinuationsAsynchronously`;
 - queues an action through `IGameContext.QueueMainThreadAction`;
 - inside the queued action, verifies the current stage is `SongSelectionStage` and executes the requested stage command;
 - completes the task with the command result.
 
-The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not add a general main-thread dispatcher abstraction.
+The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not copy `ChangeStageAsync`'s fire-and-forget semantics and do not add a general main-thread dispatcher abstraction.
 
-### 8. JSON-RPC stays explicit and authenticated
+### 9. JSON-RPC stays explicit and authenticated
 
 Add four cases/handlers to `JsonRpcServer`:
 
@@ -262,7 +303,7 @@ Validate JSON shape in the server. Stage/domain failures may be returned as a no
 
 Do not expose any method that accepts arbitrary stage/action names or mutation payloads.
 
-### 9. Automation exposes the same four narrow operations
+### 10. Automation exposes the same four narrow operations
 
 Extend `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs` with public methods for the four commands. Reuse its private `SendAsync` transport and one small command-result parser.
 
@@ -277,9 +318,9 @@ CancelPreparedChartAsync()
 
 without accessing generic JSON-RPC.
 
-A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message.
+A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message. In particular, a debounce-blocked activation is an observable failed command rather than a silent no-op.
 
-### 10. Telemetry adds only recorder-required fields
+### 11. Telemetry adds only recorder-required fields and locks the wire names
 
 Extend `GameTelemetrySnapshot` with:
 
@@ -289,14 +330,24 @@ PreparedPreviewState
 PreparedPreviewElapsedMs
 ```
 
-`SongSelectionStage.PopulateTelemetry` supplies them only from stage-owned prepared state.
+Because `JsonRpcServer` serializes DTOs with `JsonNamingPolicy.CamelCase`, the wire contract is exactly:
+
+```text
+preparedChartIdentity
+preparedPreviewState
+preparedPreviewElapsedMs
+```
+
+`SongSelectionStage.PopulateTelemetry` supplies the producer values from stage-owned prepared state.
 
 Identity policy:
 
 - prefer `chart:<SongChart.Id>` when the indexed chart has a stable non-zero database ID;
 - otherwise use a root-relative normalized path, never the absolute song-root prefix.
 
-Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with corresponding read-only accessors. Do not expose the absolute requested path in telemetry.
+Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with read-only accessors for those exact camelCase keys.
+
+The existing `DTXMania.E2E/AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` test **must** be extended with all three producer values and assertions against all three Automation accessors. This is a required producer/consumer contract gate, not an optional extra test.
 
 Screenshot remains the render barrier: after prepare returns, HPA-503 calls the existing screenshot operation and successful image completion proves Song Select completed a Draw pass.
 
@@ -309,13 +360,13 @@ Preparation fails without leaving active prepared state for:
 - path outside every active root;
 - no exact indexed chart match;
 - ambiguous indexed match;
-- no unique visible difficulty slot;
+- no unique visible difficulty slot after the DRUMS tie-break and existing path-helper fallback;
 - missing preview declaration/file;
 - unreadable or unsupported preview resource.
 
 Start fails for no prepared chart/resource or playback creation failure.
 
-Activation fails if preparation is absent or the prepared selection is no longer the active Song Select selection.
+Activation fails if preparation is absent, the prepared selection is no longer active, the stage manager is unavailable, or the global transition debounce is active. Debounce/stage-manager failure leaves the preparation intact for retry.
 
 Cancellation is idempotent success.
 
@@ -332,15 +383,20 @@ Cover:
 - root-level exact path resolution;
 - nested BOX resolution and browse context;
 - multi-chart/SET row resolves the exact requested chart and correct difficulty slot;
+- ordinary one-file multi-instrument row where DRUMS/GUITAR/BASS slots share one ChartId resolves the unique DRUMS slot;
 - duplicate titles resolve by path;
 - outside-root and unindexed failures;
 - resolved chart preview is used even when it differs from the node's primary chart preview;
 - missing/unreadable/unsupported preview failure;
 - prepare leaves preview loaded but stopped and suppresses automatic timer playback;
+- prepare projection does not invalidate itself through `SelectionChanged`/`DifficultyChanged`;
 - repeated start creates only one instance;
 - elapsed time advances only while the instance reports Playing;
+- row navigation away clears prepared state and resumes normal row preview behavior;
+- difficulty navigation away clears prepared state and resumes the normal primary-chart delayed preview;
 - cancel, replacement, user navigation, and Deactivate clean up exactly once;
-- activation stops preview before reusing `SelectSong`;
+- activation while debounce is blocked returns failure, starts no transition, and preserves prepared state/preview;
+- activation after the gate is available clears preview and reuses the existing transition data path;
 - normal interactive preview delay/loop/BGM behavior remains unchanged with no prepared chart.
 
 ### Game API / JSON-RPC
@@ -350,7 +406,8 @@ Cover:
 - command action is queued to the main thread and the returned task completes after execution;
 - command rejects non-SongSelect current stage;
 - `prepareVideoChart` parameter validation;
-- authenticated JSON-RPC routing and success/failure result shape.
+- authenticated JSON-RPC routing and success/failure result shape;
+- debounce-blocked activation propagates `success=false` instead of returning a queued-success result.
 
 ### Automation contract
 
@@ -358,16 +415,16 @@ Cover:
 
 - each new public client method sends the expected method/params;
 - command failure text is propagated;
-- prepared telemetry accessors deserialize from game JSON.
+- `AutomationContractTests.GameTelemetrySnapshot_CamelCaseRoundTrip_ShouldExposeAllConsumedFields` includes `preparedChartIdentity`, `preparedPreviewState`, and `preparedPreviewElapsedMs` and proves the Automation accessors read them.
 
 Use existing unit-test seams and mocks. No real MonoGame window, OBS server, or recorder CLI is required for HPA-510 unit coverage.
 
 ## Expected Scope
 
-This should remain one implementation PR, approximately 2–3 engineer days:
+This remains one implementation PR, approximately 2–3 engineer days:
 
 - exact resolver + browse projection;
-- prepared preview lifecycle + telemetry;
+- prepared preview lifecycle + navigation/debounce-safe activation + telemetry;
 - explicit Game API/JSON-RPC/Automation wiring;
 - focused regression/contract tests.
 

--- a/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
+++ b/docs/superpowers/specs/2026-08-11-hpa-510-prepared-chart-recording-design.md
@@ -1,0 +1,374 @@
+# HPA-510 Prepared Chart Recording Commands Design
+
+**Issue:** [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select)  
+**Date:** 2026-08-11  
+**Status:** Draft for implementation review
+
+## Context
+
+HPA-501 has landed on `main`, so the reusable `DTXMania.Automation` process and JSON-RPC foundation is available. HPA-510 is now the only code prerequisite blocking HPA-503, the Windows recording vertical slice.
+
+The recorder does not need general remote control of the game. It needs four narrow operations while Song Select is active:
+
+```text
+prepareVideoChart(chartPath)
+startPreparedPreview()
+activatePreparedChart()
+cancelPreparedChart()
+```
+
+The implementation should make one exact indexed chart visible through the normal Song Select UI, hold its declared preview audio ready but stopped, play that preview under explicit recorder control, and then activate the chart through the same path a player uses.
+
+This design deliberately keeps recording preparation inside `SongSelectionStage`. It does not add a game-wide capture session, generic mutation API, recorder state machine, database query layer, or synthetic input navigation.
+
+## Goals
+
+- Resolve one caller-supplied **absolute chart path** to the exact chart already present in the active Song Select library.
+- Support root-level charts, nested BOX hierarchy, multi-chart/SET-defined rows, and duplicate titles.
+- Project the resolved chart through the existing Song Select presentation path so status, preview image, play history, selected row, difficulty, and breadcrumb are normal UI state.
+- Load the preview declared by the **resolved chart**, not merely the node's primary chart.
+- Keep the prepared preview stopped until explicitly started.
+- Reuse the existing preview sound resource, volume, looping, and BGM fade behavior.
+- Keep all stage mutations on the game update thread.
+- Activate through the existing `SongSelectionStage.SelectSong` transition path.
+- Expose only the prepared identity/state/elapsed telemetry required by HPA-503.
+- Extend `DTXMania.Automation` with the four explicit client calls so HPA-503 never needs access to the private generic JSON-RPC transport.
+
+## Non-goals
+
+- A general Song Select remote-navigation API.
+- A generic command dispatcher or arbitrary main-thread mutation endpoint.
+- A game-wide recording/capture coordinator or immutable recording session ID.
+- A separate render-generation/readiness state machine. Screenshot completion remains the presentation barrier.
+- OBS, process launch, app-data sandboxing, Result hold timing, or video artifact handling.
+- Changing the normal interactive preview delay or primary-chart preview behavior when no prepared chart is active.
+- Restoring a pre-command filter/tab/breadcrumb after cancellation. The recorder runs in disposable app data; snapshot/restore machinery is unnecessary for MVP.
+- Direct transition to Performance.
+
+## Current Reuse Survey
+
+The required building blocks already exist:
+
+- `SongSelectionStage` owns selection, BOX navigation, status/history/preview UI, preview sound lifecycle, BGM fading, and the player activation path.
+- `SongSelectionStage` already retains the coherent applied `SongLibrarySnapshot`, including `RootSongs` and canonical `ActiveRoots`.
+- `SongSelectionStage.GetNodeChartPaths` already understands that a visible row can represent the primary `DatabaseChart` plus additional `DatabaseSong.Charts`.
+- `SongPathIdentity` already owns path normalization and root containment semantics.
+- `SongListNode.Scores` carries difficulty slots; persisted multi-chart rows carry `SongScore.ChartId`.
+- `SongChartHelper.GetCurrentDifficultyChart` is the existing runtime fallback from a visible difficulty slot to its chart and is useful for legacy/SET rows where a direct `ChartId` match is unavailable.
+- `SongListDisplay` already owns row index, difficulty, selection events, scroll target, and normal Song Select presentation updates.
+- `SongSelectionStage.LoadPreviewSound` / `TryLoadPreviewSoundFile`, `CreatePreviewSoundInstance`, `StopCurrentPreview`, and `StartBGMFade` already implement the preview resource and playback behavior.
+- `IGameContext.QueueMainThreadAction` is the existing mutation seam used by the Game API.
+- `JsonRpcServer` already authenticates every JSON-RPC request and has explicit method routing.
+- `GameTelemetrySnapshot` plus `IStageTelemetryProvider` is the existing producer telemetry seam.
+- `DTXMania.Automation.JsonRpc.JsonRpcGameClient` now owns the consumer JSON-RPC transport and keeps `SendAsync` private.
+
+The design should extend these seams rather than create parallel infrastructure.
+
+## Approaches Considered
+
+### 1. Stage-owned prepared state plus four explicit commands — selected
+
+Add a small amount of state and four command methods to `SongSelectionStage`, expose them through explicit Game API / JSON-RPC handlers, and add matching methods to `DTXMania.Automation`.
+
+This gives HPA-503 exactly what it needs while preserving the normal Song Select and transition paths.
+
+### 2. Recorder drives Song Select with repeated key input — rejected
+
+This is already the failure mode HPA-510 exists to remove. It is slow, fragile with nested boxes/filter state, and cannot safely disambiguate duplicate titles.
+
+### 3. Add a general game automation/session coordinator — rejected
+
+HPA-503 owns orchestration. A second lifecycle/session abstraction inside the game would duplicate ownership before a second use case proves it useful.
+
+### 4. Resolve chart paths through a new database repository/service — rejected
+
+The active `SongLibrarySnapshot` is already the authoritative, coherent view used by Song Select. A second DB query path could disagree with the rendered hierarchy and would add unnecessary synchronization.
+
+## Chosen Architecture
+
+### 1. Prepared state is update-thread-owned by `SongSelectionStage`
+
+Keep a minimal stage-local record for the current preparation, for example:
+
+```text
+PreparedChartSelection
+- SongListNode node
+- SongChart chart
+- int difficultyIndex
+- string telemetryIdentity
+```
+
+Keep only the additional runtime fields needed for preview control:
+
+```text
+PreparedPreviewState: None | Prepared | Playing | Failed
+PreparedPreviewElapsedMs: double
+```
+
+No lock is required for this state because every command mutation and elapsed-time update runs on the game update thread. Game telemetry reads the same fields through the existing stage telemetry provider.
+
+A preparation is cleared by:
+
+- `cancelPreparedChart`;
+- preparing a replacement chart;
+- normal interactive row/difficulty navigation away from the prepared selection;
+- activation;
+- stage deactivation.
+
+Cleanup remains idempotent. `StopCurrentPreview` already nulls disposed resources, so repeated cleanup must never stop/dispose one instance twice.
+
+### 2. Exact chart resolution uses the applied library snapshot
+
+`prepareVideoChart` accepts only a non-empty, fully-qualified path.
+
+On the update thread:
+
+1. Require Song Select to have an applied `SongLibrarySnapshot`.
+2. Normalize the requested chart path with `SongPathIdentity`.
+3. Require it to be under one of `snapshot.ActiveRoots`.
+4. Recursively walk `snapshot.RootSongs` and BOX children.
+5. For each Score node, inspect the node's primary `DatabaseChart` and every chart in `DatabaseSong.Charts`.
+6. Match by normalized path using current-platform path identity rules. Never use title/artist text.
+7. Require exactly one visible node/chart match.
+8. Resolve the visible difficulty slot:
+   - first match the resolved `SongChart.Id` against non-zero `SongListNode.Scores[i].ChartId`;
+   - when that is unavailable, scan valid score slots and reuse `SongChartHelper.GetCurrentDifficultyChart(node, i)`, matching its normalized `FilePath` to the requested path;
+   - fail rather than guess if no unique slot can be established.
+
+The recursive walk should also retain the ancestor BOX chain needed to reproduce the normal browse context.
+
+This handles duplicate titles naturally because title never participates in identity. It also reuses the current SET/multi-chart mapping instead of introducing a second difficulty-order algorithm.
+
+### 3. Reuse normal browse navigation, but do not synthesize input
+
+Preparation must leave Song Select in a normal browse context with the target row visible.
+
+Use existing stage behavior:
+
+1. Switch to the All Songs projection and clear the active search/filter projection for this recorder operation.
+2. Return to the root browse list and clear the navigation stack.
+3. Reuse `NavigateIntoBox` for each resolved ancestor BOX so the normal breadcrumb/current-list state is rebuilt.
+4. Select the target row and difficulty through `SongListDisplay`.
+
+Add one narrow programmatic selection method to `SongListDisplay`, such as:
+
+```text
+SetSelection(index, difficulty)
+```
+
+It should atomically set row + difficulty, reset the scroll target consistently, and raise the existing `SelectionChanged` path once. This avoids the current property-order problem where `CurrentList` can temporarily select row 0 and load the wrong preview before the final index is applied.
+
+This is an internal UI convenience, not a remote navigation API.
+
+During the synchronous prepare projection, set a stage-local suppression flag so normal `OnSongSelectionChanged` presentation still runs but automatic preview loading/playback is skipped. After the target selection is established, load the resolved chart's preview explicitly.
+
+### 4. Prepared preview uses the resolved `SongChart`
+
+This is the one place where blindly reusing current interactive preview loading is incorrect: `LoadPreviewSound(SongListNode)` reads `selectedNode.DatabaseChart`, which is the row's primary chart and may not be the chart selected by the recorder.
+
+Extract/reuse the existing path/load primitives so prepared loading can accept the exact resolved `SongChart`:
+
+```text
+SongChart.FilePath directory
++ SongChart.PreviewFile
+-> absolute preview path
+-> existing TryLoadPreviewSoundFile
+```
+
+Prepare fails clearly when:
+
+- `PreviewFile` is absent;
+- the resolved preview file does not exist;
+- the resource manager reports a load failure or unsupported asset.
+
+After successful load:
+
+- `_previewSound` is retained exactly as today;
+- automatic preview delay is disabled while a prepared chart exists;
+- no preview instance is created;
+- preview state becomes `Prepared`;
+- elapsed time is zero.
+
+Normal interactive preview behavior remains unchanged when no preparation exists.
+
+### 5. Explicit start owns exactly one looped preview instance
+
+`startPreparedPreview` requires a prepared chart and loaded preview resource.
+
+Reuse `CreatePreviewSoundInstance`, `SongSelectionUILayout.Audio.PreviewSoundVolume`, looping, `Play()`, and `StartBGMFade(true)`.
+
+Behavior:
+
+- first successful start creates one instance, sets volume/looping, plays, resets elapsed to zero, and reports `Playing`;
+- a repeated start while already playing is idempotent success and does not create another instance;
+- creation/playback failure disposes any partial instance, reports `Failed`, and never substitutes Song Select BGM or full-song audio.
+
+In `SongSelectionStage.OnUpdate`, increment `PreparedPreviewElapsedMs` from `GameTime.ElapsedGameTime` only when prepared state is `Playing` **and** the sound instance currently reports `SoundState.Playing`.
+
+If an explicitly-started instance unexpectedly stops, mark the prepared preview `Failed` rather than silently starting another source. HPA-503 will observe the state/elapsed telemetry and fail its bounded wait.
+
+### 6. Cancellation and activation reuse existing cleanup/transition paths
+
+`cancelPreparedChart`:
+
+- stops/disposes the current preview through existing cleanup;
+- releases the preview sound reference;
+- clears prepared identity/state/elapsed;
+- allows the normal Song Select BGM fade-in behavior to resume.
+
+`activatePreparedChart`:
+
+1. Require a current preparation.
+2. Capture the prepared node/difficulty locally.
+3. Stop/dispose the prepared preview and clear prepared state before transition audio can bleed.
+4. Ensure `_selectedSong` / `_currentDifficulty` still match the prepared selection.
+5. Call the existing `SelectSong(node)` method.
+
+Do not reproduce its shared-data construction. The existing path remains the sole owner of `selectedSong`, `selectedDifficulty`, `songId`, and the transition to `SongTransitionStage`.
+
+### 7. Game API commands queue and await the update-thread result
+
+Extend `IGameApi` / `GameApiImplementation` with four explicit methods. Keep the result contract narrow, for example:
+
+```text
+PreparedChartCommandResult
+- bool Success
+- string? Error
+```
+
+`GameApiImplementation` should use one private helper that:
+
+- creates a `TaskCompletionSource` with asynchronous continuations;
+- queues an action through `IGameContext.QueueMainThreadAction`;
+- inside the queued action, verifies the current stage is `SongSelectionStage` and executes the requested stage command;
+- completes the task with the command result.
+
+The caller therefore receives the actual prepare/start/cancel/activate result, not merely "action queued". Do not add a general main-thread dispatcher abstraction.
+
+### 8. JSON-RPC stays explicit and authenticated
+
+Add four cases/handlers to `JsonRpcServer`:
+
+```text
+prepareVideoChart   params: { chartPath: string }
+startPreparedPreview
+activatePreparedChart
+cancelPreparedChart
+```
+
+The existing server-level API-key check already protects them.
+
+Validate JSON shape in the server. Stage/domain failures may be returned as a normal command result (`success=false`, sanitized `error`) so callers receive useful failure text without adding a new JSON-RPC error taxonomy.
+
+Do not expose any method that accepts arbitrary stage/action names or mutation payloads.
+
+### 9. Automation exposes the same four narrow operations
+
+Extend `DTXMania.Automation/JsonRpc/JsonRpcGameClient.cs` with public methods for the four commands. Reuse its private `SendAsync` transport and one small command-result parser.
+
+HPA-503 should be able to call:
+
+```text
+PrepareVideoChartAsync(path)
+StartPreparedPreviewAsync()
+ActivatePreparedChartAsync()
+CancelPreparedChartAsync()
+```
+
+without accessing generic JSON-RPC.
+
+A `success=false` result becomes a clear `InvalidOperationException` containing the server-provided safe error message.
+
+### 10. Telemetry adds only recorder-required fields
+
+Extend `GameTelemetrySnapshot` with:
+
+```text
+PreparedChartIdentity
+PreparedPreviewState
+PreparedPreviewElapsedMs
+```
+
+`SongSelectionStage.PopulateTelemetry` supplies them only from stage-owned prepared state.
+
+Identity policy:
+
+- prefer `chart:<SongChart.Id>` when the indexed chart has a stable non-zero database ID;
+- otherwise use a root-relative normalized path, never the absolute song-root prefix.
+
+Extend `DTXMania.Automation.Telemetry.GameStateSnapshot` with corresponding read-only accessors. Do not expose the absolute requested path in telemetry.
+
+Screenshot remains the render barrier: after prepare returns, HPA-503 calls the existing screenshot operation and successful image completion proves Song Select completed a Draw pass.
+
+## Failure Semantics
+
+Preparation fails without leaving active prepared state for:
+
+- blank or non-absolute path;
+- library not ready;
+- path outside every active root;
+- no exact indexed chart match;
+- ambiguous indexed match;
+- no unique visible difficulty slot;
+- missing preview declaration/file;
+- unreadable or unsupported preview resource.
+
+Start fails for no prepared chart/resource or playback creation failure.
+
+Activation fails if preparation is absent or the prepared selection is no longer the active Song Select selection.
+
+Cancellation is idempotent success.
+
+Errors should describe the category without publishing an absolute path into telemetry/log snapshots intended for recorder diagnostics.
+
+## Testing Strategy
+
+Add focused tests rather than a second end-to-end framework.
+
+### Song Select
+
+Cover:
+
+- root-level exact path resolution;
+- nested BOX resolution and browse context;
+- multi-chart/SET row resolves the exact requested chart and correct difficulty slot;
+- duplicate titles resolve by path;
+- outside-root and unindexed failures;
+- resolved chart preview is used even when it differs from the node's primary chart preview;
+- missing/unreadable/unsupported preview failure;
+- prepare leaves preview loaded but stopped and suppresses automatic timer playback;
+- repeated start creates only one instance;
+- elapsed time advances only while the instance reports Playing;
+- cancel, replacement, user navigation, and Deactivate clean up exactly once;
+- activation stops preview before reusing `SelectSong`;
+- normal interactive preview delay/loop/BGM behavior remains unchanged with no prepared chart.
+
+### Game API / JSON-RPC
+
+Cover:
+
+- command action is queued to the main thread and the returned task completes after execution;
+- command rejects non-SongSelect current stage;
+- `prepareVideoChart` parameter validation;
+- authenticated JSON-RPC routing and success/failure result shape.
+
+### Automation contract
+
+Cover:
+
+- each new public client method sends the expected method/params;
+- command failure text is propagated;
+- prepared telemetry accessors deserialize from game JSON.
+
+Use existing unit-test seams and mocks. No real MonoGame window, OBS server, or recorder CLI is required for HPA-510 unit coverage.
+
+## Expected Scope
+
+This should remain one implementation PR, approximately 2–3 engineer days:
+
+- exact resolver + browse projection;
+- prepared preview lifecycle + telemetry;
+- explicit Game API/JSON-RPC/Automation wiring;
+- focused regression/contract tests.
+
+If implementation starts producing a generic automation framework, recorder session object, or alternate Song Select data model, reduce scope back to the stage-owned four-command contract above.


### PR DESCRIPTION
## Summary

Implements [HPA-510](https://linear.app/cwchanap/issue/HPA-510/add-minimal-prepared-chart-recording-commands-in-song-select) in one PR.

- Adds four authenticated, update-thread-owned prepared-chart commands: prepare, start preview, activate, cancel.
- Resolves exact active-library charts by normalized path, projects Song Select once, and preserves normal navigation/preview behavior.
- Loads the exact chart preview stopped, measures actual playing time, safely handles cancellation, transition races, and teardown.
- Extends the existing Automation client and telemetry contract with prepared chart identity/state/elapsed fields.
- Adds fixture preview audio and an existing-harness live prepared-chart E2E smoke.
- Includes the reviewed HPA-510 design and implementation plan.

## Validation

Fresh verification on the final head:

- `DTXMania.Test.Mac.csproj`: 8,208 passed, 0 warnings
- `DTXMania.Automation.Tests`: 64 passed, 0 warnings
- E2E support: 16 passed, 0 warnings
- Live macOS prepared-chart E2E: passed (prepare → screenshot → stopped state → 10s playback → SongTransition → Performance)

Windows-native CI remains the authoritative cross-platform acceptance signal.

## Scope

No recorder session/state machine, generic mutation endpoint, database query layer, fake OBS service, or second E2E harness was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a prepared-chart workflow to load a chart, preview it on demand, cancel it, or activate it for gameplay.
  - Added automation commands with validation, cancellation, authentication, and clear error reporting.
  - Added telemetry for chart identity, preview state, and elapsed preview time.
  - Added end-to-end support for preview-to-gameplay transitions.

- **Bug Fixes**
  - Improved preview cleanup and selection synchronization during chart and difficulty changes.
  - Preserved existing previews when commands are invalid or have no effect.
  - Prevented unauthorized or invalid commands from affecting gameplay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->