### PR TITLE
fix: stabilize Windows fullscreen and drum mapping

### DIFF
--- a/DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs
+++ b/DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs
@@ -366,46 +366,18 @@ public sealed class GameProcessDriverTests
         var lateHealthProbe = new TaskCompletionSource<GameHealthSnapshot?>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var startup = process.WaitForStartupAsync(
-            _ => lateHealthProbe.Task,
+            probeCancellation =>
+            {
+                probeCancellation.Register(() =>
+                    lateHealthProbe.TrySetResult(
+                        new(process.ProcessId, options.LaunchToken)));
+                return lateHealthProbe.Task;
+            },
             TimeSpan.FromMilliseconds(100),
             TimeSpan.FromMilliseconds(10),
             CancellationToken.None);
-        var lateHealthCompletion = Task.Run(async () =>
-        {
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
-            lateHealthProbe.TrySetResult(new(process.ProcessId, options.LaunchToken));
-        });
-        var completionGuard = Task.Delay(TimeSpan.FromMilliseconds(500));
 
-        try
-        {
-            var completedLateHealth = await Task.WhenAny(lateHealthCompletion, completionGuard);
-            Assert.Same(lateHealthCompletion, completedLateHealth);
-
-            var completedStartup = await Task.WhenAny(startup, completionGuard);
-            Assert.Same(startup, completedStartup);
-            await Assert.ThrowsAsync<TimeoutException>(() => startup);
-        }
-        finally
-        {
-            lateHealthProbe.TrySetResult(null);
-            try
-            {
-                await lateHealthCompletion;
-            }
-            catch (Exception)
-            {
-                // The assertion above owns the expected scheduled completion.
-            }
-            try
-            {
-                await startup;
-            }
-            catch (Exception)
-            {
-                // The assertion above owns the expected startup result.
-            }
-        }
+        await Assert.ThrowsAsync<TimeoutException>(() => startup);
     }
 
     private static GameProcessStartOptions CreateOptions(

--- a/DTXMania.E2E/DrumMappingStageSmokeTests.cs
+++ b/DTXMania.E2E/DrumMappingStageSmokeTests.cs
@@ -16,8 +16,9 @@ namespace DTXMania.E2E;
 [Trait("Category", "E2E")]
 public sealed class DrumMappingStageSmokeTests
 {
-    // Lane 0 (Splash/Crash) defaults to "Key.A"; we append "Key.Z", a key not otherwise bound
+    // Authored visual zone 0 is the Hi-Hat (lane 5). We append "Key.Z", a key not otherwise bound
     // and not reserved for navigation, so the capture is accepted (append model).
+    private const int DefaultFocusedLane = 5;
     private const string BindKey = "Z";
     private const string ExpectedBindingId = "Key.Z";
 
@@ -54,12 +55,12 @@ public sealed class DrumMappingStageSmokeTests
             // the fade transition + OnActivate (popup/focus/skip-flag init) before we send input.
             await Task.Delay(500, cancellation.Token);
 
-            // Activate the focused lane (lane 0) to open its capture popup.
+            // Activate authored visual zone 0 (Hi-Hat / lane 5) to open its capture popup.
             await client.SendKeyAsync("Enter", TimeSpan.FromMilliseconds(50), cancellation.Token);
             // Let the popup open and the one-frame capture-skip clear before sending the bind key.
             await Task.Delay(700, cancellation.Token);
 
-            // Hit the key to bind — captured and appended to lane 0.
+            // Hit the key to bind — captured and appended to the focused lane.
             await client.SendKeyAsync(BindKey, TimeSpan.FromMilliseconds(50), cancellation.Token);
             // Let the capture register before closing the popup.
             await Task.Delay(700, cancellation.Token);
@@ -83,7 +84,7 @@ public sealed class DrumMappingStageSmokeTests
 
             // [KeyBindings] serializes entries as "<buttonId>=<lane>"; assert the lane too so an
             // unbound-button entry that merely contains the id can't pass.
-            Assert.Contains($"{ExpectedBindingId}=0", configText);
+            Assert.Contains($"{ExpectedBindingId}={DefaultFocusedLane}", configText);
         }
         catch (Exception ex)
         {
@@ -101,10 +102,10 @@ public sealed class DrumMappingStageSmokeTests
 
     /// <summary>
     /// Black-box smoke for the keyboard-reachable Reset-to-defaults flow on the drum-mapping
-    /// stage: bind a non-default key to lane 0, advance keyboard focus onto the Reset action,
-    /// Activate to reset Config back to defaults (live-applied), then Back (= flush &amp; exit)
-    /// and assert the custom binding was NOT persisted (i.e. Reset overwrote it before the
-    /// flush). Exercises the live focus + Activate-dispatch + reset + flush round-trip the
+    /// stage: bind a non-default key to the default focused zone, advance keyboard focus onto the
+    /// Reset action, Activate to reset Config back to defaults (live-applied), then Back (= flush
+    /// &amp; exit), and assert the custom binding was NOT persisted (i.e. Reset overwrote it before
+    /// the flush). Exercises the live focus + Activate-dispatch + reset + flush round-trip the
     /// headless unit suite cannot reach.
     /// </summary>
     [Fact(Timeout = 180_000)]
@@ -137,19 +138,19 @@ public sealed class DrumMappingStageSmokeTests
             // Settle past the fade + OnActivate (focus/skip-flag init) before sending input.
             await Task.Delay(500, cancellation.Token);
 
-            // Focus starts on lane 0. Open its capture popup and bind the non-default key.
+            // Focus starts on authored visual zone 0 (Hi-Hat / lane 5). Open its capture popup
+            // and bind the non-default key.
             await client.SendKeyAsync("Enter", TimeSpan.FromMilliseconds(50), cancellation.Token);
             await Task.Delay(700, cancellation.Token);
             await client.SendKeyAsync(BindKey, TimeSpan.FromMilliseconds(50), cancellation.Token);
             await Task.Delay(700, cancellation.Token);
-            // First Back closes the popup (acts as "Done"); focus stays on lane 0.
+            // First Back closes the popup (acts as "Done"); focus stays on visual zone 0.
             await client.SendKeyAsync("Escape", TimeSpan.FromMilliseconds(50), cancellation.Token);
             await Task.Delay(700, cancellation.Token);
 
-            // Advance focus from lane 0 through every zone onto the Reset action (index 10):
-            // lane 0 -> 1 -> ... -> 9 -> Reset. Tab is read via ConsumePressedButtons, which
-            // records every injected press event regardless of a same-frame release, and parses
-            // server-side via Enum.TryParse<Keys> ("Tab").
+            // Advance focus through all ten authored visual zones onto the Reset action (index 10).
+            // Tab is read via ConsumePressedButtons, which records every injected press event
+            // regardless of a same-frame release, and parses server-side via Enum.TryParse<Keys>.
             for (int i = 0; i < 10; i++)
             {
                 await client.SendKeyAsync("Tab", TimeSpan.FromMilliseconds(40), cancellation.Token);
@@ -167,7 +168,7 @@ public sealed class DrumMappingStageSmokeTests
             // Reset overwrote the custom binding in Config before the flush, so it must not be on disk.
             var configText = await File.ReadAllTextAsync(fixture.ConfigPath, cancellation.Token);
             await E2EArtifactWriter.WriteTextAsync(fixture, "drum-reset-config.ini", configText);
-            Assert.DoesNotContain($"{ExpectedBindingId}=0", configText);
+            Assert.DoesNotContain($"{ExpectedBindingId}={DefaultFocusedLane}", configText);
         }
         catch (Exception ex)
         {

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -209,6 +209,10 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
 
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         _graphicsDeviceManager = new GraphicsDeviceManager(this);
+        if (OperatingSystem.IsWindows())
+        {
+            _graphicsDeviceManager.HardwareModeSwitch = false;
+        }
         Content.RootDirectory = "Content";
         IsMouseVisible = true;
 

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -838,12 +838,10 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
     /// <summary>
     /// Applies platform-specific defaults to the graphics device manager. On Windows the
     /// hardware fullscreen mode switch is disabled (borderless windowed fullscreen) to avoid
-    /// the exclusive-mode display takeover that broke drum-config mouse mapping. The
-    /// constructor calls this seam so headless tests don't need to exercise the platform
-    /// guard — the constructor itself can't run without booting MonoGame/SDL.
+    /// the exclusive-mode display takeover that broke drum-config mouse mapping.
     /// </summary>
     [ExcludeFromCodeCoverage]
-    internal virtual void ApplyPlatformGraphicsDefaults(GraphicsDeviceManager manager)
+    private static void ApplyPlatformGraphicsDefaults(GraphicsDeviceManager manager)
     {
         if (OperatingSystem.IsWindows())
             manager.HardwareModeSwitch = false;

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -209,10 +209,7 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
 
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         _graphicsDeviceManager = new GraphicsDeviceManager(this);
-        if (OperatingSystem.IsWindows())
-        {
-            _graphicsDeviceManager.HardwareModeSwitch = false;
-        }
+        ApplyPlatformGraphicsDefaults(_graphicsDeviceManager);
         Content.RootDirectory = "Content";
         IsMouseVisible = true;
 
@@ -836,6 +833,20 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
             return null;
 
         return new Point(window.ClientBounds.Width, window.ClientBounds.Height);
+    }
+
+    /// <summary>
+    /// Applies platform-specific defaults to the graphics device manager. On Windows the
+    /// hardware fullscreen mode switch is disabled (borderless windowed fullscreen) to avoid
+    /// the exclusive-mode display takeover that broke drum-config mouse mapping. The
+    /// constructor calls this seam so headless tests don't need to exercise the platform
+    /// guard — the constructor itself can't run without booting MonoGame/SDL.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal virtual void ApplyPlatformGraphicsDefaults(GraphicsDeviceManager manager)
+    {
+        if (OperatingSystem.IsWindows())
+            manager.HardwareModeSwitch = false;
     }
 
     [ExcludeFromCodeCoverage]

--- a/DTXMania.Game/Game1.cs
+++ b/DTXMania.Game/Game1.cs
@@ -742,6 +742,32 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
         return new Point(vx, vy);
     }
 
+    internal static Point? ClientToBackBufferCoordinates(
+        Point clientPoint,
+        Point clientSize,
+        Rectangle backBufferViewport)
+    {
+        if (clientSize.X <= 0 || clientSize.Y <= 0 ||
+            backBufferViewport.Width <= 0 || backBufferViewport.Height <= 0)
+            return null;
+
+        if (clientPoint.X < 0 || clientPoint.Y < 0 ||
+            clientPoint.X >= clientSize.X || clientPoint.Y >= clientSize.Y)
+            return null;
+
+        int backBufferX = backBufferViewport.X +
+            (int)Math.Round(clientPoint.X * backBufferViewport.Width / (double)clientSize.X);
+        int backBufferY = backBufferViewport.Y +
+            (int)Math.Round(clientPoint.Y * backBufferViewport.Height / (double)clientSize.Y);
+
+        if (backBufferX >= backBufferViewport.Right)
+            backBufferX = backBufferViewport.Right - 1;
+        if (backBufferY >= backBufferViewport.Bottom)
+            backBufferY = backBufferViewport.Bottom - 1;
+
+        return new Point(backBufferX, backBufferY);
+    }
+
     /// <summary>
     /// Instance wrapper around <see cref="WindowToVirtualCoordinates"/> using the current
     /// <see cref="GraphicsDevice.Viewport"/> (the back buffer during Update) and the fixed
@@ -759,7 +785,25 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
         var viewport = TryGetViewportBounds();
         if (viewport == null)
             return windowPoint;
-        return WindowToVirtualCoordinates(windowPoint, viewport.Value,
+
+        var clientSize = TryGetClientSize();
+        var backBufferPoint = windowPoint;
+        if (clientSize is Point actualClientSize)
+        {
+            if (actualClientSize.X <= 0 || actualClientSize.Y <= 0)
+                return null;
+
+            var normalizedPoint = ClientToBackBufferCoordinates(
+                windowPoint,
+                actualClientSize,
+                viewport.Value);
+            if (normalizedPoint == null)
+                return null;
+
+            backBufferPoint = normalizedPoint.Value;
+        }
+
+        return WindowToVirtualCoordinates(backBufferPoint, viewport.Value,
             GameConstants.Display.VirtualWidth, GameConstants.Display.VirtualHeight);
     }
 
@@ -782,6 +826,16 @@ public class BaseGame : Microsoft.Xna.Framework.Game, IGameContext, IStageGame, 
     {
         var graphicsDevice = GraphicsDevice;
         return graphicsDevice == null ? null : graphicsDevice.Viewport.Bounds;
+    }
+
+    [ExcludeFromCodeCoverage]
+    protected virtual Point? TryGetClientSize()
+    {
+        var window = GetGameWindow();
+        if (window == null)
+            return null;
+
+        return new Point(window.ClientBounds.Width, window.ClientBounds.Height);
     }
 
     [ExcludeFromCodeCoverage]

--- a/DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs
@@ -75,6 +75,25 @@ namespace DTXMania.Game.Lib.Stage.DrumConfig
             new DrumZone(3, KeyBindings.GetLaneName(3), DrumZoneShape.Pedal,      560f, 600f, 52f, 36f, flipHorizontal: true), // Left Pedal
         };
 
+        internal static int GetLaneForZoneIndex(int zoneIndex)
+        {
+            if (zoneIndex < 0 || zoneIndex >= Zones.Count)
+                return -1;
+
+            return Zones[zoneIndex].Lane;
+        }
+
+        internal static int FindZoneIndexByLane(int lane)
+        {
+            for (int i = 0; i < Zones.Count; i++)
+            {
+                if (Zones[i].Lane == lane)
+                    return i;
+            }
+
+            return -1;
+        }
+
         /// <summary>Returns the lane of the first zone containing the design-space point, or -1.</summary>
         public static int HitTest(float x, float y)
         {

--- a/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
@@ -67,7 +67,9 @@ namespace DTXMania.Game.Lib.Stage
         private const int StatusPadY = 4;
         private const float StatusMaxWidth = 500f;
 
-        private int _focusIndex;
+        // Authored focus element: 0..ZoneCount-1 for visual zones, ResetActionIndex for Reset.
+        // Resolve to a lane ID only when dispatching a popup or rendering lane highlights.
+        private int _focusedElementIndex;
         // Keyboard focus is only *shown* once the user navigates with arrows/Tab, and is hidden
         // again as soon as they move the mouse. Without this the default focus (lane 0) would
         // light up permanently on stage entry even though no one is using the keyboard.
@@ -124,7 +126,7 @@ namespace DTXMania.Game.Lib.Stage
                 () => _input!.GetKeyMappingSnapshot(),                        // system map (= Config)
                 note => _configManager.GetMidiVelocityThreshold(note));        // MIDI thresholds (= Config)
 
-            _focusIndex = 0;
+            _focusedElementIndex = 0;
             _keyboardFocusActive = false;
             _selectedLane = -1;
             _hoveredLane = -1;
@@ -297,7 +299,7 @@ namespace DTXMania.Game.Lib.Stage
 
             if (focusDelta != 0)
             {
-                _focusIndex = DrumKitLayout.AdvanceFocus(_focusIndex, focusDelta);
+                _focusedElementIndex = DrumKitLayout.AdvanceFocus(_focusedElementIndex, focusDelta);
                 _keyboardFocusActive = true; // user is now navigating by keyboard: show the focus ring
             }
 
@@ -307,7 +309,7 @@ namespace DTXMania.Game.Lib.Stage
             if (tabPressCount > 0)
             {
                 for (int i = 0; i < tabPressCount; i++)
-                    _focusIndex = DrumKitLayout.AdvanceFocus(_focusIndex, 1);
+                    _focusedElementIndex = DrumKitLayout.AdvanceFocus(_focusedElementIndex, 1);
                 _keyboardFocusActive = true;
             }
 
@@ -327,7 +329,7 @@ namespace DTXMania.Game.Lib.Stage
             if (leftClick && virtualMouse is { } vmClick
                 && GetResetButtonRect(rVw, rVh).Contains(vmClick.X, vmClick.Y))
             {
-                _focusIndex = DrumKitLayout.ResetActionIndex;
+                _focusedElementIndex = DrumKitLayout.ResetActionIndex;
                 ResetDrumBindingsToDefault();
                 return;
             }
@@ -341,8 +343,12 @@ namespace DTXMania.Game.Lib.Stage
 
         private void OpenPopup(int lane)
         {
+            int zoneIndex = DrumKitLayout.FindZoneIndexByLane(lane);
+            if (zoneIndex < 0)
+                return;
+
             _selectedLane = lane;
-            _focusIndex = lane;
+            _focusedElementIndex = zoneIndex;
             _popup!.Open(lane);
             _skipCaptureThisFrame = true;
         }
@@ -354,10 +360,14 @@ namespace DTXMania.Game.Lib.Stage
         /// </summary>
         private void ActivateFocusedElement()
         {
-            if (DrumKitLayout.IsResetAction(_focusIndex))
+            if (DrumKitLayout.IsResetAction(_focusedElementIndex))
                 ResetDrumBindingsToDefault();
             else
-                OpenPopup(_focusIndex);
+            {
+                int lane = DrumKitLayout.GetLaneForZoneIndex(_focusedElementIndex);
+                if (lane >= 0)
+                    OpenPopup(lane);
+            }
         }
 
         // "Reset to defaults" button, top-right of the screen in virtual space. Named rather than
@@ -440,7 +450,7 @@ namespace DTXMania.Game.Lib.Stage
             // never for the Reset action (it is not a lane). Otherwise the default focus would keep
             // a zone lit even when the user is only using the mouse.
             int focusedLaneForRender =
-                (_keyboardFocusActive && !DrumKitLayout.IsResetAction(_focusIndex)) ? _focusIndex : -1;
+                _keyboardFocusActive ? DrumKitLayout.GetLaneForZoneIndex(_focusedElementIndex) : -1;
             // Named initializer (not positional args) so the three highlight lanes can't be swapped
             // silently at the call site — the transposition hazard LaneHighlights exists to remove.
             var highlights = new LaneHighlights
@@ -504,7 +514,7 @@ namespace DTXMania.Game.Lib.Stage
             {
                 // Focus ring first (yellow, inflated) so the fill sits inside it, mirroring the
                 // zone focus highlight and giving keyboard users a visible "Reset is focused" cue.
-                if (_keyboardFocusActive && DrumKitLayout.IsResetAction(_focusIndex))
+                if (_keyboardFocusActive && DrumKitLayout.IsResetAction(_focusedElementIndex))
                 {
                     var ring = resetRect;
                     ring.Inflate(4, 4);

--- a/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
+++ b/DTXMania.Game/Lib/Stage/DrumConfigStage.cs
@@ -71,8 +71,8 @@ namespace DTXMania.Game.Lib.Stage
         // Resolve to a lane ID only when dispatching a popup or rendering lane highlights.
         private int _focusedElementIndex;
         // Keyboard focus is only *shown* once the user navigates with arrows/Tab, and is hidden
-        // again as soon as they move the mouse. Without this the default focus (lane 0) would
-        // light up permanently on stage entry even though no one is using the keyboard.
+        // again as soon as they move the mouse. Without this the default visual zone 0 (lane 5)
+        // would light up permanently on stage entry even though no one is using the keyboard.
         private bool _keyboardFocusActive;
         private int _hoveredLane = -1;
         private int _selectedLane = -1;

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -1839,7 +1839,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void ClientToBackBufferCoordinates_SameSizeIsIdentity()
+        public void ClientToBackBufferCoordinates_SameSize_ShouldBeIdentity()
         {
             var mapped = BaseGame.ClientToBackBufferCoordinates(
                 new Point(640, 360),
@@ -1850,7 +1850,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void ClientToBackBufferCoordinates_ScalesClientIntoViewport()
+        public void ClientToBackBufferCoordinates_ShouldScaleClientIntoViewport()
         {
             var mapped = BaseGame.ClientToBackBufferCoordinates(
                 new Point(960, 540),
@@ -1865,7 +1865,7 @@ namespace DTXMania.Test
         [InlineData(0, -1)]
         [InlineData(1920, 0)]
         [InlineData(0, 1080)]
-        public void ClientToBackBufferCoordinates_PointOutsideClientReturnsNull(int x, int y)
+        public void ClientToBackBufferCoordinates_PointOutsideClient_ShouldReturnNull(int x, int y)
         {
             var mapped = BaseGame.ClientToBackBufferCoordinates(
                 new Point(x, y),
@@ -1884,7 +1884,7 @@ namespace DTXMania.Test
         [InlineData(1920, -1, 1280, 720)]
         [InlineData(1920, 1080, -1, 720)]
         [InlineData(1920, 1080, 1280, -1)]
-        public void ClientToBackBufferCoordinates_NonPositiveClientOrViewportReturnsNull(
+        public void ClientToBackBufferCoordinates_NonPositiveClientOrViewport_ShouldReturnNull(
             int clientWidth,
             int clientHeight,
             int viewportWidth,
@@ -1899,7 +1899,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void ClientToBackBufferCoordinates_RoundingClampsToViewportEdge()
+        public void ClientToBackBufferCoordinates_Rounding_ShouldClampToViewportEdge()
         {
             // When the client-to-viewport scale rounds a near-edge client coordinate up to the
             // viewport's Right/Bottom, the clamp branches must pull it back inside the viewport
@@ -1915,7 +1915,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void MapMouseToVirtual_WhenClientPointOutsideClient_ReturnsNull()
+        public void MapMouseToVirtual_WhenClientPointOutsideClient_ShouldReturnNull()
         {
             // With a client size set, a point outside the client bounds is rejected by
             // ClientToBackBufferCoordinates (returns null) and MapMouseToVirtual propagates the
@@ -1974,7 +1974,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void MapMouseToVirtual_WithViewportButNoClientSize_PreservesExistingViewportMapping()
+        public void MapMouseToVirtual_WithViewportButNoClientSize_ShouldPreserveExistingViewportMapping()
         {
             var game = CreateViewportSpyGame();
             game.SetViewportBounds(new Rectangle(0, 0, 1920, 1080));
@@ -1986,7 +1986,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void MapMouseToVirtual_Non16By9ClientNormalizesBeforeBlackBarRejection()
+        public void MapMouseToVirtual_Non16By9Client_ShouldNormalizeBeforeBlackBarRejection()
         {
             var game = CreateViewportSpyGame();
             game.SetViewportBounds(new Rectangle(50, 20, 1920, 720));
@@ -2000,7 +2000,7 @@ namespace DTXMania.Test
         }
 
         [Fact]
-        public void MapMouseToVirtual_WhenClientAndBackBufferSizesDiffer_NormalizesBeforeLetterboxMapping()
+        public void MapMouseToVirtual_WhenClientAndBackBufferSizesDiffer_ShouldNormalizeBeforeLetterboxMapping()
         {
             var game = CreateViewportSpyGame();
             game.SetViewportBounds(new Rectangle(0, 0, 1280, 720));

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -1839,6 +1839,66 @@ namespace DTXMania.Test
         }
 
         [Fact]
+        public void ClientToBackBufferCoordinates_SameSizeIsIdentity()
+        {
+            var mapped = BaseGame.ClientToBackBufferCoordinates(
+                new Point(640, 360),
+                new Point(1280, 720),
+                new Rectangle(0, 0, 1280, 720));
+
+            Assert.Equal(new Point(640, 360), mapped);
+        }
+
+        [Fact]
+        public void ClientToBackBufferCoordinates_ScalesClientIntoViewport()
+        {
+            var mapped = BaseGame.ClientToBackBufferCoordinates(
+                new Point(960, 540),
+                new Point(1920, 1080),
+                new Rectangle(100, 40, 1280, 720));
+
+            Assert.Equal(new Point(740, 400), mapped);
+        }
+
+        [Theory]
+        [InlineData(-1, 0)]
+        [InlineData(0, -1)]
+        [InlineData(1920, 0)]
+        [InlineData(0, 1080)]
+        public void ClientToBackBufferCoordinates_PointOutsideClientReturnsNull(int x, int y)
+        {
+            var mapped = BaseGame.ClientToBackBufferCoordinates(
+                new Point(x, y),
+                new Point(1920, 1080),
+                new Rectangle(0, 0, 1280, 720));
+
+            Assert.Null(mapped);
+        }
+
+        [Theory]
+        [InlineData(0, 1080, 1280, 720)]
+        [InlineData(1920, 0, 1280, 720)]
+        [InlineData(1920, 1080, 0, 720)]
+        [InlineData(1920, 1080, 1280, 0)]
+        [InlineData(-1, 1080, 1280, 720)]
+        [InlineData(1920, -1, 1280, 720)]
+        [InlineData(1920, 1080, -1, 720)]
+        [InlineData(1920, 1080, 1280, -1)]
+        public void ClientToBackBufferCoordinates_NonPositiveClientOrViewportReturnsNull(
+            int clientWidth,
+            int clientHeight,
+            int viewportWidth,
+            int viewportHeight)
+        {
+            var mapped = BaseGame.ClientToBackBufferCoordinates(
+                new Point(0, 0),
+                new Point(clientWidth, clientHeight),
+                new Rectangle(0, 0, viewportWidth, viewportHeight));
+
+            Assert.Null(mapped);
+        }
+
+        [Fact]
         public void MapMouseToVirtual_WithoutGraphicsManager_ShouldReturnPointAsIs()
         {
             // Headless / pre-Initialize: no GraphicsManager means a 1:1 identity mapping so
@@ -1881,6 +1941,48 @@ namespace DTXMania.Test
 
             // Center of 1920x1080 -> center of 1280x720.
             Assert.Equal(new Point(640, 360), result);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_WithViewportButNoClientSize_PreservesExistingViewportMapping()
+        {
+            var game = CreateViewportSpyGame();
+            game.SetViewportBounds(new Rectangle(0, 0, 1920, 1080));
+            game.SetClientSize(null);
+
+            var result = game.MapMouseToVirtual(new Point(960, 540));
+
+            Assert.Equal(new Point(640, 360), result);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_Non16By9ClientNormalizesBeforeBlackBarRejection()
+        {
+            var game = CreateViewportSpyGame();
+            game.SetViewportBounds(new Rectangle(50, 20, 1920, 720));
+            game.SetClientSize(new Point(1280, 800));
+
+            // The raw client x=213 would be in the viewport's left pillarbox, but normalizing
+            // the 16:10 client into the back buffer puts it on the drawable destination edge.
+            var result = game.MapMouseToVirtual(new Point(213, 400));
+
+            Assert.Equal(new Point(0, 360), result);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_WhenClientAndBackBufferSizesDiffer_NormalizesBeforeLetterboxMapping()
+        {
+            var game = CreateViewportSpyGame();
+            game.SetViewportBounds(new Rectangle(0, 0, 1280, 720));
+            game.SetClientSize(new Point(1920, 1080));
+
+            var center = game.MapMouseToVirtual(new Point(960, 540));
+
+            Assert.Equal(new Point(640, 360), center);
+
+            game.SetClientSize(new Point(0, 1080));
+
+            Assert.Null(game.MapMouseToVirtual(new Point(0, 0)));
         }
 
         [Fact]
@@ -2367,7 +2469,16 @@ namespace DTXMania.Test
                 new StubGraphicsManager(isDeviceAvailable: true, CreateFailingRenderTargetManager()));
             }
 
+            public void SetClientSize(Point? size)
+            {
+                _clientSize = size;
+            }
+
+            private Point? _clientSize;
+
             protected override Rectangle? TryGetViewportBounds() => _viewportBounds;
+
+            protected override Point? TryGetClientSize() => _clientSize;
         }
 
         private sealed class TestGameCrashDiagnostics : IGameCrashDiagnostics

--- a/DTXMania.Test/BaseGameTests.cs
+++ b/DTXMania.Test/BaseGameTests.cs
@@ -1899,6 +1899,36 @@ namespace DTXMania.Test
         }
 
         [Fact]
+        public void ClientToBackBufferCoordinates_RoundingClampsToViewportEdge()
+        {
+            // When the client-to-viewport scale rounds a near-edge client coordinate up to the
+            // viewport's Right/Bottom, the clamp branches must pull it back inside the viewport
+            // (backBufferX = Right - 1, backBufferY = Bottom - 1) so the downstream letterbox
+            // math never receives an out-of-bounds back-buffer point.
+            // clientSize=(3,3), viewport=(0,0,1,1), point=(2,2): 2*1/3 = 0.667 rounds to 1 = Right.
+            var mapped = BaseGame.ClientToBackBufferCoordinates(
+                new Point(2, 2),
+                new Point(3, 3),
+                new Rectangle(0, 0, 1, 1));
+
+            Assert.Equal(new Point(0, 0), mapped);
+        }
+
+        [Fact]
+        public void MapMouseToVirtual_WhenClientPointOutsideClient_ReturnsNull()
+        {
+            // With a client size set, a point outside the client bounds is rejected by
+            // ClientToBackBufferCoordinates (returns null) and MapMouseToVirtual propagates the
+            // null so callers treat the click as "no hit" rather than mapping it to a stale
+            // back-buffer coordinate.
+            var game = CreateViewportSpyGame();
+            game.SetViewportBounds(new Rectangle(0, 0, 1920, 1080));
+            game.SetClientSize(new Point(100, 100));
+
+            Assert.Null(game.MapMouseToVirtual(new Point(200, 50)));
+        }
+
+        [Fact]
         public void MapMouseToVirtual_WithoutGraphicsManager_ShouldReturnPointAsIs()
         {
             // Headless / pre-Initialize: no GraphicsManager means a 1:1 identity mapping so

--- a/DTXMania.Test/Config/StaFolderPickerDispatcherAdditionalTests.cs
+++ b/DTXMania.Test/Config/StaFolderPickerDispatcherAdditionalTests.cs
@@ -12,6 +12,8 @@ namespace DTXMania.Test.Config;
 [Trait("Category", "Unit")]
 public sealed class StaFolderPickerDispatcherAdditionalTests
 {
+    private static readonly TimeSpan AsyncTimeout = TimeSpan.FromSeconds(5);
+
     [Fact]
     public void Constructor_WhenDialogFactoryIsNull_ShouldThrowArgumentNullException()
     {
@@ -55,7 +57,7 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
         using var picker = new StaFolderPickerDispatcher(factory);
 
         var result = await picker.PickFolderAsync(null, CancellationToken.None)
-            .WaitAsync(TimeSpan.FromSeconds(1));
+            .WaitAsync(AsyncTimeout);
 
         Assert.Equal(FolderPickerStatus.Failed, result.Status);
         Assert.Contains("dialog blew up", result.Message, StringComparison.Ordinal);
@@ -75,7 +77,7 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
 
         // Start the blocking request and wait for the dispatcher to enter Show().
         var firstRequest = picker.PickFolderAsync(null, CancellationToken.None);
-        await blockingDialog.ShowEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await blockingDialog.ShowEntered.Task.WaitAsync(AsyncTimeout);
 
         // Enqueue the target request and cancel it while the dispatcher is busy.
         using var cancellation = new CancellationTokenSource();
@@ -84,10 +86,10 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
 
         // Release the blocking dialog so the dispatcher dequeues the target.
         blockingDialog.Release();
-        var firstResult = await firstRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        var firstResult = await firstRequest.WaitAsync(AsyncTimeout);
         Assert.Equal(FolderPickerStatus.Selected, firstResult.Status);
 
-        var secondResult = await secondRequest.WaitAsync(TimeSpan.FromSeconds(1));
+        var secondResult = await secondRequest.WaitAsync(AsyncTimeout);
         Assert.Equal(FolderPickerStatus.Cancelled, secondResult.Status);
     }
 
@@ -100,7 +102,7 @@ public sealed class StaFolderPickerDispatcherAdditionalTests
         using var picker = new StaFolderPickerDispatcher(factory);
 
         var result = await picker.PickFolderAsync(null, CancellationToken.None)
-            .WaitAsync(TimeSpan.FromSeconds(1));
+            .WaitAsync(AsyncTimeout);
 
         Assert.Equal(FolderPickerStatus.Failed, result.Status);
         Assert.Contains("CreateDialog failed", result.Message, StringComparison.Ordinal);

--- a/DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
+++ b/DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
@@ -338,6 +338,25 @@ namespace DTXMania.Test.Stage.DrumConfig
             Assert.Equal(9, popup.Lane);
         }
 
+        [Fact]
+        public void ActivateFocusedElement_WhenFocusedElementIndexOutOfRange_DoesNotOpenPopup()
+        {
+            // Defensive guard: if _focusedElementIndex is somehow out of range (not a zone, not
+            // Reset), GetLaneForZoneIndex returns -1 and ActivateFocusedElement must not open a
+            // popup for an invalid lane. This state can't arise through normal AdvanceFocus flow
+            // but the guard prevents a crash if the field is corrupted.
+            var game = CreateGameWithViewport(1280, 720);
+            var stage = new DrumConfigStage(game);
+            var drum = new Dictionary<string, int>();
+            var popup = new DrumCapturePopup(() => drum, () => new Dictionary<Keys, InputCommandType>());
+            ReflectionHelpers.SetPrivateField(stage, "_popup", popup);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", -1);
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "ActivateFocusedElement");
+
+            Assert.False(popup.IsOpen);
+        }
+
         // ---- OnUpdate / UpdateSelection / UpdatePopup routing (headless, via graphics stub) ----
 
         private static BaseGame CreateGameWithViewport(int width, int height)

--- a/DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
+++ b/DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
@@ -298,7 +298,7 @@ namespace DTXMania.Test.Stage.DrumConfig
             // exercises the dispatch headlessly without OnActivate.
             var (stage, cm, _) = CreateWiredStage();
             ReflectionHelpers.InvokePrivateMethod(stage, "ApplyCapture", "Key.Z", 3); // non-default
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", DrumKitLayout.ResetActionIndex);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", DrumKitLayout.ResetActionIndex);
 
             ReflectionHelpers.InvokePrivateMethod(stage, "ActivateFocusedElement");
 
@@ -314,12 +314,28 @@ namespace DTXMania.Test.Stage.DrumConfig
             var drum = new Dictionary<string, int>();
             var popup = new DrumCapturePopup(() => drum, () => new Dictionary<Keys, InputCommandType>());
             ReflectionHelpers.SetPrivateField(stage, "_popup", popup);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 4); // Snare Drum
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 0); // Hi-Hat visual zone
 
             ReflectionHelpers.InvokePrivateMethod(stage, "ActivateFocusedElement");
 
             Assert.True(popup.IsOpen);
-            Assert.Equal(4, popup.Lane);
+            Assert.Equal(5, popup.Lane);
+        }
+
+        [Fact]
+        public void ActivateFocusedElement_WhenRideVisualZoneFocused_OpensPopupForLane9()
+        {
+            var game = CreateGameWithViewport(1280, 720);
+            var stage = new DrumConfigStage(game);
+            var drum = new Dictionary<string, int>();
+            var popup = new DrumCapturePopup(() => drum, () => new Dictionary<Keys, InputCommandType>());
+            ReflectionHelpers.SetPrivateField(stage, "_popup", popup);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 2); // Ride visual zone
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "ActivateFocusedElement");
+
+            Assert.True(popup.IsOpen);
+            Assert.Equal(9, popup.Lane);
         }
 
         // ---- OnUpdate / UpdateSelection / UpdatePopup routing (headless, via graphics stub) ----
@@ -422,8 +438,8 @@ namespace DTXMania.Test.Stage.DrumConfig
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(380, 430, true), true);
 
             Assert.True(popup.IsOpen);
-            Assert.Equal(4, popup.Lane);
-            Assert.Equal(4, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(4, popup.Lane); // clicked snare lane ID
+            Assert.Equal(5, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
         }
 
         [Fact]
@@ -437,7 +453,7 @@ namespace DTXMania.Test.Stage.DrumConfig
             // Reset button rect = (1070, 12, 190, 30); click its center.
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(1165, 27, true), true);
 
-            Assert.Equal(DrumKitLayout.ResetActionIndex, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(DrumKitLayout.ResetActionIndex, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
             Assert.False(cm.Config.KeyBindings.ContainsKey("Key.Z")); // non-default binding cleared
             Assert.False(ReflectionHelpers.GetPrivateField<DrumCapturePopup>(stage, "_popup")!.IsOpen);
         }
@@ -449,12 +465,12 @@ namespace DTXMania.Test.Stage.DrumConfig
             var stage = new DrumConfigStage(game);
             using var input = new FakeInput(new ConfigManager()) { ActiveCommand = InputCommandType.MoveRight };
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
-            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_keyboardFocusActive"));
         }
 
@@ -467,12 +483,12 @@ namespace DTXMania.Test.Stage.DrumConfig
             var stage = new DrumConfigStage(game);
             using var input = new FakeInput(new ConfigManager()) { ActiveCommand = InputCommandType.MoveDown };
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 3);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 3);
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
-            Assert.Equal(4, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(4, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_keyboardFocusActive"));
         }
 
@@ -484,12 +500,12 @@ namespace DTXMania.Test.Stage.DrumConfig
             var stage = new DrumConfigStage(game);
             using var input = new FakeInput(new ConfigManager()) { ActiveCommand = InputCommandType.MoveUp };
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 3);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 3);
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
-            Assert.Equal(2, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(2, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_keyboardFocusActive"));
         }
 
@@ -504,12 +520,12 @@ namespace DTXMania.Test.Stage.DrumConfig
             input.ModularInputManager.InjectButton("Key.Tab", isPressed: true);
             input.ModularInputManager.Update();
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
-            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
         }
 
         [Fact]
@@ -528,12 +544,12 @@ namespace DTXMania.Test.Stage.DrumConfig
             input.ModularInputManager.InjectButton("Key.Tab", isPressed: false);
             input.ModularInputManager.Update(); // both drain inside one ProcessInjectedInputs
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
-            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(1, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
         }
 
         [Fact]
@@ -557,12 +573,12 @@ namespace DTXMania.Test.Stage.DrumConfig
             }
             input.ModularInputManager.Update();
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 0);
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
-            Assert.Equal(10, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(10, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
         }
 
         [Fact]
@@ -592,13 +608,14 @@ namespace DTXMania.Test.Stage.DrumConfig
             var popup = new DrumCapturePopup(() => drum, () => new Dictionary<Keys, InputCommandType>());
             ReflectionHelpers.SetPrivateField(stage, "_input", input);
             ReflectionHelpers.SetPrivateField(stage, "_popup", popup);
-            ReflectionHelpers.SetPrivateField(stage, "_focusIndex", 4); // Snare zone focused
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 5); // Snare zone focused
             ReflectionHelpers.SetPrivateField(stage, "_previousMouse", MouseAt(5, 5, false));
 
             ReflectionHelpers.InvokePrivateMethod(stage, "UpdateSelection", MouseAt(5, 5, false), false);
 
             Assert.True(popup.IsOpen);
             Assert.Equal(4, popup.Lane);
+            Assert.Equal(5, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
         }
 
         [Fact]
@@ -807,8 +824,38 @@ namespace DTXMania.Test.Stage.DrumConfig
             Assert.True(popup.IsOpen);
             Assert.Equal(5, popup.Lane);
             Assert.Equal(5, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedLane"));
-            Assert.Equal(5, ReflectionHelpers.GetPrivateField<int>(stage, "_focusIndex"));
+            Assert.Equal(0, ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
             Assert.True(ReflectionHelpers.GetPrivateField<bool>(stage, "_skipCaptureThisFrame"));
+        }
+
+        [Fact]
+        public void OpenPopup_WhenLaneInvalid_LeavesSelectionFocusPopupAndSkipStateUnchanged()
+        {
+            var game = ReflectionHelpers.CreateGame();
+            ReflectionHelpers.SetProperty(game, nameof(BaseGame.ConfigManager), new StubConfigManager());
+            var stage = new DrumConfigStage(game);
+            var drum = new Dictionary<string, int>();
+            var popup = new DrumCapturePopup(() => drum, () => new Dictionary<Keys, InputCommandType>());
+            popup.Open(5);
+            ReflectionHelpers.SetPrivateField(stage, "_popup", popup);
+            ReflectionHelpers.SetPrivateField(stage, "_selectedLane", 5);
+            ReflectionHelpers.SetPrivateField(stage, "_focusedElementIndex", 0);
+            ReflectionHelpers.SetPrivateField(stage, "_skipCaptureThisFrame", true);
+
+            var selectedLaneBefore = ReflectionHelpers.GetPrivateField<int>(stage, "_selectedLane");
+            var focusedElementIndexBefore =
+                ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex");
+            var popupOpenBefore = popup.IsOpen;
+            var skipCaptureBefore = ReflectionHelpers.GetPrivateField<bool>(stage, "_skipCaptureThisFrame");
+
+            ReflectionHelpers.InvokePrivateMethod(stage, "OpenPopup", 42);
+
+            Assert.Equal(selectedLaneBefore, ReflectionHelpers.GetPrivateField<int>(stage, "_selectedLane"));
+            Assert.Equal(focusedElementIndexBefore,
+                ReflectionHelpers.GetPrivateField<int>(stage, "_focusedElementIndex"));
+            Assert.Equal(popupOpenBefore, popup.IsOpen);
+            Assert.Equal(skipCaptureBefore,
+                ReflectionHelpers.GetPrivateField<bool>(stage, "_skipCaptureThisFrame"));
         }
 
         [Fact]

--- a/DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs
+++ b/DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs
@@ -25,6 +25,45 @@ namespace DTXMania.Test.Stage.DrumConfig
         }
 
         [Fact]
+        public void GetLaneForZoneIndex_ReturnsEachAuthoredZoneLane()
+        {
+            var expectedLanes = DrumKitLayout.Zones.Select(zone => zone.Lane).ToArray();
+
+            for (int zoneIndex = 0; zoneIndex < expectedLanes.Length; zoneIndex++)
+                Assert.Equal(expectedLanes[zoneIndex], DrumKitLayout.GetLaneForZoneIndex(zoneIndex));
+
+            Assert.Equal(5, DrumKitLayout.GetLaneForZoneIndex(0));
+            Assert.Equal(9, DrumKitLayout.GetLaneForZoneIndex(2));
+        }
+
+        [Fact]
+        public void FindZoneIndexByLane_RoundTripsEveryAuthoredZone()
+        {
+            for (int zoneIndex = 0; zoneIndex < DrumKitLayout.ZoneCount; zoneIndex++)
+            {
+                var lane = DrumKitLayout.GetLaneForZoneIndex(zoneIndex);
+                Assert.Equal(zoneIndex, DrumKitLayout.FindZoneIndexByLane(lane));
+            }
+
+            Assert.Equal(5, DrumKitLayout.FindZoneIndexByLane(4));
+        }
+
+        [Fact]
+        public void GetLaneForZoneIndex_ResetAndInvalidIndicesReturnMinusOne()
+        {
+            Assert.Equal(-1, DrumKitLayout.GetLaneForZoneIndex(DrumKitLayout.ResetActionIndex));
+            Assert.Equal(-1, DrumKitLayout.GetLaneForZoneIndex(-1));
+            Assert.Equal(-1, DrumKitLayout.GetLaneForZoneIndex(DrumKitLayout.ZoneCount));
+        }
+
+        [Fact]
+        public void FindZoneIndexByLane_InvalidLaneReturnsMinusOne()
+        {
+            Assert.Equal(-1, DrumKitLayout.FindZoneIndexByLane(-1));
+            Assert.Equal(-1, DrumKitLayout.FindZoneIndexByLane(10));
+        }
+
+        [Fact]
         public void Zone_NameMatchesKeyBindingsLaneName()
         {
             var snare = DrumKitLayout.Zones.Single(z => z.Lane == 4);

--- a/DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs
+++ b/DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs
@@ -25,7 +25,7 @@ namespace DTXMania.Test.Stage.DrumConfig
         }
 
         [Fact]
-        public void GetLaneForZoneIndex_ReturnsEachAuthoredZoneLane()
+        public void GetLaneForZoneIndex_ShouldReturnEachAuthoredZoneLane()
         {
             var expectedLanes = DrumKitLayout.Zones.Select(zone => zone.Lane).ToArray();
 
@@ -37,7 +37,7 @@ namespace DTXMania.Test.Stage.DrumConfig
         }
 
         [Fact]
-        public void FindZoneIndexByLane_RoundTripsEveryAuthoredZone()
+        public void FindZoneIndexByLane_ShouldRoundTripEveryAuthoredZone()
         {
             for (int zoneIndex = 0; zoneIndex < DrumKitLayout.ZoneCount; zoneIndex++)
             {
@@ -49,7 +49,7 @@ namespace DTXMania.Test.Stage.DrumConfig
         }
 
         [Fact]
-        public void GetLaneForZoneIndex_ResetAndInvalidIndicesReturnMinusOne()
+        public void GetLaneForZoneIndex_ResetAndInvalidIndices_ShouldReturnMinusOne()
         {
             Assert.Equal(-1, DrumKitLayout.GetLaneForZoneIndex(DrumKitLayout.ResetActionIndex));
             Assert.Equal(-1, DrumKitLayout.GetLaneForZoneIndex(-1));
@@ -57,7 +57,7 @@ namespace DTXMania.Test.Stage.DrumConfig
         }
 
         [Fact]
-        public void FindZoneIndexByLane_InvalidLaneReturnsMinusOne()
+        public void FindZoneIndexByLane_InvalidLane_ShouldReturnMinusOne()
         {
             Assert.Equal(-1, DrumKitLayout.FindZoneIndexByLane(-1));
             Assert.Equal(-1, DrumKitLayout.FindZoneIndexByLane(10));

--- a/docs/superpowers/plans/2026-08-13-hpa-619-fullscreen-drum-mapping.md
+++ b/docs/superpowers/plans/2026-08-13-hpa-619-fullscreen-drum-mapping.md
@@ -1,0 +1,438 @@
+# HPA-619 Windows Fullscreen Restore and Drum Mapping Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the Windows fullscreen squeeze/hang path and make drum hover, keyboard focus, and popup lane selection match the rendered drum image in both fullscreen and windowed modes.
+
+**Architecture:** Keep the existing fixed 1280×720 virtual render target. On Windows, use MonoGame soft/borderless fullscreen and keep logical windowed configuration separate from the physical fullscreen backbuffer size. Repair an out-of-sync presentation when the game regains focus. Normalize WinForms client mouse coordinates into backbuffer coordinates before applying the existing inverse letterbox transform. Keep drum keyboard focus as a visual-zone index and convert explicitly between zone indices and lane IDs.
+
+**Tech Stack:** .NET 8, MonoGame WindowsDX 3.8.x, xUnit, existing `GraphicsManager`, `BaseGame`, and drum-configuration components.
+
+**Linear:** [HPA-619](https://linear.app/cwchanap/issue/HPA-619/fix-windows-fullscreen-restore-squeeze-and-drum-pad-hitfocus-mapping)
+
+## Global Constraints
+
+- Do not introduce a window-mode manager, display service, input-coordinate service, or second drum layout model.
+- Do not add an exclusive-versus-borderless user setting. Existing `FullScreen` remains the only persisted mode flag.
+- Preserve `ConfigData.ScreenWidth` and `ScreenHeight` as the windowed size. Desktop-sized fullscreen backbuffers must not overwrite those values.
+- Preserve the fixed 1280×720 render target and the existing `CalculateLetterboxDestination` behavior.
+- Preserve `DrumKitLayout.Zones` order and geometry. Correct identity conversion instead of reordering data to match lane numbers.
+- Keep the change cross-platform compilable. Windows-specific behavior should use the existing .NET platform check rather than a new project split.
+- Do not add permanent per-frame logging. One low-volume repair log when an actual presentation mismatch is detected is acceptable.
+- Unit-test pure state and coordinate logic headlessly. Win+D, Alt+Tab, minimize/restore, and Windows DPI behavior remain manual Windows verification.
+- Do not modify drum bindings, MIDI capture, velocity thresholds, popup content, or skin assets.
+
+## Root-Cause Contract
+
+The implementation must address all three defects rather than treating the drum click as an independent native-window action:
+
+1. WindowsDX currently uses MonoGame's default hardware mode switch. Exclusive fullscreen can be torn down during focus loss, while the game caches only the requested logical settings.
+2. `Mouse.GetState()` reports WinForms client coordinates, while `BaseGame.MapMouseToVirtual()` currently treats them as backbuffer coordinates.
+3. `DrumConfigStage._focusIndex` is a visual-zone index, but several call sites use it as a lane ID. The authored visual lane order is `5, 0, 9, 7, 8, 4, 1, 6, 2, 3`, not `0..9`.
+
+---
+
+## Task 1: Make Windows Fullscreen Borderless and Repair Presentation Drift
+
+**Files:**
+
+- Modify: `DTXMania.Game/Game1.cs`
+- Modify: `DTXMania.Game/Lib/Graphics/GraphicsManager.cs`
+- Modify: `DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs`
+- Modify: `DTXMania.Test/BaseGameTests.cs`
+
+### Step 1: Add failing physical-backbuffer policy tests
+
+- [ ] Add pure-policy tests to `GraphicsManagerLogicTests`:
+
+```csharp
+ResolveBackBufferSize_WindowedUsesLogicalSize()
+ResolveBackBufferSize_BorderlessFullscreenUsesCurrentDisplaySize()
+ResolveBackBufferSize_InvalidDisplaySizeFallsBackToLogicalSize()
+```
+
+Use representative values such as logical `1280×720` and display `2560×1440`. The helper contract is:
+
+```csharp
+internal static Point ResolveBackBufferSize(
+    GraphicsSettings settings,
+    Point currentDisplaySize,
+    bool useDesktopSizedFullscreen)
+```
+
+Expected behavior:
+
+- Windowed mode always returns the logical width and height.
+- Borderless fullscreen returns the current display size when both dimensions are positive.
+- An unavailable or invalid display size falls back to the logical width and height.
+
+### Step 2: Add failing presentation-reconciliation tests
+
+- [ ] Extend the existing testable `GraphicsManager` seam so tests can choose whether the actual presentation is synchronized.
+- [ ] Add these tests:
+
+```csharp
+ApplySettings_WhenLogicalAndPresentationStateMatch_SkipsDeviceApply()
+ApplySettings_WhenLogicalSettingsMatchButPresentationDiffers_ReappliesDeviceState()
+ApplySettings_WhenRepairingPresentation_DoesNotRaiseLogicalSettingsChanged()
+ApplySettings_WhenPresentationRepairFails_KeepsLogicalSettingsSnapshot()
+```
+
+The important contract is that `_currentSettings` remains logical configuration. A physical-only repair must call `ApplyChanges()` but must not emit `SettingsChanged`, because that event writes logical settings back to `ConfigData`.
+
+### Step 3: Add a failing activation test
+
+- [ ] In `BaseGameTests`, add:
+
+```csharp
+OnGameActivated_ReappliesCurrentLogicalGraphicsSettings()
+```
+
+Use a recording `IGraphicsManager` test double. Inject it into `BaseGame`, invoke `OnGameActivated`, and assert that `ApplySettings` receives the current `Settings` snapshot exactly once.
+
+### Step 4: Run the focused tests and confirm they fail
+
+- [ ] Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj \
+  --filter "FullyQualifiedName~GraphicsManagerLogicTests|FullyQualifiedName~BaseGameTests"
+```
+
+Expected: the new policy, reconciliation, and activation tests fail because the production seams do not exist yet.
+
+### Step 5: Configure soft fullscreen before the first device apply
+
+- [ ] In the `BaseGame` constructor, immediately after creating `GraphicsDeviceManager`, set:
+
+```csharp
+if (OperatingSystem.IsWindows())
+    _graphicsDeviceManager.HardwareModeSwitch = false;
+```
+
+Do not change this property during later toggles. MonoGame should consistently interpret the existing fullscreen flag as borderless/soft fullscreen.
+
+### Step 6: Separate logical settings from the physical backbuffer
+
+- [ ] Add the pure `ResolveBackBufferSize` helper to `GraphicsManager`.
+- [ ] Add two narrow overridable seams for headless tests:
+
+```csharp
+protected virtual Point GetCurrentDisplaySize()
+protected virtual bool UseDesktopSizedBorderlessFullscreen()
+```
+
+Production behavior:
+
+- `GetCurrentDisplaySize()` reads the current graphics adapter's display mode when available and falls back to `GraphicsAdapter.DefaultAdapter.CurrentDisplayMode` before device creation.
+- `UseDesktopSizedBorderlessFullscreen()` returns true only on Windows when `HardwareModeSwitch` is false.
+- Do not add WinForms monitor enumeration or multi-monitor selection in this ticket.
+
+- [ ] Update `SetDeviceManagerSettings(GraphicsSettings settings)` so `PreferredBackBufferWidth` and `PreferredBackBufferHeight` receive the resolved physical dimensions, while `_currentSettings` continues storing the original logical `GraphicsSettings`.
+
+Conceptually:
+
+```csharp
+var physicalSize = ResolveBackBufferSize(
+    settings,
+    GetCurrentDisplaySize(),
+    UseDesktopSizedBorderlessFullscreen());
+
+_deviceManager.PreferredBackBufferWidth = physicalSize.X;
+_deviceManager.PreferredBackBufferHeight = physicalSize.Y;
+_deviceManager.IsFullScreen = settings.IsFullscreen;
+_deviceManager.SynchronizeWithVerticalRetrace = settings.VSync;
+```
+
+Do not modify `GraphicsExtensions.ToGraphicsSettings` or `UpdateFromGraphicsSettings`; their logical configuration contract remains correct.
+
+### Step 7: Reconcile actual presentation state
+
+- [ ] Add:
+
+```csharp
+protected virtual bool IsPresentationSynchronized(GraphicsSettings settings)
+```
+
+When a live device exists, compare the expected physical dimensions and fullscreen mode against the current presentation parameters. Also verify the viewport dimensions when available, because drawing and mouse mapping both consume that viewport. Treat an unavailable graphics device as synchronized so pre-initialization/headless calls retain the existing no-op behavior.
+
+- [ ] Refactor `ApplySettings` around two booleans:
+
+```csharp
+bool logicalChanged = !settings.Equals(_currentSettings);
+bool presentationChanged = !IsPresentationSynchronized(settings);
+```
+
+Required flow:
+
+1. Return immediately only when neither value changed.
+2. Apply device-manager settings when either value changed.
+3. Update `_currentSettings` and emit `SettingsChanged` only when `logicalChanged` is true.
+4. Log one information message when repairing presentation drift without a logical change.
+5. If a physical-only repair fails, keep the existing logical snapshot and return false. Do not retry the same failing state through the logical revert path.
+6. Preserve the existing revert behavior for a failed real logical change.
+
+### Step 8: Repair on activation and clean up the event subscription
+
+- [ ] Subscribe `Activated += OnGameActivated` after `_graphicsManager` is created and its device events are wired.
+- [ ] Implement `OnGameActivated` as a null-safe call to `_graphicsManager.ApplySettings(_graphicsManager.Settings)`. Log a warning only if the repair call returns false.
+- [ ] Unsubscribe `Activated -= OnGameActivated` in `DisposeManagedResources` alongside the existing `Exiting` and graphics-event cleanup.
+
+Do not perform an unconditional reset. `GraphicsManager.IsPresentationSynchronized` is the gate that keeps ordinary Alt+Tab returns cheap.
+
+### Step 9: Run tests and commit
+
+- [ ] Run the focused command from Step 4.
+- [ ] Run the whole Windows unit project:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj
+```
+
+- [ ] Commit:
+
+```bash
+git add DTXMania.Game/Game1.cs \
+        DTXMania.Game/Lib/Graphics/GraphicsManager.cs \
+        DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs \
+        DTXMania.Test/BaseGameTests.cs
+git commit -m "fix: stabilize Windows fullscreen presentation"
+```
+
+---
+
+## Task 2: Normalize Client Mouse Coordinates Before Virtual Hit-Testing
+
+**Files:**
+
+- Modify: `DTXMania.Game/Game1.cs`
+- Modify: `DTXMania.Test/BaseGameTests.cs`
+
+### Step 1: Add failing coordinate-normalization tests
+
+- [ ] Add pure-helper tests:
+
+```csharp
+ClientToBackBufferCoordinates_SameSizeIsIdentity()
+ClientToBackBufferCoordinates_ScalesClientIntoBackBuffer()
+ClientToBackBufferCoordinates_OutsideClientReturnsNull()
+ClientToBackBufferCoordinates_InvalidBoundsReturnNull()
+```
+
+Use a contract shaped as:
+
+```csharp
+internal static Point? ClientToBackBufferCoordinates(
+    Point clientPoint,
+    Point clientSize,
+    Rectangle backBufferViewport)
+```
+
+The helper must:
+
+- Reject non-positive client or viewport dimensions.
+- Reject negative points and points at or beyond the client right/bottom edge.
+- Scale into the viewport, including its origin.
+- Clamp rounding at the final right/bottom pixel to the viewport bounds.
+
+- [ ] Add an integration-level mapping test using the existing `BaseGame` test subclass:
+
+```csharp
+MapMouseToVirtual_WhenClientAndBackBufferSizesDiffer_NormalizesBeforeLetterboxMapping()
+```
+
+Example: a `1920×1080` client and a `1280×720` backbuffer should map the client center to virtual `(640, 360)` rather than treating `(960, 540)` as a direct backbuffer point.
+
+- [ ] Add a non-16:9 case proving that client normalization happens before the existing black-bar rejection.
+
+### Step 2: Run the focused tests and confirm they fail
+
+- [ ] Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj \
+  --filter "FullyQualifiedName~BaseGameTests"
+```
+
+Expected: the new helper and client-size seam do not exist yet.
+
+### Step 3: Add the client-size seam
+
+- [ ] Add:
+
+```csharp
+[ExcludeFromCodeCoverage]
+protected virtual Point? TryGetClientSize()
+```
+
+Use the existing `GetGameWindow()` seam and return only `ClientBounds.Width` and `ClientBounds.Height`. Return null when no window is available. Do not expose WinForms types or add a platform-specific input class.
+
+### Step 4: Normalize inside `MapMouseToVirtual`
+
+- [ ] Implement `ClientToBackBufferCoordinates` as a pure helper.
+- [ ] Update `MapMouseToVirtual` in this order:
+
+1. Preserve the current raw-point fallback when graphics/window information is unavailable in headless or pre-initialization contexts.
+2. Read both the current client size and backbuffer viewport.
+3. Convert the raw client point to a backbuffer point.
+4. Return null when normalization rejects the point or either dimension is invalid.
+5. Pass the normalized point into the existing `WindowToVirtualCoordinates` helper.
+
+Do not combine the two transforms into one new abstraction. Keeping client-to-backbuffer scaling separate from backbuffer-to-virtual letterboxing makes each contract independently testable.
+
+### Step 5: Run tests and commit
+
+- [ ] Run the focused BaseGame tests.
+- [ ] Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj
+```
+
+- [ ] Commit:
+
+```bash
+git add DTXMania.Game/Game1.cs DTXMania.Test/BaseGameTests.cs
+git commit -m "fix: normalize mouse coordinates for fullscreen"
+```
+
+---
+
+## Task 3: Keep Drum Focus as a Zone Index and Resolve Lane IDs Explicitly
+
+**Files:**
+
+- Modify: `DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs`
+- Modify: `DTXMania.Game/Lib/Stage/DrumConfigStage.cs`
+- Modify: `DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs`
+- Modify: `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`
+
+### Step 1: Add failing zone/lane identity tests
+
+- [ ] Add these pure layout tests:
+
+```csharp
+GetLaneForZoneIndex_ReturnsEachAuthoredZoneLane()
+FindZoneIndexByLane_RoundTripsEveryAuthoredZone()
+GetLaneForZoneIndex_ResetAndInvalidIndicesReturnMinusOne()
+FindZoneIndexByLane_InvalidLaneReturnsMinusOne()
+```
+
+Add two small helpers to the layout contract:
+
+```csharp
+public static int GetLaneForZoneIndex(int zoneIndex)
+public static int FindZoneIndexByLane(int lane)
+```
+
+Both return `-1` for invalid input. The Reset action is not a lane.
+
+### Step 2: Strengthen stage regression tests with non-identity mappings
+
+- [ ] Rename reflection references from `_focusIndex` to `_focusedZoneIndex` in existing tests.
+- [ ] Change `ActivateFocusedElement_WhenZoneFocused_OpensPopupForThatLane` to use visual zone index `0` and assert popup lane `5`. Do not use an index whose numeric value happens to equal its lane.
+- [ ] Update the snare click test to assert:
+
+```text
+clicked lane = 4
+focused zone index = 5
+popup lane = 4
+```
+
+- [ ] Add a representative mouse-click test for another non-identity zone, such as visual index `2` / ride lane `9`.
+- [ ] Keep existing keyboard advance tests asserting zone indices, including Reset at `DrumKitLayout.ResetActionIndex`.
+
+### Step 3: Run the focused tests and confirm they fail
+
+- [ ] Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj \
+  --filter "FullyQualifiedName~DrumKitLayoutTests|FullyQualifiedName~DrumConfigStageTests"
+```
+
+Expected: the non-identity activation and click assertions expose the current index/lane confusion.
+
+### Step 4: Implement explicit conversion helpers
+
+- [ ] Implement `GetLaneForZoneIndex` using bounds checking and `Zones[zoneIndex].Lane`.
+- [ ] Implement `FindZoneIndexByLane` as one small loop over `Zones`.
+
+Do not add dictionaries, cached lookup tables, or reorder `Zones`; there are only ten entries and this code is not performance-sensitive.
+
+### Step 5: Correct `DrumConfigStage` state ownership
+
+- [ ] Rename `_focusIndex` to `_focusedZoneIndex` throughout the stage.
+- [ ] Keep arrow/Tab navigation and Reset logic operating only on `_focusedZoneIndex`.
+- [ ] Update `OpenPopup(int lane)` so it:
+
+1. Stores `_selectedLane = lane`.
+2. Resolves `FindZoneIndexByLane(lane)` and updates `_focusedZoneIndex` only when a matching zone exists.
+3. Opens the popup with the original lane ID.
+
+- [ ] Update `ActivateFocusedElement()` so a non-Reset focus resolves `GetLaneForZoneIndex(_focusedZoneIndex)` and opens only a valid lane.
+- [ ] Update `OnDraw()` so `LaneHighlights.FocusedLane` receives the resolved lane, never the zone index.
+- [ ] Keep `_hoveredLane` and `_selectedLane` as lane IDs. Their current names and renderer contract are already correct.
+
+### Step 6: Run tests and commit
+
+- [ ] Run the focused drum tests.
+- [ ] Run the whole Windows unit project.
+- [ ] Commit:
+
+```bash
+git add DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs \
+        DTXMania.Game/Lib/Stage/DrumConfigStage.cs \
+        DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs \
+        DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
+git commit -m "fix: map drum focus zones to lane identities"
+```
+
+---
+
+## Final Automated Verification
+
+- [ ] Run Windows build and tests:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj
+dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj
+```
+
+- [ ] Run macOS compile/test regression checks where the environment supports them:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+```
+
+- [ ] Confirm the diff does not modify `GraphicsExtensions`, `IGraphicsManager`, drum binding behavior, assets, or configuration schema unless a failing compiler/test proves one of those edits is unavoidable.
+- [ ] Confirm no new analyzer warnings and no skipped or weakened existing tests.
+
+## Manual Windows Verification
+
+Record the machine resolution, Windows display-scaling percentage, MonoGame package version resolved by restore, and results in the implementation PR.
+
+- [ ] Launch windowed and confirm the configured `ScreenWidth×ScreenHeight` size is retained.
+- [ ] Toggle fullscreen with Alt+Enter and confirm borderless fullscreen fills the active display without stretching the 16:9 virtual scene.
+- [ ] Repeat Win+D, Alt+Tab, minimize, and restore at least five times each. Confirm there is no half-height centered viewport, desktop switch loop, black padded squeeze, or hang.
+- [ ] Return to windowed mode and confirm the original configured windowed size is restored.
+- [ ] On Config → Drum Mapping, hover and click all ten drum images. Confirm the highlight and opened popup name/lane match each image and the game remains active.
+- [ ] Cycle all ten zones plus Reset with arrows/Tab. Confirm focus follows authored visual order and Enter opens the focused image's lane.
+- [ ] Repeat the drum checks in both windowed and fullscreen modes.
+- [ ] Repeat at 100% and one greater-than-100% Windows display-scaling setting when available.
+
+## Implementation PR Evidence
+
+The implementation PR description must include:
+
+- The resolved Windows and MonoGame version.
+- Automated build/test commands and results.
+- The manual focus-loss matrix with pass/fail results.
+- The display resolution and scaling values used.
+- Confirmation that `Config.ini` retains the configured windowed width/height after fullscreen toggles.
+- Confirmation that every visual drum zone maps to the expected popup lane.
+
+## Scope Estimate
+
+Two engineer days. Each task is independently reviewable, and no task requires a new subsystem or data migration.

--- a/docs/superpowers/plans/2026-08-13-hpa-619-fullscreen-drum-mapping.md
+++ b/docs/superpowers/plans/2026-08-13-hpa-619-fullscreen-drum-mapping.md
@@ -2,202 +2,88 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Eliminate the Windows fullscreen squeeze/hang path and make drum hover, keyboard focus, and popup lane selection match the rendered drum image in both fullscreen and windowed modes.
+**Goal:** Stabilize Windows fullscreen restore and make drum hover, keyboard focus, and popup lane selection match the rendered drum image in windowed and fullscreen modes.
 
-**Architecture:** Keep the existing fixed 1280×720 virtual render target. On Windows, use MonoGame soft/borderless fullscreen and keep logical windowed configuration separate from the physical fullscreen backbuffer size. Repair an out-of-sync presentation when the game regains focus. Normalize WinForms client mouse coordinates into backbuffer coordinates before applying the existing inverse letterbox transform. Keep drum keyboard focus as a visual-zone index and convert explicitly between zone indices and lane IDs.
+**Architecture:** Keep the existing fixed 1280×720 virtual render target and letterbox transform. Task 1 makes the smallest native-window change by disabling MonoGame's Windows hardware mode switch; Task 2 keeps client-to-backbuffer normalization separate from the existing backbuffer-to-virtual mapping; Task 3 keeps keyboard focus in authored visual-zone order and converts explicitly to lane IDs. No task changes `GraphicsManager`, the windowed configuration, the render target, or the drum content contract.
 
-**Tech Stack:** .NET 8, MonoGame WindowsDX 3.8.x, xUnit, existing `GraphicsManager`, `BaseGame`, and drum-configuration components.
-
-**Linear:** [HPA-619](https://linear.app/cwchanap/issue/HPA-619/fix-windows-fullscreen-restore-squeeze-and-drum-pad-hitfocus-mapping)
+**Tech Stack:** .NET 8, MonoGame 3.8.x, xUnit, existing `BaseGame`, `DrumKitLayout`, and drum-configuration components.
 
 ## Global Constraints
 
-- Do not introduce a window-mode manager, display service, input-coordinate service, or second drum layout model.
-- Do not add an exclusive-versus-borderless user setting. Existing `FullScreen` remains the only persisted mode flag.
-- Preserve `ConfigData.ScreenWidth` and `ScreenHeight` as the windowed size. Desktop-sized fullscreen backbuffers must not overwrite those values.
-- Preserve the fixed 1280×720 render target and the existing `CalculateLetterboxDestination` behavior.
-- Preserve `DrumKitLayout.Zones` order and geometry. Correct identity conversion instead of reordering data to match lane numbers.
-- Keep the change cross-platform compilable. Windows-specific behavior should use the existing .NET platform check rather than a new project split.
-- Do not add permanent per-frame logging. One low-volume repair log when an actual presentation mismatch is detected is acceptable.
-- Unit-test pure state and coordinate logic headlessly. Win+D, Alt+Tab, minimize/restore, and Windows DPI behavior remain manual Windows verification.
-- Do not modify drum bindings, MIDI capture, velocity thresholds, popup content, or skin assets.
+- Keep the fixed 1280×720 render target and the existing `CalculateLetterboxDestination`/`WindowToVirtualCoordinates` letterbox behavior.
+- Preserve the configured windowed size in `ConfigData.ScreenWidth` and `ConfigData.ScreenHeight`; fullscreen must not overwrite those values.
+- Do not modify `DTXMania.Game/Lib/Graphics/GraphicsManager.cs`, graphics settings ownership, or any graphics event/reapply path in this plan.
+- Do not add a window-mode manager, display service, input-coordinate service, second drum layout model, or other broad abstraction. The two explicitly requested static coordinate/lane helpers remain narrow, pure helpers.
+- Preserve existing drum bindings, MIDI capture, velocity thresholds, popup content, hover/selected lane IDs, and skin assets.
+- Keep the three tasks independently reviewable. Each task has its own focused verification and conventional commit.
+- Windows-focused and full unit-test commands use `DTXMania.Test/DTXMania.Test.csproj`. The macOS-safe test project remains `DTXMania.Test/DTXMania.Test.Mac.csproj`.
 
 ## Root-Cause Contract
 
-The implementation must address all three defects rather than treating the drum click as an independent native-window action:
+The implementation separates two confirmed managed-code defects from the native fullscreen diagnosis:
 
-1. WindowsDX currently uses MonoGame's default hardware mode switch. Exclusive fullscreen can be torn down during focus loss, while the game caches only the requested logical settings.
-2. `Mouse.GetState()` reports WinForms client coordinates, while `BaseGame.MapMouseToVirtual()` currently treats them as backbuffer coordinates.
-3. `DrumConfigStage._focusIndex` is a visual-zone index, but several call sites use it as a lane ID. The authored visual lane order is `5, 0, 9, 7, 8, 4, 1, 6, 2, 3`, not `0..9`.
+1. **Primary native diagnosis under test:** Windows exclusive fullscreen restore instability is caused by MonoGame's default `HardwareModeSwitch` behavior. Task 1 changes only that property. A Windows manual smoke is required to confirm that soft fullscreen resolves every squeeze, deactivation, and hang sequence before any native scope is expanded.
+2. **Confirmed coordinate defect:** `Mouse.GetState()` supplies WinForms client coordinates, while `BaseGame.MapMouseToVirtual()` currently sends them directly to a backbuffer viewport transform. Task 2 normalizes client pixels first.
+3. **Confirmed zone/lane defect:** `DrumConfigStage` stores keyboard focus as a visual-zone index, but current activation and rendering call sites treat that index as a lane ID. Task 3 converts explicitly without changing authored zone order.
+
+If the Task 1 manual symptoms persist, capture `Window.ClientBounds`, backbuffer dimensions, viewport bounds, fullscreen state, and hardware-mode state before proposing any additional native or graphics changes. Record the MonoGame package version resolved by restore with the manual evidence.
 
 ---
 
-## Task 1: Make Windows Fullscreen Borderless and Repair Presentation Drift
+## Task 1: Disable Windows Hardware Mode Switching for Fullscreen Restore
 
 **Files:**
 
 - Modify: `DTXMania.Game/Game1.cs`
-- Modify: `DTXMania.Game/Lib/Graphics/GraphicsManager.cs`
-- Modify: `DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs`
-- Modify: `DTXMania.Test/BaseGameTests.cs`
 
-### Step 1: Add failing physical-backbuffer policy tests
+**Interfaces:**
 
-- [ ] Add pure-policy tests to `GraphicsManagerLogicTests`:
+- Consumes: the existing `GraphicsDeviceManager` construction in the `BaseGame` constructor.
+- Produces: a Windows-only `HardwareModeSwitch = false` setting that is in place before any later graphics initialization or settings application.
 
-```csharp
-ResolveBackBufferSize_WindowedUsesLogicalSize()
-ResolveBackBufferSize_BorderlessFullscreenUsesCurrentDisplaySize()
-ResolveBackBufferSize_InvalidDisplaySizeFallsBackToLogicalSize()
-```
+### Step 1: Set the Windows-only hardware-mode flag
 
-Use representative values such as logical `1280×720` and display `2560×1440`. The helper contract is:
+- [ ] In the `BaseGame` constructor, immediately after constructing `GraphicsDeviceManager`, add exactly this guarded assignment:
 
 ```csharp
-internal static Point ResolveBackBufferSize(
-    GraphicsSettings settings,
-    Point currentDisplaySize,
-    bool useDesktopSizedFullscreen)
-```
-
-Expected behavior:
-
-- Windowed mode always returns the logical width and height.
-- Borderless fullscreen returns the current display size when both dimensions are positive.
-- An unavailable or invalid display size falls back to the logical width and height.
-
-### Step 2: Add failing presentation-reconciliation tests
-
-- [ ] Extend the existing testable `GraphicsManager` seam so tests can choose whether the actual presentation is synchronized.
-- [ ] Add these tests:
-
-```csharp
-ApplySettings_WhenLogicalAndPresentationStateMatch_SkipsDeviceApply()
-ApplySettings_WhenLogicalSettingsMatchButPresentationDiffers_ReappliesDeviceState()
-ApplySettings_WhenRepairingPresentation_DoesNotRaiseLogicalSettingsChanged()
-ApplySettings_WhenPresentationRepairFails_KeepsLogicalSettingsSnapshot()
-```
-
-The important contract is that `_currentSettings` remains logical configuration. A physical-only repair must call `ApplyChanges()` but must not emit `SettingsChanged`, because that event writes logical settings back to `ConfigData`.
-
-### Step 3: Add a failing activation test
-
-- [ ] In `BaseGameTests`, add:
-
-```csharp
-OnGameActivated_ReappliesCurrentLogicalGraphicsSettings()
-```
-
-Use a recording `IGraphicsManager` test double. Inject it into `BaseGame`, invoke `OnGameActivated`, and assert that `ApplySettings` receives the current `Settings` snapshot exactly once.
-
-### Step 4: Run the focused tests and confirm they fail
-
-- [ ] Run:
-
-```bash
-dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj \
-  --filter "FullyQualifiedName~GraphicsManagerLogicTests|FullyQualifiedName~BaseGameTests"
-```
-
-Expected: the new policy, reconciliation, and activation tests fail because the production seams do not exist yet.
-
-### Step 5: Configure soft fullscreen before the first device apply
-
-- [ ] In the `BaseGame` constructor, immediately after creating `GraphicsDeviceManager`, set:
-
-```csharp
+_graphicsDeviceManager = new GraphicsDeviceManager(this);
 if (OperatingSystem.IsWindows())
+{
     _graphicsDeviceManager.HardwareModeSwitch = false;
+}
 ```
 
-Do not change this property during later toggles. MonoGame should consistently interpret the existing fullscreen flag as borderless/soft fullscreen.
+- [ ] Leave the rest of `Game1.cs` unchanged. Do not expand this task with graphics lifecycle logic, alternate sizing policy, logging, or a unit-test seam for this native property.
 
-### Step 6: Separate logical settings from the physical backbuffer
+### Step 2: Build both game targets
 
-- [ ] Add the pure `ResolveBackBufferSize` helper to `GraphicsManager`.
-- [ ] Add two narrow overridable seams for headless tests:
-
-```csharp
-protected virtual Point GetCurrentDisplaySize()
-protected virtual bool UseDesktopSizedBorderlessFullscreen()
-```
-
-Production behavior:
-
-- `GetCurrentDisplaySize()` reads the current graphics adapter's display mode when available and falls back to `GraphicsAdapter.DefaultAdapter.CurrentDisplayMode` before device creation.
-- `UseDesktopSizedBorderlessFullscreen()` returns true only on Windows when `HardwareModeSwitch` is false.
-- Do not add WinForms monitor enumeration or multi-monitor selection in this ticket.
-
-- [ ] Update `SetDeviceManagerSettings(GraphicsSettings settings)` so `PreferredBackBufferWidth` and `PreferredBackBufferHeight` receive the resolved physical dimensions, while `_currentSettings` continues storing the original logical `GraphicsSettings`.
-
-Conceptually:
-
-```csharp
-var physicalSize = ResolveBackBufferSize(
-    settings,
-    GetCurrentDisplaySize(),
-    UseDesktopSizedBorderlessFullscreen());
-
-_deviceManager.PreferredBackBufferWidth = physicalSize.X;
-_deviceManager.PreferredBackBufferHeight = physicalSize.Y;
-_deviceManager.IsFullScreen = settings.IsFullscreen;
-_deviceManager.SynchronizeWithVerticalRetrace = settings.VSync;
-```
-
-Do not modify `GraphicsExtensions.ToGraphicsSettings` or `UpdateFromGraphicsSettings`; their logical configuration contract remains correct.
-
-### Step 7: Reconcile actual presentation state
-
-- [ ] Add:
-
-```csharp
-protected virtual bool IsPresentationSynchronized(GraphicsSettings settings)
-```
-
-When a live device exists, compare the expected physical dimensions and fullscreen mode against the current presentation parameters. Also verify the viewport dimensions when available, because drawing and mouse mapping both consume that viewport. Treat an unavailable graphics device as synchronized so pre-initialization/headless calls retain the existing no-op behavior.
-
-- [ ] Refactor `ApplySettings` around two booleans:
-
-```csharp
-bool logicalChanged = !settings.Equals(_currentSettings);
-bool presentationChanged = !IsPresentationSynchronized(settings);
-```
-
-Required flow:
-
-1. Return immediately only when neither value changed.
-2. Apply device-manager settings when either value changed.
-3. Update `_currentSettings` and emit `SettingsChanged` only when `logicalChanged` is true.
-4. Log one information message when repairing presentation drift without a logical change.
-5. If a physical-only repair fails, keep the existing logical snapshot and return false. Do not retry the same failing state through the logical revert path.
-6. Preserve the existing revert behavior for a failed real logical change.
-
-### Step 8: Repair on activation and clean up the event subscription
-
-- [ ] Subscribe `Activated += OnGameActivated` after `_graphicsManager` is created and its device events are wired.
-- [ ] Implement `OnGameActivated` as a null-safe call to `_graphicsManager.ApplySettings(_graphicsManager.Settings)`. Log a warning only if the repair call returns false.
-- [ ] Unsubscribe `Activated -= OnGameActivated` in `DisposeManagedResources` alongside the existing `Exiting` and graphics-event cleanup.
-
-Do not perform an unconditional reset. `GraphicsManager.IsPresentationSynchronized` is the gate that keeps ordinary Alt+Tab returns cheap.
-
-### Step 9: Run tests and commit
-
-- [ ] Run the focused command from Step 4.
-- [ ] Run the whole Windows unit project:
+- [ ] Run the Windows build:
 
 ```bash
-dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj
 ```
 
-- [ ] Commit:
+- [ ] Run the macOS build to prove the platform guard remains cross-platform compilable:
 
 ```bash
-git add DTXMania.Game/Game1.cs \
-        DTXMania.Game/Lib/Graphics/GraphicsManager.cs \
-        DTXMania.Test/Graphics/GraphicsManagerLogicTests.cs \
-        DTXMania.Test/BaseGameTests.cs
-git commit -m "fix: stabilize Windows fullscreen presentation"
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
 ```
+
+There is no RED/GREEN unit-test cycle for this task; a test-only seam would not exercise the native fullscreen behavior.
+
+### Step 3: Commit the isolated native change
+
+- [ ] Commit only `Game1.cs`:
+
+```bash
+git add DTXMania.Game/Game1.cs
+git commit -m "fix: disable Windows hardware fullscreen switching"
+```
+
+### Step 4: Use the Windows focus-loss smoke as the confirmation gate
+
+- [ ] On Windows, launch the game in windowed mode, toggle fullscreen with Alt+Enter, and repeat Win+D, Alt+Tab, minimize, and restore sequences. Confirm that the 16:9 virtual scene remains unsqueezed, the game remains active, and no deactivation or hang sequence occurs.
+- [ ] If all sequences pass, keep Task 1 limited to the constructor assignment. If any sequence fails, capture the diagnostic fields named in the Root-Cause Contract before expanding scope; do not add graphics-manager or backbuffer policy changes to this task.
 
 ---
 
@@ -208,97 +94,148 @@ git commit -m "fix: stabilize Windows fullscreen presentation"
 - Modify: `DTXMania.Game/Game1.cs`
 - Modify: `DTXMania.Test/BaseGameTests.cs`
 
-### Step 1: Add failing coordinate-normalization tests
+**Interfaces:**
 
-- [ ] Add pure-helper tests:
+- Produces: `internal static Point? ClientToBackBufferCoordinates(Point clientPoint, Point clientSize, Rectangle backBufferViewport)`.
+- Produces: `[ExcludeFromCodeCoverage] protected virtual Point? TryGetClientSize()` in `BaseGame`.
+- Consumes: the existing `GetGameWindow()`, `TryGetViewportBounds()`, and `WindowToVirtualCoordinates()` seams.
+
+### Step 1: Add RED tests for the pure coordinate helper
+
+- [ ] In `BaseGameTests`, add these tests for `ClientToBackBufferCoordinates`:
 
 ```csharp
 ClientToBackBufferCoordinates_SameSizeIsIdentity()
-ClientToBackBufferCoordinates_ScalesClientIntoBackBuffer()
-ClientToBackBufferCoordinates_OutsideClientReturnsNull()
-ClientToBackBufferCoordinates_InvalidBoundsReturnNull()
+ClientToBackBufferCoordinates_ScalesClientIntoViewport()
+ClientToBackBufferCoordinates_PointOutsideClientReturnsNull()
+ClientToBackBufferCoordinates_NonPositiveClientOrViewportReturnsNull()
 ```
 
-Use a contract shaped as:
+- [ ] Use a viewport with a non-zero origin in at least one case. Assert that equal client/viewport sizes preserve the point, a 1920×1080 client scales into a 1280×720 viewport, negative or right/bottom-edge client points return `null`, and any non-positive client or viewport dimension returns `null`.
+- [ ] Include a non-16:9 integration case proving normalization happens before existing black-bar rejection:
+
+```csharp
+MapMouseToVirtual_Non16By9ClientNormalizesBeforeBlackBarRejection()
+```
+
+- [ ] Keep the existing raw fallback coverage and add the explicit regression:
+
+```csharp
+MapMouseToVirtual_WithoutGraphicsManager_ShouldReturnPointAsIs()
+MapMouseToVirtual_WithGraphicsManagerButNoViewport_ShouldReturnPointAsIs()
+MapMouseToVirtual_WithViewportButNoClientSize_PreservesExistingViewportMapping()
+```
+
+`MapMouseToVirtual_WithViewportButNoClientSize_PreservesExistingViewportMapping` must configure a viewport but make `TryGetClientSize()` return `null`; the raw point is then treated as already in backbuffer space and still passed through `WindowToVirtualCoordinates`.
+
+- [ ] Add a client/backbuffer mismatch integration test:
+
+```csharp
+MapMouseToVirtual_WhenClientAndBackBufferSizesDiffer_NormalizesBeforeLetterboxMapping()
+```
+
+For a 1920×1080 client and 1280×720 backbuffer, assert that client center `(960, 540)` maps to virtual `(640, 360)` rather than being interpreted as a direct backbuffer coordinate. Add a case where a real client size has non-positive dimensions and assert that the result is `null`.
+
+### Step 2: Run the RED BaseGame tests
+
+- [ ] Run:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~BaseGameTests"
+```
+
+Expected result: the new helper, client-size seam, and normalization assertions fail because they are not implemented yet; the pre-existing raw fallback tests continue to describe the current behavior.
+
+### Step 3: Implement the pure client-to-backbuffer helper
+
+- [ ] Add this internal helper to `Game1`:
 
 ```csharp
 internal static Point? ClientToBackBufferCoordinates(
     Point clientPoint,
     Point clientSize,
     Rectangle backBufferViewport)
+{
+    if (clientSize.X <= 0 || clientSize.Y <= 0 ||
+        backBufferViewport.Width <= 0 || backBufferViewport.Height <= 0)
+        return null;
+
+    if (clientPoint.X < 0 || clientPoint.Y < 0 ||
+        clientPoint.X >= clientSize.X || clientPoint.Y >= clientSize.Y)
+        return null;
+
+    int backBufferX = backBufferViewport.X +
+        (int)Math.Round(clientPoint.X * backBufferViewport.Width / (double)clientSize.X);
+    int backBufferY = backBufferViewport.Y +
+        (int)Math.Round(clientPoint.Y * backBufferViewport.Height / (double)clientSize.Y);
+
+    if (backBufferX >= backBufferViewport.Right)
+        backBufferX = backBufferViewport.Right - 1;
+    if (backBufferY >= backBufferViewport.Bottom)
+        backBufferY = backBufferViewport.Bottom - 1;
+
+    return new Point(backBufferX, backBufferY);
+}
 ```
 
-The helper must:
+The helper must include the viewport origin and clamp rounding at the final right/bottom pixel. It must not perform the virtual-resolution or letterbox transform.
 
-- Reject non-positive client or viewport dimensions.
-- Reject negative points and points at or beyond the client right/bottom edge.
-- Scale into the viewport, including its origin.
-- Clamp rounding at the final right/bottom pixel to the viewport bounds.
-
-- [ ] Add an integration-level mapping test using the existing `BaseGame` test subclass:
-
-```csharp
-MapMouseToVirtual_WhenClientAndBackBufferSizesDiffer_NormalizesBeforeLetterboxMapping()
-```
-
-Example: a `1920×1080` client and a `1280×720` backbuffer should map the client center to virtual `(640, 360)` rather than treating `(960, 540)` as a direct backbuffer point.
-
-- [ ] Add a non-16:9 case proving that client normalization happens before the existing black-bar rejection.
-
-### Step 2: Run the focused tests and confirm they fail
-
-- [ ] Run:
-
-```bash
-dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj \
-  --filter "FullyQualifiedName~BaseGameTests"
-```
-
-Expected: the new helper and client-size seam do not exist yet.
-
-### Step 3: Add the client-size seam
+### Step 4: Add the client-size seam and preserve mapping fallbacks
 
 - [ ] Add:
 
 ```csharp
 [ExcludeFromCodeCoverage]
 protected virtual Point? TryGetClientSize()
+{
+    var window = GetGameWindow();
+    if (window == null)
+        return null;
+
+    return new Point(window.ClientBounds.Width, window.ClientBounds.Height);
+}
 ```
 
-Use the existing `GetGameWindow()` seam and return only `ClientBounds.Width` and `ClientBounds.Height`. Return null when no window is available. Do not expose WinForms types or add a platform-specific input class.
-
-### Step 4: Normalize inside `MapMouseToVirtual`
-
-- [ ] Implement `ClientToBackBufferCoordinates` as a pure helper.
 - [ ] Update `MapMouseToVirtual` in this order:
 
-1. Preserve the current raw-point fallback when graphics/window information is unavailable in headless or pre-initialization contexts.
-2. Read both the current client size and backbuffer viewport.
-3. Convert the raw client point to a backbuffer point.
-4. Return null when normalization rejects the point or either dimension is invalid.
-5. Pass the normalized point into the existing `WindowToVirtualCoordinates` helper.
+1. If `_graphicsManager` is unavailable, return the raw point exactly as today.
+2. Read `TryGetViewportBounds()`. If no viewport is available, return the raw point exactly as today.
+3. Read `TryGetClientSize()`.
+4. If a real client size is present with a non-positive width or height, return `null`.
+5. If the client size is present and positive, call `ClientToBackBufferCoordinates`; return `null` when that helper rejects the point.
+6. If the client size is unavailable (`null`), treat the input as already in backbuffer space without scaling.
+7. In both client-size branches, pass the resulting backbuffer point through the existing `WindowToVirtualCoordinates` helper and return its result.
 
-Do not combine the two transforms into one new abstraction. Keeping client-to-backbuffer scaling separate from backbuffer-to-virtual letterboxing makes each contract independently testable.
+Do not fold the two transforms into a new abstraction, and do not alter the existing letterbox calculation.
 
-### Step 5: Run tests and commit
+### Step 5: Run GREEN tests and the full Windows unit project
 
-- [ ] Run the focused BaseGame tests.
-- [ ] Run:
+- [ ] Re-run the focused tests:
 
 ```bash
-dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~BaseGameTests"
 ```
 
-- [ ] Commit:
+Expected result: all BaseGame coordinate, fallback, invalid-size, and non-16:9 tests pass.
+
+- [ ] Run the full Windows unit project:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj
+```
+
+### Step 6: Commit the coordinate-only change
+
+- [ ] Commit only the two Task 2 files:
 
 ```bash
 git add DTXMania.Game/Game1.cs DTXMania.Test/BaseGameTests.cs
-git commit -m "fix: normalize mouse coordinates for fullscreen"
+git commit -m "fix: normalize client mouse coordinates"
 ```
 
 ---
 
-## Task 3: Keep Drum Focus as a Zone Index and Resolve Lane IDs Explicitly
+## Task 3: Keep Drum Focus as an Element Index and Resolve Lane IDs Explicitly
 
 **Files:**
 
@@ -307,9 +244,15 @@ git commit -m "fix: normalize mouse coordinates for fullscreen"
 - Modify: `DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs`
 - Modify: `DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs`
 
-### Step 1: Add failing zone/lane identity tests
+**Interfaces:**
 
-- [ ] Add these pure layout tests:
+- Produces: `internal static int GetLaneForZoneIndex(int zoneIndex)`.
+- Produces: `internal static int FindZoneIndexByLane(int lane)`.
+- Preserves: `_focusedElementIndex` as the stage's private focus field, with `0..ZoneCount-1` meaning authored zones and `ResetActionIndex` meaning Reset.
+
+### Step 1: Add RED layout conversion tests
+
+- [ ] In `DrumKitLayoutTests`, add:
 
 ```csharp
 GetLaneForZoneIndex_ReturnsEachAuthoredZoneLane()
@@ -318,121 +261,158 @@ GetLaneForZoneIndex_ResetAndInvalidIndicesReturnMinusOne()
 FindZoneIndexByLane_InvalidLaneReturnsMinusOne()
 ```
 
-Add two small helpers to the layout contract:
-
-```csharp
-public static int GetLaneForZoneIndex(int zoneIndex)
-public static int FindZoneIndexByLane(int lane)
-```
-
-Both return `-1` for invalid input. The Reset action is not a lane.
-
-### Step 2: Strengthen stage regression tests with non-identity mappings
-
-- [ ] Rename reflection references from `_focusIndex` to `_focusedZoneIndex` in existing tests.
-- [ ] Change `ActivateFocusedElement_WhenZoneFocused_OpensPopupForThatLane` to use visual zone index `0` and assert popup lane `5`. Do not use an index whose numeric value happens to equal its lane.
-- [ ] Update the snare click test to assert:
+- [ ] Assert the non-identity mappings directly:
 
 ```text
-clicked lane = 4
-focused zone index = 5
-popup lane = 4
+GetLaneForZoneIndex(0) == 5
+GetLaneForZoneIndex(2) == 9
+FindZoneIndexByLane(4) == 5
 ```
 
-- [ ] Add a representative mouse-click test for another non-identity zone, such as visual index `2` / ride lane `9`.
-- [ ] Keep existing keyboard advance tests asserting zone indices, including Reset at `DrumKitLayout.ResetActionIndex`.
+- [ ] Keep Reset outside the lane mapping: `GetLaneForZoneIndex(DrumKitLayout.ResetActionIndex)` returns `-1`, and negative or out-of-range arguments return `-1`.
 
-### Step 3: Run the focused tests and confirm they fail
+### Step 2: Add RED stage regression tests
+
+- [ ] Rename every reflection-based `_focusIndex` reference in `DrumConfigStageTests` to `_focusedElementIndex` and assert the field's element-index contract.
+- [ ] Update `ActivateFocusedElement_WhenZoneFocused_OpensPopupForThatLane` to focus visual zone `0` and assert popup lane `5`; do not use an identity-valued index.
+- [ ] Add a second activation or mouse-click regression for visual zone `2` and assert popup lane `9`.
+- [ ] Update the snare case to assert clicked lane `4`, focused element index `5`, and popup lane `4`.
+- [ ] Add an invalid-lane `OpenPopup` test that snapshots `_selectedLane`, `_focusedElementIndex`, popup-open state, and `_skipCaptureThisFrame`, calls `OpenPopup` with an invalid lane, and asserts that every value is unchanged.
+- [ ] Keep existing navigation assertions for authored element indices `0..ZoneCount-1` and `ResetActionIndex`; navigation must not be rewritten in lane-ID terms.
+
+### Step 3: Run the RED drum tests
 
 - [ ] Run:
 
 ```bash
-dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj \
-  --filter "FullyQualifiedName~DrumKitLayoutTests|FullyQualifiedName~DrumConfigStageTests"
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~DrumKitLayoutTests|FullyQualifiedName~DrumConfigStageTests"
 ```
 
-Expected: the non-identity activation and click assertions expose the current index/lane confusion.
+Expected result: the non-identity activation/click assertions and the renamed field references fail against the current index/lane conflation.
 
-### Step 4: Implement explicit conversion helpers
+### Step 4: Implement the explicit layout conversions
 
-- [ ] Implement `GetLaneForZoneIndex` using bounds checking and `Zones[zoneIndex].Lane`.
-- [ ] Implement `FindZoneIndexByLane` as one small loop over `Zones`.
+- [ ] Add these methods to `DrumKitLayout`:
 
-Do not add dictionaries, cached lookup tables, or reorder `Zones`; there are only ten entries and this code is not performance-sensitive.
+```csharp
+internal static int GetLaneForZoneIndex(int zoneIndex)
+{
+    if (zoneIndex < 0 || zoneIndex >= Zones.Count)
+        return -1;
 
-### Step 5: Correct `DrumConfigStage` state ownership
+    return Zones[zoneIndex].Lane;
+}
 
-- [ ] Rename `_focusIndex` to `_focusedZoneIndex` throughout the stage.
-- [ ] Keep arrow/Tab navigation and Reset logic operating only on `_focusedZoneIndex`.
-- [ ] Update `OpenPopup(int lane)` so it:
+internal static int FindZoneIndexByLane(int lane)
+{
+    for (int i = 0; i < Zones.Count; i++)
+    {
+        if (Zones[i].Lane == lane)
+            return i;
+    }
 
-1. Stores `_selectedLane = lane`.
-2. Resolves `FindZoneIndexByLane(lane)` and updates `_focusedZoneIndex` only when a matching zone exists.
-3. Opens the popup with the original lane ID.
+    return -1;
+}
+```
 
-- [ ] Update `ActivateFocusedElement()` so a non-Reset focus resolves `GetLaneForZoneIndex(_focusedZoneIndex)` and opens only a valid lane.
-- [ ] Update `OnDraw()` so `LaneHighlights.FocusedLane` receives the resolved lane, never the zone index.
-- [ ] Keep `_hoveredLane` and `_selectedLane` as lane IDs. Their current names and renderer contract are already correct.
+Do not reorder `Zones`, add a dictionary, or cache a second lane table.
 
-### Step 6: Run tests and commit
+### Step 5: Correct stage state ownership and popup dispatch
 
-- [ ] Run the focused drum tests.
-- [ ] Run the whole Windows unit project.
-- [ ] Commit:
+- [ ] Rename the private field in `DrumConfigStage` to:
+
+```csharp
+private int _focusedElementIndex;
+```
+
+Use it only as an element index: `0..ZoneCount-1` for zones and `DrumKitLayout.ResetActionIndex` for Reset. Update arrow/Tab navigation, reset-button focus, reset detection, and tests to use this contract.
+
+- [ ] Implement `OpenPopup(int lane)` with the conversion before any mutation:
+
+```csharp
+private void OpenPopup(int lane)
+{
+    int zoneIndex = DrumKitLayout.FindZoneIndexByLane(lane);
+    if (zoneIndex < 0)
+        return;
+
+    _selectedLane = lane;
+    _focusedElementIndex = zoneIndex;
+    _popup!.Open(lane);
+    _skipCaptureThisFrame = true;
+}
+```
+
+An invalid lane must return before changing selected lane, focus, popup state, or the skip flag. For a valid lane, preserve the lane ID in `_selectedLane` and in the popup call while storing the visual zone index in `_focusedElementIndex`.
+
+- [ ] Update `ActivateFocusedElement()` so Reset still calls `ResetDrumBindingsToDefault()`, while a zone resolves `GetLaneForZoneIndex(_focusedElementIndex)` and calls `OpenPopup` only for a non-negative lane.
+- [ ] Update `OnDraw()` so `LaneHighlights.FocusedLane` receives the resolved lane ID from `GetLaneForZoneIndex`, or `-1` for Reset/inactive keyboard focus. Keep `_hoveredLane` and `_selectedLane` as lane IDs because hit-testing and renderer highlights already use those IDs.
+
+### Step 6: Run GREEN drum tests and the full Windows unit project
+
+- [ ] Re-run the focused tests:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj --filter "FullyQualifiedName~DrumKitLayoutTests|FullyQualifiedName~DrumConfigStageTests"
+```
+
+Expected result: all authored-order, non-identity, invalid-lane, Reset, hover, and popup assertions pass.
+
+- [ ] Run the full Windows unit project:
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.csproj
+```
+
+### Step 7: Commit the isolated drum mapping change
+
+- [ ] Commit the four Task 3 files:
 
 ```bash
 git add DTXMania.Game/Lib/Stage/DrumConfig/DrumKitLayout.cs \
         DTXMania.Game/Lib/Stage/DrumConfigStage.cs \
         DTXMania.Test/Stage/DrumConfig/DrumKitLayoutTests.cs \
         DTXMania.Test/Stage/DrumConfig/DrumConfigStageTests.cs
-git commit -m "fix: map drum focus zones to lane identities"
+git commit -m "fix: map drum focus elements to lane IDs"
 ```
 
 ---
 
 ## Final Automated Verification
 
-- [ ] Run Windows build and tests:
+- [ ] Build the Windows target and run its full unit suite:
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj
-dotnet test DTXMania.Test/DTXMania.Test.Windows.csproj
+dotnet test DTXMania.Test/DTXMania.Test.csproj
 ```
 
-- [ ] Run macOS compile/test regression checks where the environment supports them:
+- [ ] Build the macOS target and run the Mac-safe unit suite:
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
 ```
 
-- [ ] Confirm the diff does not modify `GraphicsExtensions`, `IGraphicsManager`, drum binding behavior, assets, or configuration schema unless a failing compiler/test proves one of those edits is unavoidable.
-- [ ] Confirm no new analyzer warnings and no skipped or weakened existing tests.
+- [ ] Confirm the diff does not modify `GraphicsManager`, `GraphicsExtensions`, `IGraphicsManager`, configuration schema, drum binding behavior, MIDI/velocity behavior, popup content, or assets.
+- [ ] Confirm no analyzer warnings, skipped tests, weakened assertions, or unresolved plan placeholders remain.
 
-## Manual Windows Verification
+## Manual Windows Verification and Handoff Evidence
 
-Record the machine resolution, Windows display-scaling percentage, MonoGame package version resolved by restore, and results in the implementation PR.
+- [ ] Restore the Windows game target and record the MonoGame package version resolved by restore:
 
-- [ ] Launch windowed and confirm the configured `ScreenWidth×ScreenHeight` size is retained.
-- [ ] Toggle fullscreen with Alt+Enter and confirm borderless fullscreen fills the active display without stretching the 16:9 virtual scene.
-- [ ] Repeat Win+D, Alt+Tab, minimize, and restore at least five times each. Confirm there is no half-height centered viewport, desktop switch loop, black padded squeeze, or hang.
+```bash
+dotnet restore DTXMania.Game/DTXMania.Game.Windows.csproj
+dotnet list DTXMania.Game/DTXMania.Game.Windows.csproj package --include-transitive | rg -i "MonoGame"
+```
+
+- [ ] Record the display resolution and Windows scaling percentage used for the smoke run.
+- [ ] Launch windowed and confirm the configured `ScreenWidth×ScreenHeight` size remains the windowed size.
+- [ ] Toggle fullscreen with Alt+Enter and confirm soft/borderless fullscreen fills the active display without stretching or squeezing the 16:9 virtual scene.
+- [ ] Repeat Win+D, Alt+Tab, minimize, and restore at least five times each. Confirm no half-height centered viewport, desktop switch loop, black padded squeeze, deactivation hang, or restore hang occurs. This is the required Task 1 confirmation gate.
 - [ ] Return to windowed mode and confirm the original configured windowed size is restored.
-- [ ] On Config → Drum Mapping, hover and click all ten drum images. Confirm the highlight and opened popup name/lane match each image and the game remains active.
-- [ ] Cycle all ten zones plus Reset with arrows/Tab. Confirm focus follows authored visual order and Enter opens the focused image's lane.
-- [ ] Repeat the drum checks in both windowed and fullscreen modes.
-- [ ] Repeat at 100% and one greater-than-100% Windows display-scaling setting when available.
+- [ ] On Config → Drum Mapping, hover and click all ten rendered drum images. Confirm each highlight and popup lane/name matches the authored image and the game remains active.
+- [ ] Cycle all ten visual zones plus Reset with arrows and Tab. Confirm focus follows authored order and Enter opens the lane for the focused image.
+- [ ] Repeat drum hover, click, and keyboard checks in both windowed and fullscreen modes, including one display-scaling setting above 100% when available.
 
-## Implementation PR Evidence
-
-The implementation PR description must include:
-
-- The resolved Windows and MonoGame version.
-- Automated build/test commands and results.
-- The manual focus-loss matrix with pass/fail results.
-- The display resolution and scaling values used.
-- Confirmation that `Config.ini` retains the configured windowed width/height after fullscreen toggles.
-- Confirmation that every visual drum zone maps to the expected popup lane.
-
-## Scope Estimate
-
-Two engineer days. Each task is independently reviewable, and no task requires a new subsystem or data migration.
+If any fullscreen squeeze, deactivation, or hang sequence remains, stop and capture these values before changing scope: `Window.ClientBounds`, backbuffer width/height, `GraphicsDevice.Viewport.Bounds`, fullscreen state, and `HardwareModeSwitch` state. Include the resolved MonoGame version, automated build/test results, display resolution/scaling, and the per-sequence manual results in the implementation handoff.


### PR DESCRIPTION
## Summary

- Switches the WindowsDX build from exclusive hardware fullscreen to MonoGame soft/borderless fullscreen.
- Normalizes mouse input from client coordinates into backbuffer coordinates before the existing 1280×720 virtual letterbox transform.
- Separates Drum Mapping focusable-element indices from non-sequential lane IDs so hover, keyboard focus, rendering, and popup selection agree.
- Revises the implementation plan to the reviewed minimal scope for [HPA-619](https://linear.app/cwchanap/issue/HPA-619/fix-windows-fullscreen-restore-squeeze-and-drum-pad-hitfocus-mapping).

## Root cause

Three defects contributed to the reported behavior:

1. MonoGame WindowsDX used the default exclusive hardware-mode switch, making focus-loss and restore transitions susceptible to native fullscreen instability.
2. `Mouse.GetState()` client coordinates were interpreted directly against a backbuffer viewport.
3. `DrumConfigStage` treated an authored visual-zone index as a lane ID even though the authored lane sequence is non-sequential.

## Implementation

### Windows fullscreen

- Sets `GraphicsDeviceManager.HardwareModeSwitch = false` immediately after construction on Windows.
- Leaves `GraphicsManager`, configured windowed dimensions, graphics lifecycle events, and backbuffer policy unchanged.

### Mouse mapping

- Adds a pure client-to-backbuffer coordinate helper.
- Preserves the existing no-graphics and no-viewport raw fallbacks.
- Preserves the headless viewport seam by treating a missing client size as already in backbuffer space.
- Rejects invalid client sizes and points before the existing virtual/letterbox transform.

### Drum mapping

- Stores focus as `_focusedElementIndex`, including Reset as a separate focusable element.
- Adds explicit internal zone-index ↔ lane-ID conversions.
- Validates a popup lane before mutating selected lane, focus, popup state, or capture-skip state.
- Preserves hover and selected values as lane IDs.

## Automated validation

- `dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj --configuration Debug --no-restore` — passed, 0 errors.
- `dotnet test DTXMania.Test/DTXMania.Test.csproj --configuration Debug --no-build --no-restore` — 8,467 passed.
- `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug --no-restore` — passed, 0 errors.
- `dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug --no-build --no-restore` — 8,277 passed.
- Focused BaseGame tests — 107 passed.
- Focused drum layout/stage tests — 68 passed.
- Final whole-branch review and scoped fix re-review — no Critical or Important findings.
- `git diff --check` — clean.
- Resolved MonoGame packages: `MonoGame.Framework.WindowsDX 3.8.5` and `MonoGame.Content.Builder.Task 3.8.5`.

The builds still report the repository’s existing nullable-reference warnings; the task test runs completed without warnings.

## Manual Windows validation pending

This PR remains draft until the native Windows acceptance matrix is recorded:

- [ ] Confirm configured windowed size before and after fullscreen toggles.
- [ ] Repeat Win+D, Alt+Tab, minimize, and restore at least five times each.
- [ ] Confirm no squeezed/centered viewport, deactivation loop, or hang.
- [ ] Hover and click all ten drum images in windowed and fullscreen modes.
- [ ] Cycle all ten authored zones plus Reset with keyboard navigation.
- [ ] Repeat at 100% and greater-than-100% Windows display scaling.
- [ ] Record Windows version, display resolution/scaling, and results.

If any native symptom remains, capture client bounds, backbuffer dimensions, viewport bounds, fullscreen state, and hardware-mode state before expanding graphics scope.

## Scope

This change does not modify `GraphicsManager`, graphics settings ownership, the fixed 1280×720 render target, configuration schema, drum bindings, MIDI capture, velocity thresholds, popup content, layout geometry, or assets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse positioning across different window sizes, display scaling, and aspect ratios.
  * Prevented invalid or out-of-bounds pointer positions from selecting unintended areas.
  * Fixed drum configuration focus, navigation, reset handling, and visual-zone selection.
  * Startup now reports a clear timeout when the game fails to become ready.

* **Improvements**
  * Added more reliable handling for nonstandard window dimensions and headless environments.
  * Improved drum-zone mapping, including specialized lanes such as Hi-Hat and Ride.
  * Expanded automated coverage for input mapping and drum configuration interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->