### PR TITLE
docs: plan HPA-512 native Apple Silicon FFmpeg

### DIFF
--- a/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
+++ b/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make normal CX Mac build/run/publish output carry a verified native Apple Silicon `ffmpeg`/`ffprobe` runtime so MP3 preview and non-default playback variants work without Rosetta or user-installed FFmpeg.
+**Goal:** Make normal CX Mac build/run/test/publish output carry a verified native Apple Silicon `ffmpeg`/`ffprobe` runtime so MP3 preview and non-default playback variants work without Rosetta or user-installed FFmpeg.
 
-**Architecture:** Extract the already-proven FFmpeg 7.0.2 arm64 source build from `release.yml` into one reusable shell builder with a versioned user cache. `DTXMania.Game.Mac.csproj` owns copying that runtime into build and publish outputs; existing `FfmpegRuntime` remains the runtime resolver. Native `macos-15` CI validates the real files and focused audio paths, and release reuses the same project-owned output.
+**Architecture:** Extract the already-proven FFmpeg 7.0.2 arm64 source build from `release.yml` into one reusable shell builder with a versioned user cache. `DTXMania.Game.Mac.csproj` stages the generated files under `obj` before MSBuild resolves output-copy items, then declares them as normal build/publish content so they propagate through `ProjectReference` into Mac tests. Existing `FfmpegRuntime` remains the runtime resolver. Native `macos-15` CI validates the real files and focused audio paths, and release reuses the same project-owned output.
 
 **Tech Stack:** .NET 8, MonoGame DesktopGL, FFMpegCore 5.4.0, FFmpeg 7.0.2 source build, Bash/MSBuild, xUnit, GitHub Actions `macos-15`.
 
@@ -35,11 +35,12 @@ Create:
 
 Modify:
   DTXMania.Game/DTXMania.Game.Mac.csproj
+  DTXMania.Test/DTXMania.Test.Mac.csproj
   DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs
   .github/workflows/build-and-test.yml
   .github/workflows/release.yml
 
-Only modify if the packaged-app verification exposes a real permission-copy bug:
+Only modify if packaged-app verification exposes a real permission-copy bug:
   installer/macos/build-dmg.sh
   installer/macos/test-build-dmg.sh
 ```
@@ -90,11 +91,15 @@ Fail before download/build unless:
 [[ "$(uname -m)" == "arm64" ]]
 ```
 
-Error text must identify native Apple Silicon as the supported Mac build rather than suggesting Rosetta.
+Use this failure meaning:
+
+```text
+Native CX macOS runtime requires Apple Silicon (arm64); Intel/Rosetta is not supported.
+```
 
 - [ ] **Step 2: Preserve the existing minimal feature set and make dependency/license behavior deterministic.**
 
-Start from the current release configure list and add explicit fail-closed flags:
+Start from the current release configure list and add:
 
 ```text
 --disable-autodetect
@@ -102,7 +107,20 @@ Start from the current release configure list and add explicit fail-closed flags
 --disable-nonfree
 ```
 
-Keep the current required decoders/demuxers/parsers/protocols/encoder/muxer/filters exactly as documented in the design spec. Do not add Homebrew codecs or external libraries.
+Keep exactly these CX requirements:
+
+```text
+decoders: mp3float, vorbis, pcm_s16le, pcm_s24le, pcm_f32le, pcm_u8,
+          pcm_alaw, pcm_mulaw, adpcm_ima_wav, adpcm_ms
+demuxers: mp3, wav, ogg, pcm_s16le
+parsers:  mpegaudio, vorbis
+protocols: file, pipe
+encoder:   pcm_s16le
+muxer:     pcm_s16le
+filters:   aformat, anull, aresample, atempo, apad, atrim
+```
+
+Do not add Homebrew/external codecs.
 
 - [ ] **Step 3: Make the versioned cache copy-only on a valid hit.**
 
@@ -115,9 +133,9 @@ cached COPYING.LGPLv2.1 exists
 cached source.sha256 contains the exact pinned tarball hash
 ```
 
-On a miss, build into a temporary directory, validate it, then replace the versioned cache. Do not add cross-process locking; CI/local build concurrency does not justify it here.
+On a miss, build into a temporary directory, validate it, then replace the versioned cache. Do not add cross-process locking.
 
-- [ ] **Step 4: Keep all native verification inside the builder.**
+- [ ] **Step 4: Keep native verification inside the builder.**
 
 For both binaries independently require:
 
@@ -125,7 +143,7 @@ For both binaries independently require:
 file -b "$bin" | grep -qi 'arm64'
 ```
 
-Require the same feature checks currently embedded in `release.yml`:
+Require:
 
 ```text
 filters:  atempo apad atrim aformat aresample
@@ -137,22 +155,24 @@ muxer:    s16le
 
 Run `ffmpeg -version` and `ffprobe -version` successfully before caching.
 
-- [ ] **Step 5: Copy license and provenance documentation.**
+- [ ] **Step 5: Copy license and document provenance/update.**
 
 Copy `COPYING.LGPLv2.1` from the verified source tree/cache to `FFmpeg-LGPL-2.1.txt` in the caller's license output directory.
 
-Document in `README.md`:
+`README.md` must record:
 
 ```text
-version + source URL + source SHA-256
-why the minimal configure set exists
-cache location and DTXMANIA_FFMPEG_CACHE_ROOT override
-rm -rf cache command for a clean rebuild
-version-update procedure
-local build/verify commands
+version
+source URL
+source SHA-256
+minimal configure rationale
+cache location + DTXMANIA_FFMPEG_CACHE_ROOT override
+clean-cache command
+version/checksum update steps
+cold/warm local verification commands
 ```
 
-- [ ] **Step 6: Validate a cold build and a warm-cache copy.**
+- [ ] **Step 6: Validate cold build and warm-cache copy.**
 
 Run on Apple Silicon:
 
@@ -174,7 +194,7 @@ time bash tools/ffmpeg/macos-arm64/build-runtime.sh \
   /tmp/dtx-ffmpeg-licenses
 ```
 
-Expected: first command builds from source; second command reuses the cache and only verifies/copies.
+Expected: first command builds from source; second reuses cache and verifies/copies only.
 
 - [ ] **Step 7: Commit checkpoint.**
 
@@ -185,7 +205,7 @@ git commit -m "build: extract native Apple Silicon ffmpeg runtime"
 
 ---
 
-### Task 2: Make the Mac project own build/run/publish runtime placement
+### Task 2: Make the Mac project expose native runtime as normal content
 
 **Files:**
 - Modify `DTXMania.Game/DTXMania.Game.Mac.csproj`
@@ -193,17 +213,16 @@ git commit -m "build: extract native Apple Silicon ffmpeg runtime"
 
 **Consumes:** `tools/ffmpeg/macos-arm64/build-runtime.sh <runtime-dir> <license-dir>` from Task 1.
 
-**Produces:** normal Mac build and publish outputs containing the native runtime and license.
+**Produces:** one transitive build/test/publish content contract for native FFmpeg.
 
-- [ ] **Step 1: Tighten the existing resolver contract test before project wiring.**
+- [ ] **Step 1: Tighten the resolver preference test first.**
 
-Change `GetFFmpegBinaryFolder_ShouldPreferFirstCompleteCandidate` so the complete preferred candidate is:
+Change `GetFFmpegBinaryFolder_ShouldPreferFirstCompleteCandidate` so both of these are complete:
 
 ```text
 <assembly>/runtimes/osx-arm64/MMTools
+<assembly>/runtimes/osx-x64/MMTools
 ```
-
-and a complete `osx-x64/MMTools` candidate also exists.
 
 Expected assertion:
 
@@ -211,55 +230,64 @@ Expected assertion:
 Assert.Equal(arm64, result);
 ```
 
-Keep the split-folder and PATH tests unchanged.
+Keep split-folder and PATH tests unchanged.
 
-- [ ] **Step 2: Remove only the obsolete x64 runtime package.**
+- [ ] **Step 2: Remove only the obsolete x64 package.**
 
-Delete from `DTXMania.Game.Mac.csproj`:
+Delete:
 
 ```xml
 <PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
 ```
 
-Do not change `FFMpegCore` or the Windows project.
+Keep `FFMpegCore` and the Windows project unchanged.
 
-- [ ] **Step 3: Add Mac-only MSBuild targets for normal build and publish.**
+- [ ] **Step 3: Define one intermediate staging root in the Mac project.**
 
-Keep the target local to `DTXMania.Game.Mac.csproj`.
-
-After a successful `Build` on macOS, invoke:
+Use project-local intermediate paths under `$(BaseIntermediateOutputPath)`:
 
 ```text
-bash tools/ffmpeg/macos-arm64/build-runtime.sh
-  $(TargetDir)/runtimes/osx-arm64/MMTools
-  $(TargetDir)/Licenses
+ffmpeg-runtime/runtimes/osx-arm64/MMTools/ffmpeg
+ffmpeg-runtime/runtimes/osx-arm64/MMTools/ffprobe
+ffmpeg-runtime/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-After `Publish`, invoke the same script for:
+Add a macOS-only target before `PrepareForBuild` that invokes the builder with the runtime and license staging directories. Resolve the script relative to `$(MSBuildProjectDirectory)` so the command does not depend on shell working directory.
+
+The builder's user cache makes this target cheap on warm builds.
+
+- [ ] **Step 4: Declare staged files as normal output + publish items.**
+
+In `DTXMania.Game.Mac.csproj`, declare the exact staged files with links:
 
 ```text
-$(PublishDir)/runtimes/osx-arm64/MMTools
-$(PublishDir)/Licenses
+runtimes/osx-arm64/MMTools/ffmpeg
+runtimes/osx-arm64/MMTools/ffprobe
+Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Use a repository-root-relative script path based on `$(MSBuildProjectDirectory)`, not the shell working directory.
+and:
 
-Do not add shared `.props`/`.targets` files for this single platform project.
+```text
+CopyToOutputDirectory=PreserveNewest
+CopyToPublishDirectory=PreserveNewest
+```
 
-- [ ] **Step 4: Prove normal `dotnet build` and `dotnet run` output is self-contained.**
+Do not post-copy directly into `bin`/publish. The declared items are intentional so `ProjectReference` can propagate them to `DTXMania.Test.Mac`.
 
-Run on Apple Silicon:
+- [ ] **Step 5: Prove normal game build output.**
 
 ```bash
 dotnet restore DTXMania.Game/DTXMania.Game.Mac.csproj
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
 
-test -x DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
-test -x DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
+runtime="DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
+test -x "$runtime/ffmpeg"
+test -x "$runtime/ffprobe"
 test -f DTXMania.Game/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Launch once with the normal project command and confirm the process itself starts as arm64:
+Launch once through the normal supported command:
 
 ```bash
 dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -267,7 +295,20 @@ dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
 
 No PATH FFmpeg installation is part of the success path.
 
-- [ ] **Step 5: Prove self-contained publish output.**
+- [ ] **Step 6: Prove project-reference propagation to Mac test output.**
+
+```bash
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug
+
+test_runtime="DTXMania.Test/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
+test -x "$test_runtime/ffmpeg"
+test -x "$test_runtime/ffprobe"
+test -f DTXMania.Test/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+If this fails, fix the Game project item metadata; do not add a second FFmpeg copy target to the test project.
+
+- [ ] **Step 7: Prove self-contained publish output.**
 
 ```bash
 rm -rf /tmp/dtx-publish-arm64
@@ -281,7 +322,7 @@ test -x /tmp/dtx-publish-arm64/runtimes/osx-arm64/MMTools/ffprobe
 test -f /tmp/dtx-publish-arm64/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-- [ ] **Step 6: Run focused resolver tests and commit checkpoint.**
+- [ ] **Step 8: Run focused resolver tests and commit checkpoint.**
 
 ```bash
 dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
@@ -300,15 +341,15 @@ git commit -m "build: bundle native ffmpeg in Mac outputs"
 **Files:**
 - Create `DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3`
 - Create `DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs`
-- Modify `DTXMania.Test/DTXMania.Test.Mac.csproj` only if the existing test-data include does not copy the new fixture
+- Modify `DTXMania.Test/DTXMania.Test.Mac.csproj`
 
-**Consumes:** bundled runtime produced by the Mac project.
+**Consumes:** native runtime propagated into the Mac test output by Task 2.
 
-**Produces:** two native integration gates: real MP3 `ManagedSound` load and one real non-default `FfmpegAudioVariantProcessor` transform.
+**Produces:** real bundled-runtime gates for MP3 `ManagedSound` and one non-default variant transform.
 
 - [ ] **Step 1: Generate one project-owned MP3 fixture.**
 
-On a development Mac with a full FFmpeg installed for test-fixture generation only:
+Use a full development FFmpeg once to create the committed test asset:
 
 ```bash
 mkdir -p DTXMania.Test/TestData/Audio
@@ -318,56 +359,74 @@ ffmpeg -hide_banner -loglevel error \
   -y DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
 ```
 
-The committed tone contains no third-party media. Do not make fixture generation part of production build.
+The tone is generated project test data, not third-party media. Fixture generation is not part of production build.
 
-- [ ] **Step 2: Add one arm64-only runtime-location/process smoke.**
+- [ ] **Step 2: Copy the audio fixture into the Mac test output.**
 
-In `FfmpegNativeRuntimeIntegrationTests`, return without asserting native behavior when the host is not `OperatingSystem.IsMacOS()` + `Architecture.Arm64`; Windows remains covered by normal tests.
+Extend `DTXMania.Test.Mac.csproj` with the same shape already used for `TestData/NxScores`:
 
-On native Mac require:
+```xml
+<None Include="TestData/Audio/**/*">
+  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+</None>
+```
+
+- [ ] **Step 3: Add the arm64-only bundled-runtime smoke.**
+
+In `FfmpegNativeRuntimeIntegrationTests`, immediately return on hosts other than macOS arm64. On native Mac assert:
 
 ```text
 FfmpegRuntime.EnsureConfigured().IsAvailable == true
-BinaryFolder ends with runtimes/osx-arm64/MMTools
-ffmpeg and ffprobe exist and are executable
-process execution of ffmpeg -version succeeds
-process execution of ffprobe -version succeeds
+BinaryFolder == test assembly/runtimes/osx-arm64/MMTools
+ffmpeg exists + Unix execute bit
+ffprobe exists + Unix execute bit
+ffmpeg -version exits 0
+ffprobe -version exits 0
 ```
 
-Do not create a reusable process-runner abstraction for two smoke commands.
+Use `ProcessStartInfo` directly in this test class. Do not create a reusable process-runner abstraction for two commands.
 
-- [ ] **Step 3: Add the real MP3 `ManagedSound` smoke.**
+- [ ] **Step 4: Add the real MP3 `ManagedSound` smoke.**
 
-With `ALSOFT_DRIVERS=null` in the test process/CI environment:
+Resolve the copied fixture from `AppContext.BaseDirectory` and run with `ALSOFT_DRIVERS=null`:
 
 ```csharp
-using var sound = new ManagedSound(mp3Fixture);
+var mp3Path = Path.Combine(
+    AppContext.BaseDirectory,
+    "TestData",
+    "Audio",
+    "ffmpeg-tone.mp3");
+using var sound = new ManagedSound(mp3Path);
 Assert.True(sound.Duration > TimeSpan.Zero);
 ```
 
-This must exercise the packaged runtime through `FfmpegRuntime`; do not configure FFMpegCore to PATH inside the test.
+Do not configure FFMpegCore to PATH in the test.
 
-- [ ] **Step 4: Add one real variant transform smoke.**
+- [ ] **Step 5: Add one real non-default variant smoke.**
 
-Generate a small PCM WAV in the test temporary directory and run the public default processor:
+Write a deterministic 44.1 kHz mono 16-bit PCM WAV to a temporary path in the test, then use the public production processor exactly as follows:
 
 ```csharp
 var processor = new FfmpegAudioVariantProcessor();
 var artifact = await processor.PrepareAsync(
     wavPath,
-    new PlaybackModifiers(/* use the existing non-default play-speed factory/constructor */),
+    new PlaybackModifiers(125, 0),
     cancellationToken);
+
+Assert.True(artifact.PcmByteLength > 0);
+Assert.Equal(44_100, artifact.SampleRate);
+Assert.Equal(1, artifact.ChannelCount);
 ```
 
-Use the repository's actual `PlaybackModifiers` API and one supported non-default speed already covered by unit tests. Assert a non-empty prepared artifact, then dispose/delete via the existing artifact ownership contract.
+`125` is a valid non-default `PlaySpeedRange` value and exercises `atempo`; pitch remains default.
 
-This test must use the real backend; do not pass the internal fake backend used by unit tests.
+Clean only the source WAV/temp test directory in `finally`. `PreparedAudioArtifact` is in-memory and does not need disposal.
 
-- [ ] **Step 5: Keep existing cancellation/timeout tests as the cleanup gate.**
+- [ ] **Step 6: Keep existing cancellation/timeout tests as the cleanup gate.**
 
-Do not duplicate cancellation machinery in the native integration class. Run the existing `FfmpegAudioVariantProcessorTests` together with the two new native smokes.
+Do not duplicate cancellation machinery in the integration class. Run existing `FfmpegAudioVariantProcessorTests` together with the new native tests.
 
-- [ ] **Step 6: Run focused native tests.**
+- [ ] **Step 7: Run focused native tests.**
 
 ```bash
 ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
@@ -376,9 +435,9 @@ ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
   --verbosity normal
 ```
 
-Expected: native runtime, MP3 load, real variant transform, and existing cancellation/timeout coverage all pass.
+Expected: bundled runtime location/process smoke, MP3 load, real 1.25x variant transform, and existing cancellation/timeout coverage pass.
 
-- [ ] **Step 7: Commit checkpoint.**
+- [ ] **Step 8: Commit checkpoint.**
 
 ```bash
 git add DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3 \
@@ -394,47 +453,40 @@ git commit -m "test: verify native Mac ffmpeg audio paths"
 **Files:**
 - Modify `.github/workflows/build-and-test.yml`
 - Modify `.github/workflows/release.yml`
-- Modify `installer/macos/build-dmg.sh` / `test-build-dmg.sh` only if verification proves execute bits are lost
+- Modify `installer/macos/build-dmg.sh` / `installer/macos/test-build-dmg.sh` only if verification proves execute bits are lost
 
-**Consumes:** project-owned build/publish runtime from Tasks 1–3.
+**Consumes:** project-owned staged/copied runtime from Tasks 1–3.
 
-**Produces:** one native CI path and one release path using the same runtime source of truth.
+**Produces:** one native CI path and one release path using the same FFmpeg source of truth.
 
-- [ ] **Step 1: Pin regular Mac CI to a native Apple Silicon runner.**
+- [ ] **Step 1: Pin regular Mac CI to native Apple Silicon.**
 
-Change:
-
-```yaml
-runs-on: macos-latest
-```
-
-to:
+Change `build-and-test-macos`:
 
 ```yaml
 runs-on: macos-15
 ```
 
-for `build-and-test-macos`.
-
-This makes the regular Mac build/test result actual arm64 evidence, matching the existing release runner.
+This matches the existing native release runner.
 
 - [ ] **Step 2: Cache the source-built runtime for PR speed.**
 
-Before the Mac build, add `actions/cache` for:
+Before the Mac build, cache:
 
 ```text
 ~/Library/Caches/DTXManiaCX/ffmpeg
 ```
 
-Key it with OS/architecture plus:
+with a key containing:
 
 ```text
+macos-arm64
 hashFiles('tools/ffmpeg/macos-arm64/build-runtime.sh')
 ```
 
-Do not cache build/publish outputs.
+Do not cache `bin`, `obj`, or publish output.
 
-- [ ] **Step 3: Verify the actual game build output before tests.**
+- [ ] **Step 3: Verify the actual Game build output.**
 
 Immediately after `dotnet build`:
 
@@ -448,13 +500,20 @@ file -b "$runtime/ffprobe" | grep -qi arm64
 "$runtime/ffprobe" -version
 ```
 
-Set `ALSOFT_DRIVERS=null` when running the focused/native audio tests.
+- [ ] **Step 4: Run the focused native audio gate before the full Mac suite.**
 
-Keep the full Mac unit suite, Automation suite, and prepared-chart AudioE2E afterward.
+```bash
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --configuration Debug \
+  --verbosity normal \
+  --filter "FullyQualifiedName~FfmpegNativeRuntimeIntegrationTests|FullyQualifiedName~FfmpegAudioVariantProcessorTests"
+```
 
-- [ ] **Step 4: Delete the duplicated FFmpeg source-build body from `release.yml`.**
+Then retain the existing full Mac unit suite, Automation suite, and prepared-chart `AudioE2E`.
 
-The `dotnet publish` step now produces:
+- [ ] **Step 5: Delete the duplicated source-build body from `release.yml`.**
+
+`dotnet publish` must now produce:
 
 ```text
 publish/mac/runtimes/osx-arm64/MMTools/ffmpeg
@@ -462,7 +521,7 @@ publish/mac/runtimes/osx-arm64/MMTools/ffprobe
 publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Replace the existing long `Build native arm64 ffmpeg` step with a short publish-artifact verification:
+Replace the current long native FFmpeg build step with a short artifact verification:
 
 ```bash
 runtime="publish/mac/runtimes/osx-arm64/MMTools"
@@ -473,11 +532,11 @@ file -b "$runtime/ffmpeg" | grep -qi arm64
 file -b "$runtime/ffprobe" | grep -qi arm64
 ```
 
-The feature-set verification remains in `build-runtime.sh`; do not duplicate it in YAML.
+Feature verification stays in `build-runtime.sh`; do not duplicate it in YAML.
 
-- [ ] **Step 5: Verify the packaged `.app` after `build-dmg.sh`.**
+- [ ] **Step 6: Verify the packaged `.app`.**
 
-After bundle creation, require:
+After `build-dmg.sh`:
 
 ```bash
 app_runtime="output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools"
@@ -488,9 +547,9 @@ file -b "$app_runtime/ffprobe" | grep -qi arm64
 test -f output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-If this passes, do not touch `build-dmg.sh`. If execute bits are actually lost, fix only its existing `cp -R` staging behavior and extend `test-build-dmg.sh` for that exact regression.
+If this passes, do not touch `build-dmg.sh`. If execute bits are actually lost, fix only its existing publish-output copy and extend `test-build-dmg.sh` for that regression.
 
-- [ ] **Step 6: Run the final local blast radius.**
+- [ ] **Step 7: Run final blast radius.**
 
 On Apple Silicon:
 
@@ -500,6 +559,8 @@ ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug 
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj -c Debug --verbosity normal
 ```
 
+Run the existing prepared-chart `AudioE2E` command from the workflow on `macos-15`.
+
 On Windows/Windows CI:
 
 ```powershell
@@ -507,19 +568,15 @@ dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
 dotnet test DTXMania.Test/DTXMania.Test.csproj -c Debug --verbosity normal
 ```
 
-Also run the Mac prepared-chart AudioE2E on the native runner using the existing workflow command.
-
-- [ ] **Step 7: Commit checkpoint.**
+- [ ] **Step 8: Commit checkpoint.**
 
 ```bash
-git add .github/workflows/build-and-test.yml \
-        .github/workflows/release.yml \
-        installer/macos/build-dmg.sh \
-        installer/macos/test-build-dmg.sh
+git add .github/workflows/build-and-test.yml .github/workflows/release.yml
+git add installer/macos/build-dmg.sh installer/macos/test-build-dmg.sh 2>/dev/null || true
 git commit -m "ci: validate bundled Apple Silicon ffmpeg"
 ```
 
-Stage only installer files if they actually changed.
+Only installer files with real changes should be staged in the final commit.
 
 ---
 
@@ -527,17 +584,18 @@ Stage only installer files if they actually changed.
 
 - [ ] `MMTools.Executables.MacOS.X64` is absent from the Mac project.
 - [ ] Normal Apple Silicon `dotnet build` output contains executable arm64 `ffmpeg` and `ffprobe`.
-- [ ] Normal `dotnet run` resolves the bundled arm64 runtime without PATH/Rosetta.
+- [ ] Mac test output receives the same runtime through the Game `ProjectReference` copy contract.
+- [ ] Normal `dotnet run` resolves bundled arm64 runtime without PATH/Rosetta.
 - [ ] `dotnet publish -r osx-arm64` contains the same runtime and FFmpeg LGPL license.
 - [ ] `FfmpegRuntime` preference test proves `osx-arm64` wins over an available x64 candidate.
-- [ ] Real packaged-runtime `ffmpeg -version` and `ffprobe -version` smoke passes.
-- [ ] MP3 preview load through `ManagedSound` passes with the bundled runtime.
-- [ ] One real non-default `FfmpegAudioVariantProcessor` transform passes.
+- [ ] Bundled `ffmpeg -version` and `ffprobe -version` smoke passes.
+- [ ] MP3 load through `ManagedSound` passes with the bundled runtime.
+- [ ] Real `FfmpegAudioVariantProcessor` transform with `new PlaybackModifiers(125, 0)` passes.
 - [ ] Existing cancellation/timeout cleanup tests remain green.
 - [ ] Regular Mac CI is pinned to `macos-15` and caches the source-built runtime.
 - [ ] Release YAML no longer owns a duplicate FFmpeg configure/build recipe.
-- [ ] `.app` bundle retains both runtime files, arm64 architecture, execute bits, and license.
-- [ ] Windows build/tests are unchanged and green.
+- [ ] `.app` bundle retains runtime files, arm64 architecture, execute bits, and license.
+- [ ] Windows build/tests remain unchanged and green.
 
 ## Handoff
 

--- a/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
+++ b/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
@@ -2,25 +2,28 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make normal CX Mac build/run/test/publish output carry a verified native Apple Silicon `ffmpeg`/`ffprobe` runtime so MP3 preview and non-default playback variants work without Rosetta or user-installed FFmpeg.
+**Goal:** Make normal CX Mac build/run/test/publish output carry one verified native Apple Silicon `ffmpeg`/`ffprobe` runtime, while preserving the existing real audio tests and Windows build behavior.
 
-**Architecture:** Extract the already-proven FFmpeg 7.0.2 arm64 source build from `release.yml` into one reusable shell builder with a versioned user cache. `DTXMania.Game.Mac.csproj` stages the generated files under `obj` before MSBuild resolves output-copy items, then declares them as normal build/publish content so they propagate through `ProjectReference` into Mac tests. Existing `FfmpegRuntime` remains the runtime resolver. Native `macos-15` CI validates the real files and focused audio paths, and release reuses the same project-owned output.
+**Architecture:** Extract the exact FFmpeg 7.0.2 arm64 source recipe already shipping in `release.yml` into one cached shell builder. `DTXMania.Game.Mac.csproj` generates the files on macOS before MSBuild resolves output-copy items, adds the generated items inside that target, and exposes them through the normal `GetCopyToOutputDirectoryItems`/publish path. Existing `FfmpegRuntime` remains unchanged. Repair the existing MP3/OGG variant test inputs instead of adding a weaker duplicate variant test.
 
 **Tech Stack:** .NET 8, MonoGame DesktopGL, FFMpegCore 5.4.0, FFmpeg 7.0.2 source build, Bash/MSBuild, xUnit, GitHub Actions `macos-15`.
 
 ## Global Constraints
 
-- Keep FFmpeg 7.0.2 for this ticket; this is packaging consolidation, not an FFmpeg upgrade.
+- Keep FFmpeg 7.0.2 for this ticket; no version upgrade.
 - Official source tarball SHA-256 stays `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`.
+- First extract the **current shipping configure list exactly**. `--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` may be retained only after a separate clean cold build passes all capability checks.
 - Supported macOS target is native Apple Silicon arm64 only; no Intel/Rosetta fallback.
 - Remove `MMTools.Executables.MacOS.X64` from `DTXMania.Game.Mac.csproj`.
-- Keep `FFMpegCore` 5.4.0 and the existing `FfmpegRuntime` production resolution flow.
-- Runtime layout stays `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`.
-- PATH remains diagnostic fallback only; never install/use PATH FFmpeg as production recovery.
-- Preserve Windows project/runtime behavior unchanged.
-- Preserve the current minimal CX codec/filter surface; do not grow a general FFmpeg build.
-- Ship upstream LGPL license material with build/publish/release output.
-- No new NuGet binary provider, binary commits, package-builder project, generic bootstrap framework, signing/notarization redesign, recorder media work, or OBS work.
+- Keep `FFMpegCore` 5.4.0 and `FfmpegRuntime` production resolution behavior unchanged.
+- Runtime layout remains `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`.
+- PATH remains a diagnostic fallback only; do not install/use PATH FFmpeg as production recovery.
+- The native generation target must be `Condition="$([MSBuild]::IsOSPlatform('OSX'))"` because Windows tests reference `DTXMania.Game.Mac.csproj`.
+- Preserve the current minimal CX codec/filter surface; do not add `libmp3lame`/`libvorbis` encoders to production only to generate test fixtures.
+- Keep the existing `PlaybackModifiers(50, 12)` real variant test; do not add a second `PlaybackModifiers(125, 0)` variant smoke.
+- Leave `ManagedSoundFFmpegPathTests` and the existing first-complete-candidate `FfmpegRuntimeCoverageTests` behavior unchanged.
+- Ship upstream `COPYING.LGPLv2.1` as `Licenses/FFmpeg-LGPL-2.1.txt`.
+- No new NuGet binary provider, committed production binaries, package-builder project, generic bootstrap framework, resolver, audio stack, recorder media work, OBS work, or signing/notarization redesign.
 
 ---
 
@@ -31,16 +34,20 @@ Create:
   tools/ffmpeg/macos-arm64/build-runtime.sh
   tools/ffmpeg/macos-arm64/README.md
   DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
-  DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs
+  DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg
 
 Modify:
   DTXMania.Game/DTXMania.Game.Mac.csproj
+  DTXMania.Game/Lib/Resources/ManagedSound.cs
+  DTXMania.Test/DTXMania.Test.csproj
   DTXMania.Test/DTXMania.Test.Mac.csproj
-  DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs
+  DTXMania.Test/Resources/FfmpegAudioVariantProcessorTests.cs
+  DTXMania.Test/Resources/FfmpegRuntimeTests.cs
+  DTXMania.Test/Resources/ManagedSoundTests.cs
   .github/workflows/build-and-test.yml
   .github/workflows/release.yml
 
-Only modify if packaged-app verification exposes a real permission-copy bug:
+Only modify if packaged-output verification proves execute bits are lost:
   installer/macos/build-dmg.sh
   installer/macos/test-build-dmg.sh
 ```
@@ -68,79 +75,102 @@ license-output-dir/
   FFmpeg-LGPL-2.1.txt
 ```
 
-The builder maintains its reusable validated cache at:
+Cache root:
 
 ```text
 ${DTXMANIA_FFMPEG_CACHE_ROOT:-$HOME/Library/Caches/DTXManiaCX/ffmpeg}/7.0.2/osx-arm64
 ```
 
-- [ ] **Step 1: Copy the proven source recipe out of `release.yml` into the script.**
+- [ ] **Step 1: Copy the currently shipping source recipe exactly out of `release.yml`.**
 
-Use constants at the top of the script:
+Start the script with:
 
 ```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 FFMPEG_VERSION="7.0.2"
 FFMPEG_TARBALL_SHA256="8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389"
 FFMPEG_URL="https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+
+if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
+  echo "Native CX macOS runtime requires Apple Silicon (arm64); Intel/Rosetta is not supported." >&2
+  exit 1
+fi
 ```
 
-Fail before download/build unless:
+Require exactly two positional destinations and normalize/create them before copying.
+
+- [ ] **Step 2: Preserve the existing configure list before trying any license-hardening delta.**
+
+Baseline configure flags must match the current release workflow:
 
 ```bash
-[[ "$(uname -s)" == "Darwin" ]]
-[[ "$(uname -m)" == "arm64" ]]
+./configure \
+  --prefix="$install_dir" \
+  --enable-static --disable-shared \
+  --disable-doc --disable-htmlpages --disable-manpages \
+  --disable-podpages --disable-txtpages \
+  --disable-ffplay \
+  --disable-everything \
+  --enable-decoder=mp3float \
+  --enable-decoder=vorbis \
+  --enable-decoder=pcm_s16le,pcm_s24le,pcm_f32le,pcm_u8,pcm_alaw,pcm_mulaw \
+  --enable-decoder=adpcm_ima_wav,adpcm_ms \
+  --enable-demuxer=mp3 \
+  --enable-demuxer=wav,ogg,pcm_s16le \
+  --enable-parser=mpegaudio,vorbis \
+  --enable-protocol=file,pipe \
+  --enable-muxer=pcm_s16le \
+  --enable-encoder=pcm_s16le \
+  --enable-filter=aformat,anull,aresample,atempo,apad,atrim
 ```
 
-Use this failure meaning:
+Do not add `libmp3lame`, `libvorbis`, Homebrew libraries, or any other external codec dependency.
 
-```text
-Native CX macOS runtime requires Apple Silicon (arm64); Intel/Rosetta is not supported.
+- [ ] **Step 3: Implement a versioned validated cache.**
+
+Use:
+
+```bash
+cache_root="${DTXMANIA_FFMPEG_CACHE_ROOT:-$HOME/Library/Caches/DTXManiaCX/ffmpeg}"
+cache_dir="$cache_root/$FFMPEG_VERSION/osx-arm64"
 ```
-
-- [ ] **Step 2: Preserve the existing minimal feature set and make dependency/license behavior deterministic.**
-
-Start from the current release configure list and add:
-
-```text
---disable-autodetect
---disable-gpl
---disable-nonfree
-```
-
-Keep exactly these CX requirements:
-
-```text
-decoders: mp3float, vorbis, pcm_s16le, pcm_s24le, pcm_f32le, pcm_u8,
-          pcm_alaw, pcm_mulaw, adpcm_ima_wav, adpcm_ms
-demuxers: mp3, wav, ogg, pcm_s16le
-parsers:  mpegaudio, vorbis
-protocols: file, pipe
-encoder:   pcm_s16le
-muxer:     pcm_s16le
-filters:   aformat, anull, aresample, atempo, apad, atrim
-```
-
-Do not add Homebrew/external codecs.
-
-- [ ] **Step 3: Make the versioned cache copy-only on a valid hit.**
 
 A cache hit is valid only when all are true:
 
 ```text
-cached ffmpeg exists + executable
-cached ffprobe exists + executable
-cached COPYING.LGPLv2.1 exists
-cached source.sha256 contains the exact pinned tarball hash
+$cache_dir/ffmpeg exists + executable
+$cache_dir/ffprobe exists + executable
+$cache_dir/COPYING.LGPLv2.1 exists
+$cache_dir/source.sha256 contains the exact pinned source hash
 ```
 
-On a miss, build into a temporary directory, validate it, then replace the versioned cache. Do not add cross-process locking.
+On a miss:
 
-- [ ] **Step 4: Keep native verification inside the builder.**
+1. create a `mktemp -d` work root;
+2. `curl -fsSL` the tarball;
+3. verify with `shasum -a 256 -c`;
+4. extract/configure/build/install under the temporary root;
+5. validate before replacing the cache;
+6. write `source.sha256` only after validation succeeds.
 
-For both binaries independently require:
+Use a shell `trap` to remove the temporary work root. Do not add cache locking.
+
+- [ ] **Step 4: Move the current release capability checks into the builder.**
+
+For each binary independently:
 
 ```bash
+test -x "$bin"
 file -b "$bin" | grep -qi 'arm64'
+```
+
+Run:
+
+```bash
+"$ffmpeg" -version
+"$ffprobe" -version
 ```
 
 Require:
@@ -153,50 +183,81 @@ encoder:  pcm_s16le
 muxer:    s16le
 ```
 
-Run `ffmpeg -version` and `ffprobe -version` successfully before caching.
+Copy validated files with:
 
-- [ ] **Step 5: Copy license and document provenance/update.**
-
-Copy `COPYING.LGPLv2.1` from the verified source tree/cache to `FFmpeg-LGPL-2.1.txt` in the caller's license output directory.
-
-`README.md` must record:
-
-```text
-version
-source URL
-source SHA-256
-minimal configure rationale
-cache location + DTXMANIA_FFMPEG_CACHE_ROOT override
-clean-cache command
-version/checksum update steps
-cold/warm local verification commands
+```bash
+install -m 755 "$cache_dir/ffmpeg" "$runtime_output_dir/ffmpeg"
+install -m 755 "$cache_dir/ffprobe" "$runtime_output_dir/ffprobe"
+install -m 644 "$cache_dir/COPYING.LGPLv2.1" "$license_output_dir/FFmpeg-LGPL-2.1.txt"
 ```
 
-- [ ] **Step 6: Validate cold build and warm-cache copy.**
+Use `install`, not a permission-ambiguous copy, for the builder's own output.
+
+- [ ] **Step 5: Prove the extracted shipping recipe with a cold build.**
 
 Run on Apple Silicon:
 
 ```bash
 rm -rf "$HOME/Library/Caches/DTXManiaCX/ffmpeg/7.0.2/osx-arm64"
 rm -rf /tmp/dtx-ffmpeg-runtime /tmp/dtx-ffmpeg-licenses
+
 bash tools/ffmpeg/macos-arm64/build-runtime.sh \
   /tmp/dtx-ffmpeg-runtime \
   /tmp/dtx-ffmpeg-licenses
 
 test -x /tmp/dtx-ffmpeg-runtime/ffmpeg
 test -x /tmp/dtx-ffmpeg-runtime/ffprobe
-file /tmp/dtx-ffmpeg-runtime/ffmpeg /tmp/dtx-ffmpeg-runtime/ffprobe
+file -b /tmp/dtx-ffmpeg-runtime/ffmpeg | grep -qi arm64
+file -b /tmp/dtx-ffmpeg-runtime/ffprobe | grep -qi arm64
 test -f /tmp/dtx-ffmpeg-licenses/FFmpeg-LGPL-2.1.txt
+```
 
+This cold build is the baseline gate. Do not change configure flags before it passes.
+
+- [ ] **Step 6: Trial explicit license/autodetect hardening only after the baseline is green.**
+
+Add these three flags together:
+
+```text
+--disable-autodetect
+--disable-gpl
+--disable-nonfree
+```
+
+Delete the cache and repeat Step 5. Keep the three flags only if the clean build plus every architecture/filter/decoder/demuxer/encoder/muxer check passes. If not, revert the flags and retain the proven recipe; HPA-512 does not depend on this hardening.
+
+- [ ] **Step 7: Prove the warm-cache path.**
+
+```bash
 rm -rf /tmp/dtx-ffmpeg-runtime /tmp/dtx-ffmpeg-licenses
 time bash tools/ffmpeg/macos-arm64/build-runtime.sh \
   /tmp/dtx-ffmpeg-runtime \
   /tmp/dtx-ffmpeg-licenses
+
+test -x /tmp/dtx-ffmpeg-runtime/ffmpeg
+test -x /tmp/dtx-ffmpeg-runtime/ffprobe
 ```
 
-Expected: first command builds from source; second reuses cache and verifies/copies only.
+Expected: no source compile; validated cached files are copied.
 
-- [ ] **Step 7: Commit checkpoint.**
+- [ ] **Step 8: Write provenance/update documentation.**
+
+`README.md` must contain:
+
+```text
+FFmpeg 7.0.2
+official source URL
+pinned SHA-256
+actual final configure command
+why the minimal feature list exists
+COPYING.LGPLv2.1 handling
+cache path and DTXMANIA_FFMPEG_CACHE_ROOT override
+clean-cache command
+version + checksum update procedure
+cold/warm verification commands
+```
+
+- [ ] **Step 9: Commit checkpoint.**
 
 ```bash
 git add tools/ffmpeg/macos-arm64
@@ -205,34 +266,16 @@ git commit -m "build: extract native Apple Silicon ffmpeg runtime"
 
 ---
 
-### Task 2: Make the Mac project expose native runtime as normal content
+### Task 2: Make the Mac project own one generated-content copy contract
 
 **Files:**
 - Modify `DTXMania.Game/DTXMania.Game.Mac.csproj`
-- Modify `DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs`
 
-**Consumes:** `tools/ffmpeg/macos-arm64/build-runtime.sh <runtime-dir> <license-dir>` from Task 1.
+**Consumes:** Task 1 builder.
 
-**Produces:** one transitive build/test/publish content contract for native FFmpeg.
+**Produces:** native runtime/license files in Game output, Test.Mac output through `ProjectReference`, and publish output, without executing the builder on Windows.
 
-- [ ] **Step 1: Tighten the resolver preference test first.**
-
-Change `GetFFmpegBinaryFolder_ShouldPreferFirstCompleteCandidate` so both of these are complete:
-
-```text
-<assembly>/runtimes/osx-arm64/MMTools
-<assembly>/runtimes/osx-x64/MMTools
-```
-
-Expected assertion:
-
-```csharp
-Assert.Equal(arm64, result);
-```
-
-Keep split-folder and PATH tests unchanged.
-
-- [ ] **Step 2: Remove only the obsolete x64 package.**
+- [ ] **Step 1: Remove only the obsolete Mac x64 runtime package.**
 
 Delete:
 
@@ -240,73 +283,102 @@ Delete:
 <PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
 ```
 
-Keep `FFMpegCore` and the Windows project unchanged.
+Keep:
 
-- [ ] **Step 3: Define one intermediate staging root in the Mac project.**
-
-Use project-local intermediate paths under `$(BaseIntermediateOutputPath)`:
-
-```text
-ffmpeg-runtime/runtimes/osx-arm64/MMTools/ffmpeg
-ffmpeg-runtime/runtimes/osx-arm64/MMTools/ffprobe
-ffmpeg-runtime/Licenses/FFmpeg-LGPL-2.1.txt
+```xml
+<PackageReference Include="FFMpegCore" Version="5.4.0" />
 ```
 
-Add a macOS-only target before `PrepareForBuild` that invokes the builder with the runtime and license staging directories. Resolve the script relative to `$(MSBuildProjectDirectory)` so the command does not depend on shell working directory.
+Do not change the Windows project or `FfmpegRuntime`.
 
-The builder's user cache makes this target cheap on warm builds.
+- [ ] **Step 2: Define intermediate staging paths in the Mac project.**
 
-- [ ] **Step 4: Declare staged files as normal output + publish items.**
+Add properties equivalent to:
 
-In `DTXMania.Game.Mac.csproj`, declare the exact staged files with links:
-
-```text
-runtimes/osx-arm64/MMTools/ffmpeg
-runtimes/osx-arm64/MMTools/ffprobe
-Licenses/FFmpeg-LGPL-2.1.txt
+```xml
+<PropertyGroup>
+  <NativeFfmpegStagingRoot>$(BaseIntermediateOutputPath)ffmpeg-runtime</NativeFfmpegStagingRoot>
+  <NativeFfmpegRuntimeDir>$(NativeFfmpegStagingRoot)/runtimes/osx-arm64/MMTools</NativeFfmpegRuntimeDir>
+  <NativeFfmpegLicenseDir>$(NativeFfmpegStagingRoot)/Licenses</NativeFfmpegLicenseDir>
+</PropertyGroup>
 ```
 
-and:
+- [ ] **Step 3: Add the generated-content target with the exact lifecycle hooks.**
 
-```text
-CopyToOutputDirectory=PreserveNewest
-CopyToPublishDirectory=PreserveNewest
+Use this shape, adapting XML escaping/path quoting only as required by MSBuild:
+
+```xml
+<Target Name="PrepareNativeFfmpegRuntime"
+        Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+        BeforeTargets="BeforeBuild;AssignTargetPaths;GetCopyToOutputDirectoryItems">
+  <Exec Command="bash &quot;$(MSBuildProjectDirectory)/../tools/ffmpeg/macos-arm64/build-runtime.sh&quot; &quot;$(NativeFfmpegRuntimeDir)&quot; &quot;$(NativeFfmpegLicenseDir)&quot;" />
+
+  <ItemGroup>
+    <None Include="$(NativeFfmpegRuntimeDir)/ffmpeg">
+      <TargetPath>runtimes/osx-arm64/MMTools/ffmpeg</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="$(NativeFfmpegRuntimeDir)/ffprobe">
+      <TargetPath>runtimes/osx-arm64/MMTools/ffprobe</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="$(NativeFfmpegLicenseDir)/FFmpeg-LGPL-2.1.txt">
+      <TargetPath>Licenses/FFmpeg-LGPL-2.1.txt</TargetPath>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Target>
 ```
 
-Do not post-copy directly into `bin`/publish. The declared items are intentional so `ProjectReference` can propagate them to `DTXMania.Test.Mac`.
+The generated `None` items are intentionally added **inside** the target after the builder has created the files. Do not replace this with static top-level items for files that do not exist during evaluation.
 
-- [ ] **Step 5: Prove normal game build output.**
+Do not add a test-project FFmpeg copy target.
+
+- [ ] **Step 4: Prove the target is inert on Windows before doing Mac validation.**
+
+On Windows or Windows CI:
+
+```powershell
+dotnet build DTXMania.Test/DTXMania.Test.csproj -c Debug
+```
+
+Expected: succeeds without attempting `tools/ffmpeg/macos-arm64/build-runtime.sh`. This is required because `DTXMania.Test.csproj` references `DTXMania.Game.Mac.csproj`.
+
+- [ ] **Step 5: Prove Game build output on Apple Silicon.**
 
 ```bash
-dotnet restore DTXMania.Game/DTXMania.Game.Mac.csproj
-dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+dotnet restore DTXMania.Test/DTXMania.Test.Mac.csproj
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug --no-restore
 
 runtime="DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
 test -x "$runtime/ffmpeg"
 test -x "$runtime/ffprobe"
+file -b "$runtime/ffmpeg" | grep -qi arm64
+file -b "$runtime/ffprobe" | grep -qi arm64
 test -f DTXMania.Game/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Launch once through the normal supported command:
+Do not use `dotnet run` as an acceptance command; the GUI does not terminate and adds no stronger packaging evidence.
+
+- [ ] **Step 6: Prove ProjectReference propagation by explicitly building Test.Mac.**
 
 ```bash
-dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
-```
-
-No PATH FFmpeg installation is part of the success path.
-
-- [ ] **Step 6: Prove project-reference propagation to Mac test output.**
-
-```bash
-dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug --no-restore
 
 test_runtime="DTXMania.Test/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
 test -x "$test_runtime/ffmpeg"
 test -x "$test_runtime/ffprobe"
+file -b "$test_runtime/ffmpeg" | grep -qi arm64
+file -b "$test_runtime/ffprobe" | grep -qi arm64
 test -f DTXMania.Test/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-If this fails, fix the Game project item metadata; do not add a second FFmpeg copy target to the test project.
+If Game output passes but Test.Mac output is missing, fix the Game project's generated-item/target metadata. Do not add a duplicate test-project copy implementation.
+
+If files exist but `test -x` fails, add the smallest macOS-only post-copy `chmod +x` target required for Game/Test/publish output and add a regression assertion. Do not weaken `FfmpegRuntime.IsRunnableFile`.
 
 - [ ] **Step 7: Prove self-contained publish output.**
 
@@ -317,285 +389,407 @@ dotnet publish DTXMania.Game/DTXMania.Game.Mac.csproj \
   -p:PublishReadyToRun=false -p:TieredCompilation=false \
   -o /tmp/dtx-publish-arm64
 
-test -x /tmp/dtx-publish-arm64/runtimes/osx-arm64/MMTools/ffmpeg
-test -x /tmp/dtx-publish-arm64/runtimes/osx-arm64/MMTools/ffprobe
+runtime="/tmp/dtx-publish-arm64/runtimes/osx-arm64/MMTools"
+test -x "$runtime/ffmpeg"
+test -x "$runtime/ffprobe"
+file -b "$runtime/ffmpeg" | grep -qi arm64
+file -b "$runtime/ffprobe" | grep -qi arm64
 test -f /tmp/dtx-publish-arm64/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-- [ ] **Step 8: Run focused resolver tests and commit checkpoint.**
+- [ ] **Step 8: Commit checkpoint.**
 
 ```bash
-dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
-  --filter "FullyQualifiedName~FfmpegRuntime" \
-  --verbosity normal
-
-git add DTXMania.Game/DTXMania.Game.Mac.csproj \
-        DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs
+git add DTXMania.Game/DTXMania.Game.Mac.csproj
 git commit -m "build: bundle native ffmpeg in Mac outputs"
 ```
 
 ---
 
-### Task 3: Add native MP3 and real audio-variant smoke coverage
+### Task 3: Repair existing Audio tests and add only missing product gates
 
 **Files:**
 - Create `DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3`
-- Create `DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs`
+- Create `DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg`
+- Modify `DTXMania.Test/DTXMania.Test.csproj`
 - Modify `DTXMania.Test/DTXMania.Test.Mac.csproj`
+- Modify `DTXMania.Test/Resources/FfmpegAudioVariantProcessorTests.cs`
+- Modify `DTXMania.Test/Resources/FfmpegRuntimeTests.cs`
+- Modify `DTXMania.Test/Resources/ManagedSoundTests.cs`
+- Modify `DTXMania.Game/Lib/Resources/ManagedSound.cs`
 
-**Consumes:** native runtime propagated into the Mac test output by Task 2.
+**Consumes:** Task 2 test-output runtime contract.
 
-**Produces:** real bundled-runtime gates for MP3 `ManagedSound` and one non-default variant transform.
+**Produces:** existing real variant coverage that works with the minimal runtime, plus one bundled-path/execute-bit gate and one successful MP3 load.
 
-- [ ] **Step 1: Generate one project-owned MP3 fixture.**
+- [ ] **Step 1: Generate deterministic project-owned MP3 and OGG fixtures once.**
 
-Use a full development FFmpeg once to create the committed test asset:
+Using a full development FFmpeg only for fixture creation:
 
 ```bash
 mkdir -p DTXMania.Test/TestData/Audio
+
 ffmpeg -hide_banner -loglevel error \
-  -f lavfi -i "sine=frequency=440:sample_rate=44100:duration=1" \
+  -f lavfi -i "sine=frequency=440:sample_rate=44100:duration=0.25" \
   -ac 1 -codec:a libmp3lame -b:a 64k \
   -y DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
+
+ffmpeg -hide_banner -loglevel error \
+  -f lavfi -i "sine=frequency=440:sample_rate=44100:duration=0.25" \
+  -ac 1 -codec:a libvorbis -q:a 4 \
+  -y DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg
 ```
 
-The tone is generated project test data, not third-party media. Fixture generation is not part of production build.
+These are small generated test inputs. Do not copy a third-party song/audio asset.
 
-- [ ] **Step 2: Copy the audio fixture into the Mac test output.**
+- [ ] **Step 2: Copy the fixtures from both test projects.**
 
-Extend `DTXMania.Test.Mac.csproj` with the same shape already used for `TestData/NxScores`:
+Add to both `DTXMania.Test.csproj` and `DTXMania.Test.Mac.csproj`:
 
 ```xml
-<None Include="TestData/Audio/**/*">
-  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-</None>
+<ItemGroup>
+  <None Include="TestData/Audio/**/*">
+    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+  </None>
+</ItemGroup>
 ```
 
-- [ ] **Step 3: Add the arm64-only bundled-runtime smoke.**
+Both projects compile the shared Audio tests, so both need the same fixture path.
 
-In `FfmpegNativeRuntimeIntegrationTests`, immediately return on hosts other than macOS arm64. On native Mac assert:
+- [ ] **Step 3: Repair the existing real encoded-audio variant test instead of adding another variant smoke.**
+
+In `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm`, remove the `FFMpegArguments` fixture-encoding block that calls `libmp3lame` / `libvorbis`.
+
+Keep the three rows and use this source selection shape:
+
+```csharp
+var source = extension switch
+{
+    "wav" => WriteToneWav("tone.wav", durationSeconds: 0.25),
+    "mp3" => Path.Combine(
+        AppContext.BaseDirectory,
+        "TestData", "Audio", "ffmpeg-tone.mp3"),
+    "ogg" => Path.Combine(
+        AppContext.BaseDirectory,
+        "TestData", "Audio", "ffmpeg-tone.ogg"),
+    _ => throw new ArgumentOutOfRangeException(nameof(extension)),
+};
+
+Assert.True(File.Exists(source), $"Missing audio fixture: {source}");
+
+var modifiers = new PlaybackModifiers(50, 12);
+var artifact = await new FfmpegAudioVariantProcessor().PrepareAsync(
+    source,
+    modifiers,
+    CancellationToken.None);
+```
+
+Keep the existing sample-rate/channel/byte-length/duration/pitch/frequency assertions unchanged.
+
+Do not add `PlaybackModifiers(125, 0)` coverage; `PlaybackModifiers(50, 12)` already exercises the harder atempo chain.
+
+- [ ] **Step 4: Add one real packaged-runtime filesystem gate to `FfmpegRuntimeTests`.**
+
+Add required usings for `System.Runtime.InteropServices` and `AudioTestUtils` if not already present.
+
+Add a test equivalent to:
+
+```csharp
+[Fact]
+[Trait("Category", AudioTestUtils.AudioTestCategory)]
+public void EnsureConfigured_OnNativeAppleSilicon_ShouldUseBundledExecutableRuntime()
+{
+    if (!OperatingSystem.IsMacOS() ||
+        RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+        return;
+
+    var result = FfmpegRuntime.EnsureConfigured();
+    Assert.True(result.IsAvailable, result.DiagnosticReason);
+
+    var expected = Path.Combine(
+        AppContext.BaseDirectory,
+        "runtimes", "osx-arm64", "MMTools");
+    Assert.Equal(Path.GetFullPath(expected), Path.GetFullPath(result.BinaryFolder!));
+
+    const UnixFileMode execute =
+        UnixFileMode.UserExecute |
+        UnixFileMode.GroupExecute |
+        UnixFileMode.OtherExecute;
+
+    foreach (var name in new[] { "ffmpeg", "ffprobe" })
+    {
+        var path = Path.Combine(expected, name);
+        Assert.True(File.Exists(path), $"Missing bundled runtime: {path}");
+        Assert.NotEqual(0, File.GetUnixFileMode(path) & execute);
+    }
+}
+```
+
+Do not change `ManagedSoundFFmpegPathTests`; it already covers arm64 preference over x64. Do not retarget `FfmpegRuntimeCoverageTests` to duplicate that behavior.
+
+- [ ] **Step 5: Add one successful ManagedSound MP3 test using the committed fixture.**
+
+In `ManagedSoundTests` add:
+
+```csharp
+[Fact]
+public void Constructor_WithValidMp3Fixture_CreatesSuccessfully()
+{
+    var path = Path.Combine(
+        AppContext.BaseDirectory,
+        "TestData", "Audio", "ffmpeg-tone.mp3");
+    Assert.True(File.Exists(path), $"Missing audio fixture: {path}");
+
+    using var sound = new ManagedSound(path);
+
+    Assert.NotNull(sound.SoundEffect);
+    Assert.True(sound.Duration > TimeSpan.Zero);
+}
+```
+
+The class already carries the Audio trait. Run with `ALSOFT_DRIVERS=null` in CI.
+
+- [ ] **Step 6: Fix the stale missing-runtime diagnostic in `ManagedSound.LoadMp3File`.**
+
+Replace the package-specific text naming `MMTools.Executables.MacOS.X64` with one platform-neutral bundled-runtime message, for example:
 
 ```text
-FfmpegRuntime.EnsureConfigured().IsAvailable == true
-BinaryFolder == test assembly/runtimes/osx-arm64/MMTools
-ffmpeg exists + Unix execute bit
-ffprobe exists + Unix execute bit
-ffmpeg -version exits 0
-ffprobe -version exits 0
+FFmpeg runtime not found. MP3 support requires the FFmpeg runtime bundled with DTXManiaCX. Rebuild or reinstall DTXManiaCX and verify the platform runtime contains both ffmpeg and ffprobe.
 ```
 
-Use `ProcessStartInfo` directly in this test class. Do not create a reusable process-runner abstraction for two commands.
+Do not change resolution logic or add recovery installation code.
 
-- [ ] **Step 4: Add the real MP3 `ManagedSound` smoke.**
-
-Resolve the copied fixture from `AppContext.BaseDirectory` and run with `ALSOFT_DRIVERS=null`:
-
-```csharp
-var mp3Path = Path.Combine(
-    AppContext.BaseDirectory,
-    "TestData",
-    "Audio",
-    "ffmpeg-tone.mp3");
-using var sound = new ManagedSound(mp3Path);
-Assert.True(sound.Duration > TimeSpan.Zero);
-```
-
-Do not configure FFMpegCore to PATH in the test.
-
-- [ ] **Step 5: Add one real non-default variant smoke.**
-
-Write a deterministic 44.1 kHz mono 16-bit PCM WAV to a temporary path in the test, then use the public production processor exactly as follows:
-
-```csharp
-var processor = new FfmpegAudioVariantProcessor();
-var artifact = await processor.PrepareAsync(
-    wavPath,
-    new PlaybackModifiers(125, 0),
-    cancellationToken);
-
-Assert.True(artifact.PcmByteLength > 0);
-Assert.Equal(44_100, artifact.SampleRate);
-Assert.Equal(1, artifact.ChannelCount);
-```
-
-`125` is a valid non-default `PlaySpeedRange` value and exercises `atempo`; pitch remains default.
-
-Clean only the source WAV/temp test directory in `finally`. `PreparedAudioArtifact` is in-memory and does not need disposal.
-
-- [ ] **Step 6: Keep existing cancellation/timeout tests as the cleanup gate.**
-
-Do not duplicate cancellation machinery in the integration class. Run existing `FfmpegAudioVariantProcessorTests` together with the new native tests.
-
-- [ ] **Step 7: Run focused native tests.**
+- [ ] **Step 7: Run the repaired existing Audio gates from an already-built Test.Mac output.**
 
 ```bash
 ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
   --configuration Debug \
-  --filter "FullyQualifiedName~FfmpegNativeRuntimeIntegrationTests|FullyQualifiedName~FfmpegAudioVariantProcessorTests" \
+  --no-build \
+  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegRuntimeTests|FullyQualifiedName~ManagedSoundTests" \
   --verbosity normal
 ```
 
-Expected: bundled runtime location/process smoke, MP3 load, real 1.25x variant transform, and existing cancellation/timeout coverage pass.
+Expected:
 
-- [ ] **Step 8: Commit checkpoint.**
+```text
+WAV/MP3/OGG PrepareAsync_EncodedAudio rows pass with PlaybackModifiers(50, 12)
+native BinaryFolder points to test-bin runtimes/osx-arm64/MMTools
+both native files retain execute bits
+ManagedSound valid MP3 load succeeds
+existing cancellation/timeout tests remain green
+```
+
+- [ ] **Step 8: Run Windows shared-test regression.**
+
+```powershell
+dotnet test DTXMania.Test/DTXMania.Test.csproj -c Debug --verbosity normal
+```
+
+Expected: Windows continues using its normal Windows runtime package; committed fixtures work identically and the Mac bootstrap target remains inert.
+
+- [ ] **Step 9: Commit checkpoint.**
 
 ```bash
-git add DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3 \
-        DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs \
-        DTXMania.Test/DTXMania.Test.Mac.csproj
-git commit -m "test: verify native Mac ffmpeg audio paths"
+git add \
+  DTXMania.Game/Lib/Resources/ManagedSound.cs \
+  DTXMania.Test/DTXMania.Test.csproj \
+  DTXMania.Test/DTXMania.Test.Mac.csproj \
+  DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3 \
+  DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg \
+  DTXMania.Test/Resources/FfmpegAudioVariantProcessorTests.cs \
+  DTXMania.Test/Resources/FfmpegRuntimeTests.cs \
+  DTXMania.Test/Resources/ManagedSoundTests.cs
+
+git commit -m "test: preserve audio coverage with minimal Mac ffmpeg"
 ```
 
 ---
 
-### Task 4: Make native CI authoritative and remove release duplication
+### Task 4: Make native CI authoritative and collapse release duplication
 
 **Files:**
 - Modify `.github/workflows/build-and-test.yml`
 - Modify `.github/workflows/release.yml`
-- Modify `installer/macos/build-dmg.sh` / `installer/macos/test-build-dmg.sh` only if verification proves execute bits are lost
+- Modify `installer/macos/build-dmg.sh` / `installer/macos/test-build-dmg.sh` only if an execute-bit regression is actually reproduced
 
-**Consumes:** project-owned staged/copied runtime from Tasks 1–3.
+**Consumes:** Tasks 1–3.
 
-**Produces:** one native CI path and one release path using the same FFmpeg source of truth.
+**Produces:** one native CI path and one release path using the same project-owned runtime.
 
-- [ ] **Step 1: Pin regular Mac CI to native Apple Silicon.**
+- [ ] **Step 1: Pin regular Mac CI to native Apple Silicon and cache only the FFmpeg source-build cache.**
 
-Change `build-and-test-macos`:
+Change:
 
 ```yaml
 runs-on: macos-15
 ```
 
-This matches the existing native release runner.
+Add after checkout/setup:
 
-- [ ] **Step 2: Cache the source-built runtime for PR speed.**
-
-Before the Mac build, cache:
-
-```text
-~/Library/Caches/DTXManiaCX/ffmpeg
-```
-
-with a key containing:
-
-```text
-macos-arm64
-hashFiles('tools/ffmpeg/macos-arm64/build-runtime.sh')
+```yaml
+- name: Cache native FFmpeg runtime
+  uses: actions/cache@v6
+  with:
+    path: ~/Library/Caches/DTXManiaCX/ffmpeg
+    key: macos-arm64-ffmpeg-${{ hashFiles('tools/ffmpeg/macos-arm64/build-runtime.sh') }}
 ```
 
 Do not cache `bin`, `obj`, or publish output.
 
-- [ ] **Step 3: Verify the actual Game build output.**
+- [ ] **Step 2: Restore through Test.Mac so all referenced projects are restored once.**
 
-Immediately after `dotnet build`:
+Use:
 
-```bash
-runtime="DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
-test -x "$runtime/ffmpeg"
-test -x "$runtime/ffprobe"
-file -b "$runtime/ffmpeg" | grep -qi arm64
-file -b "$runtime/ffprobe" | grep -qi arm64
-"$runtime/ffmpeg" -version
-"$runtime/ffprobe" -version
+```yaml
+- name: Restore dependencies
+  run: dotnet restore DTXMania.Test/DTXMania.Test.Mac.csproj
 ```
 
-- [ ] **Step 4: Run the focused native audio gate before the full Mac suite.**
+- [ ] **Step 3: Keep a named Game build and verify its runtime.**
 
-```bash
-ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
-  --configuration Debug \
-  --verbosity normal \
-  --filter "FullyQualifiedName~FfmpegNativeRuntimeIntegrationTests|FullyQualifiedName~FfmpegAudioVariantProcessorTests"
+```yaml
+- name: Build Mac game project
+  run: dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug --no-restore
+
+- name: Verify Mac game native FFmpeg runtime
+  shell: bash
+  run: |
+    runtime="DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
+    test -x "$runtime/ffmpeg"
+    test -x "$runtime/ffprobe"
+    file -b "$runtime/ffmpeg" | grep -qi arm64
+    file -b "$runtime/ffprobe" | grep -qi arm64
+    "$runtime/ffmpeg" -version
+    "$runtime/ffprobe" -version
 ```
 
-Then retain the existing full Mac unit suite, Automation suite, and prepared-chart `AudioE2E`.
+- [ ] **Step 4: Explicitly build Test.Mac before any `--no-build` test invocation.**
 
-- [ ] **Step 5: Delete the duplicated source-build body from `release.yml`.**
+```yaml
+- name: Build Mac test project
+  run: dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug --no-restore
 
-`dotnet publish` must now produce:
-
-```text
-publish/mac/runtimes/osx-arm64/MMTools/ffmpeg
-publish/mac/runtimes/osx-arm64/MMTools/ffprobe
-publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
+- name: Verify Mac test native FFmpeg runtime
+  shell: bash
+  run: |
+    runtime="DTXMania.Test/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
+    test -x "$runtime/ffmpeg"
+    test -x "$runtime/ffprobe"
+    file -b "$runtime/ffmpeg" | grep -qi arm64
+    file -b "$runtime/ffprobe" | grep -qi arm64
 ```
 
-Replace the current long native FFmpeg build step with a short artifact verification:
+This named build is the ProjectReference/copy-contract gate. Do not depend on a focused `dotnet test` accidentally building Test.Mac first.
+
+- [ ] **Step 5: Run focused audio packaging/product gates with `--no-build`, then retain the existing full suite.**
+
+```yaml
+- name: Run native FFmpeg audio checks on macOS
+  env:
+    ALSOFT_DRIVERS: 'null'
+  run: >
+    dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
+    --configuration Debug --no-build --verbosity normal
+    --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegRuntimeTests|FullyQualifiedName~ManagedSoundTests"
+```
+
+Then keep the existing full Mac test step with `--no-build` and coverage, plus Automation, VideoRecorder, and prepared-chart AudioE2E steps.
+
+- [ ] **Step 6: Keep Windows CI as the cross-platform guard.**
+
+Do not add a separate Windows FFmpeg pipeline. The existing Windows `dotnet test DTXMania.Test/DTXMania.Test.csproj` build path must remain green; it transitively evaluates/builds `DTXMania.Game.Mac.csproj` and therefore proves the macOS condition prevents the native builder from running there.
+
+- [ ] **Step 7: Delete the duplicated native source-build body from `release.yml`.**
+
+After the existing `dotnet publish ... -r osx-arm64`, require only:
 
 ```bash
 runtime="publish/mac/runtimes/osx-arm64/MMTools"
 test -x "$runtime/ffmpeg"
 test -x "$runtime/ffprobe"
-test -f publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
 file -b "$runtime/ffmpeg" | grep -qi arm64
 file -b "$runtime/ffprobe" | grep -qi arm64
+test -f publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Feature verification stays in `build-runtime.sh`; do not duplicate it in YAML.
+Do not duplicate feature checks in YAML; `build-runtime.sh` owns them.
 
-- [ ] **Step 6: Verify the packaged `.app`.**
+- [ ] **Step 8: Verify the existing app-bundle copy preserves the same runtime.**
 
 After `build-dmg.sh`:
 
 ```bash
-app_runtime="output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools"
-test -x "$app_runtime/ffmpeg"
-test -x "$app_runtime/ffprobe"
-file -b "$app_runtime/ffmpeg" | grep -qi arm64
-file -b "$app_runtime/ffprobe" | grep -qi arm64
+runtime="output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools"
+test -x "$runtime/ffmpeg"
+test -x "$runtime/ffprobe"
+file -b "$runtime/ffmpeg" | grep -qi arm64
+file -b "$runtime/ffprobe" | grep -qi arm64
 test -f output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-If this passes, do not touch `build-dmg.sh`. If execute bits are actually lost, fix only its existing publish-output copy and extend `test-build-dmg.sh` for that regression.
+If this passes, leave `installer/macos/build-dmg.sh` unchanged. If it fails only because execute bits are lost, fix the existing publish-output copy path narrowly and add the matching regression to `test-build-dmg.sh`.
 
-- [ ] **Step 7: Run final blast radius.**
+- [ ] **Step 9: Run final blast radius.**
 
-On Apple Silicon:
+Apple Silicon:
 
 ```bash
-dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
-ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug --verbosity normal
+dotnet restore DTXMania.Test/DTXMania.Test.Mac.csproj
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug --no-restore
+dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug --no-restore
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug --no-build --verbosity normal
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj -c Debug --verbosity normal
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj -c Debug --verbosity normal
 ```
 
-Run the existing prepared-chart `AudioE2E` command from the workflow on `macos-15`.
+Run the existing prepared-chart `Category=AudioE2E` command on `macos-15`.
 
-On Windows/Windows CI:
+Windows/Windows CI:
 
 ```powershell
-dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
-dotnet test DTXMania.Test/DTXMania.Test.csproj -c Debug --verbosity normal
+dotnet build DTXMania.Test/DTXMania.Test.csproj -c Debug
+dotnet test DTXMania.Test/DTXMania.Test.csproj -c Debug --no-build --verbosity normal
 ```
 
-- [ ] **Step 8: Commit checkpoint.**
+- [ ] **Step 10: Commit checkpoint.**
 
 ```bash
 git add .github/workflows/build-and-test.yml .github/workflows/release.yml
-git add installer/macos/build-dmg.sh installer/macos/test-build-dmg.sh 2>/dev/null || true
+if ! git diff --quiet -- installer/macos/build-dmg.sh installer/macos/test-build-dmg.sh; then
+  git add installer/macos/build-dmg.sh installer/macos/test-build-dmg.sh
+fi
 git commit -m "ci: validate bundled Apple Silicon ffmpeg"
 ```
-
-Only installer files with real changes should be staged in the final commit.
 
 ---
 
 ## Final acceptance checklist
 
 - [ ] `MMTools.Executables.MacOS.X64` is absent from the Mac project.
-- [ ] Normal Apple Silicon `dotnet build` output contains executable arm64 `ffmpeg` and `ffprobe`.
-- [ ] Mac test output receives the same runtime through the Game `ProjectReference` copy contract.
-- [ ] Normal `dotnet run` resolves bundled arm64 runtime without PATH/Rosetta.
-- [ ] `dotnet publish -r osx-arm64` contains the same runtime and FFmpeg LGPL license.
-- [ ] `FfmpegRuntime` preference test proves `osx-arm64` wins over an available x64 candidate.
-- [ ] Bundled `ffmpeg -version` and `ffprobe -version` smoke passes.
-- [ ] MP3 load through `ManagedSound` passes with the bundled runtime.
-- [ ] Real `FfmpegAudioVariantProcessor` transform with `new PlaybackModifiers(125, 0)` passes.
-- [ ] Existing cancellation/timeout cleanup tests remain green.
-- [ ] Regular Mac CI is pinned to `macos-15` and caches the source-built runtime.
+- [ ] Exact current `release.yml` FFmpeg recipe is reproducible from `build-runtime.sh`; optional `--disable-*` hardening is retained only after a clean verified build.
+- [ ] Normal Apple Silicon Game output contains executable arm64 `ffmpeg` and `ffprobe`.
+- [ ] `DTXMania.Test.Mac` output receives the same runtime through the Game `ProjectReference` copy contract.
+- [ ] Windows builds `DTXMania.Test.csproj` without invoking the native Mac builder.
+- [ ] Publish output contains the same runtime and FFmpeg LGPL license.
+- [ ] Existing `ManagedSoundFFmpegPathTests.WithArm64Present_ShouldPreferArm64OverX64` remains unchanged and green.
+- [ ] Existing `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` keeps WAV/MP3/OGG + `PlaybackModifiers(50, 12)` coverage without requiring bundled MP3/OGG encoders.
+- [ ] Test-owned MP3/OGG fixtures are copied by both test projects.
+- [ ] Native `FfmpegRuntime.EnsureConfigured().BinaryFolder` resolves the Test.Mac bundled arm64 directory and both files retain execute bits.
+- [ ] `ManagedSound` successfully loads the valid MP3 fixture.
+- [ ] Existing audio-variant cancellation/timeout tests remain green.
+- [ ] Stale `MMTools.Executables.MacOS.X64` user diagnostic is removed.
+- [ ] Regular Mac CI is pinned to `macos-15`, caches the script-built runtime, and explicitly builds Test.Mac before `--no-build` tests.
 - [ ] Release YAML no longer owns a duplicate FFmpeg configure/build recipe.
-- [ ] `.app` bundle retains runtime files, arm64 architecture, execute bits, and license.
-- [ ] Windows build/tests remain unchanged and green.
+- [ ] `.app` contains executable arm64 runtime files plus `FFmpeg-LGPL-2.1.txt`.
+- [ ] Windows build/tests remain green and otherwise unchanged.
+
+## Risks carried into implementation review
+
+1. **Existing Audio test fixture encoding** — must be removed before the minimal runtime replaces the full x64 build, or Mac Audio tests fail on `libmp3lame`/`libvorbis` before testing the product path.
+2. **Generated MSBuild content / ProjectReference propagation** — Game-bin success is insufficient; Test.Mac bin must be explicitly built and checked.
+3. **Unix execute-bit preservation** — any lost bit makes `FfmpegRuntime.IsRunnableFile` reject the bundled runtime and fall back to PATH; fail rather than weakening the resolver.
+4. **Windows evaluates the Mac project** — the generation target must remain macOS-only.
+5. **Configure hardening delta** — do not conflate extraction with unproven flag changes; validate the shipping recipe first.
 
 ## Handoff
 

--- a/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
+++ b/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
@@ -2,27 +2,37 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make normal CX Mac build/run/test/publish output carry one verified native Apple Silicon `ffmpeg`/`ffprobe` runtime, while preserving the existing real audio tests and Windows build behavior.
+**Goal:** Make normal CX Mac build/run/test/publish output carry one verified native Apple Silicon `ffmpeg`/`ffprobe` runtime while preserving the existing real audio coverage and Windows behavior.
 
-**Architecture:** Extract the exact FFmpeg 7.0.2 arm64 source recipe already shipping in `release.yml` into one cached shell builder. `DTXMania.Game.Mac.csproj` generates the files on macOS before MSBuild resolves output-copy items, adds the generated items inside that target, and exposes them through the normal `GetCopyToOutputDirectoryItems`/publish path. Existing `FfmpegRuntime` remains unchanged. Repair the existing MP3/OGG variant test inputs instead of adding a weaker duplicate variant test.
+**Architecture:** Extract the existing FFmpeg 7.0.2 arm64 release recipe into one cached, host-independent shell builder. `DTXMania.Game.Mac.csproj` generates/stages the runtime on macOS and exposes it through the existing MSBuild copy/publish graph. `FfmpegRuntime` remains unchanged. Repair the existing encoded-audio test inputs instead of weakening coverage or expanding production codecs.
 
-**Tech Stack:** .NET 8, MonoGame DesktopGL, FFMpegCore 5.4.0, FFmpeg 7.0.2 source build, Bash/MSBuild, xUnit, GitHub Actions `macos-15`.
+**Tech Stack:** .NET 8, MonoGame DesktopGL, FFMpegCore 5.4.0, FFmpeg 7.0.2 source build, Bash/MSBuild, xUnit, GitHub Actions.
+
+## Prerequisite
+
+HPA-623 must merge and leave `main` green before this plan starts.
+
+HPA-623 owns the pre-existing CI bug where `DTXMania.Test.Mac.csproj --no-build` currently runs zero tests because only the Game project was built. HPA-512 must start from a Mac job that already executes the real Test.Mac suite and fails when coverage is missing.
+
+Do not fold HPA-623 into the HPA-512 implementation PR.
 
 ## Global Constraints
 
-- Keep FFmpeg 7.0.2 for this ticket; no version upgrade.
-- Official source tarball SHA-256 stays `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`.
-- First extract the **current shipping configure list exactly**. `--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` may be retained only after a separate clean cold build passes all capability checks.
-- Supported macOS target is native Apple Silicon arm64 only; no Intel/Rosetta fallback.
+- Keep FFmpeg `7.0.2`; no version upgrade.
+- Keep source SHA-256 `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`.
+- Add `--disable-autodetect` from the start so developer Homebrew state cannot affect the built runtime.
+- Do not add `--disable-gpl` or `--disable-nonfree`; document that they are unnecessary for this minimal no-`--enable-lib*` build.
+- Supported Mac target is native Apple Silicon arm64 only. After this change, `DTXMania.Game.Mac.csproj` is expected to fail on Intel Macs.
 - Remove `MMTools.Executables.MacOS.X64` from `DTXMania.Game.Mac.csproj`.
-- Keep `FFMpegCore` 5.4.0 and `FfmpegRuntime` production resolution behavior unchanged.
-- Runtime layout remains `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`.
-- PATH remains a diagnostic fallback only; do not install/use PATH FFmpeg as production recovery.
-- The native generation target must be `Condition="$([MSBuild]::IsOSPlatform('OSX'))"` because Windows tests reference `DTXMania.Game.Mac.csproj`.
-- Preserve the current minimal CX codec/filter surface; do not add `libmp3lame`/`libvorbis` encoders to production only to generate test fixtures.
-- Keep the existing `PlaybackModifiers(50, 12)` real variant test; do not add a second `PlaybackModifiers(125, 0)` variant smoke.
-- Leave `ManagedSoundFFmpegPathTests` and the existing first-complete-candidate `FfmpegRuntimeCoverageTests` behavior unchanged.
+- Keep `FFMpegCore` 5.4.0 and all `FfmpegRuntime` resolution behavior unchanged.
+- Runtime layout stays `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`.
+- PATH remains diagnostic fallback only; never treat PATH FFmpeg as proof that packaging works.
+- Keep the native generation target macOS-only because Windows tests reference/evaluate `DTXMania.Game.Mac.csproj`.
+- Do not add `libmp3lame`/`libvorbis` encoders to production.
+- Keep the existing `PlaybackModifiers(50, 12)` real variant test; do not add the weaker `PlaybackModifiers(125, 0)` smoke.
+- Leave `ManagedSoundFFmpegPathTests`, `FfmpegRuntimeCoverageTests`, and production resolver logic unchanged.
 - Ship upstream `COPYING.LGPLv2.1` as `Licenses/FFmpeg-LGPL-2.1.txt`.
+- `DTXMania.VideoRecorder` continues using PATH `ffprobe` for recording artifact verification. HPA-512 does not add MP4/H.264 support or wire the bundled runtime into the recorder.
 - No new NuGet binary provider, committed production binaries, package-builder project, generic bootstrap framework, resolver, audio stack, recorder media work, OBS work, or signing/notarization redesign.
 
 ---
@@ -35,6 +45,7 @@ Create:
   tools/ffmpeg/macos-arm64/README.md
   DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
   DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg
+  DTXMania.Test/Resources/FfmpegBundledRuntimeTests.cs
 
 Modify:
   DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -42,21 +53,25 @@ Modify:
   DTXMania.Test/DTXMania.Test.csproj
   DTXMania.Test/DTXMania.Test.Mac.csproj
   DTXMania.Test/Resources/FfmpegAudioVariantProcessorTests.cs
-  DTXMania.Test/Resources/FfmpegRuntimeTests.cs
   DTXMania.Test/Resources/ManagedSoundTests.cs
   .github/workflows/build-and-test.yml
   .github/workflows/release.yml
+
+Do not modify:
+  DTXMania.Game/Lib/Resources/FfmpegRuntime.cs
+  DTXMania.Test/Resources/FfmpegRuntimeTests.cs
+  DTXMania.Test/Resources/ManagedSoundFFmpegPathTests.cs
 
 Only modify if packaged-output verification proves execute bits are lost:
   installer/macos/build-dmg.sh
   installer/macos/test-build-dmg.sh
 ```
 
-Keep all four tasks in one HPA-512 implementation PR.
+Keep the four HPA-512 tasks in one implementation PR after HPA-623 is merged.
 
 ---
 
-### Task 1: Extract the reproducible native FFmpeg builder
+### Task 1: Extract a reproducible native FFmpeg builder
 
 **Files:**
 - Create `tools/ffmpeg/macos-arm64/build-runtime.sh`
@@ -81,9 +96,9 @@ Cache root:
 ${DTXMANIA_FFMPEG_CACHE_ROOT:-$HOME/Library/Caches/DTXManiaCX/ffmpeg}/7.0.2/osx-arm64
 ```
 
-- [ ] **Step 1: Copy the currently shipping source recipe exactly out of `release.yml`.**
+- [ ] **Step 1: Create the script shell and hard-fail unsupported hosts.**
 
-Start the script with:
+Use:
 
 ```bash
 #!/usr/bin/env bash
@@ -99,11 +114,17 @@ if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
 fi
 ```
 
-Require exactly two positional destinations and normalize/create them before copying.
+Require exactly two output-directory arguments and create them before final copy.
 
-- [ ] **Step 2: Preserve the existing configure list before trying any license-hardening delta.**
+- [ ] **Step 2: Move the current release configure surface into the builder and add only `--disable-autodetect`.**
 
-Baseline configure flags must match the current release workflow:
+Use the existing release flags plus:
+
+```text
+--disable-autodetect
+```
+
+Required configure surface:
 
 ```bash
 ./configure \
@@ -113,6 +134,7 @@ Baseline configure flags must match the current release workflow:
   --disable-podpages --disable-txtpages \
   --disable-ffplay \
   --disable-everything \
+  --disable-autodetect \
   --enable-decoder=mp3float \
   --enable-decoder=vorbis \
   --enable-decoder=pcm_s16le,pcm_s24le,pcm_f32le,pcm_u8,pcm_alaw,pcm_mulaw \
@@ -126,64 +148,71 @@ Baseline configure flags must match the current release workflow:
   --enable-filter=aformat,anull,aresample,atempo,apad,atrim
 ```
 
-Do not add `libmp3lame`, `libvorbis`, Homebrew libraries, or any other external codec dependency.
+Do not add `--enable-lib*`, `libmp3lame`, `libvorbis`, `--disable-gpl`, or `--disable-nonfree`.
 
-- [ ] **Step 3: Implement a versioned validated cache.**
+- [ ] **Step 3: Implement the validated versioned cache.**
 
-Use:
-
-```bash
-cache_root="${DTXMANIA_FFMPEG_CACHE_ROOT:-$HOME/Library/Caches/DTXManiaCX/ffmpeg}"
-cache_dir="$cache_root/$FFMPEG_VERSION/osx-arm64"
-```
-
-A cache hit is valid only when all are true:
+A cache hit is valid only when:
 
 ```text
-$cache_dir/ffmpeg exists + executable
-$cache_dir/ffprobe exists + executable
-$cache_dir/COPYING.LGPLv2.1 exists
-$cache_dir/source.sha256 contains the exact pinned source hash
+ffmpeg exists + executable
+ffprobe exists + executable
+COPYING.LGPLv2.1 exists
+source.sha256 contains the exact pinned source hash
 ```
 
-On a miss:
+On cache miss:
 
 1. create a `mktemp -d` work root;
-2. `curl -fsSL` the tarball;
-3. verify with `shasum -a 256 -c`;
-4. extract/configure/build/install under the temporary root;
-5. validate before replacing the cache;
-6. write `source.sha256` only after validation succeeds.
+2. download source with `curl -fsSL`;
+3. verify SHA-256 before extraction;
+4. configure/build/install under the temporary root;
+5. validate all runtime requirements below;
+6. replace the cache only after validation succeeds;
+7. write `source.sha256` only after successful validation.
 
-Use a shell `trap` to remove the temporary work root. Do not add cache locking.
+Use a cleanup `trap`; do not add cache locking.
 
-- [ ] **Step 4: Move the current release capability checks into the builder.**
+- [ ] **Step 4: Add architecture, capability, and portability validation.**
 
-For each binary independently:
+For both executables:
 
 ```bash
 test -x "$bin"
-file -b "$bin" | grep -qi 'arm64'
+file -b "$bin" | grep -qi arm64
+"$bin" -version
 ```
 
-Run:
-
-```bash
-"$ffmpeg" -version
-"$ffprobe" -version
-```
-
-Require:
+For FFmpeg require:
 
 ```text
 filters:  atempo apad atrim aformat aresample
-decoders: mp3float vorbis pcm_s16le
+decoders: mp3float vorbis pcm_s16le adpcm_ima_wav adpcm_ms
 demuxers: mp3 wav ogg s16le
 encoder:  pcm_s16le
 muxer:    s16le
 ```
 
-Copy validated files with:
+The two ADPCM decoders are load-bearing for non-default playback of ADPCM WAV sources and must be checked explicitly.
+
+Also validate dynamic dependencies for **both** executables:
+
+```bash
+otool -L "$bin"
+```
+
+Ignore the first `otool -L` header line. Every listed dependency must resolve under either:
+
+```text
+/usr/lib/
+/System/Library/
+```
+
+Fail if `/opt/homebrew`, `/usr/local`, a build temp directory, or any other non-system dylib path appears.
+
+- [ ] **Step 5: Copy validated output with explicit modes.**
+
+Use:
 
 ```bash
 install -m 755 "$cache_dir/ffmpeg" "$runtime_output_dir/ffmpeg"
@@ -191,11 +220,11 @@ install -m 755 "$cache_dir/ffprobe" "$runtime_output_dir/ffprobe"
 install -m 644 "$cache_dir/COPYING.LGPLv2.1" "$license_output_dir/FFmpeg-LGPL-2.1.txt"
 ```
 
-Use `install`, not a permission-ambiguous copy, for the builder's own output.
+Do not use a permission-ambiguous builder copy.
 
-- [ ] **Step 5: Prove the extracted shipping recipe with a cold build.**
+- [ ] **Step 6: Prove a cold build.**
 
-Run on Apple Silicon:
+Run on Apple Silicon with any existing runtime cache removed:
 
 ```bash
 rm -rf "$HOME/Library/Caches/DTXManiaCX/ffmpeg/7.0.2/osx-arm64"
@@ -212,48 +241,30 @@ file -b /tmp/dtx-ffmpeg-runtime/ffprobe | grep -qi arm64
 test -f /tmp/dtx-ffmpeg-licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-This cold build is the baseline gate. Do not change configure flags before it passes.
-
-- [ ] **Step 6: Trial explicit license/autodetect hardening only after the baseline is green.**
-
-Add these three flags together:
-
-```text
---disable-autodetect
---disable-gpl
---disable-nonfree
-```
-
-Delete the cache and repeat Step 5. Keep the three flags only if the clean build plus every architecture/filter/decoder/demuxer/encoder/muxer check passes. If not, revert the flags and retain the proven recipe; HPA-512 does not depend on this hardening.
+The builder itself must already have failed if capability or `otool -L` checks fail.
 
 - [ ] **Step 7: Prove the warm-cache path.**
 
-```bash
-rm -rf /tmp/dtx-ffmpeg-runtime /tmp/dtx-ffmpeg-licenses
-time bash tools/ffmpeg/macos-arm64/build-runtime.sh \
-  /tmp/dtx-ffmpeg-runtime \
-  /tmp/dtx-ffmpeg-licenses
+Repeat the builder without deleting the cache. Expected: no source compile; validated cached files are copied.
 
-test -x /tmp/dtx-ffmpeg-runtime/ffmpeg
-test -x /tmp/dtx-ffmpeg-runtime/ffprobe
-```
+- [ ] **Step 8: Document provenance and support boundary.**
 
-Expected: no source compile; validated cached files are copied.
-
-- [ ] **Step 8: Write provenance/update documentation.**
-
-`README.md` must contain:
+README must include:
 
 ```text
 FFmpeg 7.0.2
 official source URL
 pinned SHA-256
-actual final configure command
-why the minimal feature list exists
+exact configure command including --disable-autodetect
+why --disable-gpl / --disable-nonfree are omitted
+required codec/filter surface including ADPCM decoders
+system-dylib-only otool policy
 COPYING.LGPLv2.1 handling
-cache path and DTXMANIA_FFMPEG_CACHE_ROOT override
+cache path and override
 clean-cache command
-version + checksum update procedure
+first-build compile behavior
+Intel Mac build unsupported/hard-fail behavior
+version/checksum update procedure
 cold/warm verification commands
 ```
 
@@ -266,16 +277,16 @@ git commit -m "build: extract native Apple Silicon ffmpeg runtime"
 
 ---
 
-### Task 2: Make the Mac project own one generated-content copy contract
+### Task 2: Make the Mac project own one incremental generated-content copy contract
 
 **Files:**
 - Modify `DTXMania.Game/DTXMania.Game.Mac.csproj`
 
 **Consumes:** Task 1 builder.
 
-**Produces:** native runtime/license files in Game output, Test.Mac output through `ProjectReference`, and publish output, without executing the builder on Windows.
+**Produces:** one native runtime/license contract for Game output, Test.Mac output through `ProjectReference`, and publish output, while remaining inert on Windows.
 
-- [ ] **Step 1: Remove only the obsolete Mac x64 runtime package.**
+- [ ] **Step 1: Remove only the obsolete x64 runtime package.**
 
 Delete:
 
@@ -283,17 +294,11 @@ Delete:
 <PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
 ```
 
-Keep:
+Keep `FFMpegCore` unchanged. Do not edit `FfmpegRuntime`.
 
-```xml
-<PackageReference Include="FFMpegCore" Version="5.4.0" />
-```
+- [ ] **Step 2: Add project-local staging properties.**
 
-Do not change the Windows project or `FfmpegRuntime`.
-
-- [ ] **Step 2: Define intermediate staging paths in the Mac project.**
-
-Add properties equivalent to:
+Use equivalent properties:
 
 ```xml
 <PropertyGroup>
@@ -303,49 +308,46 @@ Add properties equivalent to:
 </PropertyGroup>
 ```
 
-- [ ] **Step 3: Add the generated-content target with the exact lifecycle hooks.**
+- [ ] **Step 3: Add the macOS-only generated-content target.**
 
-Use this shape, adapting XML escaping/path quoting only as required by MSBuild:
+Keep the target hooked before:
+
+```text
+BeforeBuild;AssignTargetPaths;GetCopyToOutputDirectoryItems
+```
+
+Use this shape:
 
 ```xml
 <Target Name="PrepareNativeFfmpegRuntime"
         Condition="$([MSBuild]::IsOSPlatform('OSX'))"
         BeforeTargets="BeforeBuild;AssignTargetPaths;GetCopyToOutputDirectoryItems">
-  <Exec Command="bash &quot;$(MSBuildProjectDirectory)/../tools/ffmpeg/macos-arm64/build-runtime.sh&quot; &quot;$(NativeFfmpegRuntimeDir)&quot; &quot;$(NativeFfmpegLicenseDir)&quot;" />
+
+  <Exec
+    Condition="!Exists('$(NativeFfmpegRuntimeDir)/ffmpeg') Or !Exists('$(NativeFfmpegRuntimeDir)/ffprobe')"
+    Command="bash &quot;$(MSBuildProjectDirectory)/../tools/ffmpeg/macos-arm64/build-runtime.sh&quot; &quot;$(NativeFfmpegRuntimeDir)&quot; &quot;$(NativeFfmpegLicenseDir)&quot;" />
 
   <ItemGroup>
-    <None Include="$(NativeFfmpegRuntimeDir)/ffmpeg">
-      <TargetPath>runtimes/osx-arm64/MMTools/ffmpeg</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Include="$(NativeFfmpegRuntimeDir)/ffprobe">
-      <TargetPath>runtimes/osx-arm64/MMTools/ffprobe</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
-    <None Include="$(NativeFfmpegLicenseDir)/FFmpeg-LGPL-2.1.txt">
-      <TargetPath>Licenses/FFmpeg-LGPL-2.1.txt</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </None>
+    <!-- Generated None items are unconditional with respect to the Exec condition. -->
+    <!-- Set TargetPath, CopyToOutputDirectory=PreserveNewest, -->
+    <!-- and CopyToPublishDirectory=PreserveNewest for ffmpeg, ffprobe, and license. -->
   </ItemGroup>
 </Target>
 ```
 
-The generated `None` items are intentionally added **inside** the target after the builder has created the files. Do not replace this with static top-level items for files that do not exist during evaluation.
+The `Exec` is conditional on staged files being absent; the `ItemGroup` is not. Items must be declared whenever the target participates, even on warm/staged builds.
 
-Do not add a test-project FFmpeg copy target.
+Do not add a Test.Mac-specific FFmpeg copy target.
 
-- [ ] **Step 4: Prove the target is inert on Windows before doing Mac validation.**
+- [ ] **Step 4: Prove Windows evaluation is inert.**
 
-On Windows or Windows CI:
+On Windows/Windows CI:
 
 ```powershell
 dotnet build DTXMania.Test/DTXMania.Test.csproj -c Debug
 ```
 
-Expected: succeeds without attempting `tools/ffmpeg/macos-arm64/build-runtime.sh`. This is required because `DTXMania.Test.csproj` references `DTXMania.Game.Mac.csproj`.
+Expected: no Bash builder invocation.
 
 - [ ] **Step 5: Prove Game build output on Apple Silicon.**
 
@@ -361,9 +363,9 @@ file -b "$runtime/ffprobe" | grep -qi arm64
 test -f DTXMania.Game/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Do not use `dotnet run` as an acceptance command; the GUI does not terminate and adds no stronger packaging evidence.
+Run a second `dotnet build` with staging intact and confirm the builder does not perform another source build/revalidation path.
 
-- [ ] **Step 6: Prove ProjectReference propagation by explicitly building Test.Mac.**
+- [ ] **Step 6: Prove ProjectReference propagation.**
 
 ```bash
 dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug --no-restore
@@ -376,11 +378,9 @@ file -b "$test_runtime/ffprobe" | grep -qi arm64
 test -f DTXMania.Test/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-If Game output passes but Test.Mac output is missing, fix the Game project's generated-item/target metadata. Do not add a duplicate test-project copy implementation.
+If Game succeeds but Test.Mac misses files, fix the Game target/item metadata. Do not duplicate copy logic in the test project.
 
-If files exist but `test -x` fails, add the smallest macOS-only post-copy `chmod +x` target required for Game/Test/publish output and add a regression assertion. Do not weaken `FfmpegRuntime.IsRunnableFile`.
-
-- [ ] **Step 7: Prove self-contained publish output.**
+- [ ] **Step 7: Prove publish output.**
 
 ```bash
 rm -rf /tmp/dtx-publish-arm64
@@ -397,30 +397,36 @@ file -b "$runtime/ffprobe" | grep -qi arm64
 test -f /tmp/dtx-publish-arm64/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-- [ ] **Step 8: Commit checkpoint.**
+If copy steps lose execute bits, add only the smallest macOS-specific chmod hook needed by the existing build graph. Do not weaken `IsRunnableFile`.
+
+- [ ] **Step 8: Record first-run latency risk.**
+
+In the builder README/risk notes, state that a clean runtime cache miss during `dotnet run` compiles FFmpeg before launch and may exceed an E2E startup timeout. CI must warm/build before launching E2E rather than adding background bootstrap machinery.
+
+- [ ] **Step 9: Commit checkpoint.**
 
 ```bash
-git add DTXMania.Game/DTXMania.Game.Mac.csproj
+git add DTXMania.Game/DTXMania.Game.Mac.csproj tools/ffmpeg/macos-arm64/README.md
 git commit -m "build: bundle native ffmpeg in Mac outputs"
 ```
 
 ---
 
-### Task 3: Repair existing Audio tests and add only missing product gates
+### Task 3: Repair existing Audio coverage and add the bundled-runtime PATH guard
 
 **Files:**
 - Create `DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3`
 - Create `DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg`
+- Create `DTXMania.Test/Resources/FfmpegBundledRuntimeTests.cs`
 - Modify `DTXMania.Test/DTXMania.Test.csproj`
 - Modify `DTXMania.Test/DTXMania.Test.Mac.csproj`
 - Modify `DTXMania.Test/Resources/FfmpegAudioVariantProcessorTests.cs`
-- Modify `DTXMania.Test/Resources/FfmpegRuntimeTests.cs`
 - Modify `DTXMania.Test/Resources/ManagedSoundTests.cs`
 - Modify `DTXMania.Game/Lib/Resources/ManagedSound.cs`
 
-**Consumes:** Task 2 test-output runtime contract.
+**Consumes:** Task 2 Test.Mac output contract.
 
-**Produces:** existing real variant coverage that works with the minimal runtime, plus one bundled-path/execute-bit gate and one successful MP3 load.
+**Produces:** the existing strong variant test working with the minimal runtime, plus one Audio-class proof that the bundle—not PATH—was selected.
 
 - [ ] **Step 1: Generate deterministic project-owned MP3 and OGG fixtures once.**
 
@@ -440,154 +446,109 @@ ffmpeg -hide_banner -loglevel error \
   -y DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg
 ```
 
-These are small generated test inputs. Do not copy a third-party song/audio asset.
+These are small project-owned test inputs, not production assets.
 
-- [ ] **Step 2: Copy the fixtures from both test projects.**
+- [ ] **Step 2: Copy fixtures from both test projects.**
 
-Add to both `DTXMania.Test.csproj` and `DTXMania.Test.Mac.csproj`:
+Mirror the existing TestData copy pattern. Ensure `TestData/Audio/**/*` lands under the same relative path in both Windows and Mac test output.
 
-```xml
-<ItemGroup>
-  <None Include="TestData/Audio/**/*">
-    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-  </None>
-</ItemGroup>
-```
+- [ ] **Step 3: Repair `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm`.**
 
-Both projects compile the shared Audio tests, so both need the same fixture path.
+Keep:
 
-- [ ] **Step 3: Repair the existing real encoded-audio variant test instead of adding another variant smoke.**
+- generated WAV source;
+- committed MP3 source;
+- committed OGG source;
+- `new PlaybackModifiers(50, 12)`;
+- current sample-rate/channel/byte-length/duration/pitch/frequency assertions.
 
-In `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm`, remove the `FFMpegArguments` fixture-encoding block that calls `libmp3lame` / `libvorbis`.
+Delete only the fixture-generation `FFMpegArguments` calls using `libmp3lame` / `libvorbis`.
 
-Keep the three rows and use this source selection shape:
+Do not add a second weaker variant smoke.
 
-```csharp
-var source = extension switch
-{
-    "wav" => WriteToneWav("tone.wav", durationSeconds: 0.25),
-    "mp3" => Path.Combine(
-        AppContext.BaseDirectory,
-        "TestData", "Audio", "ffmpeg-tone.mp3"),
-    "ogg" => Path.Combine(
-        AppContext.BaseDirectory,
-        "TestData", "Audio", "ffmpeg-tone.ogg"),
-    _ => throw new ArgumentOutOfRangeException(nameof(extension)),
-};
+- [ ] **Step 4: Add a dedicated Audio-trait bundled-runtime class.**
 
-Assert.True(File.Exists(source), $"Missing audio fixture: {source}");
+Create `FfmpegBundledRuntimeTests.cs` with class-level Audio trait. Do **not** add real filesystem/runtime behavior to `FfmpegRuntimeTests`, which remains a Unit-trait logic class.
 
-var modifiers = new PlaybackModifiers(50, 12);
-var artifact = await new FfmpegAudioVariantProcessor().PrepareAsync(
-    source,
-    modifiers,
-    CancellationToken.None);
-```
-
-Keep the existing sample-rate/channel/byte-length/duration/pitch/frequency assertions unchanged.
-
-Do not add `PlaybackModifiers(125, 0)` coverage; `PlaybackModifiers(50, 12)` already exercises the harder atempo chain.
-
-- [ ] **Step 4: Add one real packaged-runtime filesystem gate to `FfmpegRuntimeTests`.**
-
-Add required usings for `System.Runtime.InteropServices` and `AudioTestUtils` if not already present.
-
-Add a test equivalent to:
+Test shape:
 
 ```csharp
-[Fact]
 [Trait("Category", AudioTestUtils.AudioTestCategory)]
-public void EnsureConfigured_OnNativeAppleSilicon_ShouldUseBundledExecutableRuntime()
+public class FfmpegBundledRuntimeTests
 {
-    if (!OperatingSystem.IsMacOS() ||
-        RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
-        return;
-
-    var result = FfmpegRuntime.EnsureConfigured();
-    Assert.True(result.IsAvailable, result.DiagnosticReason);
-
-    var expected = Path.Combine(
-        AppContext.BaseDirectory,
-        "runtimes", "osx-arm64", "MMTools");
-    Assert.Equal(Path.GetFullPath(expected), Path.GetFullPath(result.BinaryFolder!));
-
-    const UnixFileMode execute =
-        UnixFileMode.UserExecute |
-        UnixFileMode.GroupExecute |
-        UnixFileMode.OtherExecute;
-
-    foreach (var name in new[] { "ffmpeg", "ffprobe" })
+    [Fact]
+    public void EnsureConfigured_OnNativeAppleSilicon_ShouldUseBundledExecutableRuntime()
     {
-        var path = Path.Combine(expected, name);
-        Assert.True(File.Exists(path), $"Missing bundled runtime: {path}");
-        Assert.NotEqual(0, File.GetUnixFileMode(path) & execute);
+        if (!OperatingSystem.IsMacOS() ||
+            RuntimeInformation.ProcessArchitecture != Architecture.Arm64)
+            return;
+
+        var result = FfmpegRuntime.EnsureConfigured();
+        Assert.True(result.IsAvailable, result.DiagnosticReason);
+        Assert.NotNull(result.BinaryFolder);
+
+        var expected = Path.Combine(
+            AppContext.BaseDirectory,
+            "runtimes", "osx-arm64", "MMTools");
+
+        Assert.Equal(
+            Path.GetFullPath(expected),
+            Path.GetFullPath(result.BinaryFolder!));
+
+        // Assert ffmpeg + ffprobe exist and each has at least one Unix execute bit.
     }
 }
 ```
 
-Do not change `ManagedSoundFFmpegPathTests`; it already covers arm64 preference over x64. Do not retarget `FfmpegRuntimeCoverageTests` to duplicate that behavior.
+`Assert.NotNull(result.BinaryFolder)` is mandatory. `ProbePathAvailability` returns `BinaryFolder: null`, so this is the assertion that prevents Homebrew/PATH from satisfying the test.
 
-- [ ] **Step 5: Add one successful ManagedSound MP3 test using the committed fixture.**
+- [ ] **Step 5: Add one successful ManagedSound MP3 load.**
 
-In `ManagedSoundTests` add:
+Use `ffmpeg-tone.mp3` from `AppContext.BaseDirectory/TestData/Audio` and assert non-zero duration / valid loaded sound state.
 
-```csharp
-[Fact]
-public void Constructor_WithValidMp3Fixture_CreatesSuccessfully()
-{
-    var path = Path.Combine(
-        AppContext.BaseDirectory,
-        "TestData", "Audio", "ffmpeg-tone.mp3");
-    Assert.True(File.Exists(path), $"Missing audio fixture: {path}");
+- [ ] **Step 6: Fix the stale missing-runtime diagnostic.**
 
-    using var sound = new ManagedSound(path);
+Remove user guidance naming `MMTools.Executables.MacOS.X64`. Replace it with a generic message that the bundled platform FFmpeg runtime is missing/unusable and CX should be rebuilt/reinstalled.
 
-    Assert.NotNull(sound.SoundEffect);
-    Assert.True(sound.Duration > TimeSpan.Zero);
-}
-```
+Do not change resolution or install anything at runtime.
 
-The class already carries the Audio trait. Run with `ALSOFT_DRIVERS=null` in CI.
+- [ ] **Step 7: Run focused Test.Mac Audio checks before any Homebrew FFmpeg installation in CI.**
 
-- [ ] **Step 6: Fix the stale missing-runtime diagnostic in `ManagedSound.LoadMp3File`.**
-
-Replace the package-specific text naming `MMTools.Executables.MacOS.X64` with one platform-neutral bundled-runtime message, for example:
-
-```text
-FFmpeg runtime not found. MP3 support requires the FFmpeg runtime bundled with DTXManiaCX. Rebuild or reinstall DTXManiaCX and verify the platform runtime contains both ffmpeg and ffprobe.
-```
-
-Do not change resolution logic or add recovery installation code.
-
-- [ ] **Step 7: Run the repaired existing Audio gates from an already-built Test.Mac output.**
+From an already-built Test.Mac output:
 
 ```bash
 ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
   --configuration Debug \
   --no-build \
-  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegRuntimeTests|FullyQualifiedName~ManagedSoundTests" \
+  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegBundledRuntimeTests|FullyQualifiedName~ManagedSoundTests" \
   --verbosity normal
 ```
 
-Expected:
+Expected on Apple Silicon:
 
 ```text
-WAV/MP3/OGG PrepareAsync_EncodedAudio rows pass with PlaybackModifiers(50, 12)
-native BinaryFolder points to test-bin runtimes/osx-arm64/MMTools
-both native files retain execute bits
-ManagedSound valid MP3 load succeeds
-existing cancellation/timeout tests remain green
+WAV/MP3/OGG existing variant rows pass with PlaybackModifiers(50, 12)
+BinaryFolder is non-null and equals Test.Mac bundled osx-arm64/MMTools
+ffmpeg + ffprobe retain execute bits
+valid MP3 ManagedSound load succeeds
 ```
 
-- [ ] **Step 8: Run Windows shared-test regression.**
+- [ ] **Step 8: Run the real full Mac suite established by HPA-623.**
+
+```bash
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  -c Debug --no-build --verbosity normal
+```
+
+Do not accept a sub-second build-only result. The command must show test discovery/execution and a real summary.
+
+- [ ] **Step 9: Run Windows shared-test regression.**
 
 ```powershell
 dotnet test DTXMania.Test/DTXMania.Test.csproj -c Debug --verbosity normal
 ```
 
-Expected: Windows continues using its normal Windows runtime package; committed fixtures work identically and the Mac bootstrap target remains inert.
-
-- [ ] **Step 9: Commit checkpoint.**
+- [ ] **Step 10: Commit checkpoint.**
 
 ```bash
 git add \
@@ -597,7 +558,7 @@ git add \
   DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3 \
   DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg \
   DTXMania.Test/Resources/FfmpegAudioVariantProcessorTests.cs \
-  DTXMania.Test/Resources/FfmpegRuntimeTests.cs \
+  DTXMania.Test/Resources/FfmpegBundledRuntimeTests.cs \
   DTXMania.Test/Resources/ManagedSoundTests.cs
 
 git commit -m "test: preserve audio coverage with minimal Mac ffmpeg"
@@ -605,26 +566,22 @@ git commit -m "test: preserve audio coverage with minimal Mac ffmpeg"
 
 ---
 
-### Task 4: Make native CI authoritative and collapse release duplication
+### Task 4: Make native packaging checks authoritative and collapse release duplication
 
 **Files:**
 - Modify `.github/workflows/build-and-test.yml`
 - Modify `.github/workflows/release.yml`
-- Modify `installer/macos/build-dmg.sh` / `installer/macos/test-build-dmg.sh` only if an execute-bit regression is actually reproduced
+- Modify installer Mac scripts only if execute-bit loss is reproduced
 
-**Consumes:** Tasks 1–3.
+**Consumes:** Tasks 1–3 and the already-green HPA-623 Mac test baseline.
 
-**Produces:** one native CI path and one release path using the same project-owned runtime.
+**Produces:** one CI/release path using the same project-owned runtime without allowing PATH FFmpeg to mask packaging failures.
 
-- [ ] **Step 1: Pin regular Mac CI to native Apple Silicon and cache only the FFmpeg source-build cache.**
+- [ ] **Step 1: Pin the regular Mac job to an explicit Apple Silicon runner and cache only the FFmpeg runtime cache.**
 
-Change:
+Replace `macos-latest` with the repository's chosen explicit Apple Silicon runner label. Keep the runner choice arm64 and stable; do not rely on `macos-latest` drift.
 
-```yaml
-runs-on: macos-15
-```
-
-Add after checkout/setup:
+Add cache:
 
 ```yaml
 - name: Cache native FFmpeg runtime
@@ -636,72 +593,59 @@ Add after checkout/setup:
 
 Do not cache `bin`, `obj`, or publish output.
 
-- [ ] **Step 2: Restore through Test.Mac so all referenced projects are restored once.**
+- [ ] **Step 2: Restore Test.Mac once, then keep named Game/Test builds.**
 
-Use:
-
-```yaml
-- name: Restore dependencies
-  run: dotnet restore DTXMania.Test/DTXMania.Test.Mac.csproj
+```text
+restore DTXMania.Test.Mac.csproj
+build DTXMania.Game.Mac.csproj --no-restore
+verify Game runtime
+build DTXMania.Test.Mac.csproj --no-restore
+verify Test.Mac runtime
 ```
 
-- [ ] **Step 3: Keep a named Game build and verify its runtime.**
+For both outputs require:
 
-```yaml
-- name: Build Mac game project
-  run: dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug --no-restore
-
-- name: Verify Mac game native FFmpeg runtime
-  shell: bash
-  run: |
-    runtime="DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
-    test -x "$runtime/ffmpeg"
-    test -x "$runtime/ffprobe"
-    file -b "$runtime/ffmpeg" | grep -qi arm64
-    file -b "$runtime/ffprobe" | grep -qi arm64
-    "$runtime/ffmpeg" -version
-    "$runtime/ffprobe" -version
+```bash
+test -x ffmpeg
+test -x ffprobe
+file -b ffmpeg | grep -qi arm64
+file -b ffprobe | grep -qi arm64
 ```
 
-- [ ] **Step 4: Explicitly build Test.Mac before any `--no-build` test invocation.**
+- [ ] **Step 3: Run the bundle-sensitive Audio checks before installing Homebrew FFmpeg.**
 
-```yaml
-- name: Build Mac test project
-  run: dotnet build DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug --no-restore
+Run the Task 3 focused Audio filter immediately after Test.Mac build/runtime verification.
 
-- name: Verify Mac test native FFmpeg runtime
-  shell: bash
-  run: |
-    runtime="DTXMania.Test/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
-    test -x "$runtime/ffmpeg"
-    test -x "$runtime/ffprobe"
-    file -b "$runtime/ffmpeg" | grep -qi arm64
-    file -b "$runtime/ffprobe" | grep -qi arm64
+Then run the full real Mac suite with `--no-build` and coverage as established by HPA-623.
+
+Keep the HPA-623 missing-coverage check fail-closed; do not weaken it back to a warning.
+
+- [ ] **Step 4: Retain Automation, VideoRecorder, and prepared-chart AudioE2E.**
+
+These remain after the normal Test.Mac suite. HPA-512 does not change recorder artifact verification behavior.
+
+- [ ] **Step 5: Keep Homebrew FFmpeg installation after all HPA-512 bundle-sensitive checks.**
+
+The existing CX Neon SFX validation needs a full FFmpeg. Keep its `brew install ffmpeg` step **after**:
+
+```text
+Game runtime verification
+Test.Mac runtime verification
+FfmpegBundledRuntimeTests
+focused Audio tests
+full Test.Mac suite
+prepared-chart AudioE2E
 ```
 
-This named build is the ProjectReference/copy-contract gate. Do not depend on a focused `dotnet test` accidentally building Test.Mac first.
-
-- [ ] **Step 5: Run focused audio packaging/product gates with `--no-build`, then retain the existing full suite.**
-
-```yaml
-- name: Run native FFmpeg audio checks on macOS
-  env:
-    ALSOFT_DRIVERS: 'null'
-  run: >
-    dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj
-    --configuration Debug --no-build --verbosity normal
-    --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegRuntimeTests|FullyQualifiedName~ManagedSoundTests"
-```
-
-Then keep the existing full Mac test step with `--no-build` and coverage, plus Automation, VideoRecorder, and prepared-chart AudioE2E steps.
+This ordering prevents PATH FFmpeg from hiding a missing/broken bundle.
 
 - [ ] **Step 6: Keep Windows CI as the cross-platform guard.**
 
-Do not add a separate Windows FFmpeg pipeline. The existing Windows `dotnet test DTXMania.Test/DTXMania.Test.csproj` build path must remain green; it transitively evaluates/builds `DTXMania.Game.Mac.csproj` and therefore proves the macOS condition prevents the native builder from running there.
+Do not add a separate Windows FFmpeg pipeline. Existing Windows build/tests must stay green and prove the Mac bootstrap target remains inert when the Mac project is evaluated on Windows.
 
-- [ ] **Step 7: Delete the duplicated native source-build body from `release.yml`.**
+- [ ] **Step 7: Delete the duplicated source-build body from `release.yml`.**
 
-After the existing `dotnet publish ... -r osx-arm64`, require only:
+After normal `dotnet publish -r osx-arm64`, release YAML should only verify the project-owned output:
 
 ```bash
 runtime="publish/mac/runtimes/osx-arm64/MMTools"
@@ -712,9 +656,9 @@ file -b "$runtime/ffprobe" | grep -qi arm64
 test -f publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Do not duplicate feature checks in YAML; `build-runtime.sh` owns them.
+Do not duplicate builder capability or `otool -L` checks in YAML; `build-runtime.sh` owns those.
 
-- [ ] **Step 8: Verify the existing app-bundle copy preserves the same runtime.**
+- [ ] **Step 8: Verify the existing `.app` copy preserves the runtime.**
 
 After `build-dmg.sh`:
 
@@ -727,7 +671,7 @@ file -b "$runtime/ffprobe" | grep -qi arm64
 test -f output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-If this passes, leave `installer/macos/build-dmg.sh` unchanged. If it fails only because execute bits are lost, fix the existing publish-output copy path narrowly and add the matching regression to `test-build-dmg.sh`.
+If this passes, leave installer scripts unchanged. If only execute bits are lost, fix the existing copy path narrowly and add the matching regression test.
 
 - [ ] **Step 9: Run final blast radius.**
 
@@ -742,7 +686,7 @@ dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj -c Debug 
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj -c Debug --verbosity normal
 ```
 
-Run the existing prepared-chart `Category=AudioE2E` command on `macos-15`.
+Run the existing prepared-chart `Category=AudioE2E` command before Homebrew FFmpeg is installed.
 
 Windows/Windows CI:
 
@@ -765,32 +709,36 @@ git commit -m "ci: validate bundled Apple Silicon ffmpeg"
 
 ## Final acceptance checklist
 
+- [ ] HPA-623 is merged first and Mac CI already executes a real Test.Mac suite with fail-closed coverage.
 - [ ] `MMTools.Executables.MacOS.X64` is absent from the Mac project.
-- [ ] Exact current `release.yml` FFmpeg recipe is reproducible from `build-runtime.sh`; optional `--disable-*` hardening is retained only after a clean verified build.
+- [ ] Builder uses FFmpeg 7.0.2 + pinned source SHA + `--disable-autodetect`.
+- [ ] Builder explicitly verifies `adpcm_ima_wav` and `adpcm_ms` in addition to existing decoders.
+- [ ] `otool -L` proves both shipped executables depend only on macOS system libraries.
 - [ ] Normal Apple Silicon Game output contains executable arm64 `ffmpeg` and `ffprobe`.
-- [ ] `DTXMania.Test.Mac` output receives the same runtime through the Game `ProjectReference` copy contract.
-- [ ] Windows builds `DTXMania.Test.csproj` without invoking the native Mac builder.
-- [ ] Publish output contains the same runtime and FFmpeg LGPL license.
-- [ ] Existing `ManagedSoundFFmpegPathTests.WithArm64Present_ShouldPreferArm64OverX64` remains unchanged and green.
-- [ ] Existing `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` keeps WAV/MP3/OGG + `PlaybackModifiers(50, 12)` coverage without requiring bundled MP3/OGG encoders.
-- [ ] Test-owned MP3/OGG fixtures are copied by both test projects.
-- [ ] Native `FfmpegRuntime.EnsureConfigured().BinaryFolder` resolves the Test.Mac bundled arm64 directory and both files retain execute bits.
+- [ ] Warm/staged builds do not rerun the builder `Exec` unnecessarily.
+- [ ] Test.Mac receives the same runtime through the Game `ProjectReference` copy contract.
+- [ ] Windows evaluates/builds the Mac project without invoking the native builder.
+- [ ] Publish and `.app` output contain the same runtime and LGPL license.
+- [ ] Existing arm64 preference tests remain unchanged and green.
+- [ ] Existing `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` keeps WAV/MP3/OGG + `PlaybackModifiers(50, 12)` coverage without production encoders.
+- [ ] New `FfmpegBundledRuntimeTests` is Audio-trait, not Unit-trait.
+- [ ] Native bundled-runtime test asserts `BinaryFolder` is non-null and equals Test.Mac's bundled arm64 directory.
 - [ ] `ManagedSound` successfully loads the valid MP3 fixture.
-- [ ] Existing audio-variant cancellation/timeout tests remain green.
-- [ ] Stale `MMTools.Executables.MacOS.X64` user diagnostic is removed.
-- [ ] Regular Mac CI is pinned to `macos-15`, caches the script-built runtime, and explicitly builds Test.Mac before `--no-build` tests.
-- [ ] Release YAML no longer owns a duplicate FFmpeg configure/build recipe.
-- [ ] `.app` contains executable arm64 runtime files plus `FFmpeg-LGPL-2.1.txt`.
-- [ ] Windows build/tests remain green and otherwise unchanged.
+- [ ] Stale x64-package user diagnostic is removed.
+- [ ] Homebrew FFmpeg is installed only after bundle-sensitive Mac audio/E2E checks.
+- [ ] Release YAML no longer owns a duplicate configure/build recipe.
+- [ ] Intel Mac build failure is documented as the intentional support boundary.
+- [ ] Recorder artifact verification remains PATH-ffprobe based; no bundled MP4 verifier is introduced.
 
 ## Risks carried into implementation review
 
-1. **Existing Audio test fixture encoding** — must be removed before the minimal runtime replaces the full x64 build, or Mac Audio tests fail on `libmp3lame`/`libvorbis` before testing the product path.
-2. **Generated MSBuild content / ProjectReference propagation** — Game-bin success is insufficient; Test.Mac bin must be explicitly built and checked.
-3. **Unix execute-bit preservation** — any lost bit makes `FfmpegRuntime.IsRunnableFile` reject the bundled runtime and fall back to PATH; fail rather than weakening the resolver.
-4. **Windows evaluates the Mac project** — the generation target must remain macOS-only.
-5. **Configure hardening delta** — do not conflate extraction with unproven flag changes; validate the shipping recipe first.
+1. **Cold-build latency** — a first `dotnet run` may compile FFmpeg and exceed E2E startup expectations; warm the cache before E2E.
+2. **Host dependency leakage** — `--disable-autodetect` plus `otool -L` must prevent Homebrew-linked binaries from entering the cache.
+3. **Generated MSBuild propagation** — Game-bin success alone is insufficient; Test.Mac and publish outputs must be checked.
+4. **Unix execute bits** — any lost bit makes `IsRunnableFile` reject the bundle; fail/fix copying rather than weakening the resolver.
+5. **PATH masking** — `IsAvailable == true` is insufficient; `BinaryFolder != null` and exact bundled path are required.
+6. **Intel support** — the Mac project intentionally hard-fails outside native arm64.
 
 ## Handoff
 
-After this implementation merges, HPA-512 can close and HPA-515 has the native CX audio prerequisite it needs. Do not pull HPA-515 OBS/recorder work into this implementation PR.
+After HPA-512 merges, HPA-515 has the native **CX preview/gameplay audio** prerequisite it requires. `DTXMania.VideoRecorder` continues resolving its artifact-verification `ffprobe` from PATH and remains outside this ticket.

--- a/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
+++ b/docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md
@@ -1,0 +1,544 @@
+# HPA-512 Native Apple Silicon FFmpeg Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make normal CX Mac build/run/publish output carry a verified native Apple Silicon `ffmpeg`/`ffprobe` runtime so MP3 preview and non-default playback variants work without Rosetta or user-installed FFmpeg.
+
+**Architecture:** Extract the already-proven FFmpeg 7.0.2 arm64 source build from `release.yml` into one reusable shell builder with a versioned user cache. `DTXMania.Game.Mac.csproj` owns copying that runtime into build and publish outputs; existing `FfmpegRuntime` remains the runtime resolver. Native `macos-15` CI validates the real files and focused audio paths, and release reuses the same project-owned output.
+
+**Tech Stack:** .NET 8, MonoGame DesktopGL, FFMpegCore 5.4.0, FFmpeg 7.0.2 source build, Bash/MSBuild, xUnit, GitHub Actions `macos-15`.
+
+## Global Constraints
+
+- Keep FFmpeg 7.0.2 for this ticket; this is packaging consolidation, not an FFmpeg upgrade.
+- Official source tarball SHA-256 stays `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`.
+- Supported macOS target is native Apple Silicon arm64 only; no Intel/Rosetta fallback.
+- Remove `MMTools.Executables.MacOS.X64` from `DTXMania.Game.Mac.csproj`.
+- Keep `FFMpegCore` 5.4.0 and the existing `FfmpegRuntime` production resolution flow.
+- Runtime layout stays `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`.
+- PATH remains diagnostic fallback only; never install/use PATH FFmpeg as production recovery.
+- Preserve Windows project/runtime behavior unchanged.
+- Preserve the current minimal CX codec/filter surface; do not grow a general FFmpeg build.
+- Ship upstream LGPL license material with build/publish/release output.
+- No new NuGet binary provider, binary commits, package-builder project, generic bootstrap framework, signing/notarization redesign, recorder media work, or OBS work.
+
+---
+
+## Files
+
+```text
+Create:
+  tools/ffmpeg/macos-arm64/build-runtime.sh
+  tools/ffmpeg/macos-arm64/README.md
+  DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
+  DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs
+
+Modify:
+  DTXMania.Game/DTXMania.Game.Mac.csproj
+  DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs
+  .github/workflows/build-and-test.yml
+  .github/workflows/release.yml
+
+Only modify if the packaged-app verification exposes a real permission-copy bug:
+  installer/macos/build-dmg.sh
+  installer/macos/test-build-dmg.sh
+```
+
+Keep all four tasks in one HPA-512 implementation PR.
+
+---
+
+### Task 1: Extract the reproducible native FFmpeg builder
+
+**Files:**
+- Create `tools/ffmpeg/macos-arm64/build-runtime.sh`
+- Create `tools/ffmpeg/macos-arm64/README.md`
+
+**Produces:**
+
+```text
+build-runtime.sh <runtime-output-dir> <license-output-dir>
+
+runtime-output-dir/
+  ffmpeg
+  ffprobe
+
+license-output-dir/
+  FFmpeg-LGPL-2.1.txt
+```
+
+The builder maintains its reusable validated cache at:
+
+```text
+${DTXMANIA_FFMPEG_CACHE_ROOT:-$HOME/Library/Caches/DTXManiaCX/ffmpeg}/7.0.2/osx-arm64
+```
+
+- [ ] **Step 1: Copy the proven source recipe out of `release.yml` into the script.**
+
+Use constants at the top of the script:
+
+```bash
+FFMPEG_VERSION="7.0.2"
+FFMPEG_TARBALL_SHA256="8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389"
+FFMPEG_URL="https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+```
+
+Fail before download/build unless:
+
+```bash
+[[ "$(uname -s)" == "Darwin" ]]
+[[ "$(uname -m)" == "arm64" ]]
+```
+
+Error text must identify native Apple Silicon as the supported Mac build rather than suggesting Rosetta.
+
+- [ ] **Step 2: Preserve the existing minimal feature set and make dependency/license behavior deterministic.**
+
+Start from the current release configure list and add explicit fail-closed flags:
+
+```text
+--disable-autodetect
+--disable-gpl
+--disable-nonfree
+```
+
+Keep the current required decoders/demuxers/parsers/protocols/encoder/muxer/filters exactly as documented in the design spec. Do not add Homebrew codecs or external libraries.
+
+- [ ] **Step 3: Make the versioned cache copy-only on a valid hit.**
+
+A cache hit is valid only when all are true:
+
+```text
+cached ffmpeg exists + executable
+cached ffprobe exists + executable
+cached COPYING.LGPLv2.1 exists
+cached source.sha256 contains the exact pinned tarball hash
+```
+
+On a miss, build into a temporary directory, validate it, then replace the versioned cache. Do not add cross-process locking; CI/local build concurrency does not justify it here.
+
+- [ ] **Step 4: Keep all native verification inside the builder.**
+
+For both binaries independently require:
+
+```bash
+file -b "$bin" | grep -qi 'arm64'
+```
+
+Require the same feature checks currently embedded in `release.yml`:
+
+```text
+filters:  atempo apad atrim aformat aresample
+decoders: mp3float vorbis pcm_s16le
+demuxers: mp3 wav ogg s16le
+encoder:  pcm_s16le
+muxer:    s16le
+```
+
+Run `ffmpeg -version` and `ffprobe -version` successfully before caching.
+
+- [ ] **Step 5: Copy license and provenance documentation.**
+
+Copy `COPYING.LGPLv2.1` from the verified source tree/cache to `FFmpeg-LGPL-2.1.txt` in the caller's license output directory.
+
+Document in `README.md`:
+
+```text
+version + source URL + source SHA-256
+why the minimal configure set exists
+cache location and DTXMANIA_FFMPEG_CACHE_ROOT override
+rm -rf cache command for a clean rebuild
+version-update procedure
+local build/verify commands
+```
+
+- [ ] **Step 6: Validate a cold build and a warm-cache copy.**
+
+Run on Apple Silicon:
+
+```bash
+rm -rf "$HOME/Library/Caches/DTXManiaCX/ffmpeg/7.0.2/osx-arm64"
+rm -rf /tmp/dtx-ffmpeg-runtime /tmp/dtx-ffmpeg-licenses
+bash tools/ffmpeg/macos-arm64/build-runtime.sh \
+  /tmp/dtx-ffmpeg-runtime \
+  /tmp/dtx-ffmpeg-licenses
+
+test -x /tmp/dtx-ffmpeg-runtime/ffmpeg
+test -x /tmp/dtx-ffmpeg-runtime/ffprobe
+file /tmp/dtx-ffmpeg-runtime/ffmpeg /tmp/dtx-ffmpeg-runtime/ffprobe
+test -f /tmp/dtx-ffmpeg-licenses/FFmpeg-LGPL-2.1.txt
+
+rm -rf /tmp/dtx-ffmpeg-runtime /tmp/dtx-ffmpeg-licenses
+time bash tools/ffmpeg/macos-arm64/build-runtime.sh \
+  /tmp/dtx-ffmpeg-runtime \
+  /tmp/dtx-ffmpeg-licenses
+```
+
+Expected: first command builds from source; second command reuses the cache and only verifies/copies.
+
+- [ ] **Step 7: Commit checkpoint.**
+
+```bash
+git add tools/ffmpeg/macos-arm64
+git commit -m "build: extract native Apple Silicon ffmpeg runtime"
+```
+
+---
+
+### Task 2: Make the Mac project own build/run/publish runtime placement
+
+**Files:**
+- Modify `DTXMania.Game/DTXMania.Game.Mac.csproj`
+- Modify `DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs`
+
+**Consumes:** `tools/ffmpeg/macos-arm64/build-runtime.sh <runtime-dir> <license-dir>` from Task 1.
+
+**Produces:** normal Mac build and publish outputs containing the native runtime and license.
+
+- [ ] **Step 1: Tighten the existing resolver contract test before project wiring.**
+
+Change `GetFFmpegBinaryFolder_ShouldPreferFirstCompleteCandidate` so the complete preferred candidate is:
+
+```text
+<assembly>/runtimes/osx-arm64/MMTools
+```
+
+and a complete `osx-x64/MMTools` candidate also exists.
+
+Expected assertion:
+
+```csharp
+Assert.Equal(arm64, result);
+```
+
+Keep the split-folder and PATH tests unchanged.
+
+- [ ] **Step 2: Remove only the obsolete x64 runtime package.**
+
+Delete from `DTXMania.Game.Mac.csproj`:
+
+```xml
+<PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
+```
+
+Do not change `FFMpegCore` or the Windows project.
+
+- [ ] **Step 3: Add Mac-only MSBuild targets for normal build and publish.**
+
+Keep the target local to `DTXMania.Game.Mac.csproj`.
+
+After a successful `Build` on macOS, invoke:
+
+```text
+bash tools/ffmpeg/macos-arm64/build-runtime.sh
+  $(TargetDir)/runtimes/osx-arm64/MMTools
+  $(TargetDir)/Licenses
+```
+
+After `Publish`, invoke the same script for:
+
+```text
+$(PublishDir)/runtimes/osx-arm64/MMTools
+$(PublishDir)/Licenses
+```
+
+Use a repository-root-relative script path based on `$(MSBuildProjectDirectory)`, not the shell working directory.
+
+Do not add shared `.props`/`.targets` files for this single platform project.
+
+- [ ] **Step 4: Prove normal `dotnet build` and `dotnet run` output is self-contained.**
+
+Run on Apple Silicon:
+
+```bash
+dotnet restore DTXMania.Game/DTXMania.Game.Mac.csproj
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+
+test -x DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
+test -x DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
+test -f DTXMania.Game/bin/Debug/net8.0/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+Launch once with the normal project command and confirm the process itself starts as arm64:
+
+```bash
+dotnet run --project DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+No PATH FFmpeg installation is part of the success path.
+
+- [ ] **Step 5: Prove self-contained publish output.**
+
+```bash
+rm -rf /tmp/dtx-publish-arm64
+dotnet publish DTXMania.Game/DTXMania.Game.Mac.csproj \
+  -c Release -r osx-arm64 --self-contained \
+  -p:PublishReadyToRun=false -p:TieredCompilation=false \
+  -o /tmp/dtx-publish-arm64
+
+test -x /tmp/dtx-publish-arm64/runtimes/osx-arm64/MMTools/ffmpeg
+test -x /tmp/dtx-publish-arm64/runtimes/osx-arm64/MMTools/ffprobe
+test -f /tmp/dtx-publish-arm64/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+- [ ] **Step 6: Run focused resolver tests and commit checkpoint.**
+
+```bash
+dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --filter "FullyQualifiedName~FfmpegRuntime" \
+  --verbosity normal
+
+git add DTXMania.Game/DTXMania.Game.Mac.csproj \
+        DTXMania.Test/Resources/FfmpegRuntimeCoverageTests.cs
+git commit -m "build: bundle native ffmpeg in Mac outputs"
+```
+
+---
+
+### Task 3: Add native MP3 and real audio-variant smoke coverage
+
+**Files:**
+- Create `DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3`
+- Create `DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs`
+- Modify `DTXMania.Test/DTXMania.Test.Mac.csproj` only if the existing test-data include does not copy the new fixture
+
+**Consumes:** bundled runtime produced by the Mac project.
+
+**Produces:** two native integration gates: real MP3 `ManagedSound` load and one real non-default `FfmpegAudioVariantProcessor` transform.
+
+- [ ] **Step 1: Generate one project-owned MP3 fixture.**
+
+On a development Mac with a full FFmpeg installed for test-fixture generation only:
+
+```bash
+mkdir -p DTXMania.Test/TestData/Audio
+ffmpeg -hide_banner -loglevel error \
+  -f lavfi -i "sine=frequency=440:sample_rate=44100:duration=1" \
+  -ac 1 -codec:a libmp3lame -b:a 64k \
+  -y DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
+```
+
+The committed tone contains no third-party media. Do not make fixture generation part of production build.
+
+- [ ] **Step 2: Add one arm64-only runtime-location/process smoke.**
+
+In `FfmpegNativeRuntimeIntegrationTests`, return without asserting native behavior when the host is not `OperatingSystem.IsMacOS()` + `Architecture.Arm64`; Windows remains covered by normal tests.
+
+On native Mac require:
+
+```text
+FfmpegRuntime.EnsureConfigured().IsAvailable == true
+BinaryFolder ends with runtimes/osx-arm64/MMTools
+ffmpeg and ffprobe exist and are executable
+process execution of ffmpeg -version succeeds
+process execution of ffprobe -version succeeds
+```
+
+Do not create a reusable process-runner abstraction for two smoke commands.
+
+- [ ] **Step 3: Add the real MP3 `ManagedSound` smoke.**
+
+With `ALSOFT_DRIVERS=null` in the test process/CI environment:
+
+```csharp
+using var sound = new ManagedSound(mp3Fixture);
+Assert.True(sound.Duration > TimeSpan.Zero);
+```
+
+This must exercise the packaged runtime through `FfmpegRuntime`; do not configure FFMpegCore to PATH inside the test.
+
+- [ ] **Step 4: Add one real variant transform smoke.**
+
+Generate a small PCM WAV in the test temporary directory and run the public default processor:
+
+```csharp
+var processor = new FfmpegAudioVariantProcessor();
+var artifact = await processor.PrepareAsync(
+    wavPath,
+    new PlaybackModifiers(/* use the existing non-default play-speed factory/constructor */),
+    cancellationToken);
+```
+
+Use the repository's actual `PlaybackModifiers` API and one supported non-default speed already covered by unit tests. Assert a non-empty prepared artifact, then dispose/delete via the existing artifact ownership contract.
+
+This test must use the real backend; do not pass the internal fake backend used by unit tests.
+
+- [ ] **Step 5: Keep existing cancellation/timeout tests as the cleanup gate.**
+
+Do not duplicate cancellation machinery in the native integration class. Run the existing `FfmpegAudioVariantProcessorTests` together with the two new native smokes.
+
+- [ ] **Step 6: Run focused native tests.**
+
+```bash
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~FfmpegNativeRuntimeIntegrationTests|FullyQualifiedName~FfmpegAudioVariantProcessorTests" \
+  --verbosity normal
+```
+
+Expected: native runtime, MP3 load, real variant transform, and existing cancellation/timeout coverage all pass.
+
+- [ ] **Step 7: Commit checkpoint.**
+
+```bash
+git add DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3 \
+        DTXMania.Test/Resources/FfmpegNativeRuntimeIntegrationTests.cs \
+        DTXMania.Test/DTXMania.Test.Mac.csproj
+git commit -m "test: verify native Mac ffmpeg audio paths"
+```
+
+---
+
+### Task 4: Make native CI authoritative and remove release duplication
+
+**Files:**
+- Modify `.github/workflows/build-and-test.yml`
+- Modify `.github/workflows/release.yml`
+- Modify `installer/macos/build-dmg.sh` / `test-build-dmg.sh` only if verification proves execute bits are lost
+
+**Consumes:** project-owned build/publish runtime from Tasks 1–3.
+
+**Produces:** one native CI path and one release path using the same runtime source of truth.
+
+- [ ] **Step 1: Pin regular Mac CI to a native Apple Silicon runner.**
+
+Change:
+
+```yaml
+runs-on: macos-latest
+```
+
+to:
+
+```yaml
+runs-on: macos-15
+```
+
+for `build-and-test-macos`.
+
+This makes the regular Mac build/test result actual arm64 evidence, matching the existing release runner.
+
+- [ ] **Step 2: Cache the source-built runtime for PR speed.**
+
+Before the Mac build, add `actions/cache` for:
+
+```text
+~/Library/Caches/DTXManiaCX/ffmpeg
+```
+
+Key it with OS/architecture plus:
+
+```text
+hashFiles('tools/ffmpeg/macos-arm64/build-runtime.sh')
+```
+
+Do not cache build/publish outputs.
+
+- [ ] **Step 3: Verify the actual game build output before tests.**
+
+Immediately after `dotnet build`:
+
+```bash
+runtime="DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools"
+test -x "$runtime/ffmpeg"
+test -x "$runtime/ffprobe"
+file -b "$runtime/ffmpeg" | grep -qi arm64
+file -b "$runtime/ffprobe" | grep -qi arm64
+"$runtime/ffmpeg" -version
+"$runtime/ffprobe" -version
+```
+
+Set `ALSOFT_DRIVERS=null` when running the focused/native audio tests.
+
+Keep the full Mac unit suite, Automation suite, and prepared-chart AudioE2E afterward.
+
+- [ ] **Step 4: Delete the duplicated FFmpeg source-build body from `release.yml`.**
+
+The `dotnet publish` step now produces:
+
+```text
+publish/mac/runtimes/osx-arm64/MMTools/ffmpeg
+publish/mac/runtimes/osx-arm64/MMTools/ffprobe
+publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+Replace the existing long `Build native arm64 ffmpeg` step with a short publish-artifact verification:
+
+```bash
+runtime="publish/mac/runtimes/osx-arm64/MMTools"
+test -x "$runtime/ffmpeg"
+test -x "$runtime/ffprobe"
+test -f publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
+file -b "$runtime/ffmpeg" | grep -qi arm64
+file -b "$runtime/ffprobe" | grep -qi arm64
+```
+
+The feature-set verification remains in `build-runtime.sh`; do not duplicate it in YAML.
+
+- [ ] **Step 5: Verify the packaged `.app` after `build-dmg.sh`.**
+
+After bundle creation, require:
+
+```bash
+app_runtime="output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools"
+test -x "$app_runtime/ffmpeg"
+test -x "$app_runtime/ffprobe"
+file -b "$app_runtime/ffmpeg" | grep -qi arm64
+file -b "$app_runtime/ffprobe" | grep -qi arm64
+test -f output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+If this passes, do not touch `build-dmg.sh`. If execute bits are actually lost, fix only its existing `cp -R` staging behavior and extend `test-build-dmg.sh` for that exact regression.
+
+- [ ] **Step 6: Run the final local blast radius.**
+
+On Apple Silicon:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj -c Debug
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj -c Debug --verbosity normal
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj -c Debug --verbosity normal
+```
+
+On Windows/Windows CI:
+
+```powershell
+dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj -c Debug
+dotnet test DTXMania.Test/DTXMania.Test.csproj -c Debug --verbosity normal
+```
+
+Also run the Mac prepared-chart AudioE2E on the native runner using the existing workflow command.
+
+- [ ] **Step 7: Commit checkpoint.**
+
+```bash
+git add .github/workflows/build-and-test.yml \
+        .github/workflows/release.yml \
+        installer/macos/build-dmg.sh \
+        installer/macos/test-build-dmg.sh
+git commit -m "ci: validate bundled Apple Silicon ffmpeg"
+```
+
+Stage only installer files if they actually changed.
+
+---
+
+## Final acceptance checklist
+
+- [ ] `MMTools.Executables.MacOS.X64` is absent from the Mac project.
+- [ ] Normal Apple Silicon `dotnet build` output contains executable arm64 `ffmpeg` and `ffprobe`.
+- [ ] Normal `dotnet run` resolves the bundled arm64 runtime without PATH/Rosetta.
+- [ ] `dotnet publish -r osx-arm64` contains the same runtime and FFmpeg LGPL license.
+- [ ] `FfmpegRuntime` preference test proves `osx-arm64` wins over an available x64 candidate.
+- [ ] Real packaged-runtime `ffmpeg -version` and `ffprobe -version` smoke passes.
+- [ ] MP3 preview load through `ManagedSound` passes with the bundled runtime.
+- [ ] One real non-default `FfmpegAudioVariantProcessor` transform passes.
+- [ ] Existing cancellation/timeout cleanup tests remain green.
+- [ ] Regular Mac CI is pinned to `macos-15` and caches the source-built runtime.
+- [ ] Release YAML no longer owns a duplicate FFmpeg configure/build recipe.
+- [ ] `.app` bundle retains both runtime files, arm64 architecture, execute bits, and license.
+- [ ] Windows build/tests are unchanged and green.
+
+## Handoff
+
+After this implementation merges, HPA-512 can close and HPA-515 has the native CX audio prerequisite it needs. Do not pull HPA-515 OBS/recorder work into this implementation PR.

--- a/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
+++ b/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** HPA-512 — Package native Apple Silicon FFmpeg for CX gameplay audio  
 **Date:** 2026-08-14  
-**Status:** Revised after planning review
+**Status:** Revised after second planning review
 
 ## Goal
 
@@ -16,62 +16,78 @@ dotnet build / dotnet run / dotnet test / dotnet publish
 -> MP3 preview + non-default playback audio variants work without Rosetta or user-installed FFmpeg
 ```
 
-Keep the task to one 2–3 engineer-day implementation PR. This is packaging/build plumbing around existing audio code, not an FFmpeg or audio-engine redesign.
+Keep HPA-512 to one 2–3 engineer-day implementation PR after its CI prerequisite lands. This is packaging/build plumbing around existing audio code, not an FFmpeg, recorder, or audio-engine redesign.
 
-## Why this is the next slice
+## Prerequisite: establish real Mac test coverage first
 
-HPA-513 is the next Windows acceptance milestone, but the HPA-503 implementation is still stacked behind the open HPA-503 planning PR before it reaches `main`.
+HPA-623 must land before HPA-512 implementation.
 
-HPA-512 is high priority, unblocked, and independently blocks HPA-515 Apple Silicon recording parity.
+Current `build-and-test.yml` builds only `DTXMania.Game.Mac.csproj`, then invokes `dotnet test DTXMania.Test.Mac.csproj --no-build`. On current `main`, that command exits after a sub-second MSBuild success without a `Test run for ...` line or test summary, and the following coverage step warns that `coverage.cobertura.xml` is missing.
+
+Therefore the current Mac suite is **not** a merge gate for `DTXMania.Test.Mac` today. HPA-623 owns the baseline repair:
+
+- build `DTXMania.Test.Mac.csproj` before its `--no-build` test step, or equivalently remove `--no-build` if that is the smaller fix;
+- make missing Mac test coverage fail instead of warn;
+- resolve any pre-existing failures without mixing FFmpeg packaging changes into that PR;
+- get a green `main` baseline before HPA-512 starts.
+
+HPA-512 may rely on this repaired baseline; it must not be the PR that causes the full Mac suite to execute for the first time.
+
+## Why HPA-512 remains the next audio slice
+
+HPA-513 is the next Windows recorder acceptance milestone, but the Windows implementation sequence is separate from this Mac audio packaging work.
+
+HPA-512 is still a real prerequisite for HPA-515 Apple Silicon recorder parity, but for a narrower reason than the recorder itself:
+
+- HPA-515 requires the **CX game process** to decode MP3 preview audio and prepare gameplay audio natively on arm64;
+- `DTXMania.VideoRecorder` does not reference the Game project and does not consume the bundled audio runtime for artifact verification;
+- `RecordingArtifactVerifier` continues resolving `ffprobe` from `PATH` for MP4 stream inspection.
+
+The runtime produced by HPA-512 is intentionally audio-only. It does not need MP4/H.264 support and does not replace the recorder's PATH `ffprobe` contract.
 
 ## Current state
 
-The repository already contains most runtime behavior needed by HPA-512:
+The repository already contains the runtime behavior HPA-512 should reuse:
 
 - `DTXMania.Game.Mac.csproj` references `FFMpegCore` plus the x64-only `MMTools.Executables.MacOS.X64` package.
-- `FfmpegRuntime` already looks for `runtimes/osx-arm64/MMTools` before `osx-x64` and requires both `ffmpeg` and `ffprobe` to be runnable.
-- `ManagedSound` and `FfmpegAudioVariantProcessor` already share `FfmpegRuntime`; no second runtime resolver is needed.
-- `release.yml` already builds a native arm64 FFmpeg 7.0.2 from the official tarball, pins SHA-256 `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`, and validates the minimal codecs/filters CX actually uses.
-- that native runtime is created only after `dotnet publish`, so ordinary build/test output still resolves the x64 package or PATH.
-
-Two existing behaviors materially affect the design:
-
-1. `FfmpegAudioVariantProcessorTests.PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` is already the strongest real variant test. It runs real `FfmpegRuntime`, real `FfmpegAudioVariantProcessor`, and `new PlaybackModifiers(50, 12)` over WAV/MP3/OGG. Today its MP3/OGG rows first encode fixtures with `libmp3lame` / `libvorbis` through the configured FFmpeg. The shipping minimal arm64 runtime intentionally has only the `pcm_s16le` encoder, so replacing the x64 full build without repairing this test would make Mac Audio tests fail before the product path is exercised.
-2. Mac CI currently builds only the Game project and then runs `DTXMania.Test.Mac` with `--no-build`. A generated runtime must therefore propagate through the Game `ProjectReference`, and the test project must be built explicitly before its `--no-build` suite.
-
-Also, `DTXMania.Test.csproj` references `DTXMania.Game.Mac.csproj` on Windows. Any native bootstrap target in the Mac project must be explicitly macOS-only.
+- `FfmpegRuntime.GetFFmpegBinaryFolder` already prefers `runtimes/osx-arm64/MMTools` before `osx-x64`; do not add another resolver.
+- bundled resolution returns a non-null `BinaryFolder`; PATH fallback returns `BinaryFolder: null`, which gives tests a clean way to prove the bundled runtime won.
+- `FfmpegRuntime.IsRunnableFile` intentionally requires Unix execute bits; do not weaken it.
+- `release.yml` already builds FFmpeg 7.0.2 from the official tarball with pinned SHA-256 `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`.
+- the release recipe explicitly enables `adpcm_ima_wav` and `adpcm_ms` because non-default playback routes WAV through FFmpeg.
+- `FfmpegAudioVariantProcessorTests.PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` is already the strongest real variant gate, but its MP3/OGG fixtures are generated at test time with encoders the minimal production runtime intentionally does not ship.
 
 ## Approaches considered
 
-### A. Extract the proven source build, make the Mac project own one generated-content copy contract, and repair existing real-audio tests — chosen
+### A. Extract the proven source build, make the Mac project own generated runtime content, and repair the existing real-audio test — chosen
 
-Reuse the current release recipe, add one cached builder, generate the native runtime before MSBuild resolves copy items, and keep the existing audio test as the real variant gate using committed encoded fixtures.
+Reuse the current release recipe, make host reproducibility explicit, use one generated-content copy contract, and retain the stronger existing audio test with committed encoded fixtures.
 
 **Pros**
 
-- one upstream source/version/checksum;
-- no new binary publisher or package layout;
-- one runtime resolver and one runtime path;
-- one build/test/publish copy contract;
-- preserves the existing stricter `PlaybackModifiers(50, 12)` test instead of adding weaker duplicate coverage;
-- Windows behavior stays unchanged.
+- one upstream version/checksum;
+- no new binary supplier or NuGet runtime package;
+- one resolver and one runtime layout;
+- one Game/Test/publish copy contract;
+- preserves the stronger `PlaybackModifiers(50, 12)` gate;
+- keeps Windows behavior unchanged.
 
 **Cons**
 
-- first Apple Silicon build compiles FFmpeg once;
-- generated MSBuild content and Unix execute bits need explicit verification.
+- first Apple Silicon build compiles FFmpeg;
+- generated MSBuild content, Mach-O dependencies, and execute bits need explicit verification.
 
-### B. Add a third-party arm64 FFmpeg NuGet/binary provider — rejected
+### B. Add a third-party arm64 FFmpeg binary/NuGet provider — rejected
 
-This reduces first-build time but adds another supplier, update cadence, license/provenance surface, and layout adaptation. The repository already has a working upstream-source recipe.
+The repository already owns a pinned, checksum-verified upstream recipe. Another supplier adds provenance and maintenance without solving a missing architectural capability.
 
-### C. Expand the bundled runtime with MP3/OGG encoders only to preserve test fixture generation — rejected
+### C. Add MP3/OGG encoders to production for tests — rejected
 
-Production does not need `libmp3lame` or `libvorbis` encoding. Adding external encoder dependencies solely because tests generate their own inputs increases the runtime and licensing/dependency surface. Commit tiny project-owned MP3/OGG fixtures instead.
+Production only decodes these formats. Commit tiny project-owned encoded fixtures instead of widening the shipped runtime to satisfy test setup.
 
 ## Chosen design
 
-### 1. One source of truth for the native runtime
+### 1. One reproducible source builder
 
 Add:
 
@@ -80,19 +96,19 @@ tools/ffmpeg/macos-arm64/build-runtime.sh
 tools/ffmpeg/macos-arm64/README.md
 ```
 
-Extract the currently shipping configure recipe from `release.yml` first, unchanged:
+Keep FFmpeg 7.0.2 and the existing source checksum. Start from the current minimal release recipe, with one intentional reproducibility change:
 
 ```text
-FFmpeg 7.0.2
-source: https://ffmpeg.org/releases/ffmpeg-7.0.2.tar.xz
-SHA-256: 8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389
+--disable-autodetect
+```
 
---enable-static --disable-shared
---disable-doc --disable-htmlpages --disable-manpages
---disable-podpages --disable-txtpages
---disable-ffplay
---disable-everything
+Use it unconditionally. HPA-512 wants the same binary regardless of whether a developer machine happens to have Homebrew libraries installed.
 
+Do **not** add `--disable-gpl` or `--disable-nonfree`. With `--disable-everything` and no external `--enable-lib*` dependencies, they do not add a useful HPA-512 gate; document that decision rather than spending another cold build on it.
+
+Required runtime surface remains:
+
+```text
 decoders:
   mp3float
   vorbis
@@ -111,39 +127,32 @@ filters:
   aformat / anull / aresample / atempo / apad / atrim
 ```
 
-`--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` are sensible hardening but are **not** part of the proven recipe today. Do not make extraction depend on them. After a cold baseline build passes all existing architecture/capability checks, the implementation may add those three flags in the same PR only if another clean cold build remains green. Otherwise retain the proven flags and record the decision in the README.
+The builder must:
 
-The script must:
-
-1. reject non-macOS/non-arm64 hosts with `Native CX macOS runtime requires Apple Silicon (arm64); Intel/Rosetta is not supported.`;
-2. download the exact source tarball on a cache miss;
+1. fail on any host other than native `Darwin arm64`;
+2. download the exact official source tarball on cache miss;
 3. verify the pinned SHA-256 before extraction;
-4. configure/build/install the minimal runtime;
-5. independently verify `ffmpeg` and `ffprobe` are executable arm64 Mach-O binaries;
-6. verify the required filters, decoders, demuxers, encoder, and muxer already checked by `release.yml`;
+4. configure/build/install with `--disable-autodetect` and no external codec libraries;
+5. verify `ffmpeg` and `ffprobe` are executable arm64 Mach-O binaries;
+6. verify filters, demuxers, encoder/muxer, and **all load-bearing decoders including `adpcm_ima_wav` and `adpcm_ms`**;
 7. run `ffmpeg -version` and `ffprobe -version` successfully;
-8. cache the validated runtime under a versioned user cache;
-9. copy `ffmpeg`, `ffprobe`, and `COPYING.LGPLv2.1` to caller-provided destinations.
+8. run `otool -L` on both executables and fail if any dependency resolves outside system locations (`/usr/lib` or `/System/Library`);
+9. cache only a fully validated runtime under a versioned user cache;
+10. copy `ffmpeg`, `ffprobe`, and `COPYING.LGPLv2.1` to caller-provided destinations with explicit modes.
 
 Use:
 
 ```text
-${DTXMANIA_FFMPEG_CACHE_ROOT:-~/Library/Caches/DTXManiaCX/ffmpeg}/7.0.2/osx-arm64/
+${DTXMANIA_FFMPEG_CACHE_ROOT:-$HOME/Library/Caches/DTXManiaCX/ffmpeg}/7.0.2/osx-arm64/
 ```
 
-The cache is only an optimization. Deleting it forces a verified rebuild. Do not add a package-builder project, download service, lock daemon, or generic dependency bootstrap framework.
+The cache is an optimization only. Do not add cache locking, a package-builder project, download service, or generic bootstrap framework.
 
-### 2. The Mac project owns a generated MSBuild copy contract
+### 2. The Mac project owns one generated-content copy contract
 
-Remove only:
+Remove only `MMTools.Executables.MacOS.X64`; keep `FFMpegCore` and `FfmpegRuntime` unchanged.
 
-```xml
-<PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
-```
-
-Keep `FFMpegCore` and the Windows project unchanged.
-
-Stage generated files under a project-local intermediate root, for example:
+Stage generated files under a project-local intermediate root:
 
 ```text
 $(BaseIntermediateOutputPath)ffmpeg-runtime/
@@ -152,211 +161,180 @@ $(BaseIntermediateOutputPath)ffmpeg-runtime/
   Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-The target must be explicit because these files do not exist during normal project evaluation and must also be visible when a referencing project asks for copy-to-output items:
+Keep the existing macOS-only target hook before:
+
+```text
+BeforeBuild
+AssignTargetPaths
+GetCopyToOutputDirectoryItems
+```
+
+The target remains macOS-only because Windows tests evaluate/reference the Mac game project.
+
+Avoid rebuilding/revalidating the runtime on every MSBuild invocation. Put the cache/staging existence condition on the **`Exec` only**:
 
 ```xml
-<Target Name="PrepareNativeFfmpegRuntime"
-        Condition="$([MSBuild]::IsOSPlatform('OSX'))"
-        BeforeTargets="BeforeBuild;AssignTargetPaths;GetCopyToOutputDirectoryItems">
-  <Exec Command="bash .../tools/ffmpeg/macos-arm64/build-runtime.sh ..." />
-  <ItemGroup>
-    <!-- Add generated None items here, after generation. -->
-    <!-- Each item sets TargetPath, CopyToOutputDirectory=PreserveNewest, -->
-    <!-- and CopyToPublishDirectory=PreserveNewest. -->
-  </ItemGroup>
-</Target>
+<Exec
+  Condition="!Exists('$(NativeFfmpegRuntimeDir)/ffmpeg') Or !Exists('$(NativeFfmpegRuntimeDir)/ffprobe')"
+  Command="bash .../build-runtime.sh ..." />
 ```
 
-Required target paths:
+The generated `ItemGroup` must remain unconditional within the target so copy items are declared on every relevant project invocation even when the files are already staged.
+
+One target must propagate the runtime/license to:
 
 ```text
-runtimes/osx-arm64/MMTools/ffmpeg
-runtimes/osx-arm64/MMTools/ffprobe
-Licenses/FFmpeg-LGPL-2.1.txt
-```
-
-This one target must satisfy:
-
-```text
-Game bin output
--> ProjectReference copy into DTXMania.Test.Mac bin
+Game bin
+-> DTXMania.Test.Mac bin through ProjectReference
 -> publish output
--> .app bundle via existing cp -R
+-> existing .app copy
 ```
 
-Do not add a second copy target to the test project.
+Do not add a Test.Mac-specific FFmpeg copy implementation.
 
-Unix execute bits are part of the contract because `FfmpegRuntime.IsRunnableFile` intentionally rejects non-executable bundled binaries. Verify `test -x` in Game, Test.Mac, publish, and `.app` output. If MSBuild copy is proven to lose execute bits, add the smallest macOS-only post-copy `chmod +x` hook needed to the existing project flow; do not weaken `IsRunnableFile`.
+Execute bits remain part of the contract. Verify them in Game, Test.Mac, publish, and `.app` output; add a narrow macOS chmod hook only if copying is empirically lossy.
 
-The macOS condition is mandatory. Windows CI builds `DTXMania.Test.csproj`, which references the Mac game project; that build must not invoke `build-runtime.sh`.
+**Intel consequence:** because the builder rejects non-arm64 and the Mac project requires this generated runtime, `DTXMania.Game.Mac.csproj` no longer builds at all on Intel Macs. This is intentional for the currently supported Mac target; it is stronger than merely saying there is no playback fallback.
 
-### 3. Repair the existing real-FFmpeg tests instead of duplicating them
+### 3. Repair existing Audio coverage and add one real bundled-runtime guard
 
-Add two tiny project-owned fixtures:
+Add project-owned fixtures:
 
 ```text
 DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
 DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg
 ```
 
-Generate them once from the same deterministic sine tone using a full developer FFmpeg, then commit them. They are test inputs, not production runtime assets.
+Copy them from both test projects, then repair `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm`:
 
-Update both test project files to copy `TestData/Audio/**/*` to test output.
+- generated WAV row stays;
+- MP3/OGG rows read committed fixtures;
+- remove test-time `libmp3lame` / `libvorbis` encoding;
+- retain `PlaybackModifiers(50, 12)` and existing assertions.
 
-Modify `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm`:
+Do not add a weaker second variant smoke.
 
-- keep the WAV row generated by the existing tone/WAV helper;
-- use the committed MP3 fixture for the MP3 row;
-- use the committed OGG fixture for the OGG row;
-- delete the test-time `libmp3lame` / `libvorbis` encoding step;
-- keep `new PlaybackModifiers(50, 12)` and all current duration/frequency assertions.
-
-Do **not** add a second `PlaybackModifiers(125, 0)` variant smoke. The existing test is stricter and already exercises the real product processor.
-
-Add only missing product gates:
-
-1. a native Apple Silicon check in the existing `FfmpegRuntimeTests` that `EnsureConfigured().BinaryFolder` is the test assembly's `runtimes/osx-arm64/MMTools` directory and both files exist with Unix execute bits;
-2. one successful valid-MP3 load in `ManagedSoundTests` using `ffmpeg-tone.mp3` and asserting non-zero duration.
-
-Leave `ManagedSoundFFmpegPathTests` unchanged. It already proves a complete arm64 candidate wins over a complete x64 candidate. Leave the separate `FfmpegRuntimeCoverageTests` first-complete-candidate test unchanged as well.
-
-Update the stale `ManagedSound.LoadMp3File` missing-binary diagnostic so it no longer tells macOS users to install `MMTools.Executables.MacOS.X64`. Use one generic bundled-runtime message; this is copy correction, not resolver redesign.
-
-### 4. Native CI makes the copy contract observable
-
-Change regular Mac CI to:
-
-```yaml
-runs-on: macos-15
-```
-
-Add an Actions cache for:
+Put the packaged-runtime filesystem test in a **new Audio-trait class**, not `FfmpegRuntimeTests` (which is a pure Unit-trait class):
 
 ```text
-~/Library/Caches/DTXManiaCX/ffmpeg
+DTXMania.Test/Resources/FfmpegBundledRuntimeTests.cs
 ```
 
-keyed by Apple Silicon plus `hashFiles('tools/ffmpeg/macos-arm64/build-runtime.sh')`.
+On native Apple Silicon it must assert:
 
-Make build order explicit rather than relying on a focused `dotnet test` side effect:
+- `EnsureConfigured().IsAvailable` is true;
+- `BinaryFolder` is **non-null**;
+- `BinaryFolder` equals the Test.Mac output `runtimes/osx-arm64/MMTools` directory;
+- both binaries exist and retain Unix execute bits.
 
-```text
-restore DTXMania.Test.Mac.csproj
-build DTXMania.Game.Mac.csproj --no-restore
-verify Game bin ffmpeg/ffprobe: test -x + file -b arm64
-build DTXMania.Test.Mac.csproj --no-restore
-verify Test.Mac bin ffmpeg/ffprobe: test -x + file -b arm64
-run focused existing Audio tests + new runtime/MP3 checks with --no-build
-run the existing full Mac suite with --no-build
-run Automation / VideoRecorder / prepared-chart AudioE2E as today
-```
+The non-null assertion is the PATH guard: PATH success returns `BinaryFolder: null`.
 
-This makes ProjectReference propagation a named build gate, not an accidental prerequisite of another test step.
+Keep `ManagedSoundFFmpegPathTests` and resolver logic unchanged. Add one valid MP3 `ManagedSound` load using the committed fixture and fix the stale user-facing message naming the removed x64 NuGet package.
 
-Windows validation must continue to build/test `DTXMania.Test.csproj`; success proves the Mac project reference does not execute the native bootstrap on Windows.
+### 4. HPA-512 CI validates packaging without PATH masking
+
+After HPA-623 has made the Mac suite real and green, HPA-512 can add its runtime-specific CI checks:
+
+1. use an explicit Apple Silicon macOS runner instead of relying on `macos-latest` drift;
+2. cache only `~/Library/Caches/DTXManiaCX/ffmpeg`;
+3. build Game and verify bundled arm64 runtime files;
+4. build Test.Mac and verify ProjectReference propagation;
+5. run the focused Audio/bundled-runtime checks;
+6. run the already-established full Mac suite with `--no-build`;
+7. retain Automation, VideoRecorder, and prepared-chart AudioE2E.
+
+The existing `brew install ffmpeg` used by the CX Neon SFX validator must stay **after** the HPA-512 Audio/bundled-runtime checks. Otherwise a full Homebrew runtime on PATH can mask a broken bundle and defeat the new guard.
 
 ### 5. Release consumes project-owned publish output
 
-Delete the long inline FFmpeg source-build body from `release.yml` after `dotnet publish` owns runtime placement.
+Delete the duplicated FFmpeg source-build body from `release.yml` once `dotnet publish` produces the runtime itself.
 
-Keep short fail-closed checks for:
+Keep short fail-closed checks for runtime presence, execute bits, arm64 architecture, and license in publish and `.app` output. Capability and system-library checks belong in `build-runtime.sh`, not duplicated YAML.
 
-```text
-publish/mac/runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}
-publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
-```
+Do not modify `build-dmg.sh` unless packaged-output verification proves it loses execute bits.
 
-Require `test -x` and `file -b ... | grep -qi arm64` for both binaries.
+### 6. Recorder boundary stays explicit
 
-After `build-dmg.sh`, verify the same files under:
+HPA-512 ships an audio-focused runtime for CX. It does not wire the bundled runtime into `DTXMania.VideoRecorder` and does not add MP4/H.264 demux/decode features.
 
-```text
-output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools/
-output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
-```
-
-`build-dmg.sh` already uses `cp -R` for publish output. Do not modify it unless this check proves a real execute-bit regression.
-
-### 6. Provenance and diagnostics
-
-`tools/ffmpeg/macos-arm64/README.md` records:
-
-- FFmpeg version and exact official source URL;
-- source SHA-256;
-- actual final configure flags;
-- why the minimal codec/filter set exists;
-- LGPL source/license handling;
-- cache location and override;
-- clean-cache / version-update procedure;
-- cold/warm verification commands.
-
-Ship upstream `COPYING.LGPLv2.1` as:
+HPA-515 continues to use:
 
 ```text
-Licenses/FFmpeg-LGPL-2.1.txt
+CX Game -> bundled HPA-512 FFmpeg for preview/gameplay audio
+Recorder artifact verification -> PATH ffprobe
 ```
 
-Update the stale MP3 error message to say the bundled platform FFmpeg runtime is missing/unusable and recommend rebuilding/reinstalling CX, rather than naming the removed Mac x64 NuGet package.
+This keeps HPA-512 a valid HPA-515 prerequisite without implying that the recorder gained a bundled media verifier.
 
 ## Risks and mitigations
 
-### Existing Audio tests depend on encoders the minimal runtime intentionally omits
+### First-run build latency can affect E2E launches
 
-**Risk:** MP3/OGG rows fail during fixture generation before the actual variant processor is tested.
+**Risk:** a clean cache miss inside `dotnet run`/project build compiles FFmpeg and can make an E2E launch look hung or hit startup timeout.
 
-**Mitigation:** commit deterministic encoded fixtures and keep the existing stricter `PlaybackModifiers(50, 12)` product test unchanged after input setup.
+**Mitigation:** warm/cache the runtime in CI before E2E execution and mention the first-build behavior in README/troubleshooting. Do not add background bootstrap machinery.
 
-### Generated content may not propagate through ProjectReference or may lose execute bits
+### Host libraries leak into the runtime
 
-**Risk:** Game output works but `DTXMania.Test.Mac` lacks the runtime, or copied binaries become non-executable and `FfmpegRuntime` falls through to PATH.
+**Risk:** a developer machine with Homebrew could produce a runtime that works locally but links non-system dylibs unavailable on another Mac.
 
-**Mitigation:** generate/add items before `AssignTargetPaths` and `GetCopyToOutputDirectoryItems`; explicitly build Test.Mac; assert `test -x` in Game/Test/publish/app output; add a narrow chmod hook only if copying proves lossy.
+**Mitigation:** `--disable-autodetect` from the start plus `otool -L` fail-closed verification allowing only system library locations.
 
-### Windows evaluates the Mac project through DTXMania.Test.csproj
+### Generated content may not propagate or may lose execute bits
 
-**Risk:** Windows CI attempts to execute the Bash Apple Silicon builder.
+**Risk:** Game works but Test.Mac/publish does not, or `IsRunnableFile` rejects copied binaries.
 
-**Mitigation:** target condition is `$([MSBuild]::IsOSPlatform('OSX'))`; retain Windows full build/test as a required regression gate.
+**Mitigation:** one generated-content target, explicit Game/Test/publish verification, and narrow chmod only if empirically necessary.
 
-### Configure hardening differs from the currently shipping recipe
+### PATH can hide packaging failures
 
-**Risk:** adding `--disable-autodetect/--disable-gpl/--disable-nonfree` during extraction causes a cold-build regression unrelated to HPA-512.
+**Risk:** a Homebrew FFmpeg makes `EnsureConfigured().IsAvailable` true despite missing bundled files.
 
-**Mitigation:** prove the extracted shipping recipe first; retain the hardening flags only after a second clean build passes the same capability gates.
+**Mitigation:** the Audio packaged-runtime test requires non-null/equal `BinaryFolder`; install Homebrew FFmpeg only after those checks.
+
+### Intel Mac builds fail
+
+**Risk:** contributors on Intel Macs cannot build the Mac game project after this change.
+
+**Mitigation:** state this explicitly as the chosen support boundary. Do not add Rosetta/Intel compatibility in HPA-512.
 
 ## Scope boundaries
 
 In scope:
 
 - extract/cache the existing native FFmpeg source build;
+- deterministic host-independent configure (`--disable-autodetect`);
+- capability + system-dylib verification;
 - Mac build/test/publish generated-content integration;
-- x64 MMTools package removal from the Mac project;
-- repair existing real-FFmpeg Audio tests to use committed encoded fixtures;
-- one bundled-runtime filesystem/execute-bit gate;
+- x64 MMTools package removal;
+- repair existing real-FFmpeg Audio fixtures/tests;
+- dedicated bundled-runtime Audio guard;
 - one successful ManagedSound MP3 test;
-- stale Mac x64 diagnostic cleanup;
-- native Apple Silicon CI and release deduplication;
-- provenance/license material.
+- stale diagnostic cleanup;
+- native CI packaging checks after HPA-623;
+- release deduplication and license material.
 
 Out of scope:
 
 - FFmpeg version upgrade;
-- Intel macOS or Rosetta fallback;
+- Intel macOS or Rosetta support;
 - Windows runtime changes;
-- new audio engine, runtime resolver, or codec matrix;
-- adding production MP3/OGG encoders solely for tests;
-- recorder MP4 validation/remux;
+- new resolver/audio engine/codec matrix;
+- production MP3/OGG encoders solely for tests;
+- recorder bundled ffprobe or MP4/H.264 support;
 - OBS/ScreenCaptureKit work;
 - signing/notarization redesign;
 - generic dependency/bootstrap framework.
 
 ## Implementation shape
 
-Keep one implementation PR with four reviewer-sized checkpoints:
+**Pre-req PR:** HPA-623 makes `DTXMania.Test.Mac` a real green CI gate and fails zero-test/missing-coverage runs.
 
-1. extract/cache/document the current release FFmpeg recipe and prove cold/warm builds;
-2. add the macOS-only generated MSBuild copy contract, remove x64 MMTools, and prove Game/Test/publish propagation;
-3. repair existing Audio fixtures/tests, add bundled-path/execute-bit + valid MP3 checks, and fix the stale diagnostic;
-4. pin/cache native CI, explicitly build Test.Mac, and collapse release duplication to publish/.app verification.
+Then HPA-512 remains one implementation PR with four reviewer-sized checkpoints:
 
-This gives HPA-515 one clear prerequisite: the ordinary supported Mac build and its tests already carry the exact native audio runtime the packaged app will use.
+1. reproducible cached FFmpeg builder with `--disable-autodetect`, full decoder checks, and `otool -L` portability gate;
+2. incremental macOS-only generated MSBuild copy contract and Game/Test/publish verification;
+3. committed fixtures, repaired existing variant test, dedicated bundled-runtime Audio guard, ManagedSound MP3 check, and diagnostic cleanup;
+4. runtime-specific CI checks plus release YAML deduplication, keeping PATH/Homebrew FFmpeg after the bundle-sensitive tests.
+
+After HPA-512 merges, HPA-515 gets the native **CX audio** prerequisite it needs; recorder artifact probing remains a separate PATH-based concern.

--- a/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
+++ b/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
@@ -1,0 +1,321 @@
+# HPA-512 Native Apple Silicon FFmpeg Design
+
+**Issue:** HPA-512 — Package native Apple Silicon FFmpeg for CX gameplay audio  
+**Date:** 2026-08-14  
+**Status:** Proposed for review
+
+## Goal
+
+Make the supported macOS build self-contained for the existing CX audio paths on native Apple Silicon:
+
+```text
+dotnet build / dotnet run / dotnet publish
+-> runtimes/osx-arm64/MMTools/ffmpeg
+-> runtimes/osx-arm64/MMTools/ffprobe
+-> FfmpegRuntime resolves the bundled arm64 runtime
+-> MP3 preview + non-default playback audio variants work without Rosetta or user-installed FFmpeg
+```
+
+Keep the task to one 2–3 engineer-day implementation PR. This is packaging/build plumbing around existing audio code, not an FFmpeg or audio-engine redesign.
+
+## Why this is the next slice
+
+HPA-513 is the next Windows acceptance milestone but its HPA-503 implementation is still stacked behind the open HPA-503 planning PR before it reaches `main`.
+
+HPA-512 is high priority, unblocked, and independently blocks HPA-515 Apple Silicon recording parity.
+
+## Current state
+
+The repository is already close to the desired design:
+
+- `DTXMania.Game.Mac.csproj` references `FFMpegCore` plus `MMTools.Executables.MacOS.X64`.
+- `FfmpegRuntime` already prefers `runtimes/osx-arm64/MMTools` before the x64/Windows/Linux candidates and requires both binaries to be runnable.
+- `FfmpegAudioVariantProcessor` and `ManagedSound` already share `FfmpegRuntime`.
+- the release workflow already builds a minimal native arm64 FFmpeg 7.0.2 from the official source tarball, pins its SHA-256, copies `ffmpeg`/`ffprobe` to the exact expected runtime folder, and validates architecture plus the required codecs/filters.
+- that native runtime is created only after `dotnet publish`, so ordinary Mac build/run/test output still depends on the x64 package or PATH.
+
+The missing work is therefore to make the proven release-only runtime a normal Mac build input and remove duplicate ownership from `release.yml`.
+
+## Approaches considered
+
+### A. Extract the existing official source build and make Mac build/publish consume it — chosen
+
+Create one small build script from the already-proven release recipe. The Mac project invokes it after build/publish, using a versioned user cache so repeated builds only copy the already-built runtime.
+
+**Pros**
+
+- reuses known working configure flags and checksum;
+- no new package/provider/supply chain;
+- exact existing `FfmpegRuntime` layout;
+- no Rosetta dependency;
+- minimal release-workflow code after consolidation;
+- license/features remain under project control.
+
+**Cons**
+
+- first native Mac build compiles FFmpeg once;
+- requires normal Apple developer command-line build tools.
+
+This is the smallest long-term shape because the repository already owns the same source build in CI.
+
+### B. Replace MMTools with a third-party arm64 binary/NuGet package — rejected
+
+This shortens first-build time but adds another binary publisher, package layout, update cadence, and license/provenance surface. It would also require adapting the package layout back into the existing `runtimes/osx-arm64/MMTools` contract.
+
+Do not add that dependency while a working upstream-source recipe already exists.
+
+### C. Commit `ffmpeg` and `ffprobe` binaries to the repository — rejected
+
+This makes builds fast but turns large generated binaries into source-controlled artifacts and makes updates/review/provenance worse. It is unnecessary for this hobby project.
+
+## Chosen design
+
+### 1. One source of truth for the native runtime
+
+Add:
+
+```text
+tools/ffmpeg/macos-arm64/build-runtime.sh
+tools/ffmpeg/macos-arm64/README.md
+```
+
+Move the current native build recipe out of `.github/workflows/release.yml` into `build-runtime.sh`.
+
+Keep the currently proven source version for this ticket:
+
+```text
+FFmpeg 7.0.2
+source: official ffmpeg.org release tarball
+SHA-256: 8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389
+```
+
+HPA-512 is not an FFmpeg-version upgrade. A later version bump is one isolated edit to the script plus validation.
+
+Retain the current minimal feature set required by CX and make license intent explicit:
+
+```text
+static executables; no shared dylib deployment
+disable docs / ffplay / everything by default
+disable autodetect
+disable GPL and nonfree features
+
+decoders:
+  mp3float
+  vorbis
+  pcm_s16le / pcm_s24le / pcm_f32le / pcm_u8 / pcm_alaw / pcm_mulaw
+  adpcm_ima_wav / adpcm_ms
+
+demuxers:
+  mp3 / wav / ogg / pcm_s16le
+parsers:
+  mpegaudio / vorbis
+protocols:
+  file / pipe
+encoder + muxer:
+  pcm_s16le
+filters:
+  aformat / anull / aresample / atempo / apad / atrim
+```
+
+`--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` make the build fail closed instead of accidentally changing redistribution/dependency behavior based on what happens to be installed on a developer or runner machine.
+
+The script must:
+
+1. reject non-macOS/non-arm64 hosts with an actionable message;
+2. download the exact source tarball when the cache is missing;
+3. verify SHA-256 before extraction;
+4. configure/build/install the minimal runtime;
+5. verify both outputs are executable arm64 Mach-O binaries;
+6. verify the required filters, decoders, demuxers, encoder, and muxer;
+7. cache the validated pair under a versioned user cache;
+8. copy `ffmpeg`, `ffprobe`, and the upstream LGPL license into destinations supplied by the caller.
+
+Use a simple cache such as:
+
+```text
+~/Library/Caches/DTXManiaCX/ffmpeg/7.0.2/osx-arm64/
+```
+
+The cache is an optimization only. Deleting it forces a clean verified rebuild.
+
+Do not create a package-builder project, runtime manifest schema, download service, lock daemon, or generic cross-platform FFmpeg installer.
+
+### 2. Mac project owns build/run/publish placement
+
+Update `DTXMania.Game/DTXMania.Game.Mac.csproj`:
+
+- remove `MMTools.Executables.MacOS.X64`;
+- keep `FFMpegCore` unchanged;
+- on macOS, run the native-runtime script after a normal build and copy into:
+
+```text
+$(TargetDir)/runtimes/osx-arm64/MMTools/ffmpeg
+$(TargetDir)/runtimes/osx-arm64/MMTools/ffprobe
+$(TargetDir)/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+- after publish, ensure the same files under `$(PublishDir)`.
+
+The script cache makes repeated `dotnet build` / `dotnet run` calls copy-only after the first successful build.
+
+The Mac project is already the platform boundary, so do not introduce shared cross-platform MSBuild props/targets for a single Apple-Silicon-only dependency.
+
+Intel macOS remains out of scope. A Mac x64 host should fail the native bootstrap instead of silently selecting Rosetta.
+
+### 3. Keep runtime code stable
+
+Do not redesign `FfmpegRuntime`.
+
+Its current contract is already correct for HPA-512:
+
+```text
+bundled osx-arm64
+-> bundled osx-x64
+-> Windows/Linux candidates
+-> PATH diagnostic fallback
+```
+
+Once the x64 package is removed, the supported Mac project only supplies the arm64 folder. PATH remains a development diagnostic fallback, not the supported runtime source.
+
+Only tighten focused tests so the first complete arm64 folder demonstrably beats an otherwise-complete x64 folder.
+
+Do not add architecture registries, RID providers, process wrappers, or a second availability service.
+
+### 4. Native audio validation
+
+Use the existing seams instead of creating a parallel audio harness.
+
+Add a small generated/committed test tone under `DTXMania.Test/TestData/Audio/` for the real MP3 decode path. The test asset is project-generated, not third-party media.
+
+On native Apple Silicon verify:
+
+1. `RuntimeInformation.ProcessArchitecture == Arm64`;
+2. `FfmpegRuntime.EnsureConfigured()` reports the bundled `osx-arm64/MMTools` directory;
+3. both binaries execute and report normally;
+4. `new ManagedSound(mp3Fixture)` succeeds with a non-zero duration;
+5. `new FfmpegAudioVariantProcessor().PrepareAsync(...)` succeeds for one generated WAV source at a non-default play-speed modifier;
+6. cancellation/timeout coverage already owned by `FfmpegAudioVariantProcessorTests` remains green.
+
+Do not broaden this into a codec matrix. MP3 preview plus one real variant path are the product gates named by HPA-512.
+
+### 5. CI and release consolidation
+
+Pin the regular macOS build/test job to the same native Apple Silicon class already used by release (`macos-15`) so it is real arm64 evidence rather than an ambiguous `macos-latest` alias.
+
+Add an Actions cache for the versioned FFmpeg build cache keyed by the builder script. A cache miss compiles; a hit keeps routine PR builds fast.
+
+After the Mac project build, verify the actual game output:
+
+```text
+test -x .../runtimes/osx-arm64/MMTools/ffmpeg
+test -x .../runtimes/osx-arm64/MMTools/ffprobe
+file -b each binary contains arm64
+run focused native FFmpeg/MP3/variant tests
+```
+
+In `release.yml` delete the large inline source-build step. `dotnet publish` now owns runtime placement. Keep a short fail-closed artifact check before `build-dmg.sh`.
+
+After `build-dmg.sh`, also verify the copied app bundle still contains executable arm64 binaries at:
+
+```text
+output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools/
+```
+
+`build-dmg.sh` already copies publish output recursively; no new installer abstraction is needed unless this verification exposes a real permission-loss bug.
+
+### 6. Provenance and update procedure
+
+`tools/ffmpeg/macos-arm64/README.md` is the human-maintained provenance/update document. Record:
+
+- FFmpeg version;
+- exact official source URL;
+- source SHA-256;
+- why the selected configure features exist;
+- license mode/constraints;
+- cache location;
+- how to force a clean rebuild;
+- how to update version + checksum;
+- local validation commands.
+
+Ship the exact `COPYING.LGPLv2.1` from the verified source tarball as:
+
+```text
+Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+Do not add a general third-party-license generator for one dependency.
+
+## Error handling
+
+Keep failures early and actionable:
+
+```text
+wrong host/architecture
+-> "Native CX macOS runtime requires Apple Silicon (arm64)."
+
+download/checksum/configure/build failure
+-> fail the Mac build; never fall back to the x64 NuGet runtime
+
+missing/non-executable/wrong-architecture output
+-> fail the builder or CI/release verification
+
+runtime unexpectedly unavailable after a successful build
+-> existing FfmpegRuntime diagnostic + focused test failure
+```
+
+Do not silently install Homebrew FFmpeg or use PATH as production recovery.
+
+## Testing strategy
+
+### Fast/unit
+
+- update `FfmpegRuntimeCoverageTests` so a complete `osx-arm64` candidate is preferred over complete `osx-x64`;
+- keep missing/split candidate and PATH tests unchanged;
+- keep existing audio-variant unit/cancellation tests unchanged.
+
+### Native integration
+
+On `macos-15`:
+
+- normal Mac `dotnet build` produces executable arm64 runtime files;
+- focused MP3 `ManagedSound` smoke passes;
+- focused real `FfmpegAudioVariantProcessor` smoke passes;
+- `dotnet publish -r osx-arm64` produces the same runtime + license;
+- `.app` bundle preserves both binaries and execute bits.
+
+### Regression
+
+- Windows build/tests remain unchanged and must stay green;
+- existing macOS full test suite and prepared-chart audio E2E remain green.
+
+## Scope boundaries
+
+In scope:
+
+- native FFmpeg/ffprobe source bootstrap for the supported Mac project;
+- Mac build/run/publish integration;
+- x64 MMTools package removal from the Mac project;
+- provenance/license material;
+- native Apple Silicon verification and release deduplication.
+
+Out of scope:
+
+- FFmpeg 8.x upgrade;
+- Intel macOS/Rosetta support;
+- Windows runtime changes;
+- recorder MP4 validation/remux;
+- OBS/ScreenCaptureKit work;
+- code signing/notarization redesign;
+- general codec expansion;
+- generic dependency/bootstrap framework.
+
+## Implementation shape
+
+Keep one implementation PR with four reviewer-sized checkpoints:
+
+1. extract and verify the reproducible native FFmpeg builder + provenance;
+2. wire Mac build/run/publish and remove x64 MMTools;
+3. add native runtime/MP3/variant validation;
+4. pin/cache CI and collapse release duplication.
+
+This gives HPA-515 one clear prerequisite: the ordinary supported Mac build already carries the audio runtime it needs.

--- a/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
+++ b/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
@@ -2,7 +2,7 @@
 
 **Issue:** HPA-512 — Package native Apple Silicon FFmpeg for CX gameplay audio  
 **Date:** 2026-08-14  
-**Status:** Proposed for review
+**Status:** Revised after planning review
 
 ## Goal
 
@@ -20,56 +20,54 @@ Keep the task to one 2–3 engineer-day implementation PR. This is packaging/bui
 
 ## Why this is the next slice
 
-HPA-513 is the next Windows acceptance milestone, but its HPA-503 implementation is still stacked behind the open HPA-503 planning PR before it reaches `main`.
+HPA-513 is the next Windows acceptance milestone, but the HPA-503 implementation is still stacked behind the open HPA-503 planning PR before it reaches `main`.
 
 HPA-512 is high priority, unblocked, and independently blocks HPA-515 Apple Silicon recording parity.
 
 ## Current state
 
-The repository is already close to the desired design:
+The repository already contains most runtime behavior needed by HPA-512:
 
-- `DTXMania.Game.Mac.csproj` references `FFMpegCore` plus `MMTools.Executables.MacOS.X64`.
-- `FfmpegRuntime` already prefers `runtimes/osx-arm64/MMTools` before the x64/Windows/Linux candidates and requires both binaries to be runnable.
-- `FfmpegAudioVariantProcessor` and `ManagedSound` already share `FfmpegRuntime`.
-- the release workflow already builds a minimal native arm64 FFmpeg 7.0.2 from the official source tarball, pins its SHA-256, copies `ffmpeg`/`ffprobe` to the exact expected runtime folder, and validates architecture plus required codecs/filters.
-- that native runtime is created only after `dotnet publish`, so ordinary Mac build/run/test output still depends on the x64 package or PATH.
+- `DTXMania.Game.Mac.csproj` references `FFMpegCore` plus the x64-only `MMTools.Executables.MacOS.X64` package.
+- `FfmpegRuntime` already looks for `runtimes/osx-arm64/MMTools` before `osx-x64` and requires both `ffmpeg` and `ffprobe` to be runnable.
+- `ManagedSound` and `FfmpegAudioVariantProcessor` already share `FfmpegRuntime`; no second runtime resolver is needed.
+- `release.yml` already builds a native arm64 FFmpeg 7.0.2 from the official tarball, pins SHA-256 `8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389`, and validates the minimal codecs/filters CX actually uses.
+- that native runtime is created only after `dotnet publish`, so ordinary build/test output still resolves the x64 package or PATH.
 
-The missing work is to turn the proven release-only recipe into a normal Mac project build input and remove duplicate ownership from `release.yml`.
+Two existing behaviors materially affect the design:
+
+1. `FfmpegAudioVariantProcessorTests.PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` is already the strongest real variant test. It runs real `FfmpegRuntime`, real `FfmpegAudioVariantProcessor`, and `new PlaybackModifiers(50, 12)` over WAV/MP3/OGG. Today its MP3/OGG rows first encode fixtures with `libmp3lame` / `libvorbis` through the configured FFmpeg. The shipping minimal arm64 runtime intentionally has only the `pcm_s16le` encoder, so replacing the x64 full build without repairing this test would make Mac Audio tests fail before the product path is exercised.
+2. Mac CI currently builds only the Game project and then runs `DTXMania.Test.Mac` with `--no-build`. A generated runtime must therefore propagate through the Game `ProjectReference`, and the test project must be built explicitly before its `--no-build` suite.
+
+Also, `DTXMania.Test.csproj` references `DTXMania.Game.Mac.csproj` on Windows. Any native bootstrap target in the Mac project must be explicitly macOS-only.
 
 ## Approaches considered
 
-### A. Extract the existing official source build and expose it as normal Mac project content — chosen
+### A. Extract the proven source build, make the Mac project own one generated-content copy contract, and repair existing real-audio tests — chosen
 
-Create one small build script from the already-proven release recipe. Before normal output-copy resolution, the Mac project asks that script to populate an intermediate staging directory. The generated runtime/license files are declared as ordinary MSBuild items with `CopyToOutputDirectory` and `CopyToPublishDirectory`, so they also flow through `ProjectReference` into the Mac test output.
-
-A versioned user cache makes repeated builds copy-only after the first successful native compile.
+Reuse the current release recipe, add one cached builder, generate the native runtime before MSBuild resolves copy items, and keep the existing audio test as the real variant gate using committed encoded fixtures.
 
 **Pros**
 
-- reuses known working configure flags and checksum;
-- no new package/provider/supply chain;
-- exact existing `FfmpegRuntime` layout;
-- one MSBuild content path covers run, tests, and publish;
-- no Rosetta dependency;
-- minimal release-workflow code after consolidation;
-- license/features remain under project control.
+- one upstream source/version/checksum;
+- no new binary publisher or package layout;
+- one runtime resolver and one runtime path;
+- one build/test/publish copy contract;
+- preserves the existing stricter `PlaybackModifiers(50, 12)` test instead of adding weaker duplicate coverage;
+- Windows behavior stays unchanged.
 
 **Cons**
 
-- first native Mac build compiles FFmpeg once;
-- requires normal Apple developer command-line build tools.
+- first Apple Silicon build compiles FFmpeg once;
+- generated MSBuild content and Unix execute bits need explicit verification.
 
-This is the smallest long-term shape because the repository already owns the same source build in CI.
+### B. Add a third-party arm64 FFmpeg NuGet/binary provider — rejected
 
-### B. Replace MMTools with a third-party arm64 binary/NuGet package — rejected
+This reduces first-build time but adds another supplier, update cadence, license/provenance surface, and layout adaptation. The repository already has a working upstream-source recipe.
 
-This shortens first-build time but adds another binary publisher, package layout, update cadence, and license/provenance surface. It also requires adapting that package back into the existing `runtimes/osx-arm64/MMTools` contract.
+### C. Expand the bundled runtime with MP3/OGG encoders only to preserve test fixture generation — rejected
 
-Do not add that dependency while a working upstream-source recipe already exists.
-
-### C. Commit `ffmpeg` and `ffprobe` binaries to the repository — rejected
-
-This makes builds fast but turns large generated binaries into source-controlled artifacts and makes updates/review/provenance worse. It is unnecessary for this project.
+Production does not need `libmp3lame` or `libvorbis` encoding. Adding external encoder dependencies solely because tests generate their own inputs increases the runtime and licensing/dependency surface. Commit tiny project-owned MP3/OGG fixtures instead.
 
 ## Chosen design
 
@@ -82,25 +80,18 @@ tools/ffmpeg/macos-arm64/build-runtime.sh
 tools/ffmpeg/macos-arm64/README.md
 ```
 
-Move the current native build recipe out of `.github/workflows/release.yml` into `build-runtime.sh`.
-
-Keep the currently proven source version for this ticket:
+Extract the currently shipping configure recipe from `release.yml` first, unchanged:
 
 ```text
 FFmpeg 7.0.2
-source: official ffmpeg.org release tarball
+source: https://ffmpeg.org/releases/ffmpeg-7.0.2.tar.xz
 SHA-256: 8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389
-```
 
-HPA-512 is not an FFmpeg-version upgrade. A later version bump is one isolated script/documentation change plus validation.
-
-Retain the current minimal feature set required by CX and make dependency/license intent explicit:
-
-```text
-static executables; no shared dylib deployment
-disable docs / ffplay / everything by default
-disable autodetect
-disable GPL and nonfree features
+--enable-static --disable-shared
+--disable-doc --disable-htmlpages --disable-manpages
+--disable-podpages --disable-txtpages
+--disable-ffplay
+--disable-everything
 
 decoders:
   mp3float
@@ -120,36 +111,39 @@ filters:
   aformat / anull / aresample / atempo / apad / atrim
 ```
 
-`--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` make the build fail closed instead of accidentally changing dependency/redistribution behavior based on what happens to be installed on a developer or runner machine.
+`--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` are sensible hardening but are **not** part of the proven recipe today. Do not make extraction depend on them. After a cold baseline build passes all existing architecture/capability checks, the implementation may add those three flags in the same PR only if another clean cold build remains green. Otherwise retain the proven flags and record the decision in the README.
 
 The script must:
 
-1. reject non-macOS/non-arm64 hosts with an actionable message;
-2. download the exact source tarball when the cache is missing;
-3. verify SHA-256 before extraction;
+1. reject non-macOS/non-arm64 hosts with `Native CX macOS runtime requires Apple Silicon (arm64); Intel/Rosetta is not supported.`;
+2. download the exact source tarball on a cache miss;
+3. verify the pinned SHA-256 before extraction;
 4. configure/build/install the minimal runtime;
-5. verify both outputs are executable arm64 Mach-O binaries;
-6. verify the required filters, decoders, demuxers, encoder, and muxer;
-7. cache the validated pair under a versioned user cache;
-8. copy `ffmpeg`, `ffprobe`, and the upstream LGPL license into staging destinations supplied by the caller.
+5. independently verify `ffmpeg` and `ffprobe` are executable arm64 Mach-O binaries;
+6. verify the required filters, decoders, demuxers, encoder, and muxer already checked by `release.yml`;
+7. run `ffmpeg -version` and `ffprobe -version` successfully;
+8. cache the validated runtime under a versioned user cache;
+9. copy `ffmpeg`, `ffprobe`, and `COPYING.LGPLv2.1` to caller-provided destinations.
 
-Use a simple cache:
+Use:
 
 ```text
-~/Library/Caches/DTXManiaCX/ffmpeg/7.0.2/osx-arm64/
+${DTXMANIA_FFMPEG_CACHE_ROOT:-~/Library/Caches/DTXManiaCX/ffmpeg}/7.0.2/osx-arm64/
 ```
 
-The cache is an optimization only. Deleting it forces a clean verified rebuild.
+The cache is only an optimization. Deleting it forces a verified rebuild. Do not add a package-builder project, download service, lock daemon, or generic dependency bootstrap framework.
 
-Do not create a package-builder project, runtime manifest schema, download service, lock daemon, or generic cross-platform FFmpeg installer.
+### 2. The Mac project owns a generated MSBuild copy contract
 
-### 2. Mac project owns one transitive output/publish path
+Remove only:
 
-Update `DTXMania.Game/DTXMania.Game.Mac.csproj`:
+```xml
+<PackageReference Include="MMTools.Executables.MacOS.X64" Version="1.0.6" />
+```
 
-- remove `MMTools.Executables.MacOS.X64`;
-- keep `FFMpegCore` unchanged;
-- define an intermediate staging root under the existing project `obj` tree, for example:
+Keep `FFMpegCore` and the Windows project unchanged.
+
+Stage generated files under a project-local intermediate root, for example:
 
 ```text
 $(BaseIntermediateOutputPath)ffmpeg-runtime/
@@ -158,8 +152,22 @@ $(BaseIntermediateOutputPath)ffmpeg-runtime/
   Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-- add one macOS-only target early enough to populate that staging directory before MSBuild resolves files copied to build/reference outputs;
-- declare the staged files as normal `None`/content items with target links:
+The target must be explicit because these files do not exist during normal project evaluation and must also be visible when a referencing project asks for copy-to-output items:
+
+```xml
+<Target Name="PrepareNativeFfmpegRuntime"
+        Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+        BeforeTargets="BeforeBuild;AssignTargetPaths;GetCopyToOutputDirectoryItems">
+  <Exec Command="bash .../tools/ffmpeg/macos-arm64/build-runtime.sh ..." />
+  <ItemGroup>
+    <!-- Add generated None items here, after generation. -->
+    <!-- Each item sets TargetPath, CopyToOutputDirectory=PreserveNewest, -->
+    <!-- and CopyToPublishDirectory=PreserveNewest. -->
+  </ItemGroup>
+</Target>
+```
+
+Required target paths:
 
 ```text
 runtimes/osx-arm64/MMTools/ffmpeg
@@ -167,180 +175,188 @@ runtimes/osx-arm64/MMTools/ffprobe
 Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-and both:
+This one target must satisfy:
 
 ```text
-CopyToOutputDirectory=PreserveNewest
-CopyToPublishDirectory=PreserveNewest
+Game bin output
+-> ProjectReference copy into DTXMania.Test.Mac bin
+-> publish output
+-> .app bundle via existing cp -R
 ```
 
-This matters because `DTXMania.Test.Mac.csproj` references the game project. Generated files that are merely copied into `DTXMania.Game/bin` after the build are not a reliable project-reference contract; declared copy items are.
+Do not add a second copy target to the test project.
 
-The builder's user cache keeps the early target cheap after the first compile: each normal build stages from cache, then MSBuild handles output/test/publish copying consistently.
+Unix execute bits are part of the contract because `FfmpegRuntime.IsRunnableFile` intentionally rejects non-executable bundled binaries. Verify `test -x` in Game, Test.Mac, publish, and `.app` output. If MSBuild copy is proven to lose execute bits, add the smallest macOS-only post-copy `chmod +x` hook needed to the existing project flow; do not weaken `IsRunnableFile`.
 
-The Mac project is already the platform boundary, so do not introduce shared cross-platform MSBuild props/targets for one Apple-Silicon-only dependency.
+The macOS condition is mandatory. Windows CI builds `DTXMania.Test.csproj`, which references the Mac game project; that build must not invoke `build-runtime.sh`.
 
-Intel macOS remains out of scope. A Mac x64 host should fail the native bootstrap instead of silently selecting Rosetta.
+### 3. Repair the existing real-FFmpeg tests instead of duplicating them
 
-### 3. Keep runtime code stable
-
-Do not redesign `FfmpegRuntime`.
-
-Its current contract is already correct for HPA-512:
+Add two tiny project-owned fixtures:
 
 ```text
-bundled osx-arm64
--> bundled osx-x64
--> Windows/Linux candidates
--> PATH diagnostic fallback
+DTXMania.Test/TestData/Audio/ffmpeg-tone.mp3
+DTXMania.Test/TestData/Audio/ffmpeg-tone.ogg
 ```
 
-Once the x64 package is removed, the supported Mac project only supplies the arm64 folder. PATH remains a development diagnostic fallback, not the supported runtime source.
+Generate them once from the same deterministic sine tone using a full developer FFmpeg, then commit them. They are test inputs, not production runtime assets.
 
-Only tighten focused tests so the first complete arm64 folder demonstrably beats an otherwise-complete x64 folder.
+Update both test project files to copy `TestData/Audio/**/*` to test output.
 
-Do not add architecture registries, RID providers, process wrappers, or a second availability service.
+Modify `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm`:
 
-### 4. Native audio validation
+- keep the WAV row generated by the existing tone/WAV helper;
+- use the committed MP3 fixture for the MP3 row;
+- use the committed OGG fixture for the OGG row;
+- delete the test-time `libmp3lame` / `libvorbis` encoding step;
+- keep `new PlaybackModifiers(50, 12)` and all current duration/frequency assertions.
 
-Use the existing seams instead of creating a parallel audio harness.
+Do **not** add a second `PlaybackModifiers(125, 0)` variant smoke. The existing test is stricter and already exercises the real product processor.
 
-Add one small generated/committed test tone under `DTXMania.Test/TestData/Audio/` for the real MP3 decode path. The test asset is project-generated, not third-party media. Add that test-data folder to the existing Mac test output-copy rules.
+Add only missing product gates:
 
-On native Apple Silicon verify from the **test assembly output**:
+1. a native Apple Silicon check in the existing `FfmpegRuntimeTests` that `EnsureConfigured().BinaryFolder` is the test assembly's `runtimes/osx-arm64/MMTools` directory and both files exist with Unix execute bits;
+2. one successful valid-MP3 load in `ManagedSoundTests` using `ffmpeg-tone.mp3` and asserting non-zero duration.
 
-1. `RuntimeInformation.ProcessArchitecture == Arm64`;
-2. `FfmpegRuntime.EnsureConfigured()` reports the bundled `osx-arm64/MMTools` directory next to the test/game assembly;
-3. both binaries execute normally;
-4. `new ManagedSound(mp3Fixture)` succeeds with a non-zero duration;
-5. `new FfmpegAudioVariantProcessor().PrepareAsync(wav, new PlaybackModifiers(125, 0), token)` produces non-empty PCM;
-6. cancellation/timeout coverage already owned by `FfmpegAudioVariantProcessorTests` remains green.
+Leave `ManagedSoundFFmpegPathTests` unchanged. It already proves a complete arm64 candidate wins over a complete x64 candidate. Leave the separate `FfmpegRuntimeCoverageTests` first-complete-candidate test unchanged as well.
 
-The test-output location is intentional: it proves the project-reference propagation that HPA-512 needs for normal Mac tests, rather than only proving files exist in `DTXMania.Game/bin`.
+Update the stale `ManagedSound.LoadMp3File` missing-binary diagnostic so it no longer tells macOS users to install `MMTools.Executables.MacOS.X64`. Use one generic bundled-runtime message; this is copy correction, not resolver redesign.
 
-Do not broaden this into a codec matrix. MP3 preview plus one real non-default variant path are the product gates named by HPA-512.
+### 4. Native CI makes the copy contract observable
 
-### 5. CI and release consolidation
+Change regular Mac CI to:
 
-Pin the regular macOS build/test job to the same native Apple Silicon class already used by release (`macos-15`) so it is real arm64 evidence rather than an ambiguous `macos-latest` alias.
+```yaml
+runs-on: macos-15
+```
 
-Add an Actions cache for the versioned FFmpeg user cache keyed by the builder script. A cache miss compiles; a hit keeps routine PR builds fast.
-
-After the Mac project build, verify the actual game output:
+Add an Actions cache for:
 
 ```text
-test -x .../runtimes/osx-arm64/MMTools/ffmpeg
-test -x .../runtimes/osx-arm64/MMTools/ffprobe
-file -b each binary contains arm64
+~/Library/Caches/DTXManiaCX/ffmpeg
 ```
 
-Then run focused native runtime/MP3/variant tests from `DTXMania.Test.Mac` before the normal full Mac suite and prepared-chart AudioE2E.
+keyed by Apple Silicon plus `hashFiles('tools/ffmpeg/macos-arm64/build-runtime.sh')`.
 
-In `release.yml` delete the large inline source-build step. `dotnet publish` now carries the declared runtime content itself. Keep a short fail-closed artifact check before `build-dmg.sh`.
+Make build order explicit rather than relying on a focused `dotnet test` side effect:
 
-After `build-dmg.sh`, also verify the copied app bundle still contains executable arm64 binaries and the license at:
+```text
+restore DTXMania.Test.Mac.csproj
+build DTXMania.Game.Mac.csproj --no-restore
+verify Game bin ffmpeg/ffprobe: test -x + file -b arm64
+build DTXMania.Test.Mac.csproj --no-restore
+verify Test.Mac bin ffmpeg/ffprobe: test -x + file -b arm64
+run focused existing Audio tests + new runtime/MP3 checks with --no-build
+run the existing full Mac suite with --no-build
+run Automation / VideoRecorder / prepared-chart AudioE2E as today
+```
+
+This makes ProjectReference propagation a named build gate, not an accidental prerequisite of another test step.
+
+Windows validation must continue to build/test `DTXMania.Test.csproj`; success proves the Mac project reference does not execute the native bootstrap on Windows.
+
+### 5. Release consumes project-owned publish output
+
+Delete the long inline FFmpeg source-build body from `release.yml` after `dotnet publish` owns runtime placement.
+
+Keep short fail-closed checks for:
+
+```text
+publish/mac/runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}
+publish/mac/Licenses/FFmpeg-LGPL-2.1.txt
+```
+
+Require `test -x` and `file -b ... | grep -qi arm64` for both binaries.
+
+After `build-dmg.sh`, verify the same files under:
 
 ```text
 output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools/
 output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-`build-dmg.sh` already copies publish output recursively; no installer change is needed unless this verification exposes a real permission-loss bug.
+`build-dmg.sh` already uses `cp -R` for publish output. Do not modify it unless this check proves a real execute-bit regression.
 
-### 6. Provenance and update procedure
+### 6. Provenance and diagnostics
 
-`tools/ffmpeg/macos-arm64/README.md` is the human-maintained provenance/update document. Record:
+`tools/ffmpeg/macos-arm64/README.md` records:
 
-- FFmpeg version;
-- exact official source URL;
+- FFmpeg version and exact official source URL;
 - source SHA-256;
-- why the selected configure features exist;
-- license mode/constraints;
-- cache location;
-- how to force a clean rebuild;
-- how to update version + checksum;
-- local validation commands.
+- actual final configure flags;
+- why the minimal codec/filter set exists;
+- LGPL source/license handling;
+- cache location and override;
+- clean-cache / version-update procedure;
+- cold/warm verification commands.
 
-Ship the exact `COPYING.LGPLv2.1` from the verified source tarball as:
+Ship upstream `COPYING.LGPLv2.1` as:
 
 ```text
 Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-Do not add a general third-party-license generator for one dependency.
+Update the stale MP3 error message to say the bundled platform FFmpeg runtime is missing/unusable and recommend rebuilding/reinstalling CX, rather than naming the removed Mac x64 NuGet package.
 
-## Error handling
+## Risks and mitigations
 
-Keep failures early and actionable:
+### Existing Audio tests depend on encoders the minimal runtime intentionally omits
 
-```text
-wrong host/architecture
--> "Native CX macOS runtime requires Apple Silicon (arm64)."
+**Risk:** MP3/OGG rows fail during fixture generation before the actual variant processor is tested.
 
-download/checksum/configure/build failure
--> fail the Mac build; never fall back to the x64 NuGet runtime
+**Mitigation:** commit deterministic encoded fixtures and keep the existing stricter `PlaybackModifiers(50, 12)` product test unchanged after input setup.
 
-missing/non-executable/wrong-architecture staging output
--> fail the builder or CI/release verification
+### Generated content may not propagate through ProjectReference or may lose execute bits
 
-runtime unexpectedly unavailable after a successful build
--> existing FfmpegRuntime diagnostic + focused test failure
-```
+**Risk:** Game output works but `DTXMania.Test.Mac` lacks the runtime, or copied binaries become non-executable and `FfmpegRuntime` falls through to PATH.
 
-Do not silently install Homebrew FFmpeg or use PATH as production recovery.
+**Mitigation:** generate/add items before `AssignTargetPaths` and `GetCopyToOutputDirectoryItems`; explicitly build Test.Mac; assert `test -x` in Game/Test/publish/app output; add a narrow chmod hook only if copying proves lossy.
 
-## Testing strategy
+### Windows evaluates the Mac project through DTXMania.Test.csproj
 
-### Fast/unit
+**Risk:** Windows CI attempts to execute the Bash Apple Silicon builder.
 
-- update `FfmpegRuntimeCoverageTests` so a complete `osx-arm64` candidate is preferred over complete `osx-x64`;
-- keep missing/split candidate and PATH tests unchanged;
-- keep existing audio-variant unit/cancellation tests unchanged.
+**Mitigation:** target condition is `$([MSBuild]::IsOSPlatform('OSX'))`; retain Windows full build/test as a required regression gate.
 
-### Native integration
+### Configure hardening differs from the currently shipping recipe
 
-On `macos-15`:
+**Risk:** adding `--disable-autodetect/--disable-gpl/--disable-nonfree` during extraction causes a cold-build regression unrelated to HPA-512.
 
-- normal Mac `dotnet build` contains executable arm64 runtime files;
-- the Mac test output also contains them through `ProjectReference` copy-item propagation;
-- focused MP3 `ManagedSound` smoke passes;
-- focused real `FfmpegAudioVariantProcessor` smoke with `new PlaybackModifiers(125, 0)` passes;
-- `dotnet publish -r osx-arm64` contains the same runtime + license;
-- `.app` bundle preserves both binaries and execute bits.
-
-### Regression
-
-- Windows build/tests remain unchanged and must stay green;
-- existing macOS full test suite and prepared-chart audio E2E remain green.
+**Mitigation:** prove the extracted shipping recipe first; retain the hardening flags only after a second clean build passes the same capability gates.
 
 ## Scope boundaries
 
 In scope:
 
-- native FFmpeg/ffprobe source bootstrap for the supported Mac project;
-- one transitive Mac build/test/publish copy contract;
+- extract/cache the existing native FFmpeg source build;
+- Mac build/test/publish generated-content integration;
 - x64 MMTools package removal from the Mac project;
-- provenance/license material;
-- native Apple Silicon verification and release deduplication.
+- repair existing real-FFmpeg Audio tests to use committed encoded fixtures;
+- one bundled-runtime filesystem/execute-bit gate;
+- one successful ManagedSound MP3 test;
+- stale Mac x64 diagnostic cleanup;
+- native Apple Silicon CI and release deduplication;
+- provenance/license material.
 
 Out of scope:
 
-- FFmpeg 8.x upgrade;
-- Intel macOS/Rosetta support;
+- FFmpeg version upgrade;
+- Intel macOS or Rosetta fallback;
 - Windows runtime changes;
+- new audio engine, runtime resolver, or codec matrix;
+- adding production MP3/OGG encoders solely for tests;
 - recorder MP4 validation/remux;
 - OBS/ScreenCaptureKit work;
-- code signing/notarization redesign;
-- general codec expansion;
+- signing/notarization redesign;
 - generic dependency/bootstrap framework.
 
 ## Implementation shape
 
 Keep one implementation PR with four reviewer-sized checkpoints:
 
-1. extract and verify the reproducible native FFmpeg builder + provenance;
-2. wire the Mac project staging/copy contract and remove x64 MMTools;
-3. add native runtime/MP3/variant validation from the test output;
-4. pin/cache CI and collapse release duplication.
+1. extract/cache/document the current release FFmpeg recipe and prove cold/warm builds;
+2. add the macOS-only generated MSBuild copy contract, remove x64 MMTools, and prove Game/Test/publish propagation;
+3. repair existing Audio fixtures/tests, add bundled-path/execute-bit + valid MP3 checks, and fix the stale diagnostic;
+4. pin/cache native CI, explicitly build Test.Mac, and collapse release duplication to publish/.app verification.
 
-This gives HPA-515 one clear prerequisite: the ordinary supported Mac build already carries the audio runtime it needs.
+This gives HPA-515 one clear prerequisite: the ordinary supported Mac build and its tests already carry the exact native audio runtime the packaged app will use.

--- a/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
+++ b/docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md
@@ -9,7 +9,7 @@
 Make the supported macOS build self-contained for the existing CX audio paths on native Apple Silicon:
 
 ```text
-dotnet build / dotnet run / dotnet publish
+dotnet build / dotnet run / dotnet test / dotnet publish
 -> runtimes/osx-arm64/MMTools/ffmpeg
 -> runtimes/osx-arm64/MMTools/ffprobe
 -> FfmpegRuntime resolves the bundled arm64 runtime
@@ -20,7 +20,7 @@ Keep the task to one 2–3 engineer-day implementation PR. This is packaging/bui
 
 ## Why this is the next slice
 
-HPA-513 is the next Windows acceptance milestone but its HPA-503 implementation is still stacked behind the open HPA-503 planning PR before it reaches `main`.
+HPA-513 is the next Windows acceptance milestone, but its HPA-503 implementation is still stacked behind the open HPA-503 planning PR before it reaches `main`.
 
 HPA-512 is high priority, unblocked, and independently blocks HPA-515 Apple Silicon recording parity.
 
@@ -31,22 +31,25 @@ The repository is already close to the desired design:
 - `DTXMania.Game.Mac.csproj` references `FFMpegCore` plus `MMTools.Executables.MacOS.X64`.
 - `FfmpegRuntime` already prefers `runtimes/osx-arm64/MMTools` before the x64/Windows/Linux candidates and requires both binaries to be runnable.
 - `FfmpegAudioVariantProcessor` and `ManagedSound` already share `FfmpegRuntime`.
-- the release workflow already builds a minimal native arm64 FFmpeg 7.0.2 from the official source tarball, pins its SHA-256, copies `ffmpeg`/`ffprobe` to the exact expected runtime folder, and validates architecture plus the required codecs/filters.
+- the release workflow already builds a minimal native arm64 FFmpeg 7.0.2 from the official source tarball, pins its SHA-256, copies `ffmpeg`/`ffprobe` to the exact expected runtime folder, and validates architecture plus required codecs/filters.
 - that native runtime is created only after `dotnet publish`, so ordinary Mac build/run/test output still depends on the x64 package or PATH.
 
-The missing work is therefore to make the proven release-only runtime a normal Mac build input and remove duplicate ownership from `release.yml`.
+The missing work is to turn the proven release-only recipe into a normal Mac project build input and remove duplicate ownership from `release.yml`.
 
 ## Approaches considered
 
-### A. Extract the existing official source build and make Mac build/publish consume it — chosen
+### A. Extract the existing official source build and expose it as normal Mac project content — chosen
 
-Create one small build script from the already-proven release recipe. The Mac project invokes it after build/publish, using a versioned user cache so repeated builds only copy the already-built runtime.
+Create one small build script from the already-proven release recipe. Before normal output-copy resolution, the Mac project asks that script to populate an intermediate staging directory. The generated runtime/license files are declared as ordinary MSBuild items with `CopyToOutputDirectory` and `CopyToPublishDirectory`, so they also flow through `ProjectReference` into the Mac test output.
+
+A versioned user cache makes repeated builds copy-only after the first successful native compile.
 
 **Pros**
 
 - reuses known working configure flags and checksum;
 - no new package/provider/supply chain;
 - exact existing `FfmpegRuntime` layout;
+- one MSBuild content path covers run, tests, and publish;
 - no Rosetta dependency;
 - minimal release-workflow code after consolidation;
 - license/features remain under project control.
@@ -60,13 +63,13 @@ This is the smallest long-term shape because the repository already owns the sam
 
 ### B. Replace MMTools with a third-party arm64 binary/NuGet package — rejected
 
-This shortens first-build time but adds another binary publisher, package layout, update cadence, and license/provenance surface. It would also require adapting the package layout back into the existing `runtimes/osx-arm64/MMTools` contract.
+This shortens first-build time but adds another binary publisher, package layout, update cadence, and license/provenance surface. It also requires adapting that package back into the existing `runtimes/osx-arm64/MMTools` contract.
 
 Do not add that dependency while a working upstream-source recipe already exists.
 
 ### C. Commit `ffmpeg` and `ffprobe` binaries to the repository — rejected
 
-This makes builds fast but turns large generated binaries into source-controlled artifacts and makes updates/review/provenance worse. It is unnecessary for this hobby project.
+This makes builds fast but turns large generated binaries into source-controlled artifacts and makes updates/review/provenance worse. It is unnecessary for this project.
 
 ## Chosen design
 
@@ -89,9 +92,9 @@ source: official ffmpeg.org release tarball
 SHA-256: 8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389
 ```
 
-HPA-512 is not an FFmpeg-version upgrade. A later version bump is one isolated edit to the script plus validation.
+HPA-512 is not an FFmpeg-version upgrade. A later version bump is one isolated script/documentation change plus validation.
 
-Retain the current minimal feature set required by CX and make license intent explicit:
+Retain the current minimal feature set required by CX and make dependency/license intent explicit:
 
 ```text
 static executables; no shared dylib deployment
@@ -117,7 +120,7 @@ filters:
   aformat / anull / aresample / atempo / apad / atrim
 ```
 
-`--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` make the build fail closed instead of accidentally changing redistribution/dependency behavior based on what happens to be installed on a developer or runner machine.
+`--disable-autodetect`, `--disable-gpl`, and `--disable-nonfree` make the build fail closed instead of accidentally changing dependency/redistribution behavior based on what happens to be installed on a developer or runner machine.
 
 The script must:
 
@@ -128,9 +131,9 @@ The script must:
 5. verify both outputs are executable arm64 Mach-O binaries;
 6. verify the required filters, decoders, demuxers, encoder, and muxer;
 7. cache the validated pair under a versioned user cache;
-8. copy `ffmpeg`, `ffprobe`, and the upstream LGPL license into destinations supplied by the caller.
+8. copy `ffmpeg`, `ffprobe`, and the upstream LGPL license into staging destinations supplied by the caller.
 
-Use a simple cache such as:
+Use a simple cache:
 
 ```text
 ~/Library/Caches/DTXManiaCX/ffmpeg/7.0.2/osx-arm64/
@@ -140,25 +143,42 @@ The cache is an optimization only. Deleting it forces a clean verified rebuild.
 
 Do not create a package-builder project, runtime manifest schema, download service, lock daemon, or generic cross-platform FFmpeg installer.
 
-### 2. Mac project owns build/run/publish placement
+### 2. Mac project owns one transitive output/publish path
 
 Update `DTXMania.Game/DTXMania.Game.Mac.csproj`:
 
 - remove `MMTools.Executables.MacOS.X64`;
 - keep `FFMpegCore` unchanged;
-- on macOS, run the native-runtime script after a normal build and copy into:
+- define an intermediate staging root under the existing project `obj` tree, for example:
 
 ```text
-$(TargetDir)/runtimes/osx-arm64/MMTools/ffmpeg
-$(TargetDir)/runtimes/osx-arm64/MMTools/ffprobe
-$(TargetDir)/Licenses/FFmpeg-LGPL-2.1.txt
+$(BaseIntermediateOutputPath)ffmpeg-runtime/
+  runtimes/osx-arm64/MMTools/ffmpeg
+  runtimes/osx-arm64/MMTools/ffprobe
+  Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-- after publish, ensure the same files under `$(PublishDir)`.
+- add one macOS-only target early enough to populate that staging directory before MSBuild resolves files copied to build/reference outputs;
+- declare the staged files as normal `None`/content items with target links:
 
-The script cache makes repeated `dotnet build` / `dotnet run` calls copy-only after the first successful build.
+```text
+runtimes/osx-arm64/MMTools/ffmpeg
+runtimes/osx-arm64/MMTools/ffprobe
+Licenses/FFmpeg-LGPL-2.1.txt
+```
 
-The Mac project is already the platform boundary, so do not introduce shared cross-platform MSBuild props/targets for a single Apple-Silicon-only dependency.
+and both:
+
+```text
+CopyToOutputDirectory=PreserveNewest
+CopyToPublishDirectory=PreserveNewest
+```
+
+This matters because `DTXMania.Test.Mac.csproj` references the game project. Generated files that are merely copied into `DTXMania.Game/bin` after the build are not a reliable project-reference contract; declared copy items are.
+
+The builder's user cache keeps the early target cheap after the first compile: each normal build stages from cache, then MSBuild handles output/test/publish copying consistently.
+
+The Mac project is already the platform boundary, so do not introduce shared cross-platform MSBuild props/targets for one Apple-Silicon-only dependency.
 
 Intel macOS remains out of scope. A Mac x64 host should fail the native bootstrap instead of silently selecting Rosetta.
 
@@ -185,24 +205,26 @@ Do not add architecture registries, RID providers, process wrappers, or a second
 
 Use the existing seams instead of creating a parallel audio harness.
 
-Add a small generated/committed test tone under `DTXMania.Test/TestData/Audio/` for the real MP3 decode path. The test asset is project-generated, not third-party media.
+Add one small generated/committed test tone under `DTXMania.Test/TestData/Audio/` for the real MP3 decode path. The test asset is project-generated, not third-party media. Add that test-data folder to the existing Mac test output-copy rules.
 
-On native Apple Silicon verify:
+On native Apple Silicon verify from the **test assembly output**:
 
 1. `RuntimeInformation.ProcessArchitecture == Arm64`;
-2. `FfmpegRuntime.EnsureConfigured()` reports the bundled `osx-arm64/MMTools` directory;
-3. both binaries execute and report normally;
+2. `FfmpegRuntime.EnsureConfigured()` reports the bundled `osx-arm64/MMTools` directory next to the test/game assembly;
+3. both binaries execute normally;
 4. `new ManagedSound(mp3Fixture)` succeeds with a non-zero duration;
-5. `new FfmpegAudioVariantProcessor().PrepareAsync(...)` succeeds for one generated WAV source at a non-default play-speed modifier;
+5. `new FfmpegAudioVariantProcessor().PrepareAsync(wav, new PlaybackModifiers(125, 0), token)` produces non-empty PCM;
 6. cancellation/timeout coverage already owned by `FfmpegAudioVariantProcessorTests` remains green.
 
-Do not broaden this into a codec matrix. MP3 preview plus one real variant path are the product gates named by HPA-512.
+The test-output location is intentional: it proves the project-reference propagation that HPA-512 needs for normal Mac tests, rather than only proving files exist in `DTXMania.Game/bin`.
+
+Do not broaden this into a codec matrix. MP3 preview plus one real non-default variant path are the product gates named by HPA-512.
 
 ### 5. CI and release consolidation
 
 Pin the regular macOS build/test job to the same native Apple Silicon class already used by release (`macos-15`) so it is real arm64 evidence rather than an ambiguous `macos-latest` alias.
 
-Add an Actions cache for the versioned FFmpeg build cache keyed by the builder script. A cache miss compiles; a hit keeps routine PR builds fast.
+Add an Actions cache for the versioned FFmpeg user cache keyed by the builder script. A cache miss compiles; a hit keeps routine PR builds fast.
 
 After the Mac project build, verify the actual game output:
 
@@ -210,18 +232,20 @@ After the Mac project build, verify the actual game output:
 test -x .../runtimes/osx-arm64/MMTools/ffmpeg
 test -x .../runtimes/osx-arm64/MMTools/ffprobe
 file -b each binary contains arm64
-run focused native FFmpeg/MP3/variant tests
 ```
 
-In `release.yml` delete the large inline source-build step. `dotnet publish` now owns runtime placement. Keep a short fail-closed artifact check before `build-dmg.sh`.
+Then run focused native runtime/MP3/variant tests from `DTXMania.Test.Mac` before the normal full Mac suite and prepared-chart AudioE2E.
 
-After `build-dmg.sh`, also verify the copied app bundle still contains executable arm64 binaries at:
+In `release.yml` delete the large inline source-build step. `dotnet publish` now carries the declared runtime content itself. Keep a short fail-closed artifact check before `build-dmg.sh`.
+
+After `build-dmg.sh`, also verify the copied app bundle still contains executable arm64 binaries and the license at:
 
 ```text
 output/DTXMania.app/Contents/MacOS/runtimes/osx-arm64/MMTools/
+output/DTXMania.app/Contents/MacOS/Licenses/FFmpeg-LGPL-2.1.txt
 ```
 
-`build-dmg.sh` already copies publish output recursively; no new installer abstraction is needed unless this verification exposes a real permission-loss bug.
+`build-dmg.sh` already copies publish output recursively; no installer change is needed unless this verification exposes a real permission-loss bug.
 
 ### 6. Provenance and update procedure
 
@@ -256,7 +280,7 @@ wrong host/architecture
 download/checksum/configure/build failure
 -> fail the Mac build; never fall back to the x64 NuGet runtime
 
-missing/non-executable/wrong-architecture output
+missing/non-executable/wrong-architecture staging output
 -> fail the builder or CI/release verification
 
 runtime unexpectedly unavailable after a successful build
@@ -277,10 +301,11 @@ Do not silently install Homebrew FFmpeg or use PATH as production recovery.
 
 On `macos-15`:
 
-- normal Mac `dotnet build` produces executable arm64 runtime files;
+- normal Mac `dotnet build` contains executable arm64 runtime files;
+- the Mac test output also contains them through `ProjectReference` copy-item propagation;
 - focused MP3 `ManagedSound` smoke passes;
-- focused real `FfmpegAudioVariantProcessor` smoke passes;
-- `dotnet publish -r osx-arm64` produces the same runtime + license;
+- focused real `FfmpegAudioVariantProcessor` smoke with `new PlaybackModifiers(125, 0)` passes;
+- `dotnet publish -r osx-arm64` contains the same runtime + license;
 - `.app` bundle preserves both binaries and execute bits.
 
 ### Regression
@@ -293,7 +318,7 @@ On `macos-15`:
 In scope:
 
 - native FFmpeg/ffprobe source bootstrap for the supported Mac project;
-- Mac build/run/publish integration;
+- one transitive Mac build/test/publish copy contract;
 - x64 MMTools package removal from the Mac project;
 - provenance/license material;
 - native Apple Silicon verification and release deduplication.
@@ -314,8 +339,8 @@ Out of scope:
 Keep one implementation PR with four reviewer-sized checkpoints:
 
 1. extract and verify the reproducible native FFmpeg builder + provenance;
-2. wire Mac build/run/publish and remove x64 MMTools;
-3. add native runtime/MP3/variant validation;
+2. wire the Mac project staging/copy contract and remove x64 MMTools;
+3. add native runtime/MP3/variant validation from the test output;
 4. pin/cache CI and collapse release duplication.
 
 This gives HPA-515 one clear prerequisite: the ordinary supported Mac build already carries the audio runtime it needs.


### PR DESCRIPTION
## Summary

Planning-only PR for HPA-512: **Package native Apple Silicon FFmpeg for CX gameplay audio**.

Second review exposed one prerequisite outside HPA-512: current macOS CI invokes `DTXMania.Test.Mac.csproj --no-build` without ever building the test project, so the main Test.Mac suite currently runs zero tests. HPA-623 now owns that baseline repair and blocks HPA-512. HPA-512 implementation starts only after HPA-623 is green on `main`.

This PR still changes only:

- `docs/superpowers/specs/2026-08-14-hpa-512-apple-silicon-ffmpeg-design.md`
- `docs/superpowers/plans/2026-08-14-hpa-512-apple-silicon-ffmpeg.md`

## Final design direction

- Reuse the existing official FFmpeg 7.0.2 arm64 source recipe already shipping in `release.yml`; no third-party binary/NuGet provider.
- Extract one cached `tools/ffmpeg/macos-arm64/build-runtime.sh` with the pinned source SHA and minimal CX audio feature surface.
- Add `--disable-autodetect` unconditionally so developer Homebrew state cannot change the produced runtime; do not spend another cold build trial on `--disable-gpl` / `--disable-nonfree`.
- Extend capability verification to include the already-enabled load-bearing `adpcm_ima_wav` and `adpcm_ms` decoders.
- Add `otool -L` verification so cached/shipped binaries depend only on macOS system libraries and cannot accidentally capture Homebrew dylibs.
- Remove `MMTools.Executables.MacOS.X64`; keep `FFMpegCore`, `FfmpegRuntime`, `IsRunnableFile`, and arm64-over-x64 resolver behavior unchanged.
- Keep one macOS-only generated-content MSBuild target. Condition only its builder `Exec` on staged `ffmpeg`/`ffprobe` absence; keep generated copy items declared unconditionally within the target.
- Repair the existing `PrepareAsync_EncodedAudio_ShouldNormalizeToRawPcm` test with committed MP3/OGG fixtures; retain the stronger `PlaybackModifiers(50, 12)` assertions and do not add production encoders.
- Put real packaged-runtime I/O coverage in a dedicated Audio-trait `FfmpegBundledRuntimeTests` class. Require `BinaryFolder != null` and the exact bundled Test.Mac directory so PATH/Homebrew cannot satisfy the guard.
- Keep the existing Homebrew FFmpeg installation **after** all bundle-sensitive Audio and prepared-chart E2E checks.
- Collapse `release.yml` to publish/.app verification after the project owns runtime generation.

## HPA-515 boundary

HPA-512 remains a real prerequisite for HPA-515, but specifically for **CX game audio**: HPA-515 requires MP3 preview/gameplay audio to work natively on arm64.

`DTXMania.VideoRecorder` does not reference the Game project and `RecordingArtifactVerifier` continues resolving `ffprobe` from PATH for MP4 stream inspection. HPA-512 does **not** provide a bundled recorder verifier or add MP4/H.264 codec support.

## Review findings incorporated

1. **Mac zero-test CI:** valid. Split to prerequisite HPA-623 rather than letting HPA-512 accidentally activate the suite for the first time.
2. **HPA-515 claim:** partially rejected. The recorder does not use the bundled runtime for artifact verification, but Linear HPA-515 explicitly depends on HPA-512 for native CX preview/gameplay audio. The docs now state that boundary precisely.
3. **Bundled runtime test placement/PATH masking:** valid. New dedicated Audio-trait class with non-null/equal `BinaryFolder` assertion.
4. **ADPCM verification gap:** valid. Add `adpcm_ima_wav` and `adpcm_ms` to builder checks.
5. **Portability:** valid. Add fail-closed `otool -L` system-library-only check.
6. **Configure decision:** valid. Use `--disable-autodetect` from the start; omit the GPL/nonfree experiment.
7. **MSBuild incrementality:** valid. Condition the `Exec`, not the generated item declaration, and document first-run E2E latency risk.
8. **Intel consequence:** valid. State clearly that the Mac game project itself will no longer build on Intel Macs.

## Deliberate non-goals

- no FFmpeg version upgrade;
- no Intel macOS or Rosetta support;
- no Windows runtime changes;
- no production MP3/OGG encoders just for tests;
- no generic dependency/bootstrap framework;
- no second runtime resolver or audio stack;
- no bundled recorder ffprobe, MP4/H.264 expansion, OBS, or signing/notarization redesign.

## Implementation shape

**Prerequisite:** HPA-623 — make Test.Mac a real green fail-closed CI gate.

Then one 2–3 engineer-day HPA-512 implementation PR with four reviewer checkpoints:

1. reproducible cached builder with `--disable-autodetect`, full decoder checks, and `otool -L` portability gate;
2. incremental macOS-only generated MSBuild copy contract and Game/Test/publish verification;
3. committed fixtures, repaired existing variant test, dedicated bundled-runtime Audio guard, ManagedSound MP3 check, and diagnostic cleanup;
4. runtime-specific CI checks plus release deduplication, keeping Homebrew FFmpeg after bundle-sensitive checks.

## Validation

Planning branch still changes exactly two documentation files; no production/test/workflow files are modified by this PR.

No tests run because this PR contains documentation only.

Linear: HPA-512  
Prerequisite: HPA-623

This planning PR does not close HPA-512; the follow-up implementation PR executes the approved plan after HPA-623 lands.