### PR TITLE
ci: lower Codecov coverage target to 85%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,13 +2,13 @@ coverage:
   status:
     project:
       default:
-        target: 95%
+        target: 85%
         threshold: 0%
         informational: false
         if_not_found: failure
     patch:
       default:
-        target: 95%
+        target: 85%
         threshold: 0%
         informational: false
         if_not_found: failure


### PR DESCRIPTION
## Summary

- lower Codecov project coverage target from 95% to 85%
- lower Codecov patch coverage target from 95% to 85%
- keep `threshold: 0%`, blocking statuses, and `if_not_found: failure` unchanged

## Validation

- `codecov.yml` only
- DTXManiaCX is intentionally lower than the 90% target used by the other repos
