### PR TITLE
docs: plan HPA-513 Windows live recording acceptance

### DIFF
--- a/docs/superpowers/plans/2026-08-15-hpa-513-windows-live-recording-acceptance.md
+++ b/docs/superpowers/plans/2026-08-15-hpa-513-windows-live-recording-acceptance.md
@@ -1,0 +1,408 @@
+# HPA-513 Windows Live Recording Acceptance Implementation Plan
+
+> **For agentic workers:** Execute this as a proof/documentation task. Do not change recorder production code inside HPA-513. If the proof exposes a real defect, stop, file a focused blocker, fix it separately, then rerun this plan against the fixed commit.
+
+**Goal:** Produce and accept the first real Windows x64 DTXManiaCX AutoPlay recording using the merged HPA-503 `dtx-video` recorder, prove source app-data isolation and OBS ownership, and commit a reusable Windows setup guide plus sanitized verification record.
+
+**Architecture:** No new runtime architecture. Use the existing `DTXMania.VideoRecorder`, dedicated manually configured OBS profile/scene, existing diagnostics, and existing portable tests. The implementation PR should normally be documentation-only.
+
+**Expected effort:** < 1 engineer day once a Windows + OBS proof workstation and a short indexed chart are available.
+
+## Global constraints
+
+- Use a clean checkout of the commit being accepted.
+- Windows 10 version 2004+ or Windows 11, x64.
+- OBS Studio 30.2+ with obs-websocket 5.x.
+- Keep OBS setup manual; no source/scene automation.
+- Use one short indexed chart with valid preview audio.
+- Do not commit MP4s, raw diagnostics, passwords, API keys, or private absolute paths.
+- Do not change `DTXMania.VideoRecorder` production/test code in this ticket.
+- If a product bug appears, open a separate blocker/fix PR and rerun acceptance after it merges.
+- HPA-506/HPA-504 remain optional follow-ups; do not pull their stricter media/preflight scope into this task.
+
+## Intended execution PR files
+
+```text
+Add:
+  docs/video-recorder/windows-obs-setup.md
+  docs/verification/hpa-513-windows-live-recording.md
+
+Normally unchanged:
+  DTXMania.VideoRecorder/**
+  DTXMania.VideoRecorder.Tests/**
+  DTXMania.Automation/**
+  DTXMania.Game/**
+```
+
+---
+
+## Task 1: Prepare the proof workstation and capture the baseline
+
+**Produces:** an isolated local proof directory, a known accepted commit candidate, source app-data before-state, and a correctly configured idle OBS instance.
+
+- [ ] **Step 1: Update and build the exact commit under test.**
+
+From repository root:
+
+```powershell
+git status --short
+git rev-parse HEAD
+dotnet build DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug
+```
+
+Require a clean working tree before the native proof. Record the full commit SHA for the verification document.
+
+- [ ] **Step 2: Select one short indexed chart.**
+
+Use an existing chart already visible to normal CX Song Select and known to have preview audio. Record a non-sensitive chart identity for the verification document; do not commit the private absolute chart path.
+
+Do not create a special test chart or modify the song database for HPA-513.
+
+- [ ] **Step 3: Create a proof directory outside the Git checkout.**
+
+Example only:
+
+```text
+C:\DTXManiaCX-HPA-513\
+  raw\
+  published\
+```
+
+Configure OBS raw recording output to the `raw` directory. The exact local path is not part of the product contract.
+
+- [ ] **Step 4: Configure the dedicated OBS profile/collection/scene manually.**
+
+Required settings:
+
+```text
+Game Capture -> DTXManiaCX game window/process
+Application Audio Capture -> DTXManiaCX
+Desktop Audio -> disabled
+Microphone -> disabled
+Recording format -> Hybrid MP4
+obs-websocket -> enabled + authenticated
+OBS output directory -> proof raw directory
+```
+
+Keep OBS open and inactive.
+
+- [ ] **Step 5: Export recorder environment variables in the proof shell.**
+
+```powershell
+$env:DTXMANIA_VIDEO_OBS_URL = "ws://127.0.0.1:4455"
+$env:DTXMANIA_VIDEO_OBS_PASSWORD = "<local-secret>"
+$env:DTXMANIA_VIDEO_OBS_OUTPUT_DIR = "<absolute-raw-directory>"
+```
+
+Only set `DTXMANIA_APPDATA_ROOT` when the proof intentionally uses a non-default source CX app-data root.
+
+Do not echo the OBS password into retained command transcripts.
+
+- [ ] **Step 6: Capture source app-data before-state.**
+
+For the source CX app-data root, capture presence, file size, and SHA-256 for:
+
+```text
+Config.ini
+songs.db
+songs.db-wal
+songs.db-shm
+```
+
+A small local PowerShell snippet is sufficient. Handle missing WAL/SHM files as `absent`; do not create them for the proof.
+
+Save the result as `<proof-root>\source-state-before.txt`.
+
+- [ ] **Step 7: Commit nothing yet.**
+
+Task 1 is workstation preparation only.
+
+---
+
+## Task 2: Prove preflight and ownership/failure behavior
+
+**Produces:** passing `doctor`, focused automated cleanup proof, and native OBS ownership evidence.
+
+- [ ] **Step 1: Run focused portable recorder tests.**
+
+```powershell
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug --no-restore --filter "FullyQualifiedName~RecordWorkflowTests|FullyQualifiedName~RecordFinalizationTests|FullyQualifiedName~RecordingArtifactVerifierTests"
+```
+
+Record pass/fail counts in the verification document. These tests remain the proof for platform-neutral launch/stage/finalization cleanup behavior.
+
+- [ ] **Step 2: Run `doctor` with OBS idle.**
+
+```powershell
+dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug --no-build -- doctor 2>&1 | Tee-Object -FilePath "<proof-root>\doctor.txt"
+```
+
+Require exit code `0` and these gates:
+
+```text
+Windows: passed
+Repository: passed
+Game project: passed
+Source config validation: passed
+Raw output directory: passed
+OBS auth/status: Hello + Identify succeeded
+OBS recording status: inactive
+OBS state mutation: none
+```
+
+`ffprobe` absent is acceptable and should be recorded as the existing warning-only condition.
+
+- [ ] **Step 3: Native pre-existing OBS ownership check.**
+
+1. Start recording manually in OBS.
+2. Run `record` with the valid proof chart/output directory.
+3. Require the recorder to reject the run because OBS is already recording.
+4. Confirm OBS continues recording after the command fails.
+5. Stop the manually owned OBS recording yourself.
+
+Record outcome only; the disposable manual artifact from this ownership check does not need to be retained.
+
+- [ ] **Step 4: Lightweight invalid/unindexed chart check.**
+
+Run one `record` attempt using an invalid or unindexed chart input.
+
+Require:
+
+- non-zero exit;
+- actionable failure;
+- no unrelated OBS recording is started/stopped;
+- no source app-data mutation.
+
+Do not manufacture a destructive CX launch failure. Existing automated coverage is sufficient for that platform-neutral path.
+
+- [ ] **Step 5: Do not commit yet.**
+
+If either native ownership check reveals a product defect, stop HPA-513 and open a focused blocker.
+
+---
+
+## Task 3: Produce the accepted happy-path recording
+
+**Produces:** one raw MP4, one published MP4, completed recorder diagnostics, and native cancellation proof.
+
+- [ ] **Step 1: Run the happy path once.**
+
+With OBS idle:
+
+```powershell
+dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug --no-build -- `
+  record --chart "<absolute-chart-path>" --output "<proof-root>\published"
+```
+
+Require exit code `0`.
+
+Retain:
+
+```text
+raw OBS MP4
+published MP4
+published\diagnostics\<run-id>\run.json
+published\diagnostics\<run-id>\cx-stdout.log
+published\diagnostics\<run-id>\cx-stderr.log
+```
+
+- [ ] **Step 2: Inspect `run.json`.**
+
+Require `status == Completed` and verify the key telemetry:
+
+```text
+SongSelectReady -> non-empty selectedSongTitle
+PreviewReady -> preparedPreviewState == Playing
+                preparedPreviewElapsedMs >= 10000
+PerformanceReady -> performanceReady == true
+                    autoPlayEnabled == true
+                    totalNotes > 0
+ResultCompleted -> stageCompleted == true
+                   clearFlag == true
+                   completionReason == SongComplete
+                   totalJudgements == totalNotes
+OBS -> Connect/Status/Start/Stop all succeeded
+Completed -> present
+failure/failureType/retainedSandboxPath -> absent
+```
+
+Also confirm raw/published paths point to the expected proof directories.
+
+- [ ] **Step 3: Native Ctrl+C ownership check.**
+
+Start a second normal `record` run. After OBS has started and preview/gameplay is active, press Ctrl+C once.
+
+Require:
+
+- the command exits through cancellation;
+- OBS is no longer recording afterward;
+- any partial raw artifact remains available;
+- failed-run diagnostics are written when possible;
+- the failed-run sandbox is retained and referenced by diagnostics.
+
+Inspect the retained sandbox only as needed, then delete it manually after the proof is recorded.
+
+Do not use the cancellation run as the accepted MP4.
+
+---
+
+## Task 4: Validate source isolation and manually accept the media
+
+**Produces:** deterministic source before/after comparison and formal human acceptance of the published MP4.
+
+- [ ] **Step 1: Capture source app-data after-state.**
+
+Repeat the exact same presence/size/SHA-256 capture used in Task 1 and save it as:
+
+```text
+<proof-root>\source-state-after.txt
+```
+
+Require no change to source `Config.ini`, `songs.db`, `songs.db-wal`, or `songs.db-shm`, including no newly created source WAL/SHM file.
+
+- [ ] **Step 2: Confirm recorder cleanup/publication behavior.**
+
+Require:
+
+- successful-run sandbox deleted;
+- raw OBS MP4 still exists;
+- published MP4 exists;
+- diagnostics directory exists;
+- raw and published MP4 are non-empty.
+
+Calculate byte size and SHA-256 for both MP4s for the verification document.
+
+- [ ] **Step 3: Watch the complete published MP4.**
+
+Confirm all of the following:
+
+```text
+[ ] intended populated Song Select is first
+[ ] preview audio begins after visible Song Select
+[ ] at least 10 seconds of actual preview audio
+[ ] complete Song Transition
+[ ] full AutoPlay gameplay
+[ ] BGM/chip audio audible and plausible
+[ ] fully rendered Result
+[ ] Result remains visible >= 5 seconds
+[ ] recording ends after Result hold
+[ ] no OBS UI / desktop / unrelated window
+[ ] no cursor or notification captured
+[ ] no microphone or unrelated application audio
+[ ] no duplicated/echoed CX audio
+[ ] no severe stutter, clipping, aspect squeeze, or missing viewport region
+```
+
+Do not add automated quality scoring or new media thresholds.
+
+- [ ] **Step 4: Optional `ffprobe` sanity only when already available.**
+
+If `ffprobe` is on PATH, record that the verifier found both audio and video streams. Do not install an FFmpeg dependency solely to satisfy HPA-513.
+
+---
+
+## Task 5: Commit the reusable runbook and sanitized verification record
+
+**Files:**
+
+```text
+docs/video-recorder/windows-obs-setup.md
+docs/verification/hpa-513-windows-live-recording.md
+```
+
+- [ ] **Step 1: Write `windows-obs-setup.md`.**
+
+Keep it concise and operator-focused:
+
+```text
+Prerequisites
+Dedicated OBS profile/scene setup
+Application audio + disabled desktop/mic
+Hybrid MP4 + WebSocket setup
+Required environment variables
+doctor command
+record command
+How to choose an indexed chart
+Where raw/published/diagnostics land
+Success indicators
+Troubleshooting:
+  source Config.ini not normalized
+  OBS auth failure
+  OBS already recording
+  chart invalid/unindexed
+  preview unavailable
+  ffprobe optional warning
+```
+
+Do not duplicate OBS upstream documentation beyond the settings this recorder requires.
+
+- [ ] **Step 2: Write `hpa-513-windows-live-recording.md`.**
+
+Record only sanitized evidence:
+
+```text
+accepted commit SHA
+Windows version / architecture
+.NET SDK/host version
+OBS version
+non-sensitive chart identity
+doctor result summary
+successful command summary with private paths redacted
+raw MP4 filename + size + SHA-256
+published MP4 filename + size + SHA-256
+run.json acceptance values
+source before/after result
+pre-existing OBS ownership result
+Ctrl+C ownership result
+invalid/unindexed chart result
+manual media checklist result
+focused automated test command + pass counts
+warnings/deviations
+```
+
+Do not paste full raw logs or local absolute paths.
+
+- [ ] **Step 3: Final repo validation.**
+
+```powershell
+git diff --check
+git status --short
+```
+
+Expected execution PR diff: two documentation files only.
+
+- [ ] **Step 4: Commit and open the HPA-513 execution PR.**
+
+Suggested commit:
+
+```text
+docs: record HPA-513 Windows recorder acceptance
+```
+
+Suggested PR title:
+
+```text
+docs: validate first Windows live recording
+```
+
+The PR body should state explicitly that no recorder code changed, identify the accepted commit, summarize native/automated proof, and link HPA-513.
+
+---
+
+## Completion checklist
+
+HPA-513 is complete only when:
+
+- [ ] `doctor` passes against real Windows + dedicated OBS;
+- [ ] one accepted raw and published MP4 are retained outside Git;
+- [ ] diagnostics show the complete 10-second-preview / full-gameplay / five-second-Result journey;
+- [ ] source Config.ini/database/WAL/SHM are byte-for-byte unchanged;
+- [ ] pre-existing OBS recording is not owned/stopped by the recorder;
+- [ ] Ctrl+C after owned start stops only the recorder-owned OBS recording;
+- [ ] focused portable recorder cleanup/finalization tests pass;
+- [ ] manual video/audio inspection passes;
+- [ ] `docs/video-recorder/windows-obs-setup.md` is committed;
+- [ ] `docs/verification/hpa-513-windows-live-recording.md` is committed;
+- [ ] no production-code changes, MP4s, secrets, private paths, or raw logs are included in the HPA-513 execution PR.
+
+After this closes, HPA-515 becomes the next recorder-platform task. Optional HPA-504/HPA-506 hardening remains deferred until real usage justifies it.

--- a/docs/superpowers/specs/2026-08-15-hpa-513-windows-live-recording-acceptance-design.md
+++ b/docs/superpowers/specs/2026-08-15-hpa-513-windows-live-recording-acceptance-design.md
@@ -1,0 +1,327 @@
+# HPA-513 Windows Live Recording Acceptance Design
+
+**Issue:** [HPA-513](https://linear.app/cwchanap/issue/HPA-513/produce-and-validate-the-first-live-windows-recording)  
+**Date:** 2026-08-15  
+**Status:** Proposed
+
+## Goal
+
+Prove the already-merged HPA-503 recorder on one real Windows x64 workstation with a dedicated OBS configuration, retain one accepted recording/evidence bundle, and document the minimum setup needed to repeat it.
+
+This is an acceptance and documentation slice, not a second recorder implementation.
+
+The successful captured journey must be:
+
+```text
+Song Select
+-> at least 10 seconds of prepared preview audio
+-> complete Song Transition
+-> full AutoPlay Performance
+-> completed Result held for at least 5 seconds
+```
+
+HPA-503 already owns the reusable recorder implementation and portable automated coverage. HPA-513 owns the deferred native Windows/OBS proof.
+
+## Why this is the next actionable task
+
+- HPA-503 is complete and its implementation is merged.
+- HPA-513 is now unblocked.
+- HPA-513 blocks HPA-515 Apple Silicon parity and the optional Windows OBS preflight work.
+- The remaining backlog recorder items are explicitly optional hardening and should not precede the first real proof.
+
+## Scope
+
+### In scope
+
+- one Windows 10 2004+ or Windows 11 x64 proof workstation;
+- OBS Studio 30.2+ with obs-websocket 5.x;
+- one dedicated OBS profile/collection/scene configured manually;
+- one short indexed DTX chart with valid preview audio;
+- successful `dtx-video doctor`;
+- one successful `dtx-video record` run;
+- source CX app-data isolation evidence;
+- manual video/audio inspection;
+- a small set of native ownership/failure checks where real OBS behavior matters;
+- a concise Windows OBS setup/runbook;
+- a sanitized committed verification record.
+
+### Out of scope
+
+- recorder architecture changes;
+- automatic OBS scene/source/audio diagnosis;
+- persistent recorder databases or song caches;
+- MKV fallback/remux/re-encoding;
+- Apple Silicon implementation or acceptance;
+- YouTube upload/editing/overlays/batch processing;
+- committing MP4s, raw recorder diagnostics, private chart paths, or secrets to Git.
+
+If the native proof exposes a recorder defect, HPA-513 stops at that defect. Fix the defect in a separate focused issue/PR, then rerun acceptance. Do not mix production-code changes into the proof PR because that makes the evidence ambiguous about which implementation was actually accepted.
+
+## Existing implementation to validate
+
+Use the current HPA-503 seams as-is:
+
+- `DTXMania.VideoRecorder/Program.cs`
+  - `doctor` validates the local environment and performs read-only OBS Hello/Identify/GetRecordStatus;
+  - `record` owns the CX process, OBS recording started by the run, finalization, diagnostics, and sandbox cleanup.
+- `DTXMania.VideoRecorder/RecorderCommandLine.cs`
+  - `DTXMANIA_VIDEO_OBS_URL` defaults to `ws://127.0.0.1:4455` and must stay loopback;
+  - `DTXMANIA_VIDEO_OBS_PASSWORD` carries the local WebSocket secret;
+  - `DTXMANIA_VIDEO_OBS_OUTPUT_DIR` is the existing raw OBS output directory;
+  - `DTXMANIA_APPDATA_ROOT` may override the source CX app-data root.
+- `RecordWorkflow`
+  - waits for populated Song Select before preparing the exact chart;
+  - starts OBS before prepared preview;
+  - requires preview elapsed >= 10,000 ms;
+  - observes Song Transition;
+  - requires ready AutoPlay Performance with non-zero notes;
+  - requires completed/cleared Result with `TotalJudgements == TotalNotes`;
+  - captures a Result screenshot barrier and performs a five-second no-input hold;
+  - stops only OBS recording owned by this run.
+- `RecorderDiagnostics`
+  - writes `run.json`, `cx-stdout.log`, and `cx-stderr.log` under `<output>/diagnostics/<run-id>/`;
+  - records stage telemetry and OBS outcomes;
+  - redacts the known recorder API key and OBS password.
+
+HPA-513 should validate these contracts rather than add another abstraction around them.
+
+## Proof outputs
+
+### Committed files
+
+The HPA-513 execution PR should add only two durable documents unless a separate bug fix becomes necessary:
+
+```text
+docs/video-recorder/windows-obs-setup.md
+docs/verification/hpa-513-windows-live-recording.md
+```
+
+`windows-obs-setup.md` is the reusable operator runbook.  
+`hpa-513-windows-live-recording.md` is the sanitized proof record for the accepted run.
+
+### Local retained evidence
+
+Keep the full evidence outside the Git checkout, for example under a dedicated proof directory on the Windows workstation:
+
+```text
+<proof-root>/
+  doctor.txt
+  source-state-before.txt
+  source-state-after.txt
+  raw/
+    <obs-produced-file>.mp4
+  published/
+    <published-file>.mp4
+    diagnostics/<run-id>/
+      run.json
+      cx-stdout.log
+      cx-stderr.log
+```
+
+The exact local directory layout is not a product contract. The important rule is that raw/published media and unsanitized workstation paths stay out of Git while the committed verification document records enough metadata to reproduce and audit the result.
+
+## OBS configuration contract
+
+Keep OBS setup manual and minimal:
+
+1. Create/select a dedicated DTXManiaCX profile and scene collection.
+2. Configure Game Capture for the CX game window/process.
+3. Configure application audio capture for CX.
+4. Disable Desktop Audio and microphone inputs for the recorded track.
+5. Configure Hybrid MP4 recording.
+6. Enable obs-websocket 5.x authentication.
+7. Set the OBS recording directory to the same path exported as `DTXMANIA_VIDEO_OBS_OUTPUT_DIR`.
+8. Keep OBS open and idle before `record` starts.
+
+Do not add scene enumeration, source inspection, screenshots, or auto-repair to the recorder for this ticket. The human inspection below is the acceptance gate for capture correctness.
+
+## Source app-data isolation proof
+
+The recorder is required to use a disposable sandbox and must not mutate normal CX state.
+
+Immediately before the proof run, record presence, byte size, and SHA-256 for the source files when they exist:
+
+```text
+Config.ini
+songs.db
+songs.db-wal
+songs.db-shm
+```
+
+Repeat the same capture immediately after the successful run.
+
+Acceptance:
+
+- every file present before the run has the same size and SHA-256 afterward;
+- files absent before the run are not newly created by the recorder in the source app-data root;
+- the successful recorder sandbox has been deleted after finalization;
+- the raw OBS file remains in the OBS output directory;
+- the published copy and diagnostics remain under the requested output directory.
+
+Do not rely on timestamps alone. Content hashes give a simple deterministic proof and avoid adding any new recorder instrumentation.
+
+## Happy-path native run
+
+### Preflight
+
+From the repository root on the proof workstation:
+
+```powershell
+dotnet build DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug
+
+dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug --no-build -- doctor
+```
+
+Retain the sanitized doctor output. It must report:
+
+- Windows available;
+- repository/game project/source config available;
+- source config validation passed;
+- raw output directory valid;
+- OBS Hello/Identify succeeded;
+- OBS recording inactive;
+- no OBS state mutation.
+
+`ffprobe` may be absent; that remains a warning-only condition under HPA-503.
+
+### Recording
+
+Run exactly one short indexed chart:
+
+```powershell
+dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug --no-build -- \
+  record --chart "<absolute-chart-path>" --output "<proof-root>\published"
+```
+
+Do not put secrets on the command line. OBS password remains in the environment.
+
+The run must finish with exit code `0`, print both raw and published output paths, and leave a completed diagnostics bundle.
+
+## Automated telemetry acceptance
+
+Inspect `run.json` from the successful run. Require:
+
+- `status == Completed`;
+- the expected ordered steps are present from `Started` through `Completed`;
+- `SongSelectReady` has a non-empty selected song;
+- `PreviewReady` reports `preparedPreviewState == Playing` and `preparedPreviewElapsedMs >= 10000`;
+- `PerformanceReady` reports `performanceReady == true`, `autoPlayEnabled == true`, and `totalNotes > 0`;
+- `ResultCompleted` reports `stageCompleted == true`, `clearFlag == true`, `completionReason == SongComplete`, and `totalJudgements == totalNotes`;
+- OBS Connect/Status/Start/Stop all succeeded;
+- raw and published paths are recorded;
+- `failure`, `failureType`, and retained sandbox path are absent;
+- the verifier warning is either absent or only the expected optional-`ffprobe` warning.
+
+The diagnostics are evidence for game/recorder state; they do not replace visual/audio inspection.
+
+## Manual media acceptance
+
+Watch the complete published MP4 at normal speed and confirm:
+
+- the captured content starts with the intended populated Song Select presentation;
+- preview audio starts only after Song Select is visibly captured;
+- at least ten seconds of real preview audio are present;
+- Song Transition is visually complete;
+- the whole AutoPlay gameplay is visible and audible;
+- BGM/chip audio is present and plausible;
+- the Result screen is fully rendered and remains visible for at least five seconds;
+- the recording ends after the Result hold;
+- no OBS UI, desktop, unrelated window, cursor, notification, microphone, or unrelated application audio is captured;
+- CX audio is not duplicated or echoed;
+- there is no obvious clipping, severe stutter, aspect-ratio error, or missing frame region that makes the proof unusable.
+
+Do not introduce numeric quality thresholds or frame-analysis tooling for this first proof. HPA-506 owns stricter media policy if real usage needs it.
+
+## Failure and ownership proof
+
+Do not manually replay every portable unit-test scenario. Reuse HPA-503 automated coverage for platform-neutral cleanup and run only the native checks that add real Windows/OBS evidence.
+
+### Re-run focused automated tests
+
+At minimum retain a passing result for recorder tests covering:
+
+- pre-existing OBS recording is never started/stopped by the recorder;
+- Start failure does not stop unowned OBS state;
+- cancellation after recorder-owned OBS start stops owned recording;
+- unexpected stage/performance/result failures stop owned recording;
+- finalization preserves the raw artifact and does not delete the sandbox before diagnostics/publication complete.
+
+### Native check 1: pre-existing OBS ownership
+
+1. Start an OBS recording manually.
+2. Run `dtx-video record` with the valid proof chart.
+3. Require the recorder to fail before starting its own recording.
+4. Confirm the manually started OBS recording is still active.
+5. Stop that manual recording yourself.
+
+This proves the real OBS ownership boundary without adding recorder APIs.
+
+### Native check 2: cancellation after owned start
+
+1. Start a normal proof recording.
+2. After the recorder has started OBS and preview/gameplay is active, press Ctrl+C once.
+3. Require the command to exit through its cancellation path.
+4. Confirm OBS is no longer recording.
+5. Confirm the partial raw OBS artifact and diagnostics are retained when available.
+6. Confirm the failed-run sandbox is retained and recorded for diagnostics.
+
+Delete the retained failed-run sandbox manually after inspection.
+
+### Lightweight input failure
+
+Use one invalid or unindexed chart attempt and confirm it fails without starting or stopping unrelated OBS recording. This is sufficient native confirmation for chart validation; do not manufacture a separate destructive CX-launch failure on the proof workstation.
+
+The existing automated suite remains the proof for platform-neutral CX launch/start/timeout cleanup behavior.
+
+## Documentation contract
+
+`docs/video-recorder/windows-obs-setup.md` should contain only the information an operator needs:
+
+- prerequisites;
+- exact OBS profile/scene/audio settings;
+- required environment variables;
+- `doctor` and `record` commands;
+- how to choose an indexed chart;
+- artifact locations;
+- success indicators;
+- common troubleshooting for source config normalization, OBS auth, OBS already recording, unindexed chart, missing preview, and optional `ffprobe`.
+
+Do not turn this into general OBS documentation.
+
+`docs/verification/hpa-513-windows-live-recording.md` should record:
+
+- accepted commit SHA;
+- Windows/.NET/OBS versions;
+- chart identity in a non-sensitive form;
+- doctor result summary;
+- successful command summary with secrets/absolute private paths redacted;
+- raw/published MP4 file names, byte sizes, and SHA-256;
+- `run.json` acceptance values;
+- source-state before/after comparison;
+- native ownership/cancellation check outcomes;
+- manual visual/audio checklist result;
+- focused automated test command/results;
+- any warnings or deviations.
+
+The verification document should not embed raw logs, full local paths, passwords, API keys, or video binaries.
+
+## Stop conditions
+
+The acceptance run is not complete if any of the following occurs:
+
+- `doctor` cannot authenticate to OBS or reports OBS already active;
+- the exact chart cannot be prepared from the populated library;
+- preview is shorter than ten seconds;
+- Song Transition, Performance, or completed Result is missing;
+- Result is not held for five seconds;
+- the source Config.ini/database/WAL state changes;
+- OBS captures desktop/OBS UI/unrelated audio or misses CX audio;
+- the recorder leaves OBS active after owned cancellation/failure;
+- published/raw media is missing or unreadable;
+- diagnostics report failure or inconsistent gameplay totals.
+
+When a stop condition indicates a product defect, file a focused blocker and fix it separately before claiming HPA-513 acceptance.
+
+## Acceptance
+
+HPA-513 is complete when one real Windows x64 recording is accepted end-to-end; the source CX app-data state is proven unchanged; the real OBS ownership/cancellation boundary is demonstrated; the portable recorder regression tests still pass; a minimal reproducible Windows OBS runbook is committed; and a sanitized verification record ties the accepted media/evidence to the exact repository commit.


### PR DESCRIPTION
## Summary

Planning-only PR for HPA-513: **Produce and validate the first live Windows recording**.

HPA-503 is complete, so HPA-513 is now the next unblocked leaf task in the DTXManiaCX recorder epic. It also blocks HPA-515 Apple Silicon parity and the optional Windows OBS preflight follow-up.

This PR adds only:

- `docs/superpowers/specs/2026-08-15-hpa-513-windows-live-recording-acceptance-design.md`
- `docs/superpowers/plans/2026-08-15-hpa-513-windows-live-recording-acceptance.md`

## Design direction

- Treat HPA-513 as native acceptance + documentation, not a second recorder implementation.
- Reuse the merged HPA-503 `dtx-video` recorder, its diagnostics, and existing portable cleanup/finalization tests unchanged.
- Keep OBS setup manual: dedicated Game Capture + CX application audio, disabled desktop/mic, Hybrid MP4, authenticated obs-websocket.
- Produce one real Windows x64 happy-path recording covering visible Song Select, >=10s preview, complete transition, full AutoPlay gameplay, and >=5s Result hold.
- Prove source Config.ini/database/WAL/SHM isolation with before/after size + SHA-256 rather than new recorder instrumentation.
- Run only native failure checks that add real OBS evidence: pre-existing recording ownership, Ctrl+C after recorder-owned start, and one invalid/unindexed chart attempt. Reuse HPA-503 tests for platform-neutral cleanup paths.
- Keep MP4s/raw diagnostics outside Git. The execution PR should normally add only a concise Windows OBS runbook and a sanitized verification record.
- If the proof exposes a recorder defect, fix it in a separate focused issue/PR and rerun acceptance; do not mix production-code changes into the proof PR.

## Implementation shape

Expected effort is under one engineer day once the Windows + OBS workstation is available:

1. prepare the proof workstation, OBS scene, chart, and source-state baseline;
2. run focused portable tests + live `doctor` + native ownership/input-failure checks;
3. produce the accepted recording and a separate Ctrl+C ownership proof;
4. compare source-state hashes and manually inspect the full MP4;
5. commit `docs/video-recorder/windows-obs-setup.md` and `docs/verification/hpa-513-windows-live-recording.md`.

## Validation

Planning branch is exactly two documentation files ahead of `main` with no production/test changes.

No tests run because this PR contains planning documentation only.

Linear: https://linear.app/cwchanap/issue/HPA-513/produce-and-validate-the-first-live-windows-recording

This planning PR does not close HPA-513; the follow-up execution PR performs the real Windows/OBS acceptance run.