### PR TITLE
docs: plan HPA-515 Apple Silicon recorder parity

### DIFF
--- a/DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs
+++ b/DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs
@@ -72,6 +72,49 @@ public sealed class GameProcessDriverTests
     }
 
     [Fact(Timeout = 60_000)]
+    public async Task Start_ProjectTargetWithNoBuildRunArguments_ShouldRunPreviouslyBuiltOutputWithoutRebuilding()
+    {
+        using var fixture = CreateChildFixture();
+        BuildChild(fixture);
+        File.WriteAllText(
+            Path.Combine(fixture.Root, "Program.cs"),
+            "!!! this source must not compile !!!",
+            Encoding.UTF8);
+
+        await using var process = new GameProcessDriver();
+        var options = CreateOptions(
+            fixture,
+            GameLaunchTarget.Project(fixture.ProjectPath),
+            projectRunArguments: new[] { "--no-build", "--configuration", "Debug" });
+
+        process.Start(options);
+
+        var exitCode = await process.WaitForExitAsync(
+            TimeSpan.FromSeconds(30),
+            CancellationToken.None);
+
+        Assert.Equal(23, exitCode);
+        Assert.Contains("appdata=" + options.AppDataRoot, process.StandardOutput, StringComparison.Ordinal);
+        Assert.Contains("token=" + options.LaunchToken, process.StandardOutput, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Start_WhenProjectRunArgumentsSuppliedToExecutableTarget_ShouldReject()
+    {
+        using var fixture = CreateChildFixture();
+        var process = new GameProcessDriver();
+        var options = CreateOptions(
+            fixture,
+            GameLaunchTarget.Executable(GetBuiltAppHostPath(fixture.Root)),
+            projectRunArguments: new[] { "--no-build" });
+
+        var exception = Assert.Throws<ArgumentException>(() => process.Start(options));
+
+        Assert.Contains("ProjectRunArguments", exception.Message, StringComparison.Ordinal);
+        Assert.Null(process.ProcessId);
+    }
+
+    [Fact(Timeout = 60_000)]
     public async Task Start_WhenCalledTwice_ShouldRejectDuplicateOwnership()
     {
         using var fixture = CreateChildFixture();
@@ -383,14 +426,16 @@ public sealed class GameProcessDriverTests
     private static GameProcessStartOptions CreateOptions(
         ChildFixture fixture,
         GameLaunchTarget target,
-        IReadOnlyDictionary<string, string?>? environmentOverrides = null)
+        IReadOnlyDictionary<string, string?>? environmentOverrides = null,
+        IReadOnlyList<string>? projectRunArguments = null)
     {
         return new GameProcessStartOptions(
             fixture.Root,
             target,
             Path.Combine(fixture.Root, "appdata"),
             "automation-token-123",
-            environmentOverrides);
+            environmentOverrides,
+            projectRunArguments);
     }
 
     private static ChildFixture CreateChildFixture()

--- a/DTXMania.Automation/Process/GameProcessDriver.cs
+++ b/DTXMania.Automation/Process/GameProcessDriver.cs
@@ -62,6 +62,7 @@ public sealed class GameProcessDriver : IAsyncDisposable
             throw new InvalidOperationException("Game process has already been started.");
 
         ValidateEnvironmentOverrides(options.EnvironmentOverrides);
+        ValidateProjectRunArguments(options);
 
         var startInfo = new ProcessStartInfo
         {
@@ -78,6 +79,13 @@ public sealed class GameProcessDriver : IAsyncDisposable
             startInfo.ArgumentList.Add("run");
             startInfo.ArgumentList.Add("--project");
             startInfo.ArgumentList.Add(options.Target.Path);
+            if (options.ProjectRunArguments is not null)
+            {
+                foreach (var argument in options.ProjectRunArguments)
+                {
+                    startInfo.ArgumentList.Add(argument);
+                }
+            }
         }
         else
         {
@@ -361,6 +369,17 @@ public sealed class GameProcessDriver : IAsyncDisposable
     private static string Format(string? value)
     {
         return value ?? "<null>";
+    }
+
+    private static void ValidateProjectRunArguments(GameProcessStartOptions options)
+    {
+        if (options.Target.Kind != GameLaunchKind.Project
+            && options.ProjectRunArguments is { Count: > 0 })
+        {
+            throw new ArgumentException(
+                "Project run arguments are only valid for project targets.",
+                nameof(options.ProjectRunArguments));
+        }
     }
 
     private static void ValidateEnvironmentOverrides(

--- a/DTXMania.Automation/Process/GameProcessStartOptions.cs
+++ b/DTXMania.Automation/Process/GameProcessStartOptions.cs
@@ -5,4 +5,5 @@ public sealed record GameProcessStartOptions(
     GameLaunchTarget Target,
     string AppDataRoot,
     string LaunchToken,
-    IReadOnlyDictionary<string, string?>? EnvironmentOverrides = null);
+    IReadOnlyDictionary<string, string?>? EnvironmentOverrides = null,
+    IReadOnlyList<string>? ProjectRunArguments = null);

--- a/DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj
+++ b/DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -8,9 +8,10 @@ namespace DTXMania.VideoRecorder.Tests.Diagnostics;
 public sealed class RecorderPlatformPreflightTests
 {
     [Fact]
-    public void Evaluate_WindowsFacts_ReportsCommonProjectGateOnly()
+    public void Evaluate_WindowsFactsWithDebugOutput_ReportsProjectAndDebugOutputGates()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Windows);
+        WriteWindowsApphost(repo, GameProjectPaths.Windows);
         try
         {
             var result = RecorderPlatformPreflight.Evaluate(
@@ -18,11 +19,12 @@ public sealed class RecorderPlatformPreflightTests
                 CreateTarget(repo, GameProjectPaths.Windows));
 
             Assert.True(result.Passed);
-            // Windows keeps the common project-existence gate but adds no
-            // native-runtime/version/architecture gates.
-            var gate = Assert.Single(result.Gates);
-            Assert.Equal("Game project exists", gate.Name);
-            Assert.True(gate.Passed);
+            // Windows keeps the common project-existence gate and adds the
+            // Debug output gate, but no native-runtime/version/architecture
+            // gates.
+            Assert.Equal(2, result.Gates.Count);
+            Assert.True(result.Gates.Single(g => g.Name == "Game project exists").Passed);
+            Assert.True(result.Gates.Single(g => g.Name == "Debug output").Passed);
             Assert.Null(result.MacRuntimeDirectory);
         }
         finally
@@ -32,11 +34,47 @@ public sealed class RecorderPlatformPreflightTests
     }
 
     [Fact]
-    public void Evaluate_WindowsFactsWithMissingProject_FailsProjectGate()
+    public void Evaluate_WindowsFactsWithoutDebugOutput_FailsDebugOutputGateWithRecoveryCommand()
+    {
+        // Regression: CreateOptions applies --no-build --configuration Debug
+        // to Windows as well, so dotnet run --no-build executes the native
+        // apphost (DTXMania.Game.Windows.exe) from bin/Debug/net8.0-windows.
+        // A clean Windows checkout has the project but no bin/Debug output;
+        // preflight must reject it on the "Debug output" gate BEFORE the
+        // recorder sandbox is created, with the Windows recovery command.
+        // Without this gate, preflight would pass, the sandbox would be
+        // created, and dotnet run --no-build would fail post-sandbox — the
+        // exact ordering problem preflight exists to prevent.
+        var repo = CreateFakeRepo(GameProjectPaths.Windows);
+        try
+        {
+            var result = RecorderPlatformPreflight.Evaluate(
+                Facts(isWindows: true, isMacOS: false, new Version(10, 0, 22621), Architecture.X64),
+                CreateTarget(repo, GameProjectPaths.Windows));
+
+            Assert.False(result.Passed);
+            var debugGate = FailedGate(result, "Debug output");
+            Assert.Contains(RecorderPlatformPreflight.WindowsRuntimeRecoveryCommand, debugGate.Detail);
+            // The common project-existence gate still passes, isolating the
+            // failure to the Debug output gate.
+            Assert.True(result.Gates.Single(g => g.Name == "Game project exists").Passed);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_WindowsFactsWithMissingProject_FailsProjectAndTargetFrameworkGates()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Windows);
         // Remove the project file so the common existence gate fails even on
-        // Windows, where the old early-return skipped all validation.
+        // Windows, where the old early-return skipped all validation. With the
+        // project missing, <TargetFramework> is also unreadable, so the
+        // Windows "Target framework" gate fails alongside it (the Debug
+        // output gate is deliberately not evaluated so a stale bin/Debug
+        // directory cannot satisfy preflight when the project is gone).
         File.Delete(Resolve(repo, GameProjectPaths.Windows));
         try
         {
@@ -45,9 +83,15 @@ public sealed class RecorderPlatformPreflightTests
                 CreateTarget(repo, GameProjectPaths.Windows));
 
             Assert.False(result.Passed);
-            var gate = Assert.Single(result.Gates);
-            Assert.Equal("Game project exists", gate.Name);
-            Assert.False(gate.Passed);
+            Assert.Equal(2, result.Gates.Count);
+            var projectGate = result.Gates.Single(g => g.Name == "Game project exists");
+            Assert.False(projectGate.Passed);
+            var tfmGate = result.Gates.Single(g => g.Name == "Target framework");
+            Assert.False(tfmGate.Passed);
+            // The Debug output gate must be absent (not merely failing) so a
+            // stale bin/Debug directory cannot green-light preflight when the
+            // project file is missing.
+            Assert.DoesNotContain(result.Gates, g => g.Name == "Debug output");
         }
         finally
         {
@@ -408,13 +452,17 @@ public sealed class RecorderPlatformPreflightTests
     {
         var projectPath = Resolve(root, relativeProjectPath);
         Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
-        // The fake project carries the same TargetFramework the real Mac
-        // project does, so the TFM-pinned Debug output resolver exercises the
-        // production path rather than the unreadable-project fallback.
+        // The fake project carries the same TargetFramework the real project
+        // does (net8.0-windows for Windows, net8.0 for Mac), so the
+        // TFM-pinned Debug output resolver exercises the production path
+        // rather than the unreadable-project fallback.
+        var targetFramework = relativeProjectPath == GameProjectPaths.Windows
+            ? "net8.0-windows"
+            : "net8.0";
         File.WriteAllText(
             projectPath,
             "<Project Sdk=\"Microsoft.NET.Sdk\">"
-                + "<PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>"
+                + $"<PropertyGroup><TargetFramework>{targetFramework}</TargetFramework></PropertyGroup>"
                 + "</Project>");
     }
 
@@ -435,6 +483,22 @@ public sealed class RecorderPlatformPreflightTests
         var debugDir = Path.Combine(
             Path.GetDirectoryName(projectPath)!, "bin", "Debug", "net8.0");
         WriteExecutableFile(Path.Combine(debugDir, assemblyName));
+    }
+
+    private static void WriteWindowsApphost(string repo, string relativeProjectPath)
+    {
+        // dotnet run --no-build on a net8.0-windows WinExe with
+        // UseAppHost=true executes the native apphost (named after the
+        // assembly with a .exe extension on Windows). Tests stage the apphost
+        // in the TFM-pinned bin/Debug/net8.0-windows directory — the artifact
+        // the Windows "Debug output" gate certifies. On Unix test hosts the
+        // executable bit is set so IsExecutable (which keys off the host OS,
+        // not the synthetic facts) treats it as usable.
+        var projectPath = Resolve(repo, relativeProjectPath);
+        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+        var debugDir = Path.Combine(
+            Path.GetDirectoryName(projectPath)!, "bin", "Debug", "net8.0-windows");
+        WriteExecutableFile(Path.Combine(debugDir, assemblyName + ".exe"));
     }
 
     private static void WriteNonExecutableApphost(string repo, string relativeProjectPath)

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -202,7 +202,7 @@ public sealed class RecorderPlatformPreflightTests
     public void Evaluate_MacOs13Arm64WithExecutablePair_Passes()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Mac);
-        WriteManagedAssembly(repo, GameProjectPaths.Mac);
+        WriteApphost(repo, GameProjectPaths.Mac);
         WriteRuntimeBinary(repo, "ffmpeg", executable: true);
         WriteRuntimeBinary(repo, "ffprobe", executable: true);
         try
@@ -212,6 +212,69 @@ public sealed class RecorderPlatformPreflightTests
             Assert.True(result.Passed);
             Assert.All(result.Gates, gate => Assert.True(gate.Passed));
             Assert.Equal(RuntimeDirectory(repo), result.MacRuntimeDirectory);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithManagedDllButNoApphost_FailsDebugOutputGate()
+    {
+        // Regression: the Mac project is a net8.0 WinExe with the SDK default
+        // UseAppHost=true, so dotnet run --no-build executes the native
+        // apphost (DTXMania.Game.Mac, no extension), not the managed DLL.
+        // A previous version of the "Debug output" gate checked only the
+        // managed DLL, so a missing/non-executable apphost would pass
+        // preflight, create the sandbox, and then fail at process launch —
+        // the exact ordering problem preflight exists to prevent. This test
+        // stages the DLL + bundled ffmpeg/ffprobe but NO apphost and asserts
+        // preflight fails on the "Debug output" gate.
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteManagedAssembly(repo, GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.False(result.Passed);
+            var debugGate = FailedGate(result, "Debug output");
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, debugGate.Detail);
+            // The bundled runtime gates pass, isolating the failure to the
+            // apphost-only "Debug output" gate.
+            var ffmpegGate = Assert.Single(result.Gates, g => g.Name == "Bundled ffmpeg");
+            Assert.True(ffmpegGate.Passed);
+            var ffprobeGate = Assert.Single(result.Gates, g => g.Name == "Bundled ffprobe");
+            Assert.True(ffprobeGate.Passed);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [SkippableFact]
+    public void Evaluate_MacOs13Arm64WithNonExecutableApphost_FailsDebugOutputGate()
+    {
+        // The apphost exists but is not executable. dotnet run --no-build
+        // would fail to launch it, so preflight must reject it the same way
+        // it rejects a non-executable ffmpeg/ffprobe.
+        Skip.IfNot(UnixFileModeSupported, "Unix file mode is not representable on this host.");
+
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteManagedAssembly(repo, GameProjectPaths.Mac);
+        WriteNonExecutableApphost(repo, GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.False(result.Passed);
+            var debugGate = FailedGate(result, "Debug output");
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, debugGate.Detail);
         }
         finally
         {
@@ -253,7 +316,7 @@ public sealed class RecorderPlatformPreflightTests
     public void Evaluate_MacOs13Arm64WithUnreadableTargetFramework_FailsTargetFrameworkGateBeforeRuntimeGates()
     {
         // Project file exists but carries no readable <TargetFramework>, while
-        // a stale bin/Debug/net8.0 build output (managed assembly + bundled
+        // a stale bin/Debug/net8.0 build output (apphost + bundled
         // ffmpeg/ffprobe) is present. The net8.0 fallback must NOT let the
         // runtime/output gates pass: preflight fails on a dedicated
         // "Target framework" gate, and the runtime/output gates are not
@@ -261,7 +324,7 @@ public sealed class RecorderPlatformPreflightTests
         // when the current project's TFM is unreadable.
         var repo = CreateFakeRepo(GameProjectPaths.Mac);
         OverwriteProjectWithoutTargetFramework(repo, GameProjectPaths.Mac);
-        WriteManagedAssembly(repo, GameProjectPaths.Mac);
+        WriteApphost(repo, GameProjectPaths.Mac);
         WriteRuntimeBinary(repo, "ffmpeg", executable: true);
         WriteRuntimeBinary(repo, "ffprobe", executable: true);
         try
@@ -335,7 +398,7 @@ public sealed class RecorderPlatformPreflightTests
     private static string CreateMacRuntimeRepo()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Mac);
-        WriteManagedAssembly(repo, GameProjectPaths.Mac);
+        WriteApphost(repo, GameProjectPaths.Mac);
         WriteRuntimeBinary(repo, "ffmpeg", executable: true);
         WriteRuntimeBinary(repo, "ffprobe", executable: true);
         return repo;
@@ -360,6 +423,34 @@ public sealed class RecorderPlatformPreflightTests
 
     private static string RuntimeDirectory(string repo)
         => Path.Combine(repo, "DTXMania.Game", "bin", "Debug", "net8.0", "runtimes", "osx-arm64", "MMTools");
+
+    private static void WriteApphost(string repo, string relativeProjectPath)
+    {
+        // dotnet run --no-build on a net8.0 WinExe with UseAppHost=true
+        // executes the native apphost (named after the assembly, no extension
+        // on macOS), not the managed DLL. Tests must therefore stage the
+        // apphost — the artifact the "Debug output" gate certifies.
+        var projectPath = Resolve(repo, relativeProjectPath);
+        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+        var debugDir = Path.Combine(
+            Path.GetDirectoryName(projectPath)!, "bin", "Debug", "net8.0");
+        WriteExecutableFile(Path.Combine(debugDir, assemblyName));
+    }
+
+    private static void WriteNonExecutableApphost(string repo, string relativeProjectPath)
+    {
+        var projectPath = Resolve(repo, relativeProjectPath);
+        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+        var debugDir = Path.Combine(
+            Path.GetDirectoryName(projectPath)!, "bin", "Debug", "net8.0");
+        var path = Path.Combine(debugDir, assemblyName);
+        Directory.CreateDirectory(debugDir);
+        File.WriteAllText(path, "stub");
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
 
     private static void WriteManagedAssembly(string repo, string relativeProjectPath)
     {

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -28,6 +28,28 @@ public sealed class RecorderPlatformPreflightTests
     }
 
     [Fact]
+    public void Evaluate_UnsupportedPlatformFacts_FailsPlatformGateOnly()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        try
+        {
+            var result = RecorderPlatformPreflight.Evaluate(
+                Facts(isWindows: false, isMacOS: false, new Version(0, 0), Architecture.X64),
+                CreateTarget(repo, GameProjectPaths.Mac));
+
+            Assert.False(result.Passed);
+            Assert.Null(result.NativeRuntimeDirectory);
+            var gate = Assert.Single(result.Gates);
+            Assert.False(gate.Passed);
+            Assert.Contains("Windows and macOS only", gate.Detail);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
     public void Evaluate_MacOs12Arm64_FailsVersionGate()
     {
         var repo = CreateMacRuntimeRepo();
@@ -93,7 +115,8 @@ public sealed class RecorderPlatformPreflightTests
 
             var gate = FailedGate(result, "Bundled ffmpeg");
             Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, gate.Detail);
-            Assert.All(result.Gates.Where(g => g.Name == "Bundled ffprobe"), g => Assert.True(g.Passed));
+            var ffprobeGate = Assert.Single(result.Gates, g => g.Name == "Bundled ffprobe");
+            Assert.True(ffprobeGate.Passed);
         }
         finally
         {
@@ -112,7 +135,8 @@ public sealed class RecorderPlatformPreflightTests
 
             var gate = FailedGate(result, "Bundled ffprobe");
             Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, gate.Detail);
-            Assert.All(result.Gates.Where(g => g.Name == "Bundled ffmpeg"), g => Assert.True(g.Passed));
+            var ffmpegGate = Assert.Single(result.Gates, g => g.Name == "Bundled ffmpeg");
+            Assert.True(ffmpegGate.Passed);
         }
         finally
         {
@@ -120,11 +144,10 @@ public sealed class RecorderPlatformPreflightTests
         }
     }
 
-    [Fact]
+    [SkippableFact]
     public void Evaluate_MacOs13Arm64WithNonExecutablePair_FailsRuntimeGates()
     {
-        if (!UnixFileModeSupported)
-            return; // exec bit not representable on this host; pass-case covers the fallback
+        Skip.IfNot(UnixFileModeSupported, "Unix file mode is not representable on this host.");
 
         var repo = CreateFakeRepo(GameProjectPaths.Mac);
         WriteRuntimeBinary(repo, "ffmpeg", executable: false);

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -1,0 +1,250 @@
+using System.Runtime.InteropServices;
+using DTXMania.Automation.Process;
+using DTXMania.VideoRecorder.Diagnostics;
+using DTXMania.VideoRecorder.Workflow;
+
+namespace DTXMania.VideoRecorder.Tests.Diagnostics;
+
+public sealed class RecorderPlatformPreflightTests
+{
+    [Fact]
+    public void Evaluate_WindowsFacts_AddNoPlatformOrRuntimeGates()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Windows);
+        try
+        {
+            var result = RecorderPlatformPreflight.Evaluate(
+                Facts(isWindows: true, isMacOS: false, new Version(10, 0, 22621), Architecture.X64),
+                CreateTarget(repo, GameProjectPaths.Windows));
+
+            Assert.True(result.Passed);
+            Assert.Empty(result.Gates);
+            Assert.Null(result.NativeRuntimeDirectory);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs12Arm64_FailsVersionGate()
+    {
+        var repo = CreateMacRuntimeRepo();
+        try
+        {
+            var result = EvaluateMac(repo, new Version(12, 0), Architecture.Arm64);
+
+            var gate = FailedGate(result, "macOS >= 13");
+            Assert.Contains("macOS 12", gate.Detail);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13X64_FailsArchitectureGate()
+    {
+        var repo = CreateMacRuntimeRepo();
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.X64);
+
+            var gate = FailedGate(result, "Apple Silicon (arm64)");
+            Assert.Contains("X64", gate.Detail);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithWrongProject_FailsTargetGate()
+    {
+        var repo = CreateMacRuntimeRepo();
+        WriteProject(repo, GameProjectPaths.Windows);
+        try
+        {
+            var result = RecorderPlatformPreflight.Evaluate(
+                Facts(isWindows: false, isMacOS: true, new Version(13, 0), Architecture.Arm64),
+                CreateTarget(repo, GameProjectPaths.Windows));
+
+            Assert.False(result.Passed);
+            var gate = FailedGate(result, "Mac game project");
+            Assert.Contains("DTXMania.Game.Windows.csproj", gate.Detail);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithoutFfmpeg_FailsRuntimeGateWithRecoveryCommand()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            var gate = FailedGate(result, "Bundled ffmpeg");
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, gate.Detail);
+            Assert.All(result.Gates.Where(g => g.Name == "Bundled ffprobe"), g => Assert.True(g.Passed));
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithoutFfprobe_FailsRuntimeGateWithRecoveryCommand()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            var gate = FailedGate(result, "Bundled ffprobe");
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, gate.Detail);
+            Assert.All(result.Gates.Where(g => g.Name == "Bundled ffmpeg"), g => Assert.True(g.Passed));
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithNonExecutablePair_FailsRuntimeGates()
+    {
+        if (!UnixFileModeSupported)
+            return; // exec bit not representable on this host; pass-case covers the fallback
+
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: false);
+        WriteRuntimeBinary(repo, "ffprobe", executable: false);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.False(result.Passed);
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand,
+                FailedGate(result, "Bundled ffmpeg").Detail);
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand,
+                FailedGate(result, "Bundled ffprobe").Detail);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithExecutablePair_Passes()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.True(result.Passed);
+            Assert.All(result.Gates, gate => Assert.True(gate.Passed));
+            Assert.Equal(RuntimeDirectory(repo), result.NativeRuntimeDirectory);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    private static RecorderPlatformPreflightResult EvaluateMac(
+        string repo,
+        Version osVersion,
+        Architecture architecture)
+        => RecorderPlatformPreflight.Evaluate(
+            Facts(isWindows: false, isMacOS: true, osVersion, architecture),
+            CreateTarget(repo, GameProjectPaths.Mac));
+
+    private static RecorderPlatformFacts Facts(
+        bool isWindows,
+        bool isMacOS,
+        Version osVersion,
+        Architecture architecture)
+        => new(isWindows, isMacOS, osVersion, architecture);
+
+    private static ResolvedRecorderTarget CreateTarget(string repo, string relativeProjectPath)
+        => new(repo, repo, GameLaunchTarget.Project(Resolve(repo, relativeProjectPath)));
+
+    private static string CreateFakeRepo(string relativeProjectPath)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-video-preflight-repo",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "DTXMania.sln"), string.Empty);
+        WriteProject(root, relativeProjectPath);
+        return root;
+    }
+
+    private static string CreateMacRuntimeRepo()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        return repo;
+    }
+
+    private static void WriteProject(string root, string relativeProjectPath)
+    {
+        var projectPath = Resolve(root, relativeProjectPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+    }
+
+    private static string Resolve(string root, string relativeProjectPath)
+        => Path.Combine(new[] { root }.Concat(relativeProjectPath.Split('/')).ToArray());
+
+    private static string RuntimeDirectory(string repo)
+        => Path.Combine(repo, "DTXMania.Game", "bin", "Debug", "net8.0", "runtimes", "osx-arm64", "MMTools");
+
+    private static void WriteRuntimeBinary(string repo, string name, bool executable)
+    {
+        var directory = RuntimeDirectory(repo);
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, name);
+        File.WriteAllText(path, "stub");
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            File.SetUnixFileMode(
+                path,
+                executable
+                    ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+                    : UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
+    private static bool UnixFileModeSupported =>
+        OperatingSystem.IsLinux() || OperatingSystem.IsMacOS();
+
+    private static RecorderPreflightGate FailedGate(RecorderPlatformPreflightResult result, string name)
+    {
+        var gate = Assert.Single(result.Gates, g => g.Name == name);
+        Assert.False(gate.Passed);
+        return gate;
+    }
+
+    private static void Delete(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+}

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -249,6 +249,59 @@ public sealed class RecorderPlatformPreflightTests
         }
     }
 
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithUnreadableTargetFramework_FailsTargetFrameworkGateBeforeRuntimeGates()
+    {
+        // Project file exists but carries no readable <TargetFramework>, while
+        // a stale bin/Debug/net8.0 build output (managed assembly + bundled
+        // ffmpeg/ffprobe) is present. The net8.0 fallback must NOT let the
+        // runtime/output gates pass: preflight fails on a dedicated
+        // "Target framework" gate, and the runtime/output gates are not
+        // evaluated, so a stale net8.0 directory cannot satisfy preflight
+        // when the current project's TFM is unreadable.
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        OverwriteProjectWithoutTargetFramework(repo, GameProjectPaths.Mac);
+        WriteManagedAssembly(repo, GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.False(result.Passed);
+
+            var tfmGate = FailedGate(result, "Target framework");
+            Assert.Contains(GameProjectPaths.Mac, tfmGate.Detail);
+            Assert.Contains("net8.0", tfmGate.Detail);
+
+            // The runtime/output gates must be absent (not merely failing) so
+            // a stale net8.0 directory cannot green-light preflight.
+            Assert.DoesNotContain(result.Gates, gate => gate.Name == "Debug output");
+            Assert.DoesNotContain(result.Gates, gate => gate.Name == "Bundled ffmpeg");
+            Assert.DoesNotContain(result.Gates, gate => gate.Name == "Bundled ffprobe");
+
+            // The fallback directory is still surfaced for diagnostics.
+            Assert.Contains("net8.0", result.MacRuntimeDirectory!);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    private static void OverwriteProjectWithoutTargetFramework(string root, string relativeProjectPath)
+    {
+        var projectPath = Resolve(root, relativeProjectPath);
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        // Project file with no <TargetFramework> element so ReadTargetFramework
+        // returns null and the fallback path is exercised.
+        File.WriteAllText(
+            projectPath,
+            "<Project Sdk=\"Microsoft.NET.Sdk\">"
+                + "<PropertyGroup><AssemblyName>DTXMania.Game.Mac</AssemblyName></PropertyGroup>"
+                + "</Project>");
+    }
+
     private static RecorderPlatformPreflightResult EvaluateMac(
         string repo,
         Version osVersion,

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -8,7 +8,7 @@ namespace DTXMania.VideoRecorder.Tests.Diagnostics;
 public sealed class RecorderPlatformPreflightTests
 {
     [Fact]
-    public void Evaluate_WindowsFacts_AddNoPlatformOrRuntimeGates()
+    public void Evaluate_WindowsFacts_ReportsCommonProjectGateOnly()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Windows);
         try
@@ -18,8 +18,36 @@ public sealed class RecorderPlatformPreflightTests
                 CreateTarget(repo, GameProjectPaths.Windows));
 
             Assert.True(result.Passed);
-            Assert.Empty(result.Gates);
-            Assert.Null(result.NativeRuntimeDirectory);
+            // Windows keeps the common project-existence gate but adds no
+            // native-runtime/version/architecture gates.
+            var gate = Assert.Single(result.Gates);
+            Assert.Equal("Game project exists", gate.Name);
+            Assert.True(gate.Passed);
+            Assert.Null(result.MacRuntimeDirectory);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_WindowsFactsWithMissingProject_FailsProjectGate()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Windows);
+        // Remove the project file so the common existence gate fails even on
+        // Windows, where the old early-return skipped all validation.
+        File.Delete(Resolve(repo, GameProjectPaths.Windows));
+        try
+        {
+            var result = RecorderPlatformPreflight.Evaluate(
+                Facts(isWindows: true, isMacOS: false, new Version(10, 0, 22621), Architecture.X64),
+                CreateTarget(repo, GameProjectPaths.Windows));
+
+            Assert.False(result.Passed);
+            var gate = Assert.Single(result.Gates);
+            Assert.Equal("Game project exists", gate.Name);
+            Assert.False(gate.Passed);
         }
         finally
         {
@@ -38,9 +66,11 @@ public sealed class RecorderPlatformPreflightTests
                 CreateTarget(repo, GameProjectPaths.Mac));
 
             Assert.False(result.Passed);
-            Assert.Null(result.NativeRuntimeDirectory);
-            var gate = Assert.Single(result.Gates);
-            Assert.False(gate.Passed);
+            Assert.Null(result.MacRuntimeDirectory);
+            // The common project-existence gate is present (and passes here
+            // because the fake repo wrote the project), but the platform gate
+            // is the one that rejects an unsupported host.
+            var gate = FailedGate(result, "Platform");
             Assert.Contains("Windows and macOS only", gate.Detail);
         }
         finally
@@ -172,6 +202,7 @@ public sealed class RecorderPlatformPreflightTests
     public void Evaluate_MacOs13Arm64WithExecutablePair_Passes()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteManagedAssembly(repo, GameProjectPaths.Mac);
         WriteRuntimeBinary(repo, "ffmpeg", executable: true);
         WriteRuntimeBinary(repo, "ffprobe", executable: true);
         try
@@ -180,7 +211,37 @@ public sealed class RecorderPlatformPreflightTests
 
             Assert.True(result.Passed);
             Assert.All(result.Gates, gate => Assert.True(gate.Passed));
-            Assert.Equal(RuntimeDirectory(repo), result.NativeRuntimeDirectory);
+            Assert.Equal(RuntimeDirectory(repo), result.MacRuntimeDirectory);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void Evaluate_MacOs13Arm64WithStaleTfmRuntimeOnly_FailsDebugOutputGate()
+    {
+        // Project targets net8.0, but only a stale previous-TFM runtime exists.
+        // The old enumerator-based resolution would accept the stale runtime;
+        // the TFM-pinned resolver must reject it because the current Debug
+        // output directory has no build output.
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        var staleRuntime = Path.Combine(
+            repo, "DTXMania.Game", "bin", "Debug", "net7.0", "runtimes", "osx-arm64", "MMTools");
+        WriteExecutableFile(Path.Combine(staleRuntime, "ffmpeg"));
+        WriteExecutableFile(Path.Combine(staleRuntime, "ffprobe"));
+        try
+        {
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.False(result.Passed);
+            var debugGate = FailedGate(result, "Debug output");
+            Assert.Contains("net8.0", debugGate.Detail);
+            // The resolved runtime directory must follow the current TFM, not
+            // the stale one, so a stale net7.0 runtime cannot satisfy gates.
+            Assert.Contains("net8.0", result.MacRuntimeDirectory!);
+            Assert.DoesNotContain("net7.0", result.MacRuntimeDirectory!);
         }
         finally
         {
@@ -221,6 +282,7 @@ public sealed class RecorderPlatformPreflightTests
     private static string CreateMacRuntimeRepo()
     {
         var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteManagedAssembly(repo, GameProjectPaths.Mac);
         WriteRuntimeBinary(repo, "ffmpeg", executable: true);
         WriteRuntimeBinary(repo, "ffprobe", executable: true);
         return repo;
@@ -230,7 +292,14 @@ public sealed class RecorderPlatformPreflightTests
     {
         var projectPath = Resolve(root, relativeProjectPath);
         Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
-        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        // The fake project carries the same TargetFramework the real Mac
+        // project does, so the TFM-pinned Debug output resolver exercises the
+        // production path rather than the unreadable-project fallback.
+        File.WriteAllText(
+            projectPath,
+            "<Project Sdk=\"Microsoft.NET.Sdk\">"
+                + "<PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>"
+                + "</Project>");
     }
 
     private static string Resolve(string root, string relativeProjectPath)
@@ -239,20 +308,41 @@ public sealed class RecorderPlatformPreflightTests
     private static string RuntimeDirectory(string repo)
         => Path.Combine(repo, "DTXMania.Game", "bin", "Debug", "net8.0", "runtimes", "osx-arm64", "MMTools");
 
+    private static void WriteManagedAssembly(string repo, string relativeProjectPath)
+    {
+        var projectPath = Resolve(repo, relativeProjectPath);
+        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+        var debugDir = Path.Combine(
+            Path.GetDirectoryName(projectPath)!, "bin", "Debug", "net8.0");
+        Directory.CreateDirectory(debugDir);
+        File.WriteAllText(Path.Combine(debugDir, assemblyName + ".dll"), "stub");
+    }
+
     private static void WriteRuntimeBinary(string repo, string name, bool executable)
     {
-        var directory = RuntimeDirectory(repo);
-        Directory.CreateDirectory(directory);
-        var path = Path.Combine(directory, name);
+        var path = Path.Combine(RuntimeDirectory(repo), name);
+        if (executable)
+        {
+            WriteExecutableFile(path);
+            return;
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         File.WriteAllText(path, "stub");
         if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
-        {
             File.SetUnixFileMode(
                 path,
-                executable
-                    ? UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
-                    : UnixFileMode.UserRead | UnixFileMode.UserWrite);
-        }
+                UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    private static void WriteExecutableFile(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "stub");
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
     private static bool UnixFileModeSupported =>

--- a/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
@@ -396,6 +396,76 @@ public sealed class RecorderPlatformPreflightTests
         }
     }
 
+    [SkippableFact]
+    public void Evaluate_MacOs13Arm64WithPermissionDeniedProject_FailsTargetFrameworkGateBeforeRuntimeGates()
+    {
+        // Regression: File.ReadAllText throws UnauthorizedAccessException (not
+        // IOException) when the project file exists but is unreadable due to
+        // file permissions. ReadTargetFramework must catch it and return null
+        // so Evaluate reports a failed "Target framework" gate rather than
+        // propagating the exception and crashing preflight after the sandbox
+        // is created. Stages a valid <TargetFramework> plus a stale net8.0
+        // build output (apphost + bundled ffmpeg/ffprobe) so the only thing
+        // preventing TFM resolution is the permission denial.
+        Skip.IfNot(UnixFileModeSupported, "Unix file mode is not representable on this host.");
+
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        WriteApphost(repo, GameProjectPaths.Mac);
+        WriteRuntimeBinary(repo, "ffmpeg", executable: true);
+        WriteRuntimeBinary(repo, "ffprobe", executable: true);
+        var projectPath = Resolve(repo, GameProjectPaths.Mac);
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            File.SetUnixFileMode(projectPath, UnixFileMode.None);
+        try
+        {
+            // If the test host can still read a 000-mode file (e.g. running
+            // as root), the permission-denied path is not exercisable here;
+            // skip rather than assert falsely.
+            Skip.If(CanReadDespiteModeNone(projectPath),
+                "Test host bypasses file read permissions (running as root).");
+
+            var result = EvaluateMac(repo, new Version(13, 0), Architecture.Arm64);
+
+            Assert.False(result.Passed);
+
+            var tfmGate = FailedGate(result, "Target framework");
+            Assert.Contains(GameProjectPaths.Mac, tfmGate.Detail);
+            Assert.Contains("net8.0", tfmGate.Detail);
+
+            // The runtime/output gates must be absent (not merely failing) so
+            // a stale net8.0 directory cannot green-light preflight when the
+            // current project's TFM is unreadable.
+            Assert.DoesNotContain(result.Gates, gate => gate.Name == "Debug output");
+            Assert.DoesNotContain(result.Gates, gate => gate.Name == "Bundled ffmpeg");
+            Assert.DoesNotContain(result.Gates, gate => gate.Name == "Bundled ffprobe");
+
+            // The fallback directory is still surfaced for diagnostics.
+            Assert.Contains("net8.0", result.MacRuntimeDirectory!);
+        }
+        finally
+        {
+            // Restore read/write so the shared Delete helper can remove the
+            // file even on hosts where unlink requires write permission on
+            // the file itself (defensive; POSIX only requires parent write).
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+                File.SetUnixFileMode(projectPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            Delete(repo);
+        }
+    }
+
+    private static bool CanReadDespiteModeNone(string path)
+    {
+        try
+        {
+            File.ReadAllText(path);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private static void OverwriteProjectWithoutTargetFramework(string root, string relativeProjectPath)
     {
         var projectPath = Resolve(root, relativeProjectPath);

--- a/DTXMania.VideoRecorder.Tests/ProgramTests.cs
+++ b/DTXMania.VideoRecorder.Tests/ProgramTests.cs
@@ -38,7 +38,7 @@ public sealed class ProgramTests
                         Detail: "'/missing/ffmpeg' not found. Build the bundled runtime: "
                             + RecorderPlatformPreflight.MacRuntimeRecoveryCommand)
                 },
-                NativeRuntimeDirectory: null);
+                MacRuntimeDirectory: null);
 
             // No OBS server is required for this call to complete: completing
             // without one is exactly the invariant under test.
@@ -117,7 +117,7 @@ public sealed class ProgramTests
                     GameLaunchTarget.Project(Path.Combine(repo, GameProjectPaths.Mac))));
 
             Assert.False(preflight.Passed);
-            Assert.Null(preflight.NativeRuntimeDirectory);
+            Assert.Null(preflight.MacRuntimeDirectory);
 
             using var writer = new StringWriter();
             var passed = Program.ReportPlatformPreflight(writer, facts, preflight);
@@ -179,16 +179,22 @@ public sealed class ProgramTests
         File.WriteAllText(Path.Combine(root, "DTXMania.sln"), string.Empty);
         var projectPath = Path.Combine(root, "DTXMania.Game", "DTXMania.Game.Mac.csproj");
         Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
-        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
-        var runtimeDirectory = Path.Combine(
+        File.WriteAllText(
+            projectPath,
+            "<Project Sdk=\"Microsoft.NET.Sdk\">"
+                + "<PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup>"
+                + "</Project>");
+        var debugOutputDirectory = Path.Combine(
             root,
             "DTXMania.Game",
             "bin",
             "Debug",
-            "net8.0",
-            "runtimes",
-            "osx-arm64",
-            "MMTools");
+            "net8.0");
+        Directory.CreateDirectory(debugOutputDirectory);
+        File.WriteAllText(
+            Path.Combine(debugOutputDirectory, "DTXMania.Game.Mac.dll"),
+            "stub");
+        var runtimeDirectory = Path.Combine(debugOutputDirectory, "runtimes", "osx-arm64", "MMTools");
         Directory.CreateDirectory(runtimeDirectory);
         foreach (var name in new[] { "ffmpeg", "ffprobe" })
         {

--- a/DTXMania.VideoRecorder.Tests/ProgramTests.cs
+++ b/DTXMania.VideoRecorder.Tests/ProgramTests.cs
@@ -191,9 +191,18 @@ public sealed class ProgramTests
             "Debug",
             "net8.0");
         Directory.CreateDirectory(debugOutputDirectory);
-        File.WriteAllText(
-            Path.Combine(debugOutputDirectory, "DTXMania.Game.Mac.dll"),
-            "stub");
+        // dotnet run --no-build on a net8.0 WinExe with UseAppHost=true
+        // executes the native apphost (no extension on macOS), not the DLL.
+        // Stage the apphost with the executable bit so the "Debug output"
+        // gate passes, matching a real Debug build's output.
+        var apphostPath = Path.Combine(debugOutputDirectory, "DTXMania.Game.Mac");
+        File.WriteAllText(apphostPath, "stub");
+        if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+        {
+            File.SetUnixFileMode(
+                apphostPath,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
         var runtimeDirectory = Path.Combine(debugOutputDirectory, "runtimes", "osx-arm64", "MMTools");
         Directory.CreateDirectory(runtimeDirectory);
         foreach (var name in new[] { "ffmpeg", "ffprobe" })

--- a/DTXMania.VideoRecorder.Tests/ProgramTests.cs
+++ b/DTXMania.VideoRecorder.Tests/ProgramTests.cs
@@ -1,0 +1,195 @@
+using System.Runtime.InteropServices;
+using DTXMania.Automation.Process;
+using DTXMania.VideoRecorder;
+using DTXMania.VideoRecorder.Configuration;
+using DTXMania.VideoRecorder.Diagnostics;
+using DTXMania.VideoRecorder.Workflow;
+
+namespace DTXMania.VideoRecorder.Tests;
+
+public sealed class ProgramTests
+{
+    [Fact]
+    public async Task RunRecordAsync_FailedPreflight_RejectsBeforeSandboxDiagnosticsOrObs()
+    {
+        var sourceRoot = CreateSandboxSourceRoot();
+        var outputDirectory = Path.Combine(sourceRoot, "out");
+        try
+        {
+            var command = new RecorderCommand(
+                RecorderVerb.Record,
+                Path.Combine(sourceRoot, "song.dtx"),
+                outputDirectory);
+            var environment = new RecorderEnvironment(
+                new Uri("ws://127.0.0.1:4455"),
+                string.Empty,
+                Path.Combine(sourceRoot, "raw"),
+                sourceRoot);
+            var target = new ResolvedRecorderTarget(
+                sourceRoot,
+                sourceRoot,
+                GameLaunchTarget.Project(Path.Combine(sourceRoot, "DTXMania.Game", "DTXMania.Game.Mac.csproj")));
+            var preflight = new RecorderPlatformPreflightResult(
+                new[]
+                {
+                    new RecorderPreflightGate(
+                        "Bundled ffmpeg",
+                        Passed: false,
+                        Detail: "'/missing/ffmpeg' not found. Build the bundled runtime: "
+                            + RecorderPlatformPreflight.MacRuntimeRecoveryCommand)
+                },
+                NativeRuntimeDirectory: null);
+
+            // No OBS server is required for this call to complete: completing
+            // without one is exactly the invariant under test.
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => Program.RunRecordAsync(command, environment, target, preflight));
+
+            Assert.Contains("Recorder platform preflight failed", exception.Message);
+            Assert.Contains("Bundled ffmpeg", exception.Message);
+            Assert.Contains(RecorderPlatformPreflight.MacRuntimeRecoveryCommand, exception.Message);
+            Assert.Empty(FindSandboxesSourcedFrom(sourceRoot));
+            Assert.False(Directory.Exists(Path.Combine(outputDirectory, "diagnostics")));
+        }
+        finally
+        {
+            Delete(sourceRoot);
+        }
+    }
+
+    [Fact]
+    public void ReportPlatformPreflight_MacFacts_ReportsMacGatesAndGuidanceWithoutWindowsGate()
+    {
+        var repo = CreateFakeMacRepo();
+        try
+        {
+            var facts = new RecorderPlatformFacts(
+                IsWindows: false,
+                IsMacOS: true,
+                OsVersion: new Version(14, 0),
+                ProcessArchitecture: Architecture.Arm64);
+            var preflight = RecorderPlatformPreflight.Evaluate(
+                facts,
+                new ResolvedRecorderTarget(
+                    repo,
+                    repo,
+                    GameLaunchTarget.Project(Path.Combine(repo, "DTXMania.Game", "DTXMania.Game.Mac.csproj"))));
+            Assert.True(preflight.Passed);
+
+            using var writer = new StringWriter();
+            var passed = Program.ReportPlatformPreflight(writer, facts, preflight);
+
+            Assert.True(passed);
+            var output = writer.ToString();
+            Assert.Contains("macOS >= 13: passed", output);
+            Assert.Contains("Bundled ffmpeg: passed", output);
+            Assert.DoesNotContain("Windows: ", output);
+            Assert.DoesNotContain("Windows-only", output);
+            Assert.Contains("ScreenCaptureKit application/window capture scoped to CX", output);
+            Assert.Contains("Desktop Audio disabled", output);
+            Assert.Contains("Microphone disabled", output);
+            Assert.Contains("Screen Recording permission granted manually", output);
+            Assert.Contains("Raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR", output);
+            Assert.DoesNotContain("CX window/program capture configured", output);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    /// <summary>
+    /// Identifies recorder sandboxes created from <paramref name="sourceRoot"/>
+    /// by the marker paths its copied Config.ini embeds. Unique per source root,
+    /// so parallel tests creating their own sandboxes never match here.
+    /// </summary>
+    private static string[] FindSandboxesSourcedFrom(string sourceRoot)
+    {
+        var sandboxHome = Path.Combine(Path.GetTempPath(), "DTXManiaCX-video");
+        if (!Directory.Exists(sandboxHome))
+            return Array.Empty<string>();
+
+        return Directory.GetDirectories(sandboxHome)
+            .Where(runRoot => SandboxConfigReferences(runRoot, sourceRoot))
+            .ToArray();
+    }
+
+    private static bool SandboxConfigReferences(string runRoot, string sourceRoot)
+    {
+        var configPath = Path.Combine(runRoot, "appdata", "Config.ini");
+        try
+        {
+            return File.Exists(configPath) &&
+                File.ReadAllText(configPath).Contains(sourceRoot, StringComparison.Ordinal);
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static string CreateFakeMacRepo()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-video-program-tests-repo",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "DTXMania.sln"), string.Empty);
+        var projectPath = Path.Combine(root, "DTXMania.Game", "DTXMania.Game.Mac.csproj");
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        var runtimeDirectory = Path.Combine(
+            root,
+            "DTXMania.Game",
+            "bin",
+            "Debug",
+            "net8.0",
+            "runtimes",
+            "osx-arm64",
+            "MMTools");
+        Directory.CreateDirectory(runtimeDirectory);
+        foreach (var name in new[] { "ffmpeg", "ffprobe" })
+        {
+            var path = Path.Combine(runtimeDirectory, name);
+            File.WriteAllText(path, "stub");
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            {
+                File.SetUnixFileMode(
+                    path,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+
+        return root;
+    }
+
+    private static string CreateSandboxSourceRoot()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-video-program-tests-source",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var songs = Path.Combine(root, "Songs");
+        File.WriteAllText(
+            Path.Combine(root, "Config.ini"),
+            string.Join(
+                '\n',
+                "SkinPath=Default",
+                "DTXPath=" + songs,
+                "SongRoot.0=" + songs,
+                "SystemSkinRoot=" + Path.Combine(root, "System")) + "\n");
+        return root;
+    }
+
+    private static void Delete(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+}

--- a/DTXMania.VideoRecorder.Tests/ProgramTests.cs
+++ b/DTXMania.VideoRecorder.Tests/ProgramTests.cs
@@ -98,6 +98,43 @@ public sealed class ProgramTests
         }
     }
 
+    [Fact]
+    public void ReportPlatformPreflight_UnsupportedPlatform_DoesNotEmitWindowsOrMacPrerequisites()
+    {
+        var repo = CreateFakeRepo(GameProjectPaths.Mac);
+        try
+        {
+            var facts = new RecorderPlatformFacts(
+                IsWindows: false,
+                IsMacOS: false,
+                OsVersion: new Version(0, 0),
+                ProcessArchitecture: Architecture.X64);
+            var preflight = RecorderPlatformPreflight.Evaluate(
+                facts,
+                new ResolvedRecorderTarget(
+                    repo,
+                    repo,
+                    GameLaunchTarget.Project(Path.Combine(repo, GameProjectPaths.Mac))));
+
+            Assert.False(preflight.Passed);
+            Assert.Null(preflight.NativeRuntimeDirectory);
+
+            using var writer = new StringWriter();
+            var passed = Program.ReportPlatformPreflight(writer, facts, preflight);
+
+            Assert.False(passed);
+            var output = writer.ToString();
+            Assert.Contains("Windows and macOS only", output);
+            Assert.DoesNotContain("CX window/program capture configured", output);
+            Assert.DoesNotContain("ScreenCaptureKit application/window capture scoped to CX", output);
+            Assert.Contains("Manual OBS prerequisites are unavailable on this platform", output);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
     /// <summary>
     /// Identifies recorder sandboxes created from <paramref name="sourceRoot"/>
     /// by the marker paths its copied Config.ini embeds. Unique per source root,
@@ -165,6 +202,21 @@ public sealed class ProgramTests
             }
         }
 
+        return root;
+    }
+
+    private static string CreateFakeRepo(string relativeProjectPath)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-video-program-tests-repo",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "DTXMania.sln"), string.Empty);
+        var projectPath = Path.Combine(
+            new[] { root }.Concat(relativeProjectPath.Split('/')).ToArray());
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
         return root;
     }
 

--- a/DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
+++ b/DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
@@ -116,12 +116,20 @@ public sealed class RecorderCommandLineTests
     public void ValidateRecord_NonLoopbackObsUrl_ShouldExpectFailure()
     {
         var environment = CreateEnvironment(obsUrl: "ws://192.168.0.5:4455");
-        var command = new RecorderCommand(RecorderVerb.Record, "/nonexistent/chart.dtx", CreateTempDirectory());
+        var outputDirectory = CreateTempDirectory();
+        var command = new RecorderCommand(RecorderVerb.Record, "/nonexistent/chart.dtx", outputDirectory);
 
-        var exception = Assert.Throws<InvalidOperationException>(
-            () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
 
-        Assert.Contains("loopback", exception.Message);
+            Assert.Contains("loopback", exception.Message);
+        }
+        finally
+        {
+            Delete(outputDirectory);
+        }
     }
 
     [Fact]

--- a/DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
+++ b/DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
@@ -1,0 +1,428 @@
+using DTXMania.VideoRecorder;
+using DTXMania.VideoRecorder.Configuration;
+
+namespace DTXMania.VideoRecorder.Tests;
+
+public sealed class RecorderCommandLineTests
+{
+    private const string ObsUrlEnvironmentVariable = "DTXMANIA_VIDEO_OBS_URL";
+    private const string ObsOutputEnvironmentVariable = "DTXMANIA_VIDEO_OBS_OUTPUT_DIR";
+    private const string AppDataEnvironmentVariable = "DTXMANIA_APPDATA_ROOT";
+
+    [Fact]
+    public void Parse_EmptyArgs_ShouldExpectUsageFailure()
+    {
+        Assert.Throws<ArgumentException>(() => RecorderCommandLine.Parse(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Parse_UnknownVerb_ShouldExpectFailure()
+    {
+        Assert.Throws<ArgumentException>(() => RecorderCommandLine.Parse(new[] { "frobnicate" }));
+    }
+
+    [Fact]
+    public void Parse_DoctorWithoutArguments_ShouldExpectDoctorVerb()
+    {
+        var command = RecorderCommandLine.Parse(new[] { "doctor" });
+
+        Assert.Equal(RecorderVerb.Doctor, command.Verb);
+    }
+
+    [Fact]
+    public void Parse_DoctorWithArguments_ShouldExpectFailure()
+    {
+        Assert.Throws<ArgumentException>(
+            () => RecorderCommandLine.Parse(new[] { "doctor", "--chart", "x" }));
+    }
+
+    [Fact]
+    public void Parse_RecordMissingChartAndOutput_ShouldExpectFailure()
+    {
+        Assert.Throws<ArgumentException>(
+            () => RecorderCommandLine.Parse(new[] { "record" }));
+    }
+
+    [Fact]
+    public void Parse_RecordMissingOutput_ShouldExpectFailure()
+    {
+        Assert.Throws<ArgumentException>(
+            () => RecorderCommandLine.Parse(new[] { "record", "--chart", "/tmp/chart.dtx" }));
+    }
+
+    [Fact]
+    public void Parse_RecordUnknownOption_ShouldExpectFailure()
+    {
+        Assert.Throws<ArgumentException>(
+            () => RecorderCommandLine.Parse(new[] { "record", "--verbose", "x", "--output", "/tmp/out" }));
+    }
+
+    [Fact]
+    public void Parse_RecordDuplicateChart_ShouldExpectFailure()
+    {
+        Assert.Throws<ArgumentException>(
+            () => RecorderCommandLine.Parse(new[] { "record", "--chart", "a", "--chart", "b", "--output", "/tmp/out" }));
+    }
+
+    [Fact]
+    public void Parse_RecordWithChartAndOutput_ShouldExpectRecordVerb()
+    {
+        var command = RecorderCommandLine.Parse(new[] { "record", "--chart", "/tmp/chart.dtx", "--output", "/tmp/out" });
+
+        Assert.Equal(RecorderVerb.Record, command.Verb);
+        Assert.Equal("/tmp/chart.dtx", command.ChartPath);
+        Assert.Equal("/tmp/out", command.OutputDirectory);
+    }
+
+    [Fact]
+    public void ReadEnvironment_AppDataRootOverride_ShouldExpectOverrideToWin()
+    {
+        var overrideRoot = CreateTempDirectory();
+
+        try
+        {
+            var environment = RecorderCommandLine.ReadEnvironment(
+                name => name == AppDataEnvironmentVariable ? overrideRoot : null,
+                requireOutputDirectory: false);
+
+            Assert.Equal(Path.GetFullPath(overrideRoot), environment.SourceAppDataRoot);
+            Assert.Equal(new Uri("ws://127.0.0.1:4455"), environment.ObsUrl);
+        }
+        finally
+        {
+            Delete(overrideRoot);
+        }
+    }
+
+    [Fact]
+    public void ReadEnvironment_RecordWithoutObsOutputDirectory_ShouldExpectFailure()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => RecorderCommandLine.ReadEnvironment(
+                _ => null,
+                requireOutputDirectory: true));
+    }
+
+    [Fact]
+    public void ReadEnvironment_NonWebSocketObsUrl_ShouldExpectFailure()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => RecorderCommandLine.ReadEnvironment(
+                name => name == ObsUrlEnvironmentVariable ? "http://127.0.0.1:4455" : null,
+                requireOutputDirectory: false));
+    }
+
+    [Fact]
+    public void ValidateRecord_NonLoopbackObsUrl_ShouldExpectFailure()
+    {
+        var environment = CreateEnvironment(obsUrl: "ws://192.168.0.5:4455");
+        var command = new RecorderCommand(RecorderVerb.Record, "/nonexistent/chart.dtx", CreateTempDirectory());
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
+
+        Assert.Contains("loopback", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateRecord_RelativeChartPath_ShouldExpectFailure()
+    {
+        var environment = CreateEnvironment();
+        var command = new RecorderCommand(RecorderVerb.Record, "chart.dtx", CreateTempDirectory());
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
+        }
+        finally
+        {
+            Delete(command.OutputDirectory!);
+        }
+    }
+
+    [Fact]
+    public void ValidateRecord_MissingChartFile_ShouldExpectFileNotFound()
+    {
+        var environment = CreateEnvironment();
+        var missingChart = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "missing.dtx");
+        var command = new RecorderCommand(RecorderVerb.Record, missingChart, CreateTempDirectory());
+
+        try
+        {
+            Assert.Throws<FileNotFoundException>(
+                () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
+        }
+        finally
+        {
+            Delete(command.OutputDirectory!);
+        }
+    }
+
+    [Fact]
+    public void ValidateRecord_PublishPathIsFile_ShouldExpectFailure()
+    {
+        var environment = CreateEnvironment();
+        var publishFile = Path.Combine(Path.GetTempPath(), $"dtx-video-test-{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(publishFile, "file");
+        var command = new RecorderCommand(RecorderVerb.Record, CreateChartFile(), publishFile);
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
+
+            Assert.Contains("file, not a directory", exception.Message);
+        }
+        finally
+        {
+            File.Delete(publishFile);
+            Delete(Path.GetDirectoryName(command.ChartPath!)!);
+        }
+    }
+
+    [Fact]
+    public void ValidateRecord_MissingObsOutputDirectory_ShouldExpectFailure()
+    {
+        var environment = CreateEnvironment(
+            obsOutputDirectory: Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var command = new RecorderCommand(RecorderVerb.Record, CreateChartFile(), CreateTempDirectory());
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => RecorderCommandLine.ValidateRecord(command, environment, isWindows: true, isMacOS: false));
+        }
+        finally
+        {
+            Delete(Path.GetDirectoryName(command.ChartPath!)!);
+            Delete(command.OutputDirectory!);
+        }
+    }
+
+    [Fact]
+    public void ValidateRecord_WindowsWithWritableDirectories_ShouldExpectSuccess()
+    {
+        using var fixture = RecordFixture.Create();
+
+        RecorderCommandLine.ValidateRecord(
+            fixture.Command,
+            fixture.Environment,
+            isWindows: true,
+            isMacOS: false);
+    }
+
+    [Fact]
+    public void ValidateRecord_MacOsWithWritableDirectories_ShouldExpectSuccess()
+    {
+        using var fixture = RecordFixture.Create();
+
+        RecorderCommandLine.ValidateRecord(
+            fixture.Command,
+            fixture.Environment,
+            isWindows: false,
+            isMacOS: true);
+    }
+
+    [Fact]
+    public void ValidateRecord_UnsupportedOs_ShouldExpectPlatformNotSupported()
+    {
+        using var fixture = RecordFixture.Create();
+
+        Assert.Throws<PlatformNotSupportedException>(
+            () => RecorderCommandLine.ValidateRecord(
+                fixture.Command,
+                fixture.Environment,
+                isWindows: false,
+                isMacOS: false));
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_Windows_ShouldExpectLocalApplicationData()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: true,
+            isMacOS: false,
+            getFolderPath: _ => "/win/local",
+            getEnvironmentVariable: _ => null);
+
+        Assert.Equal(Path.Combine("/win/local", "DTXManiaCX"), root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_WindowsUnusableBasePath_ShouldExpectHomeConfigFallback()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: true,
+            isMacOS: false,
+            getFolderPath: folder => folder == Environment.SpecialFolder.UserProfile ? "/win/home" : "relative",
+            getEnvironmentVariable: _ => null);
+
+        Assert.Equal(Path.Combine("/win/home", ".config", "DTXManiaCX"), root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_MacOsUserProfileAvailable_ShouldExpectLibraryApplicationSupport()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: false,
+            isMacOS: true,
+            getFolderPath: folder => folder == Environment.SpecialFolder.UserProfile ? "/Users/tester" : "",
+            getEnvironmentVariable: _ => null);
+
+        Assert.Equal(
+            Path.Combine(Path.Combine("/Users/tester", "Library", "Application Support"), "DTXManiaCX"),
+            root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_MacOsUserProfileEmpty_ShouldFallBackToPersonal()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: false,
+            isMacOS: true,
+            getFolderPath: folder => folder == Environment.SpecialFolder.Personal ? "/Users/personal" : "",
+            getEnvironmentVariable: _ => null);
+
+        Assert.Equal(
+            Path.Combine(Path.Combine("/Users/personal", "Library", "Application Support"), "DTXManiaCX"),
+            root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_MacOsUserProfileAndPersonalEmpty_ShouldFallBackToHome()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: false,
+            isMacOS: true,
+            getFolderPath: _ => "",
+            getEnvironmentVariable: name => name == "HOME" ? "/Users/envhome" : null);
+
+        Assert.Equal(
+            Path.Combine(Path.Combine("/Users/envhome", "Library", "Application Support"), "DTXManiaCX"),
+            root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_OtherOs_ShouldExpectApplicationData()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: false,
+            isMacOS: false,
+            getFolderPath: folder => folder == Environment.SpecialFolder.ApplicationData ? "/xdg/config" : "",
+            getEnvironmentVariable: _ => null);
+
+        Assert.Equal(Path.Combine("/xdg/config", "DTXManiaCX"), root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_OtherOsUnusableBasePath_ShouldExpectHomeConfigFallback()
+    {
+        var root = RecorderCommandLine.GetDefaultSourceAppDataRoot(
+            isWindows: false,
+            isMacOS: false,
+            getFolderPath: folder => folder == Environment.SpecialFolder.UserProfile ? "/home/tester" : "",
+            getEnvironmentVariable: _ => null);
+
+        Assert.Equal(Path.Combine("/home/tester", ".config", "DTXManiaCX"), root);
+    }
+
+    [Fact]
+    public void GetDefaultSourceAppDataRoot_NoHomeDirectoryAnywhere_ShouldExpectFailure()
+    {
+        Assert.Throws<InvalidOperationException>(
+            () => RecorderCommandLine.GetDefaultSourceAppDataRoot(
+                isWindows: false,
+                isMacOS: true,
+                getFolderPath: _ => "",
+                getEnvironmentVariable: _ => null));
+    }
+
+    private static RecorderEnvironment CreateEnvironment(
+        string? obsUrl = null,
+        string? obsOutputDirectory = null,
+        string? sourceAppDataRoot = null)
+        => RecorderCommandLine.ReadEnvironment(
+            name => name switch
+            {
+                ObsUrlEnvironmentVariable => obsUrl,
+                ObsOutputEnvironmentVariable => obsOutputDirectory,
+                AppDataEnvironmentVariable => sourceAppDataRoot,
+                _ => null
+            },
+            requireOutputDirectory: false);
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "dtx-video-cli-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string CreateChartFile()
+    {
+        var directory = CreateTempDirectory();
+        var chartPath = Path.Combine(directory, "chart.dtx");
+        File.WriteAllText(chartPath, "#TITLE: test\n");
+        return chartPath;
+    }
+
+    private static void Delete(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+
+    private sealed class RecordFixture : IDisposable
+    {
+        private readonly string _root;
+
+        private RecordFixture(string root, RecorderCommand command, RecorderEnvironment environment)
+        {
+            _root = root;
+            Command = command;
+            Environment = environment;
+        }
+
+        public RecorderCommand Command { get; }
+
+        public RecorderEnvironment Environment { get; }
+
+        public static RecordFixture Create()
+        {
+            var root = CreateTempDirectory();
+            var songs = Path.Combine(root, "Songs");
+            Directory.CreateDirectory(songs);
+            var systemSkin = Path.Combine(root, "System");
+            Directory.CreateDirectory(systemSkin);
+            File.WriteAllText(
+                Path.Combine(root, "Config.ini"),
+                string.Join(
+                    '\n',
+                    "SkinPath=Default",
+                    "DTXPath=" + songs,
+                    "SongRoot.0=" + songs,
+                    "SystemSkinRoot=" + systemSkin) + "\n");
+            var chartPath = Path.Combine(root, "chart.dtx");
+            File.WriteAllText(chartPath, "#TITLE: test\n");
+            var publishDirectory = Path.Combine(root, "publish");
+            var obsOutputDirectory = Path.Combine(root, "obs-output");
+            Directory.CreateDirectory(obsOutputDirectory);
+
+            var environment = RecorderCommandLine.ReadEnvironment(
+                name => name switch
+                {
+                    ObsOutputEnvironmentVariable => obsOutputDirectory,
+                    AppDataEnvironmentVariable => root,
+                    _ => null
+                },
+                requireOutputDirectory: false);
+            return new RecordFixture(
+                root,
+                new RecorderCommand(RecorderVerb.Record, chartPath, publishDirectory),
+                environment);
+        }
+
+        public void Dispose() => Delete(_root);
+    }
+}

--- a/DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
+++ b/DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
@@ -1,0 +1,167 @@
+using DTXMania.Automation.Process;
+using DTXMania.VideoRecorder.Sandbox;
+using DTXMania.VideoRecorder.Workflow;
+
+namespace DTXMania.VideoRecorder.Tests.Workflow;
+
+public sealed class RecorderGameLaunchPolicyTests
+{
+    [Fact]
+    public void ResolveTarget_FromRepositoryRoot()
+    {
+        var repo = CreateFakeRepo();
+        try
+        {
+            var resolved = RecorderGameLaunchPolicy.ResolveTarget(repo);
+
+            Assert.Equal(Path.GetFullPath(repo), resolved.RepositoryRoot);
+            Assert.Equal(resolved.RepositoryRoot, resolved.WorkingDirectory);
+            Assert.Equal(GameLaunchKind.Project, resolved.Target.Kind);
+            Assert.Equal(
+                Path.GetFullPath(Path.Combine(repo, GameProjectPaths.Current)),
+                resolved.Target.Path);
+            Assert.True(File.Exists(resolved.Target.Path));
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void ResolveTarget_FromNestedDirectory()
+    {
+        var repo = CreateFakeRepo();
+        var nested = Path.Combine(repo, "DTXMania.Game", "Properties");
+        Directory.CreateDirectory(nested);
+        try
+        {
+            var resolved = RecorderGameLaunchPolicy.ResolveTarget(nested);
+
+            Assert.Equal(Path.GetFullPath(repo), resolved.RepositoryRoot);
+            Assert.Equal(
+                Path.GetFullPath(Path.Combine(repo, GameProjectPaths.Current)),
+                resolved.Target.Path);
+        }
+        finally
+        {
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void CreateOptions_PreservesResolvedTarget()
+    {
+        var repo = CreateFakeRepo();
+        var sourceRoot = CreateSandboxSourceRoot();
+        RecordingSandbox? sandbox = null;
+        try
+        {
+            sandbox = RecordingSandbox.Create(sourceRoot);
+            var resolved = RecorderGameLaunchPolicy.ResolveTarget(repo);
+
+            var options = RecorderGameLaunchPolicy.CreateOptions(sandbox, resolved);
+
+            Assert.Equal(resolved.WorkingDirectory, options.WorkingDirectory);
+            Assert.Equal(resolved.Target, options.Target);
+            Assert.Equal(sandbox.AppDataRoot, options.AppDataRoot);
+        }
+        finally
+        {
+            if (sandbox is not null)
+                Delete(sandbox.RunRoot);
+            Delete(sourceRoot);
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void CreateOptions_AddsFreshLaunchToken()
+    {
+        var repo = CreateFakeRepo();
+        var sourceRoot = CreateSandboxSourceRoot();
+        RecordingSandbox? sandbox = null;
+        try
+        {
+            sandbox = RecordingSandbox.Create(sourceRoot);
+            var resolved = RecorderGameLaunchPolicy.ResolveTarget(repo);
+
+            var first = RecorderGameLaunchPolicy.CreateOptions(sandbox, resolved);
+            var second = RecorderGameLaunchPolicy.CreateOptions(sandbox, resolved);
+
+            Assert.False(string.IsNullOrWhiteSpace(first.LaunchToken));
+            Assert.False(string.IsNullOrWhiteSpace(second.LaunchToken));
+            Assert.NotEqual(first.LaunchToken, second.LaunchToken);
+        }
+        finally
+        {
+            if (sandbox is not null)
+                Delete(sandbox.RunRoot);
+            Delete(sourceRoot);
+            Delete(repo);
+        }
+    }
+
+    [Fact]
+    public void CreateOptions_UsesNoBuildDebugArguments()
+    {
+        var repo = CreateFakeRepo();
+        var sourceRoot = CreateSandboxSourceRoot();
+        RecordingSandbox? sandbox = null;
+        try
+        {
+            sandbox = RecordingSandbox.Create(sourceRoot);
+            var resolved = RecorderGameLaunchPolicy.ResolveTarget(repo);
+
+            var options = RecorderGameLaunchPolicy.CreateOptions(sandbox, resolved);
+
+            Assert.Equal(new[] { "--no-build", "--configuration", "Debug" }, options.ProjectRunArguments);
+        }
+        finally
+        {
+            if (sandbox is not null)
+                Delete(sandbox.RunRoot);
+            Delete(sourceRoot);
+            Delete(repo);
+        }
+    }
+
+    private static string CreateFakeRepo()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-video-launch-policy-repo",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "DTXMania.sln"), string.Empty);
+        var projectPath = Path.Combine(root, GameProjectPaths.Current);
+        Directory.CreateDirectory(Path.GetDirectoryName(projectPath)!);
+        File.WriteAllText(projectPath, "<Project Sdk=\"Microsoft.NET.Sdk\" />");
+        return root;
+    }
+
+    private static string CreateSandboxSourceRoot()
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(),
+            "dtx-video-launch-policy-source",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var songs = Path.Combine(root, "Songs");
+        File.WriteAllText(
+            Path.Combine(root, "Config.ini"),
+            string.Join(
+                '\n',
+                "SkinPath=Default",
+                "DTXPath=" + songs,
+                "SongRoot.0=" + songs,
+                "SystemSkinRoot=" + Path.Combine(root, "System")) + "\n");
+        return root;
+    }
+
+    private static void Delete(string path)
+    {
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+    }
+}

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -28,24 +28,30 @@ internal sealed record RecorderPlatformPreflightResult(
 /// environment. HPA-515 recorder certification requires the bundled
 /// osx-arm64 Debug runtime; a working PATH FFmpeg is deliberately not
 /// accepted as evidence. Because <c>record</c> launches with
-/// <c>dotnet run --no-build --configuration Debug</c>, preflight certifies
-/// the exact Debug output artifact that launch will execute. The Mac project
-/// is a net8.0 <c>WinExe</c> with the SDK default <c>UseAppHost=true</c>, so
-/// <c>dotnet run --no-build</c> executes the native apphost
-/// (<c>&lt;AssemblyName&gt;</c>, no extension on macOS) — not the managed
-/// DLL. The "Debug output" gate therefore certifies the apphost itself
-/// (existence + executable bit), since a missing/non-executable apphost
-/// would pass a DLL-only gate and then fail at process launch after the
-/// sandbox is already created. The Debug output directory is resolved from
-/// the project's <c>&lt;TargetFramework&gt;</c> rather than by enumerating
-/// <c>bin/Debug</c> framework directories (a stale previous TFM could
-/// otherwise satisfy preflight while the current project has no runnable
-/// Debug output).
+/// <c>dotnet run --no-build --configuration Debug</c> on every platform,
+/// preflight certifies the exact Debug output artifact that launch will
+/// execute. The Mac project is a net8.0 <c>WinExe</c> with the SDK default
+/// <c>UseAppHost=true</c>, so <c>dotnet run --no-build</c> executes the
+/// native apphost (<c>&lt;AssemblyName&gt;</c>, no extension on macOS) — not
+/// the managed DLL. The Windows project is a net8.0-windows <c>WinExe</c>
+/// with the same SDK default, so its apphost is
+/// <c>&lt;AssemblyName&gt;.exe</c>. The "Debug output" gate therefore
+/// certifies the apphost itself (existence + executable bit on macOS;
+/// existence on Windows, which has no executable bit), since a
+/// missing/non-executable apphost would pass a DLL-only gate and then fail
+/// at process launch after the sandbox is already created. The Debug output
+/// directory is resolved from the project's <c>&lt;TargetFramework&gt;</c>
+/// rather than by enumerating <c>bin/Debug</c> framework directories (a
+/// stale previous TFM could otherwise satisfy preflight while the current
+/// project has no runnable Debug output).
 /// </summary>
 internal static class RecorderPlatformPreflight
 {
     internal const string MacRuntimeRecoveryCommand =
         "dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug";
+
+    internal const string WindowsRuntimeRecoveryCommand =
+        "dotnet build DTXMania.Game/DTXMania.Game.Windows.csproj --configuration Debug";
 
     private static readonly Regex TargetFrameworkRegex = new(
         @"<TargetFramework>\s*([^<\s]+)\s*</TargetFramework>",
@@ -60,10 +66,13 @@ internal static class RecorderPlatformPreflight
     /// <summary>
     /// Evaluates the platform gates. The "Game project exists" gate is
     /// common to Windows and macOS so doctor cannot report success when the
-    /// resolved project is missing on either platform. Windows adds no
-    /// native-runtime, version, or architecture rejection; macOS must be 13+
-    /// on Apple Silicon with the Mac project and a usable bundled runtime in
-    /// the exact Debug output directory <c>--no-build</c> will launch.
+    /// resolved project is missing on either platform. Windows certifies the
+    /// Debug output apphost (<c>&lt;AssemblyName&gt;.exe</c>) in the exact
+    /// <c>bin/Debug/&lt;TargetFramework&gt;</c> directory
+    /// <c>--no-build</c> will launch, with no native-runtime, version, or
+    /// architecture rejection; macOS must be 13+ on Apple Silicon with the
+    /// Mac project and a usable bundled runtime in the exact Debug output
+    /// directory <c>--no-build</c> will launch.
     /// </summary>
     internal static RecorderPlatformPreflightResult Evaluate(
         RecorderPlatformFacts facts,
@@ -82,7 +91,11 @@ internal static class RecorderPlatformPreflight
         };
 
         if (facts.IsWindows)
-            return new RecorderPlatformPreflightResult(commonGates, null);
+        {
+            return new RecorderPlatformPreflightResult(
+                commonGates.Concat(EvaluateWindowsGates(projectPath)).ToArray(),
+                null);
+        }
 
         if (!facts.IsMacOS)
         {
@@ -97,7 +110,7 @@ internal static class RecorderPlatformPreflight
         }
 
         var projectDirectory = Path.GetDirectoryName(projectPath) ?? string.Empty;
-        var debugOutputResolution = ResolveMacDebugOutputDirectory(projectPath, projectDirectory);
+        var debugOutputResolution = ResolveDebugOutputDirectory(projectPath, projectDirectory);
         var debugOutputDirectory = debugOutputResolution.Directory;
         var runtimeDirectory = Path.Combine(debugOutputDirectory, "runtimes", "osx-arm64", "MMTools");
         // dotnet run --no-build on a net8.0 WinExe with UseAppHost=true (the
@@ -145,15 +158,15 @@ internal static class RecorderPlatformPreflight
             macGates.Add(new RecorderPreflightGate(
                 "Debug output",
                 IsUsableRuntimeBinary(apphost),
-                DescribeRuntimeBinary(apphost)));
+                DescribeRuntimeBinary(apphost, MacRuntimeRecoveryCommand)));
             macGates.Add(new RecorderPreflightGate(
                 "Bundled ffmpeg",
                 IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
-                DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"))));
+                DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"), MacRuntimeRecoveryCommand)));
             macGates.Add(new RecorderPreflightGate(
                 "Bundled ffprobe",
                 IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")),
-                DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe"))));
+                DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe"), MacRuntimeRecoveryCommand)));
         }
 
         return new RecorderPlatformPreflightResult(
@@ -166,16 +179,66 @@ internal static class RecorderPlatformPreflight
             .EndsWith(GameProjectPaths.Mac, StringComparison.Ordinal);
 
     /// <summary>
+    /// Windows-only gates. <c>dotnet run --no-build</c> on a net8.0-windows
+    /// <c>WinExe</c> with the SDK default <c>UseAppHost=true</c> executes the
+    /// native apphost (<c>&lt;AssemblyName&gt;.exe</c>), not the managed DLL.
+    /// The "Debug output" gate certifies that apphost in the TFM-pinned
+    /// <c>bin/Debug</c> directory so a clean checkout cannot pass preflight
+    /// and then fail at process launch after the sandbox is created — the
+    /// same ordering guarantee the Mac gates provide. When the project's
+    /// <c>&lt;TargetFramework&gt;</c> is unreadable, a failed "Target
+    /// framework" gate replaces the "Debug output" gate so a stale
+    /// <c>bin/Debug</c> directory cannot satisfy preflight.
+    /// </summary>
+    private static IEnumerable<RecorderPreflightGate> EvaluateWindowsGates(string projectPath)
+    {
+        var projectDirectory = Path.GetDirectoryName(projectPath) ?? string.Empty;
+        var debugOutputResolution = ResolveDebugOutputDirectory(projectPath, projectDirectory);
+        var debugOutputDirectory = debugOutputResolution.Directory;
+        var apphost = Path.Combine(debugOutputDirectory, WindowsApphostName(projectPath));
+
+        if (debugOutputResolution.TargetFramework is null)
+        {
+            // Target-framework resolution failed (project missing, IO error,
+            // or no <TargetFramework> element). The fallback directory is
+            // retained only to name a diagnostic location in the gate detail;
+            // the Debug output gate is deliberately not evaluated so a stale
+            // bin/Debug directory cannot satisfy preflight when the current
+            // project's TFM is unreadable.
+            yield return new RecorderPreflightGate(
+                "Target framework",
+                Passed: false,
+                Detail: $"Could not read <TargetFramework> from '{projectPath.Replace('\\', '/')}'. "
+                    + $"Diagnostic fallback Debug output directory is '{debugOutputDirectory.Replace('\\', '/')}'; "
+                    + $"build the project so a readable <TargetFramework> is present.");
+            yield break;
+        }
+
+        yield return new RecorderPreflightGate(
+            "Debug output",
+            IsUsableRuntimeBinary(apphost),
+            DescribeRuntimeBinary(apphost, WindowsRuntimeRecoveryCommand));
+    }
+
+    /// <summary>
     /// Derives the native apphost file name that
     /// <c>dotnet run --no-build</c> executes for a net8.0 <c>WinExe</c>
     /// project with the SDK default <c>UseAppHost=true</c>. The apphost is
-    /// named after the assembly with no extension on macOS (and
-    /// <c>.exe</c> on Windows, but this gate is macOS-only). This matches the
+    /// named after the assembly with no extension on macOS. This matches the
     /// default MSBuild assembly name for a single-target project that does
     /// not override <c>&lt;AssemblyName&gt;</c>.
     /// </summary>
     private static string ApphostName(string projectPath)
         => Path.GetFileNameWithoutExtension(projectPath);
+
+    /// <summary>
+    /// Derives the native Windows apphost file name that
+    /// <c>dotnet run --no-build</c> executes for a net8.0-windows
+    /// <c>WinExe</c> project with the SDK default <c>UseAppHost=true</c>:
+    /// <c>&lt;AssemblyName&gt;.exe</c>.
+    /// </summary>
+    private static string WindowsApphostName(string projectPath)
+        => Path.GetFileNameWithoutExtension(projectPath) + ".exe";
 
     /// <summary>
     /// Resolves the single Debug output directory that
@@ -185,8 +248,8 @@ internal static class RecorderPlatformPreflight
     /// directories: a stale previous TFM could otherwise satisfy preflight
     /// while the current project has no runnable Debug output. When the
     /// project file or target framework cannot be read,
-    /// <see cref="MacDebugOutputResolution.TargetFramework"/> is null and the
-    /// returned <see cref="MacDebugOutputResolution.Directory"/> falls back to
+    /// <see cref="DebugOutputResolution.TargetFramework"/> is null and the
+    /// returned <see cref="DebugOutputResolution.Directory"/> falls back to
     /// a best-effort <c>net8.0</c> path so downstream diagnostic strings
     /// (gate detail, <see cref="RecorderPlatformPreflightResult.MacRuntimeDirectory"/>)
     /// still name a location; the caller must add a failed gate in that case
@@ -194,18 +257,18 @@ internal static class RecorderPlatformPreflight
     /// gates, since a stale <c>bin/Debug/net8.0</c> directory could otherwise
     /// pass those <see cref="File.Exists"/> checks.
     /// </summary>
-    private static MacDebugOutputResolution ResolveMacDebugOutputDirectory(
+    private static DebugOutputResolution ResolveDebugOutputDirectory(
         string projectPath,
         string projectDirectory)
     {
         var targetFramework = ReadTargetFramework(projectPath);
         var binDebug = Path.Combine(projectDirectory, "bin", "Debug");
-        return new MacDebugOutputResolution(
+        return new DebugOutputResolution(
             Path.Combine(binDebug, targetFramework ?? "net8.0"),
             targetFramework);
     }
 
-    private sealed record MacDebugOutputResolution(
+    private sealed record DebugOutputResolution(
         string Directory,
         string? TargetFramework);
 
@@ -229,10 +292,10 @@ internal static class RecorderPlatformPreflight
     private static bool IsUsableRuntimeBinary(string path)
         => File.Exists(path) && IsExecutable(path);
 
-    private static string DescribeRuntimeBinary(string path)
+    private static string DescribeRuntimeBinary(string path, string recoveryCommand)
         => File.Exists(path) && IsExecutable(path)
             ? path
-            : $"'{path}' is missing or not executable. Build the bundled Debug runtime first: {MacRuntimeRecoveryCommand}";
+            : $"'{path}' is missing or not executable. Build the Debug output first: {recoveryCommand}";
 
     private static bool IsExecutable(string path)
     {

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -136,8 +136,8 @@ internal static class RecorderPlatformPreflight
             macGates.Add(new RecorderPreflightGate(
                 "Target framework",
                 Passed: false,
-                Detail: $"Could not read <TargetFramework> from '{projectPath}'. "
-                    + $"Diagnostic fallback Debug output directory is '{debugOutputDirectory}'; "
+                Detail: $"Could not read <TargetFramework> from '{projectPath.Replace('\\', '/')}'. "
+                    + $"Diagnostic fallback Debug output directory is '{debugOutputDirectory.Replace('\\', '/')}'; "
                     + $"build the project so a readable <TargetFramework> is present."));
         }
         else

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -68,9 +68,8 @@ internal static class RecorderPlatformPreflight
         }
 
         var projectPath = Path.GetFullPath(target.Target.Path);
-        var runtimeDirectory = Path.Combine(
-            Path.GetDirectoryName(projectPath) ?? string.Empty,
-            "bin", "Debug", "net8.0", "runtimes", "osx-arm64", "MMTools");
+        var runtimeDirectory = ResolveMacRuntimeDirectory(
+            Path.GetDirectoryName(projectPath) ?? string.Empty);
         return new RecorderPlatformPreflightResult(
             new[]
             {
@@ -105,6 +104,33 @@ internal static class RecorderPlatformPreflight
     private static bool IsMacProject(string projectPath)
         => projectPath.Replace('\\', '/')
             .EndsWith(GameProjectPaths.Mac, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Locates the bundled osx-arm64 MMTools runtime directory by enumerating
+    /// the framework directories under <c>bin/Debug</c> rather than hardcoding
+    /// a target-framework segment, so the check stays aligned after framework
+    /// changes. Falls back to a best-effort path when nothing has been built
+    /// yet so the gate diagnostic still names a location.
+    /// </summary>
+    private static string ResolveMacRuntimeDirectory(string projectDirectory)
+    {
+        var binDebug = Path.Combine(projectDirectory, "bin", "Debug");
+        string? firstFrameworkDir = null;
+        if (Directory.Exists(binDebug))
+        {
+            foreach (var frameworkDir in Directory.GetDirectories(binDebug))
+            {
+                firstFrameworkDir ??= frameworkDir;
+                var candidate = Path.Combine(frameworkDir, "runtimes", "osx-arm64", "MMTools");
+                if (Directory.Exists(candidate))
+                    return candidate;
+            }
+        }
+
+        return firstFrameworkDir is null
+            ? Path.Combine(binDebug, "runtimes", "osx-arm64", "MMTools")
+            : Path.Combine(firstFrameworkDir, "runtimes", "osx-arm64", "MMTools");
+    }
 
     private static bool IsUsableRuntimeBinary(string path)
         => File.Exists(path) && IsExecutable(path);

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -285,6 +285,10 @@ internal static class RecorderPlatformPreflight
         {
             return null;
         }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
         var match = TargetFrameworkRegex.Match(projectXml);
         return match.Success ? match.Groups[1].Value : null;
     }

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -90,39 +90,61 @@ internal static class RecorderPlatformPreflight
         }
 
         var projectDirectory = Path.GetDirectoryName(projectPath) ?? string.Empty;
-        var debugOutputDirectory = ResolveMacDebugOutputDirectory(projectPath, projectDirectory);
+        var debugOutputResolution = ResolveMacDebugOutputDirectory(projectPath, projectDirectory);
+        var debugOutputDirectory = debugOutputResolution.Directory;
         var runtimeDirectory = Path.Combine(debugOutputDirectory, "runtimes", "osx-arm64", "MMTools");
         var managedAssembly = Path.Combine(debugOutputDirectory, ManagedAssemblyName(projectPath));
+
+        var macGates = new List<RecorderPreflightGate>
+        {
+            new RecorderPreflightGate(
+                "macOS >= 13",
+                facts.OsVersion.Major >= 13,
+                $"found macOS {facts.OsVersion}"),
+            new RecorderPreflightGate(
+                "Apple Silicon (arm64)",
+                facts.ProcessArchitecture == Architecture.Arm64,
+                $"process architecture is {facts.ProcessArchitecture}"),
+            new RecorderPreflightGate(
+                "Mac game project",
+                IsMacProject(projectPath),
+                projectPath),
+        };
+
+        if (debugOutputResolution.TargetFramework is null)
+        {
+            // Target-framework resolution failed (project missing, IO error,
+            // or no <TargetFramework> element). The net8.0 fallback below is
+            // retained only to name a diagnostic location in
+            // MacRuntimeDirectory and the gate detail; the runtime/output
+            // gates are deliberately not evaluated so a stale
+            // bin/Debug/net8.0 directory cannot satisfy preflight when the
+            // current project's TFM is unreadable.
+            macGates.Add(new RecorderPreflightGate(
+                "Target framework",
+                Passed: false,
+                Detail: $"Could not read <TargetFramework> from '{projectPath}'. "
+                    + $"Diagnostic fallback Debug output directory is '{debugOutputDirectory}'; "
+                    + $"build the project so a readable <TargetFramework> is present."));
+        }
+        else
+        {
+            macGates.Add(new RecorderPreflightGate(
+                "Debug output",
+                File.Exists(managedAssembly),
+                managedAssembly));
+            macGates.Add(new RecorderPreflightGate(
+                "Bundled ffmpeg",
+                IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
+                DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"))));
+            macGates.Add(new RecorderPreflightGate(
+                "Bundled ffprobe",
+                IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")),
+                DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe"))));
+        }
+
         return new RecorderPlatformPreflightResult(
-            commonGates
-                .Concat(new[]
-                {
-                    new RecorderPreflightGate(
-                        "macOS >= 13",
-                        facts.OsVersion.Major >= 13,
-                        $"found macOS {facts.OsVersion}"),
-                    new RecorderPreflightGate(
-                        "Apple Silicon (arm64)",
-                        facts.ProcessArchitecture == Architecture.Arm64,
-                        $"process architecture is {facts.ProcessArchitecture}"),
-                    new RecorderPreflightGate(
-                        "Mac game project",
-                        IsMacProject(projectPath),
-                        projectPath),
-                    new RecorderPreflightGate(
-                        "Debug output",
-                        File.Exists(managedAssembly),
-                        managedAssembly),
-                    new RecorderPreflightGate(
-                        "Bundled ffmpeg",
-                        IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
-                        DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"))),
-                    new RecorderPreflightGate(
-                        "Bundled ffprobe",
-                        IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")),
-                        DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe"))),
-                })
-                .ToArray(),
+            commonGates.Concat(macGates).ToArray(),
             runtimeDirectory);
     }
 
@@ -145,19 +167,31 @@ internal static class RecorderPlatformPreflight
     /// reading <c>&lt;TargetFramework&gt;</c> from the project file. This
     /// intentionally does not enumerate <c>bin/Debug</c> framework
     /// directories: a stale previous TFM could otherwise satisfy preflight
-    /// while the current project has no runnable Debug output. Falls back to
-    /// a best-effort <c>net8.0</c> path when the project file or target
-    /// framework cannot be read so the gate diagnostic still names a
-    /// location; the <see cref="File.Exists"/> checks will fail in that case.
+    /// while the current project has no runnable Debug output. When the
+    /// project file or target framework cannot be read,
+    /// <see cref="MacDebugOutputResolution.TargetFramework"/> is null and the
+    /// returned <see cref="MacDebugOutputResolution.Directory"/> falls back to
+    /// a best-effort <c>net8.0</c> path so downstream diagnostic strings
+    /// (gate detail, <see cref="RecorderPlatformPreflightResult.MacRuntimeDirectory"/>)
+    /// still name a location; the caller must add a failed gate in that case
+    /// rather than relying on the fallback directory to satisfy runtime/output
+    /// gates, since a stale <c>bin/Debug/net8.0</c> directory could otherwise
+    /// pass those <see cref="File.Exists"/> checks.
     /// </summary>
-    private static string ResolveMacDebugOutputDirectory(
+    private static MacDebugOutputResolution ResolveMacDebugOutputDirectory(
         string projectPath,
         string projectDirectory)
     {
         var targetFramework = ReadTargetFramework(projectPath);
         var binDebug = Path.Combine(projectDirectory, "bin", "Debug");
-        return Path.Combine(binDebug, targetFramework ?? "net8.0");
+        return new MacDebugOutputResolution(
+            Path.Combine(binDebug, targetFramework ?? "net8.0"),
+            targetFramework);
     }
+
+    private sealed record MacDebugOutputResolution(
+        string Directory,
+        string? TargetFramework);
 
     private static string? ReadTargetFramework(string projectPath)
     {

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using DTXMania.Automation.Process;
 using DTXMania.VideoRecorder.Workflow;
 
@@ -17,7 +18,7 @@ internal sealed record RecorderPreflightGate(
 
 internal sealed record RecorderPlatformPreflightResult(
     IReadOnlyList<RecorderPreflightGate> Gates,
-    string? NativeRuntimeDirectory)
+    string? MacRuntimeDirectory)
 {
     public bool Passed => Gates.All(gate => gate.Passed);
 }
@@ -26,12 +27,22 @@ internal sealed record RecorderPlatformPreflightResult(
 /// Shared record/doctor preflight for the native recorder launch
 /// environment. HPA-515 recorder certification requires the bundled
 /// osx-arm64 Debug runtime; a working PATH FFmpeg is deliberately not
-/// accepted as evidence.
+/// accepted as evidence. Because <c>record</c> launches with
+/// <c>dotnet run --no-build --configuration Debug</c>, preflight certifies
+/// the exact Debug output directory that launch will use, resolved from the
+/// project's <c>&lt;TargetFramework&gt;</c> rather than by enumerating
+/// <c>bin/Debug</c> framework directories (a stale previous TFM could
+/// otherwise satisfy preflight while the current project has no runnable
+/// Debug output).
 /// </summary>
 internal static class RecorderPlatformPreflight
 {
     internal const string MacRuntimeRecoveryCommand =
         "dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug";
+
+    private static readonly Regex TargetFrameworkRegex = new(
+        @"<TargetFramework>\s*([^<\s]+)\s*</TargetFramework>",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     internal static RecorderPlatformFacts CaptureFacts() => new(
         OperatingSystem.IsWindows(),
@@ -40,9 +51,12 @@ internal static class RecorderPlatformPreflight
         RuntimeInformation.ProcessArchitecture);
 
     /// <summary>
-    /// Evaluates the platform gates. Windows adds no native-runtime,
-    /// version, or architecture rejection; macOS must be 13+ on Apple
-    /// Silicon with the Mac project and a usable bundled runtime.
+    /// Evaluates the platform gates. The "Game project exists" gate is
+    /// common to Windows and macOS so doctor cannot report success when the
+    /// resolved project is missing on either platform. Windows adds no
+    /// native-runtime, version, or architecture rejection; macOS must be 13+
+    /// on Apple Silicon with the Mac project and a usable bundled runtime in
+    /// the exact Debug output directory <c>--no-build</c> will launch.
     /// </summary>
     internal static RecorderPlatformPreflightResult Evaluate(
         RecorderPlatformFacts facts,
@@ -51,53 +65,64 @@ internal static class RecorderPlatformPreflight
         ArgumentNullException.ThrowIfNull(facts);
         ArgumentNullException.ThrowIfNull(target);
 
+        var projectPath = Path.GetFullPath(target.Target.Path);
+        var commonGates = new[]
+        {
+            new RecorderPreflightGate(
+                "Game project exists",
+                File.Exists(projectPath),
+                projectPath),
+        };
+
         if (facts.IsWindows)
-            return new RecorderPlatformPreflightResult(Array.Empty<RecorderPreflightGate>(), null);
+            return new RecorderPlatformPreflightResult(commonGates, null);
 
         if (!facts.IsMacOS)
         {
             return new RecorderPlatformPreflightResult(
-                new[]
-                {
-                    new RecorderPreflightGate(
+                commonGates
+                    .Append(new RecorderPreflightGate(
                         "Platform",
                         Passed: false,
-                        Detail: "dtx-video record is supported on Windows and macOS only.")
-                },
+                        Detail: "dtx-video record is supported on Windows and macOS only."))
+                    .ToArray(),
                 null);
         }
 
-        var projectPath = Path.GetFullPath(target.Target.Path);
-        var runtimeDirectory = ResolveMacRuntimeDirectory(
-            Path.GetDirectoryName(projectPath) ?? string.Empty);
+        var projectDirectory = Path.GetDirectoryName(projectPath) ?? string.Empty;
+        var debugOutputDirectory = ResolveMacDebugOutputDirectory(projectPath, projectDirectory);
+        var runtimeDirectory = Path.Combine(debugOutputDirectory, "runtimes", "osx-arm64", "MMTools");
+        var managedAssembly = Path.Combine(debugOutputDirectory, ManagedAssemblyName(projectPath));
         return new RecorderPlatformPreflightResult(
-            new[]
-            {
-                new RecorderPreflightGate(
-                    "macOS >= 13",
-                    facts.OsVersion.Major >= 13,
-                    $"found macOS {facts.OsVersion}"),
-                new RecorderPreflightGate(
-                    "Apple Silicon (arm64)",
-                    facts.ProcessArchitecture == Architecture.Arm64,
-                    $"process architecture is {facts.ProcessArchitecture}"),
-                new RecorderPreflightGate(
-                    "Mac game project",
-                    IsMacProject(projectPath),
-                    projectPath),
-                new RecorderPreflightGate(
-                    "Game project exists",
-                    File.Exists(projectPath),
-                    projectPath),
-                new RecorderPreflightGate(
-                    "Bundled ffmpeg",
-                    IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
-                    DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"))),
-                new RecorderPreflightGate(
-                    "Bundled ffprobe",
-                    IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")),
-                    DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")))
-            },
+            commonGates
+                .Concat(new[]
+                {
+                    new RecorderPreflightGate(
+                        "macOS >= 13",
+                        facts.OsVersion.Major >= 13,
+                        $"found macOS {facts.OsVersion}"),
+                    new RecorderPreflightGate(
+                        "Apple Silicon (arm64)",
+                        facts.ProcessArchitecture == Architecture.Arm64,
+                        $"process architecture is {facts.ProcessArchitecture}"),
+                    new RecorderPreflightGate(
+                        "Mac game project",
+                        IsMacProject(projectPath),
+                        projectPath),
+                    new RecorderPreflightGate(
+                        "Debug output",
+                        File.Exists(managedAssembly),
+                        managedAssembly),
+                    new RecorderPreflightGate(
+                        "Bundled ffmpeg",
+                        IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
+                        DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"))),
+                    new RecorderPreflightGate(
+                        "Bundled ffprobe",
+                        IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")),
+                        DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe"))),
+                })
+                .ToArray(),
             runtimeDirectory);
     }
 
@@ -106,30 +131,49 @@ internal static class RecorderPlatformPreflight
             .EndsWith(GameProjectPaths.Mac, StringComparison.Ordinal);
 
     /// <summary>
-    /// Locates the bundled osx-arm64 MMTools runtime directory by enumerating
-    /// the framework directories under <c>bin/Debug</c> rather than hardcoding
-    /// a target-framework segment, so the check stays aligned after framework
-    /// changes. Falls back to a best-effort path when nothing has been built
-    /// yet so the gate diagnostic still names a location.
+    /// Derives the managed assembly file name
+    /// (<c>&lt;AssemblyName&gt;.dll</c>) from the resolved project file name,
+    /// matching the default MSBuild assembly name for a single-target project
+    /// that does not override <c>&lt;AssemblyName&gt;</c>.
     /// </summary>
-    private static string ResolveMacRuntimeDirectory(string projectDirectory)
-    {
-        var binDebug = Path.Combine(projectDirectory, "bin", "Debug");
-        string? firstFrameworkDir = null;
-        if (Directory.Exists(binDebug))
-        {
-            foreach (var frameworkDir in Directory.GetDirectories(binDebug))
-            {
-                firstFrameworkDir ??= frameworkDir;
-                var candidate = Path.Combine(frameworkDir, "runtimes", "osx-arm64", "MMTools");
-                if (Directory.Exists(candidate))
-                    return candidate;
-            }
-        }
+    private static string ManagedAssemblyName(string projectPath)
+        => Path.GetFileNameWithoutExtension(projectPath) + ".dll";
 
-        return firstFrameworkDir is null
-            ? Path.Combine(binDebug, "runtimes", "osx-arm64", "MMTools")
-            : Path.Combine(firstFrameworkDir, "runtimes", "osx-arm64", "MMTools");
+    /// <summary>
+    /// Resolves the single Debug output directory that
+    /// <c>dotnet run --no-build --configuration Debug</c> will launch, by
+    /// reading <c>&lt;TargetFramework&gt;</c> from the project file. This
+    /// intentionally does not enumerate <c>bin/Debug</c> framework
+    /// directories: a stale previous TFM could otherwise satisfy preflight
+    /// while the current project has no runnable Debug output. Falls back to
+    /// a best-effort <c>net8.0</c> path when the project file or target
+    /// framework cannot be read so the gate diagnostic still names a
+    /// location; the <see cref="File.Exists"/> checks will fail in that case.
+    /// </summary>
+    private static string ResolveMacDebugOutputDirectory(
+        string projectPath,
+        string projectDirectory)
+    {
+        var targetFramework = ReadTargetFramework(projectPath);
+        var binDebug = Path.Combine(projectDirectory, "bin", "Debug");
+        return Path.Combine(binDebug, targetFramework ?? "net8.0");
+    }
+
+    private static string? ReadTargetFramework(string projectPath)
+    {
+        if (!File.Exists(projectPath))
+            return null;
+        string projectXml;
+        try
+        {
+            projectXml = File.ReadAllText(projectPath);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        var match = TargetFrameworkRegex.Match(projectXml);
+        return match.Success ? match.Groups[1].Value : null;
     }
 
     private static bool IsUsableRuntimeBinary(string path)
@@ -156,14 +200,10 @@ internal static class RecorderPlatformPreflight
 
     private static Version CaptureOsVersion()
     {
-        var version = Environment.OSVersion.Version;
-        if (!OperatingSystem.IsMacOS() || version.Major < 20)
-            return version;
-
-        // Environment.OSVersion reports the Darwin kernel version on macOS
-        // (macOS 13 ships Darwin 22). Convert back to the product major so
-        // the "macOS >= 13" gate compares product versions; Darwin 25+
-        // (year-based releases) still clears the threshold after conversion.
-        return new Version(version.Major - 9, version.Minor);
+        // On .NET 5+ (this project targets net8.0), Environment.OSVersion
+        // returns the macOS product version directly (e.g. macOS 26 reports
+        // 26.5.2), not the Darwin kernel version. The "macOS >= 13" gate
+        // therefore compares product versions without any Darwin conversion.
+        return Environment.OSVersion.Version;
     }
 }

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -1,0 +1,143 @@
+using System.Runtime.InteropServices;
+using DTXMania.Automation.Process;
+using DTXMania.VideoRecorder.Workflow;
+
+namespace DTXMania.VideoRecorder.Diagnostics;
+
+internal sealed record RecorderPlatformFacts(
+    bool IsWindows,
+    bool IsMacOS,
+    Version OsVersion,
+    Architecture ProcessArchitecture);
+
+internal sealed record RecorderPreflightGate(
+    string Name,
+    bool Passed,
+    string Detail);
+
+internal sealed record RecorderPlatformPreflightResult(
+    IReadOnlyList<RecorderPreflightGate> Gates,
+    string? NativeRuntimeDirectory)
+{
+    public bool Passed => Gates.All(gate => gate.Passed);
+}
+
+/// <summary>
+/// Shared record/doctor preflight for the native recorder launch
+/// environment. HPA-515 recorder certification requires the bundled
+/// osx-arm64 Debug runtime; a working PATH FFmpeg is deliberately not
+/// accepted as evidence.
+/// </summary>
+internal static class RecorderPlatformPreflight
+{
+    internal const string MacRuntimeRecoveryCommand =
+        "dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug";
+
+    internal static RecorderPlatformFacts CaptureFacts() => new(
+        OperatingSystem.IsWindows(),
+        OperatingSystem.IsMacOS(),
+        CaptureOsVersion(),
+        RuntimeInformation.ProcessArchitecture);
+
+    /// <summary>
+    /// Evaluates the platform gates. Windows adds no native-runtime,
+    /// version, or architecture rejection; macOS must be 13+ on Apple
+    /// Silicon with the Mac project and a usable bundled runtime.
+    /// </summary>
+    internal static RecorderPlatformPreflightResult Evaluate(
+        RecorderPlatformFacts facts,
+        ResolvedRecorderTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(facts);
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (facts.IsWindows)
+            return new RecorderPlatformPreflightResult(Array.Empty<RecorderPreflightGate>(), null);
+
+        if (!facts.IsMacOS)
+        {
+            return new RecorderPlatformPreflightResult(
+                new[]
+                {
+                    new RecorderPreflightGate(
+                        "Platform",
+                        Passed: false,
+                        Detail: "dtx-video record is supported on Windows and macOS only.")
+                },
+                null);
+        }
+
+        var projectPath = Path.GetFullPath(target.Target.Path);
+        var runtimeDirectory = Path.Combine(
+            Path.GetDirectoryName(projectPath) ?? string.Empty,
+            "bin", "Debug", "net8.0", "runtimes", "osx-arm64", "MMTools");
+        return new RecorderPlatformPreflightResult(
+            new[]
+            {
+                new RecorderPreflightGate(
+                    "macOS >= 13",
+                    facts.OsVersion.Major >= 13,
+                    $"found macOS {facts.OsVersion}"),
+                new RecorderPreflightGate(
+                    "Apple Silicon (arm64)",
+                    facts.ProcessArchitecture == Architecture.Arm64,
+                    $"process architecture is {facts.ProcessArchitecture}"),
+                new RecorderPreflightGate(
+                    "Mac game project",
+                    IsMacProject(projectPath),
+                    projectPath),
+                new RecorderPreflightGate(
+                    "Game project exists",
+                    File.Exists(projectPath),
+                    projectPath),
+                new RecorderPreflightGate(
+                    "Bundled ffmpeg",
+                    IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
+                    DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg"))),
+                new RecorderPreflightGate(
+                    "Bundled ffprobe",
+                    IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")),
+                    DescribeRuntimeBinary(Path.Combine(runtimeDirectory, "ffprobe")))
+            },
+            runtimeDirectory);
+    }
+
+    private static bool IsMacProject(string projectPath)
+        => projectPath.Replace('\\', '/')
+            .EndsWith(GameProjectPaths.Mac, StringComparison.Ordinal);
+
+    private static bool IsUsableRuntimeBinary(string path)
+        => File.Exists(path) && IsExecutable(path);
+
+    private static string DescribeRuntimeBinary(string path)
+        => File.Exists(path) && IsExecutable(path)
+            ? path
+            : $"'{path}' is missing or not executable. Build the bundled Debug runtime first: {MacRuntimeRecoveryCommand}";
+
+    private static bool IsExecutable(string path)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+        {
+            // The host filesystem has no executable bit (e.g. Windows CI
+            // evaluating synthetic macOS facts); existence is the strongest
+            // check available there.
+            return true;
+        }
+
+        var mode = File.GetUnixFileMode(path);
+        return (mode & (UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute)) != 0;
+    }
+
+    private static Version CaptureOsVersion()
+    {
+        var version = Environment.OSVersion.Version;
+        if (!OperatingSystem.IsMacOS() || version.Major < 20)
+            return version;
+
+        // Environment.OSVersion reports the Darwin kernel version on macOS
+        // (macOS 13 ships Darwin 22). Convert back to the product major so
+        // the "macOS >= 13" gate compares product versions; Darwin 25+
+        // (year-based releases) still clears the threshold after conversion.
+        return new Version(version.Major - 9, version.Minor);
+    }
+}

--- a/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+++ b/DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
@@ -29,8 +29,15 @@ internal sealed record RecorderPlatformPreflightResult(
 /// osx-arm64 Debug runtime; a working PATH FFmpeg is deliberately not
 /// accepted as evidence. Because <c>record</c> launches with
 /// <c>dotnet run --no-build --configuration Debug</c>, preflight certifies
-/// the exact Debug output directory that launch will use, resolved from the
-/// project's <c>&lt;TargetFramework&gt;</c> rather than by enumerating
+/// the exact Debug output artifact that launch will execute. The Mac project
+/// is a net8.0 <c>WinExe</c> with the SDK default <c>UseAppHost=true</c>, so
+/// <c>dotnet run --no-build</c> executes the native apphost
+/// (<c>&lt;AssemblyName&gt;</c>, no extension on macOS) — not the managed
+/// DLL. The "Debug output" gate therefore certifies the apphost itself
+/// (existence + executable bit), since a missing/non-executable apphost
+/// would pass a DLL-only gate and then fail at process launch after the
+/// sandbox is already created. The Debug output directory is resolved from
+/// the project's <c>&lt;TargetFramework&gt;</c> rather than by enumerating
 /// <c>bin/Debug</c> framework directories (a stale previous TFM could
 /// otherwise satisfy preflight while the current project has no runnable
 /// Debug output).
@@ -93,7 +100,13 @@ internal static class RecorderPlatformPreflight
         var debugOutputResolution = ResolveMacDebugOutputDirectory(projectPath, projectDirectory);
         var debugOutputDirectory = debugOutputResolution.Directory;
         var runtimeDirectory = Path.Combine(debugOutputDirectory, "runtimes", "osx-arm64", "MMTools");
-        var managedAssembly = Path.Combine(debugOutputDirectory, ManagedAssemblyName(projectPath));
+        // dotnet run --no-build on a net8.0 WinExe with UseAppHost=true (the
+        // SDK default for executable projects) executes the native apphost,
+        // not the managed DLL. The apphost is named after the assembly with
+        // no extension on macOS. Certify the apphost itself so a
+        // missing/non-executable apphost cannot pass preflight and then fail
+        // at process launch after the sandbox is created.
+        var apphost = Path.Combine(debugOutputDirectory, ApphostName(projectPath));
 
         var macGates = new List<RecorderPreflightGate>
         {
@@ -131,8 +144,8 @@ internal static class RecorderPlatformPreflight
         {
             macGates.Add(new RecorderPreflightGate(
                 "Debug output",
-                File.Exists(managedAssembly),
-                managedAssembly));
+                IsUsableRuntimeBinary(apphost),
+                DescribeRuntimeBinary(apphost)));
             macGates.Add(new RecorderPreflightGate(
                 "Bundled ffmpeg",
                 IsUsableRuntimeBinary(Path.Combine(runtimeDirectory, "ffmpeg")),
@@ -153,13 +166,16 @@ internal static class RecorderPlatformPreflight
             .EndsWith(GameProjectPaths.Mac, StringComparison.Ordinal);
 
     /// <summary>
-    /// Derives the managed assembly file name
-    /// (<c>&lt;AssemblyName&gt;.dll</c>) from the resolved project file name,
-    /// matching the default MSBuild assembly name for a single-target project
-    /// that does not override <c>&lt;AssemblyName&gt;</c>.
+    /// Derives the native apphost file name that
+    /// <c>dotnet run --no-build</c> executes for a net8.0 <c>WinExe</c>
+    /// project with the SDK default <c>UseAppHost=true</c>. The apphost is
+    /// named after the assembly with no extension on macOS (and
+    /// <c>.exe</c> on Windows, but this gate is macOS-only). This matches the
+    /// default MSBuild assembly name for a single-target project that does
+    /// not override <c>&lt;AssemblyName&gt;</c>.
     /// </summary>
-    private static string ManagedAssemblyName(string projectPath)
-        => Path.GetFileNameWithoutExtension(projectPath) + ".dll";
+    private static string ApphostName(string projectPath)
+        => Path.GetFileNameWithoutExtension(projectPath);
 
     /// <summary>
     /// Resolves the single Debug output directory that

--- a/DTXMania.VideoRecorder/Program.cs
+++ b/DTXMania.VideoRecorder/Program.cs
@@ -21,7 +21,13 @@ internal static class Program
                 return await RunDoctorAsync(environment).ConfigureAwait(false);
 
             RecorderCommandLine.Validate(command, environment);
-            return await RunRecordAsync(command, environment).ConfigureAwait(false);
+
+            var target = RecorderGameLaunchPolicy.ResolveTarget(Environment.CurrentDirectory);
+            var preflight = RecorderPlatformPreflight.Evaluate(
+                RecorderPlatformPreflight.CaptureFacts(),
+                target);
+            return await RunRecordAsync(command, environment, target, preflight)
+                .ConfigureAwait(false);
         }
         catch (Exception exception)
         {
@@ -30,10 +36,14 @@ internal static class Program
         }
     }
 
-    private static async Task<int> RunRecordAsync(
+    internal static async Task<int> RunRecordAsync(
         RecorderCommand command,
-        RecorderEnvironment environment)
+        RecorderEnvironment environment,
+        ResolvedRecorderTarget target,
+        RecorderPlatformPreflightResult preflight)
     {
+        RejectFailedPreflight(preflight);
+
         using var cancellation = new CancellationTokenSource();
         ConsoleCancelEventHandler cancelHandler = (_, eventArgs) =>
         {
@@ -55,7 +65,7 @@ internal static class Program
             try
             {
                 Console.WriteLine($"Recorder sandbox ready at '{sandbox.RunRoot}'.");
-                var startOptions = RecorderGameLaunchPolicy.CreateOptions(sandbox);
+                var startOptions = RecorderGameLaunchPolicy.CreateOptions(sandbox, target);
                 game = new AutomationGameRecordingControl(
                     sandbox.ApiPort,
                     sandbox.ApiKey);
@@ -144,13 +154,28 @@ internal static class Program
         }
     }
 
+    /// <summary>
+    /// Rejects a failed platform preflight before any run-owned resource
+    /// exists: no sandbox, no diagnostics run-root, no game/OBS client, no
+    /// workflow.
+    /// </summary>
+    private static void RejectFailedPreflight(RecorderPlatformPreflightResult preflight)
+    {
+        ArgumentNullException.ThrowIfNull(preflight);
+        if (preflight.Passed)
+            return;
+
+        var failures = string.Join(
+            "; ",
+            preflight.Gates
+                .Where(gate => !gate.Passed)
+                .Select(gate => $"{gate.Name}: {gate.Detail}"));
+        throw new InvalidOperationException($"Recorder platform preflight failed. {failures}");
+    }
+
     private static async Task<int> RunDoctorAsync(RecorderEnvironment environment)
     {
         var passed = true;
-        var repoRoot = FindRepositoryRoot(Environment.CurrentDirectory);
-        var gameProject = repoRoot is null
-            ? null
-            : Path.Combine(repoRoot, "DTXMania.Game", "DTXMania.Game.Windows.csproj");
         var sourceConfig = Path.Combine(environment.SourceAppDataRoot, "Config.ini");
         var ffprobe = RecordingArtifactVerifier.FindFfprobeOnPath();
 
@@ -168,19 +193,26 @@ internal static class Program
             Console.WriteLine($"Recorder configuration validation: FAILED ({exception.Message})");
         }
 
-        passed &= ReportGate(
-            "Windows",
-            OperatingSystem.IsWindows(),
-            OperatingSystem.IsWindows() ? "available" : "record is Windows-only");
-        passed &= ReportGate(
-            "Repository",
-            repoRoot is not null,
-            repoRoot ?? "not found from current directory");
-        passed &= ReportGate(
-            "Game project",
-            gameProject is not null && File.Exists(gameProject),
-            gameProject ?? "not found");
-        passed &= ReportGate("Source config", File.Exists(sourceConfig), sourceConfig);
+        ResolvedRecorderTarget? target = null;
+        string? targetFailure = null;
+        try
+        {
+            target = RecorderGameLaunchPolicy.ResolveTarget(Environment.CurrentDirectory);
+        }
+        catch (Exception exception)
+        {
+            targetFailure = exception.Message;
+        }
+
+        var facts = RecorderPlatformPreflight.CaptureFacts();
+        var preflight = target is null
+            ? new RecorderPlatformPreflightResult(
+                new[] { new RecorderPreflightGate("Launch target", Passed: false, Detail: targetFailure!) },
+                null)
+            : RecorderPlatformPreflight.Evaluate(facts, target);
+        passed &= ReportPlatformPreflight(Console.Out, facts, preflight);
+
+        passed &= ReportGate(Console.Out, "Source config", File.Exists(sourceConfig), sourceConfig);
         if (File.Exists(sourceConfig))
         {
             try
@@ -206,16 +238,9 @@ internal static class Program
         {
             var rawOutput = Path.GetFullPath(environment.ObsOutputDirectory);
             var rawOutputValid = Directory.Exists(rawOutput) && Path.IsPathFullyQualified(rawOutput);
-            passed &= ReportGate("Raw output directory", rawOutputValid, rawOutput);
+            passed &= ReportGate(Console.Out, "Raw output directory", rawOutputValid, rawOutput);
         }
 
-        Console.WriteLine("Manual OBS prerequisites:");
-        Console.WriteLine("Dedicated profile/collection/scene already selected");
-        Console.WriteLine("CX window/program capture configured");
-        Console.WriteLine("CX application audio configured");
-        Console.WriteLine("Hybrid MP4 configured");
-        Console.WriteLine("WebSocket enabled");
-        Console.WriteLine("raw output dir matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR");
         Console.WriteLine("Warning: each HPA-503 run uses a fresh songs.db; cold enumeration may take minutes.");
 
         if (ffprobe is null)
@@ -258,27 +283,58 @@ internal static class Program
         return passed ? 0 : 2;
     }
 
-    private static bool ReportGate(string name, bool passed, string detail)
+    /// <summary>
+    /// Reports the shared platform preflight gates plus the platform-specific
+    /// manual OBS prerequisites. Manual items are never claimed to be
+    /// programmatically verified. Factored over injected facts/result so Mac
+    /// parity is testable without a live OBS server.
+    /// </summary>
+    internal static bool ReportPlatformPreflight(
+        TextWriter writer,
+        RecorderPlatformFacts facts,
+        RecorderPlatformPreflightResult preflight)
     {
-        Console.WriteLine($"{name}: {(passed ? "passed" : "FAILED")} ({detail})");
+        ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(facts);
+        ArgumentNullException.ThrowIfNull(preflight);
+
+        var passed = true;
+        foreach (var gate in preflight.Gates)
+            passed &= ReportGate(writer, gate.Name, gate.Passed, gate.Detail);
+
+        writer.WriteLine("Manual OBS prerequisites:");
+        foreach (var line in facts.IsMacOS ? MacManualPrerequisites : WindowsManualPrerequisites)
+            writer.WriteLine(line);
+
         return passed;
     }
 
-    private static string? FindRepositoryRoot(string startDirectory)
+    private static readonly string[] MacManualPrerequisites =
     {
-        var candidate = Path.GetFullPath(startDirectory);
-        while (true)
-        {
-            if (File.Exists(Path.Combine(candidate, "DTXMania.sln")) ||
-                File.Exists(Path.Combine(candidate, "DTXMania.slnx")))
-            {
-                return candidate;
-            }
+        "Dedicated profile/collection/scene selected",
+        "ScreenCaptureKit application/window capture scoped to CX",
+        "CX application audio configured",
+        "Desktop Audio disabled",
+        "Microphone disabled",
+        "Hybrid MP4 configured",
+        "Screen Recording permission granted manually",
+        "WebSocket enabled/authenticated",
+        "Raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR"
+    };
 
-            var parent = Directory.GetParent(candidate);
-            if (parent is null)
-                return null;
-            candidate = parent.FullName;
-        }
+    private static readonly string[] WindowsManualPrerequisites =
+    {
+        "Dedicated profile/collection/scene already selected",
+        "CX window/program capture configured",
+        "CX application audio configured",
+        "Hybrid MP4 configured",
+        "WebSocket enabled",
+        "raw output dir matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR"
+    };
+
+    private static bool ReportGate(TextWriter writer, string name, bool passed, string detail)
+    {
+        writer.WriteLine($"{name}: {(passed ? "passed" : "FAILED")} ({detail})");
+        return passed;
     }
 }

--- a/DTXMania.VideoRecorder/Program.cs
+++ b/DTXMania.VideoRecorder/Program.cs
@@ -303,7 +303,12 @@ internal static class Program
             passed &= ReportGate(writer, gate.Name, gate.Passed, gate.Detail);
 
         writer.WriteLine("Manual OBS prerequisites:");
-        foreach (var line in facts.IsMacOS ? MacManualPrerequisites : WindowsManualPrerequisites)
+        var prerequisites = facts.IsMacOS
+            ? MacManualPrerequisites
+            : facts.IsWindows
+                ? WindowsManualPrerequisites
+                : UnsupportedPlatformManualPrerequisites;
+        foreach (var line in prerequisites)
             writer.WriteLine(line);
 
         return passed;
@@ -330,6 +335,12 @@ internal static class Program
         "Hybrid MP4 configured",
         "WebSocket enabled",
         "raw output dir matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR"
+    };
+
+    private static readonly string[] UnsupportedPlatformManualPrerequisites =
+    {
+        "Manual OBS prerequisites are unavailable on this platform.",
+        "dtx-video record is supported on Windows and macOS only."
     };
 
     private static bool ReportGate(TextWriter writer, string name, bool passed, string detail)

--- a/DTXMania.VideoRecorder/RecorderCommandLine.cs
+++ b/DTXMania.VideoRecorder/RecorderCommandLine.cs
@@ -313,6 +313,9 @@ internal static class RecorderCommandLine
         Func<Environment.SpecialFolder, string> getFolderPath,
         Func<string, string?> getEnvironmentVariable)
     {
+        ArgumentNullException.ThrowIfNull(getFolderPath);
+        ArgumentNullException.ThrowIfNull(getEnvironmentVariable);
+
         string basePath;
         if (isWindows)
         {

--- a/DTXMania.VideoRecorder/RecorderCommandLine.cs
+++ b/DTXMania.VideoRecorder/RecorderCommandLine.cs
@@ -122,14 +122,25 @@ internal static class RecorderCommandLine
     }
 
     public static void ValidateRecord(RecorderCommand command, RecorderEnvironment environment)
+        => ValidateRecord(
+            command,
+            environment,
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS());
+
+    internal static void ValidateRecord(
+        RecorderCommand command,
+        RecorderEnvironment environment,
+        bool isWindows,
+        bool isMacOS)
     {
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(environment);
 
-        if (!OperatingSystem.IsWindows())
+        if (!isWindows && !isMacOS)
         {
             throw new PlatformNotSupportedException(
-                "dtx-video record is supported on Windows only.");
+                "dtx-video record is supported on Windows and macOS only.");
         }
 
         ValidateObsUrl(environment.ObsUrl);
@@ -289,19 +300,65 @@ internal static class RecorderCommandLine
         }
     }
 
-    private static string GetDefaultSourceAppDataRoot()
+    /// <summary>
+    /// Mirrors the default (non-override) resolution of
+    /// <c>AppPaths.GetAppDataRoot()</c> in <c>DTXMania.Game/Lib/Utilities/AppPaths.cs</c>,
+    /// which is the authoritative contract — keep the two in sync. Deliberately
+    /// duplicated here instead of referencing the game assembly so the recorder
+    /// stays a standalone tool.
+    /// </summary>
+    internal static string GetDefaultSourceAppDataRoot(
+        bool isWindows,
+        bool isMacOS,
+        Func<Environment.SpecialFolder, string> getFolderPath,
+        Func<string, string?> getEnvironmentVariable)
     {
-        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        if (string.IsNullOrWhiteSpace(localAppData))
+        string basePath;
+        if (isWindows)
         {
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            if (string.IsNullOrWhiteSpace(home))
-                throw new InvalidOperationException("Unable to determine the CX app-data root.");
-            localAppData = OperatingSystem.IsMacOS()
-                ? Path.Combine(home, "Library", "Application Support")
-                : Path.Combine(home, ".config");
+            basePath = getFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        }
+        else if (isMacOS)
+        {
+            var home = GetHomeDirectory(getFolderPath, getEnvironmentVariable);
+            basePath = Path.Combine(home, "Library", "Application Support");
+        }
+        else
+        {
+            basePath = getFolderPath(Environment.SpecialFolder.ApplicationData);
         }
 
-        return Path.Combine(localAppData, "DTXManiaCX");
+        if (string.IsNullOrWhiteSpace(basePath) || !Path.IsPathRooted(basePath))
+        {
+            var fallbackHome = GetHomeDirectory(getFolderPath, getEnvironmentVariable);
+            if (string.IsNullOrWhiteSpace(fallbackHome))
+                throw new InvalidOperationException("Unable to determine the CX app-data root.");
+            basePath = isMacOS
+                ? Path.Combine(fallbackHome, "Library", "Application Support")
+                : Path.Combine(fallbackHome, ".config");
+        }
+
+        return Path.Combine(basePath, "DTXManiaCX");
+    }
+
+    private static string GetDefaultSourceAppDataRoot()
+        => GetDefaultSourceAppDataRoot(
+            OperatingSystem.IsWindows(),
+            OperatingSystem.IsMacOS(),
+            Environment.GetFolderPath,
+            Environment.GetEnvironmentVariable);
+
+    private static string GetHomeDirectory(
+        Func<Environment.SpecialFolder, string> getFolderPath,
+        Func<string, string?> getEnvironmentVariable)
+    {
+        var home = getFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrWhiteSpace(home))
+            home = getFolderPath(Environment.SpecialFolder.Personal);
+
+        if (string.IsNullOrWhiteSpace(home))
+            home = getEnvironmentVariable("HOME") ?? string.Empty;
+
+        return home;
     }
 }

--- a/DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
+++ b/DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
@@ -5,15 +5,14 @@ namespace DTXMania.VideoRecorder.Workflow;
 
 /// <summary>
 /// Recorder-local launch policy. Automation deliberately does not know how a
-/// disposable recorder sandbox maps to the repository's Windows game project.
+/// disposable recorder sandbox maps to the repository's game projects.
 /// </summary>
 /// <remarks>
 /// <b>Repository-root contract:</b> <c>dtx-video</c> must be invoked with the
-/// repository checkout as its working directory. <see cref="CreateOptions"/>
-/// treats <see cref="Directory.GetCurrentDirectory"/> as the declared root
-/// source and walks upward from it to locate the solution, so the Windows game
-/// project (<c>DTXMania.Game/DTXMania.Game.Windows.csproj</c>) is always
-/// resolved relative to that single declared root.
+/// repository checkout as its working directory. <see cref="ResolveTarget"/>
+/// walks upward from the declared start directory to locate the solution, so
+/// the current-platform game project is always resolved relative to that
+/// single declared root.
 /// </remarks>
 internal sealed record ResolvedRecorderTarget(
     string RepositoryRoot,
@@ -53,25 +52,6 @@ internal static class RecorderGameLaunchPolicy
             sandbox.AppDataRoot,
             Guid.NewGuid().ToString("N"),
             ProjectRunArguments: new[] { "--no-build", "--configuration", "Debug" });
-    }
-
-    /// <summary>
-    /// Builds the launch options for the Windows game project rooted at the
-    /// repository root declared via the current working directory.
-    /// </summary>
-    public static GameProcessStartOptions CreateOptions(RecordingSandbox sandbox)
-    {
-        ArgumentNullException.ThrowIfNull(sandbox);
-        var repoRoot = ResolveRepoRoot(Directory.GetCurrentDirectory());
-        var projectPath = Path.Combine(
-            repoRoot,
-            "DTXMania.Game",
-            "DTXMania.Game.Windows.csproj");
-        return new GameProcessStartOptions(
-            repoRoot,
-            GameLaunchTarget.Project(projectPath),
-            sandbox.AppDataRoot,
-            Guid.NewGuid().ToString("N"));
     }
 
     internal static string ResolveRepoRoot(string startDirectory)

--- a/DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
+++ b/DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
@@ -8,11 +8,10 @@ namespace DTXMania.VideoRecorder.Workflow;
 /// disposable recorder sandbox maps to the repository's game projects.
 /// </summary>
 /// <remarks>
-/// <b>Repository-root contract:</b> <c>dtx-video</c> must be invoked with the
-/// repository checkout as its working directory. <see cref="ResolveTarget"/>
-/// walks upward from the declared start directory to locate the solution, so
-/// the current-platform game project is always resolved relative to that
-/// single declared root.
+/// <see cref="ResolveTarget"/> walks upward from the declared start directory
+/// to locate the solution, so <c>dtx-video</c> may be invoked from the
+/// repository root or any nested directory within it. The current-platform
+/// game project is always resolved relative to the located solution root.
 /// </remarks>
 internal sealed record ResolvedRecorderTarget(
     string RepositoryRoot,

--- a/DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
+++ b/DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
@@ -15,8 +15,46 @@ namespace DTXMania.VideoRecorder.Workflow;
 /// project (<c>DTXMania.Game/DTXMania.Game.Windows.csproj</c>) is always
 /// resolved relative to that single declared root.
 /// </remarks>
+internal sealed record ResolvedRecorderTarget(
+    string RepositoryRoot,
+    string WorkingDirectory,
+    GameLaunchTarget Target);
+
 internal static class RecorderGameLaunchPolicy
 {
+    /// <summary>
+    /// Sandbox-free resolution of the current-platform game launch target
+    /// rooted at the repository containing <paramref name="startDirectory"/>.
+    /// </summary>
+    internal static ResolvedRecorderTarget ResolveTarget(string startDirectory)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(startDirectory);
+        var repoRoot = ResolveRepoRoot(startDirectory);
+        var projectPath = Path.GetFullPath(Path.Combine(repoRoot, GameProjectPaths.Current));
+        return new ResolvedRecorderTarget(
+            repoRoot,
+            repoRoot,
+            GameLaunchTarget.Project(projectPath));
+    }
+
+    /// <summary>
+    /// Builds the launch options for the resolved target, pinned to the
+    /// prebuilt Debug output via no-build.
+    /// </summary>
+    internal static GameProcessStartOptions CreateOptions(
+        RecordingSandbox sandbox,
+        ResolvedRecorderTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(sandbox);
+        ArgumentNullException.ThrowIfNull(target);
+        return new GameProcessStartOptions(
+            target.WorkingDirectory,
+            target.Target,
+            sandbox.AppDataRoot,
+            Guid.NewGuid().ToString("N"),
+            ProjectRunArguments: new[] { "--no-build", "--configuration", "Debug" });
+    }
+
     /// <summary>
     /// Builds the launch options for the Windows game project rooted at the
     /// repository root declared via the current working directory.

--- a/docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md
@@ -1,0 +1,781 @@
+# HPA-515 Apple Silicon Recorder Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to execute this plan task-by-task. Keep the implementation minimal; HPA-515 is Mac parity for the existing recorder, not a recorder/platform redesign.
+
+**Goal:** Make the existing `dtx-video` workflow run natively on Apple Silicon macOS, prove one real ScreenCaptureKit/OBS recording with bundled arm64 FFmpeg audio, and retain a concise Mac setup guide plus sanitized verification record.
+
+**Architecture:** Preserve the existing `RecordWorkflow`, OBS client, sandbox, diagnostics, and finalization. Remove only the recorder's three Windows assumptions by making command validation and launch selection platform-aware and adding one focused Mac preflight helper for `doctor`. Use the existing `GameProjectPaths` / `GameLaunchTarget.Project` / `GameLaunchTarget.Executable` primitives from `DTXMania.Automation`; do not add platform adapters.
+
+**Tech stack:** .NET 8, MonoGame CX Mac project, `DTXMania.Automation`, obs-websocket 5.x, OBS Studio 30.2+, ScreenCaptureKit, existing HPA-512 native FFmpeg runtime.
+
+**Expected effort:** 2–3 engineer days including one real Apple Silicon/OBS acceptance run.
+
+## Global constraints
+
+- Keep `dtx-video doctor` and `dtx-video record --chart ... --output ...` unchanged.
+- Windows behavior must remain unchanged.
+- Mac support is macOS 13+ on native arm64 only; no Intel Mac or Rosetta fallback.
+- Reuse the same `RecordWorkflow`; no Mac workflow/session subclass.
+- Reuse `GameProcessDriver`; do not change process ownership/readiness semantics unless a proven blocker requires it.
+- Reuse `ObsWebSocketRecorder`; no ScreenCaptureKit source discovery or permission diagnosis.
+- Reuse HPA-512's bundled `osx-arm64` FFmpeg; do not add another resolver/download/dependency.
+- Recorder-side MP4 `ffprobe` stays optional PATH-based as today.
+- Keep the successful-run disposable app-data behavior unchanged.
+- Do not add strict media policy, remux, or transcoding; HPA-506 owns that.
+- Do not add automated Mac OBS diagnostics; HPA-505 owns that.
+- If the native proof exposes an unrelated recorder/game defect, stop and file a focused blocker instead of expanding HPA-515.
+
+## Intended implementation PR file surface
+
+```text
+Modify:
+  DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs
+  DTXMania.VideoRecorder/RecorderCommandLine.cs
+  DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
+  DTXMania.VideoRecorder/Program.cs
+
+Create:
+  DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs
+  DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
+  DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
+  DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+  docs/video-recorder/macos-obs-setup.md
+  docs/verification/hpa-515-apple-silicon-live-recording.md
+
+Normally unchanged:
+  DTXMania.VideoRecorder/Workflow/RecordWorkflow.cs
+  DTXMania.VideoRecorder/Obs/**
+  DTXMania.VideoRecorder/Media/**
+  DTXMania.VideoRecorder/Sandbox/**
+  DTXMania.Automation/Process/GameProcessDriver.cs
+  DTXMania.Game/Lib/Resources/FfmpegRuntime.cs
+  DTXMania.Game/DTXMania.Game.Mac.csproj
+  .github/workflows/**
+```
+
+---
+
+## Task 1: Make recorder validation and game launch target platform-aware
+
+**Files:**
+
+- Modify: `DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs`
+- Modify: `DTXMania.VideoRecorder/RecorderCommandLine.cs`
+- Modify: `DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs`
+- Create: `DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs`
+- Create: `DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs`
+
+**Interfaces:**
+
+- Add optional environment setting `DTXMANIA_VIDEO_GAME_EXECUTABLE` to `RecorderEnvironment`.
+- Keep the public CLI verbs/options unchanged.
+- Keep returning the existing `GameProcessStartOptions`; no new public Automation types.
+- Default launch target is the current platform project from `GameProjectPaths.Current`.
+- Explicit executable mode uses `GameLaunchTarget.Executable` and executable-parent working directory.
+
+- [ ] **Step 1: Add failing command-line environment tests.**
+
+Cover these behaviors:
+
+```text
+unset DTXMANIA_VIDEO_GAME_EXECUTABLE
+  -> RecorderEnvironment.GameExecutablePath == null
+
+absolute existing executable path
+  -> value is normalized to a full path
+
+relative executable path
+  -> rejected with an actionable validation error
+
+missing executable path
+  -> rejected before record starts
+```
+
+Do not add a new CLI option for the game target.
+
+- [ ] **Step 2: Run the focused command-line tests and confirm the new cases fail.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~RecorderCommandLineTests"
+```
+
+Expected before implementation: the new `GameExecutablePath`/environment behavior does not exist.
+
+- [ ] **Step 3: Extend `RecorderEnvironment` and environment parsing minimally.**
+
+Add one nullable field for the optional executable target and one environment-variable constant:
+
+```text
+DTXMANIA_VIDEO_GAME_EXECUTABLE
+```
+
+Normalize it only when non-empty. Preserve all existing OBS/app-data environment behavior.
+
+Validation rule:
+
+```text
+unset -> default project mode
+set   -> absolute existing file required
+```
+
+Do not inspect `.app` metadata or search for executables.
+
+- [ ] **Step 4: Replace the Windows-only record gate with the intended support contract.**
+
+`ValidateRecord` should allow:
+
+```text
+Windows -> existing behavior
+macOS   -> only macOS 13+ and native arm64
+other   -> PlatformNotSupportedException
+```
+
+Do not tighten existing Windows architecture/version behavior in this ticket.
+
+Keep chart/output/OBS/source validation ordering deterministic and actionable.
+
+- [ ] **Step 5: Add failing launch-policy tests.**
+
+Required cases:
+
+```text
+default target
+  -> resolves repository root
+  -> uses GameProjectPaths.Current
+  -> creates GameLaunchTarget.Project(absolute current-platform project)
+  -> working directory is repository root
+
+explicit executable
+  -> exact executable is selected through GameLaunchTarget.Executable
+  -> working directory is executable parent
+  -> sandbox AppDataRoot is preserved
+  -> launch token remains fresh/non-empty
+```
+
+Tests may branch on `OperatingSystem.IsWindows()` / `OperatingSystem.IsMacOS()`; the repository already runs VideoRecorder tests on both CI platforms.
+
+- [ ] **Step 6: Run the launch-policy tests and confirm the new cases fail.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~RecorderGameLaunchPolicyTests"
+```
+
+- [ ] **Step 7: Generalize `RecorderGameLaunchPolicy.CreateOptions`.**
+
+Keep repository-root resolution in this class.
+
+Implementation rules:
+
+```text
+if GameExecutablePath is null:
+  target = Project(repoRoot + GameProjectPaths.Current)
+  workingDirectory = repoRoot
+else:
+  target = Executable(GameExecutablePath)
+  workingDirectory = parent(GameExecutablePath)
+```
+
+Do not modify `GameProcessDriver`.
+
+- [ ] **Step 8: Wire `RunRecordAsync` to pass the selected executable override into the launch policy.**
+
+No other workflow construction changes are expected.
+
+- [ ] **Step 9: Run the focused tests until green.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~RecorderCommandLineTests|FullyQualifiedName~RecorderGameLaunchPolicyTests"
+```
+
+- [ ] **Step 10: Commit Task 1.**
+
+```bash
+git add \
+  DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs \
+  DTXMania.VideoRecorder/RecorderCommandLine.cs \
+  DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs \
+  DTXMania.VideoRecorder/Program.cs \
+  DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs \
+  DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
+
+git commit -m "feat: support Mac recorder launch targets"
+```
+
+---
+
+## Task 2: Add a focused Mac `doctor` preflight without changing the recorder workflow
+
+**Files:**
+
+- Create: `DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs`
+- Modify: `DTXMania.VideoRecorder/Program.cs`
+- Create: `DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs`
+
+**Interfaces:**
+
+Keep this helper internal to VideoRecorder. It owns only platform/target/native-runtime preflight needed by `doctor`; it does not launch CX or talk to OBS.
+
+The helper must support these inputs already available to `Program`:
+
+```text
+repository root
+GameProcessStartOptions / selected GameLaunchTarget
+current OS/version/process architecture
+```
+
+It must expose enough result detail for `Program` to print individual pass/fail gates and the resolved Mac runtime directory. Do not create a generic plug-in interface.
+
+- [ ] **Step 1: Add failing preflight tests for project and executable runtime layout.**
+
+Use temporary directories/files rather than the real build output.
+
+Required path rules:
+
+```text
+Mac project mode:
+  <repo>/DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}
+
+Mac explicit executable mode:
+  <executable-dir>/runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}
+```
+
+Required failure cases:
+
+```text
+missing ffmpeg
+missing ffprobe
+non-executable runtime file on macOS
+unsupported macOS version
+non-arm64 Mac process
+```
+
+The path-resolution tests should remain runnable on either OS. Unix execute-bit assertions may be guarded to macOS.
+
+- [ ] **Step 2: Run the focused preflight tests and confirm they fail.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~RecorderPlatformPreflightTests"
+```
+
+- [ ] **Step 3: Implement the smallest internal preflight helper.**
+
+Responsibilities only:
+
+```text
+validate supported host for record/doctor reporting
+resolve selected target description
+resolve expected Mac native runtime directory
+verify ffmpeg + ffprobe exist
+verify executable permission on macOS
+return actionable gate detail
+```
+
+Do not:
+
+```text
+reference DTXMania.Game
+configure FFMpegCore
+probe codecs
+search PATH for CX audio runtime
+download FFmpeg
+inspect OBS sources
+modify privacy permissions
+```
+
+- [ ] **Step 4: Rework `RunDoctorAsync` to use the same launch target selection as `record`.**
+
+Remove the hard-coded Windows project path and duplicate repository-root policy.
+
+`doctor` should report:
+
+```text
+Recorder platform
+Repository
+Selected game target
+Source config
+Raw output directory
+OBS URL/auth/status
+```
+
+On macOS additionally report:
+
+```text
+macOS >= 13
+process architecture == arm64
+native CX FFmpeg runtime directory
+ffmpeg executable
+ffprobe executable
+```
+
+The existing recorder-side PATH `ffprobe` message remains optional and must be clearly distinguished from the bundled CX FFmpeg gate.
+
+- [ ] **Step 5: Make manual OBS prerequisite text platform-specific.**
+
+Windows keeps existing Game Capture/application-audio text.
+
+macOS prints only the minimal operator checklist:
+
+```text
+Dedicated profile/collection/scene selected
+ScreenCaptureKit application/window capture scoped to CX
+CX application audio configured
+Desktop Audio disabled
+Microphone disabled
+Hybrid MP4 configured
+Screen Recording permission granted manually
+WebSocket enabled/authenticated
+Raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR
+```
+
+Never print a claim that source selection or privacy permission was programmatically verified.
+
+- [ ] **Step 6: Keep OBS mutation behavior unchanged.**
+
+`doctor` must still perform only:
+
+```text
+Hello
+Identify
+GetRecordStatus
+```
+
+No StartRecord/StopRecord and no source APIs.
+
+- [ ] **Step 7: Run focused preflight + existing OBS tests.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~RecorderPlatformPreflightTests|FullyQualifiedName~Obs"
+```
+
+- [ ] **Step 8: Run the whole VideoRecorder and Automation test projects.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
+```
+
+Do not edit CI merely to create a new job; these suites already run on Windows and macOS CI.
+
+- [ ] **Step 9: Commit Task 2.**
+
+```bash
+git add \
+  DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs \
+  DTXMania.VideoRecorder/Program.cs \
+  DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+
+git commit -m "feat: add Mac recorder doctor preflight"
+```
+
+---
+
+## Task 3: Validate the implementation on Apple Silicon before involving OBS
+
+**Files:** normally no new files.
+
+**Produces:** a green native Mac build/test baseline and proof that the default CX target carries the HPA-512 runtime.
+
+- [ ] **Step 1: Confirm the host is native Apple Silicon.**
+
+Run on the proof workstation:
+
+```bash
+uname -m
+sw_vers -productVersion
+dotnet --info
+```
+
+Require:
+
+```text
+uname -m -> arm64
+macOS major version -> 13 or later
+.NET -> SDK 8.x available
+```
+
+- [ ] **Step 2: Build the Mac game before `doctor`.**
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+```
+
+This materializes the HPA-512 runtime in the same Debug output used by default `dotnet run` project mode.
+
+- [ ] **Step 3: Verify native runtime architecture directly.**
+
+```bash
+file DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac
+file DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
+file DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
+```
+
+Require each relevant executable description to include `arm64`.
+
+- [ ] **Step 4: Run Mac game/audio tests that prove bundled runtime use.**
+
+```bash
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --configuration Debug \
+  --no-build \
+  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegBundledRuntimeTests|FullyQualifiedName~ManagedSoundTests"
+```
+
+- [ ] **Step 5: Run recorder + Automation suites on the same host.**
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
+```
+
+- [ ] **Step 6: Exercise both launch-selection modes without broadening the task.**
+
+Default project mode is required for the live proof.
+
+For explicit executable mode, use an existing published/app-bundle executable if already available on the workstation. It is sufficient to verify `doctor` resolves the target/runtime correctly; HPA-515 does not require two full videos.
+
+Do not build a new DMG workflow just for this test.
+
+- [ ] **Step 7: Do not commit acceptance evidence yet.**
+
+If any Mac-only code defect is found, fix it inside HPA-515 only when it is directly caused by launch/preflight parity. Otherwise open a focused blocker.
+
+---
+
+## Task 4: Produce and accept one native Apple Silicon recording
+
+**Files:** local evidence only during this task.
+
+**Produces:** one accepted MP4, recorder diagnostics, source-isolation proof, and one cancellation/ownership proof.
+
+- [ ] **Step 1: Prepare one proof directory outside the Git checkout.**
+
+Create local variables pointing at actual workstation paths:
+
+```bash
+export HPA515_PROOF_ROOT="$HOME/DTXManiaCX-HPA-515-proof"
+export HPA515_RAW="$HPA515_PROOF_ROOT/raw"
+export HPA515_PUBLISHED="$HPA515_PROOF_ROOT/published"
+mkdir -p "$HPA515_RAW" "$HPA515_PUBLISHED"
+```
+
+Choose one existing indexed chart with MP3 or another encoded preview/BGM that exercises bundled FFmpeg and export its absolute path:
+
+```bash
+export HPA515_CHART="$(python3 -c 'import os; print(os.path.abspath(os.environ["HPA515_CHART_INPUT"]))')"
+```
+
+Before running the command, set `HPA515_CHART_INPUT` to the actual selected chart path in the local shell. Do not commit it.
+
+- [ ] **Step 2: Configure OBS manually.**
+
+Required state:
+
+```text
+OBS 30.2+
+Dedicated DTXManiaCX profile/collection/scene
+ScreenCaptureKit app/window source -> CX
+CX application audio enabled through that source or one dedicated macOS Audio Capture source
+Desktop Audio disabled
+Microphone disabled
+Hybrid MP4
+Screen Recording permission granted
+obs-websocket 5.x enabled/authenticated
+Recording directory == HPA515_RAW
+OBS idle
+```
+
+Visually confirm the source shows CX before starting the recorder. This manual check is the source/permission gate for HPA-515.
+
+- [ ] **Step 3: Export recorder environment.**
+
+```bash
+export DTXMANIA_VIDEO_OBS_URL="ws://127.0.0.1:4455"
+export DTXMANIA_VIDEO_OBS_PASSWORD="$HPA515_LOCAL_OBS_PASSWORD"
+export DTXMANIA_VIDEO_OBS_OUTPUT_DIR="$HPA515_RAW"
+unset DTXMANIA_VIDEO_GAME_EXECUTABLE
+```
+
+`HPA515_LOCAL_OBS_PASSWORD` is a local secret and must never be written to committed evidence.
+
+- [ ] **Step 4: Capture source app-data before-state.**
+
+For the actual source CX app-data root, record presence, byte size, and SHA-256 for:
+
+```text
+Config.ini
+songs.db
+songs.db-wal
+songs.db-shm
+```
+
+Save the sanitized local output to:
+
+```text
+$HPA515_PROOF_ROOT/source-state-before.txt
+```
+
+Absent WAL/SHM files remain absent; do not create them for the proof.
+
+- [ ] **Step 5: Run `doctor` and retain output.**
+
+```bash
+dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj \
+  --configuration Debug -- doctor \
+  2>&1 | tee "$HPA515_PROOF_ROOT/doctor.txt"
+```
+
+Require exit code `0` and these Mac gates:
+
+```text
+supported macOS
+arm64 recorder process
+repository found
+Mac game target found
+native CX ffmpeg found/executable
+native CX ffprobe found/executable
+source config valid
+raw output directory valid
+OBS auth/status succeeded
+OBS recording inactive
+OBS state mutation none
+```
+
+- [ ] **Step 6: Retain architecture evidence.**
+
+Write sanitized `file` output for the game apphost and bundled FFmpeg pair to:
+
+```text
+$HPA515_PROOF_ROOT/architecture.txt
+```
+
+Require `arm64` for all three.
+
+- [ ] **Step 7: Run the accepted recording.**
+
+```bash
+dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj \
+  --configuration Debug --no-build -- \
+  record --chart "$HPA515_CHART" --output "$HPA515_PUBLISHED"
+```
+
+Require exit code `0` and retain:
+
+```text
+raw OBS MP4
+published MP4
+published/diagnostics/<run-id>/run.json
+published/diagnostics/<run-id>/cx-stdout.log
+published/diagnostics/<run-id>/cx-stderr.log
+```
+
+- [ ] **Step 8: Validate `run.json` using the shared Windows contract.**
+
+Require:
+
+```text
+status == Completed
+SongSelectReady -> selected song present
+PreviewReady -> Playing and elapsed >= 10000 ms
+PerformanceReady -> ready, AutoPlay enabled, totalNotes > 0
+ResultCompleted -> completed, clear, SongComplete, totalJudgements == totalNotes
+OBS Connect/Status/Start/Stop -> success
+raw/published paths -> present
+failure/failureType/retained successful sandbox -> absent
+```
+
+Do not add Mac-only telemetry just to make the proof easier.
+
+- [ ] **Step 9: Run one native Ctrl+C ownership check.**
+
+Start a second valid `record` run. After OBS is recorder-owned and preview/gameplay is active, press Ctrl+C once.
+
+Require:
+
+```text
+command exits via cancellation
+OBS is no longer recording
+partial raw artifact retained when available
+failed-run diagnostics retained when available
+failed-run sandbox retained and referenced for debugging
+normal source app-data unchanged
+```
+
+Delete the failed-run sandbox manually only after evidence is inspected.
+
+- [ ] **Step 10: Capture source app-data after-state.**
+
+Repeat the exact same presence/size/SHA-256 capture as Step 4.
+
+Require no source Config.ini/database/WAL/SHM content change and no new source WAL/SHM creation caused by the recorder.
+
+- [ ] **Step 11: Watch the complete published MP4.**
+
+Confirm:
+
+```text
+[ ] intended populated Song Select first
+[ ] preview begins after visible Song Select
+[ ] >= 10 seconds actual preview audio
+[ ] complete Song Transition
+[ ] full AutoPlay gameplay
+[ ] BGM/chip audio audible
+[ ] fully rendered Result
+[ ] Result held >= 5 seconds
+[ ] recording ends after Result hold
+[ ] no OBS UI / desktop / unrelated window
+[ ] no cursor / notifications
+[ ] no microphone / unrelated application audio
+[ ] no duplicated or echoed CX audio
+[ ] no aspect squeeze / severe stutter / missing viewport region
+[ ] encoded preview/gameplay audio works without user-installed FFmpeg or Rosetta
+```
+
+If capture selection/privacy is wrong, fix the manual OBS setup and rerun. Do not add automatic source diagnosis to HPA-515.
+
+---
+
+## Task 5: Commit the Mac runbook and sanitized verification record
+
+**Files:**
+
+- Create: `docs/video-recorder/macos-obs-setup.md`
+- Create: `docs/verification/hpa-515-apple-silicon-live-recording.md`
+
+- [ ] **Step 1: Write `macos-obs-setup.md`.**
+
+Keep it operator-focused and concise. Required sections:
+
+```text
+Prerequisites: macOS 13+, Apple Silicon, OBS 30.2+
+Build the default Mac project target
+Optional DTXMANIA_VIDEO_GAME_EXECUTABLE usage
+ScreenCaptureKit app/window source
+CX application audio source
+Screen Recording permission
+Disable Desktop Audio + microphone
+Hybrid MP4 + obs-websocket
+Required environment variables
+doctor command
+record command
+Native bundled FFmpeg gate
+Raw/published/diagnostics locations
+Troubleshooting:
+  unsupported/non-arm64 host
+  missing bundled runtime
+  OBS auth/already-recording
+  Screen Recording permission
+  stale/wrong ScreenCaptureKit target
+  duplicated/missing audio
+  invalid/unindexed chart
+  optional recorder-side ffprobe warning
+```
+
+Do not turn this into general OBS/macOS documentation.
+
+- [ ] **Step 2: Write `hpa-515-apple-silicon-live-recording.md`.**
+
+Record only sanitized evidence:
+
+```text
+accepted commit SHA
+macOS version + arm64 host
+.NET SDK/host version
+OBS version
+launch mode (project or explicit executable)
+non-sensitive chart identity
+arm64 game/ffmpeg/ffprobe evidence summary
+doctor gate summary
+successful command summary with private paths redacted
+raw MP4 filename + size + SHA-256
+published MP4 filename + size + SHA-256
+key run.json values
+source before/after result
+Ctrl+C ownership/cleanup result
+manual media checklist result
+focused test commands + pass counts
+warnings/deviations
+```
+
+Never embed passwords, API keys, private absolute chart paths, raw logs, or MP4 binaries.
+
+- [ ] **Step 3: Run final cross-platform-safe validation on the implementation branch.**
+
+On Apple Silicon:
+
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug --no-build
+```
+
+Then rely on the existing GitHub Windows/macOS CI jobs for the authoritative cross-platform gate.
+
+- [ ] **Step 4: Confirm scope before committing.**
+
+```bash
+git status --short
+git diff --stat main...HEAD
+git diff --check
+```
+
+Reject unrelated changes and any unexpected edits under:
+
+```text
+RecordWorkflow.cs
+Obs/
+Media/
+Sandbox/
+GameProcessDriver.cs
+FfmpegRuntime.cs
+.github/workflows/
+```
+
+unless a separately reviewed, directly necessary fix was explicitly added.
+
+- [ ] **Step 5: Commit the acceptance documents.**
+
+```bash
+git add \
+  docs/video-recorder/macos-obs-setup.md \
+  docs/verification/hpa-515-apple-silicon-live-recording.md
+
+git commit -m "docs: record Apple Silicon recorder acceptance"
+```
+
+- [ ] **Step 6: Final PR checklist.**
+
+The implementation PR is ready for review only when all are true:
+
+```text
+[ ] same CLI contract on Windows + Mac
+[ ] Mac default project launch is DTXMania.Game.Mac.csproj
+[ ] optional explicit packaged executable works
+[ ] Mac doctor fails unsupported OS/arch and unusable bundled runtime
+[ ] existing Windows VideoRecorder/Automation tests green
+[ ] Mac VideoRecorder/Automation/audio tests green
+[ ] real Apple Silicon doctor green
+[ ] accepted MP4 manually inspected
+[ ] source app-data unchanged
+[ ] Ctrl+C stops only owned OBS recording
+[ ] no ScreenCaptureKit automation/platform framework/strict media scope added
+```
+
+## Implementation-agent handoff
+
+Execute this as one HPA-515 implementation PR with three review checkpoints:
+
+1. **Launch parity:** command/environment validation and platform project/executable selection.
+2. **Doctor parity:** Mac host/native-runtime gates with focused tests; shared workflow remains untouched.
+3. **Native acceptance:** real Apple Silicon OBS proof plus the two committed docs.
+
+Do not parallelize Tasks 1 and 2 against different assumptions: Task 2 consumes the exact launch target selected by Task 1. Task 4 cannot be accepted until Tasks 1–3 are green.

--- a/docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md
@@ -1,37 +1,38 @@
 # HPA-515 Apple Silicon Recorder Parity Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to execute this plan task-by-task. HPA-515 is Mac parity for the existing recorder. Keep one project-mode launch path and do not expand into packaged-app support.
+> **For agentic workers:** use `superpowers:subagent-driven-development` or `superpowers:executing-plans`. Keep HPA-515 as Mac parity for the existing recorder. Do not add a second workflow, platform adapter, or packaged-app mode.
 
-**Goal:** Make the existing `dtx-video` project-mode workflow run natively on Apple Silicon macOS, fail unsupported/missing-runtime Mac runs before OBS starts, prove one real ScreenCaptureKit recording with bundled arm64 FFmpeg audio, and retain a concise Mac setup guide plus sanitized verification record.
+**Goal:** Make the existing `dtx-video` project-mode workflow run natively on Apple Silicon macOS, certify and launch the same prebuilt Debug artifact, fail unsupported/missing-runtime runs before sandbox/OBS side effects, and retain one inspected ScreenCaptureKit recording plus concise proof documentation.
 
-**Architecture:** Preserve `RecordWorkflow`, OBS ownership, sandboxing, diagnostics, finalization, and `GameProcessDriver`. Extract one sandbox-free project-target resolver from `RecorderGameLaunchPolicy`, add one focused `RecorderPlatformPreflight` consumed by both record and doctor, and make the default Mac app-data path explicitly match CX. No platform adapter and no second launch mode.
-
-**Tech Stack:** .NET 8, MonoGame Mac project, `DTXMania.Automation`, obs-websocket 5.x, OBS Studio 30.2+, ScreenCaptureKit, existing HPA-512 `osx-arm64` FFmpeg runtime.
+**Architecture:** Preserve `RecordWorkflow`, OBS ownership, sandboxing, diagnostics, and finalization. Add one additive project-run-argument seam to Automation so the recorder can launch `--no-build --configuration Debug`; resolve the current-platform target once; evaluate one Mac preflight against that exact Debug output; pass the result into the side-effecting record method; and reuse the same result in doctor.
 
 **Expected effort:** 2–3 engineer days including one real Apple Silicon/OBS acceptance run.
 
-## Global Constraints
+## Global constraints
 
 - Keep `dtx-video doctor` and `dtx-video record --chart ... --output ...` unchanged.
-- HPA-515 supports project mode only: Windows project on Windows, Mac project on macOS.
-- Keep existing Windows behavior unchanged.
-- Mac support is macOS 13+ on native arm64 only; no Intel/Rosetta fallback.
-- Run the Mac host/runtime preflight before creating the recorder sandbox or touching OBS.
-- Reuse the same `RecordWorkflow`; no Mac workflow/session subclass.
-- Reuse `GameProcessDriver`; do not change its process ownership/readiness behavior.
-- Reuse `ObsWebSocketRecorder`; do not add ScreenCaptureKit source discovery or privacy diagnosis.
-- Reuse HPA-512's bundled `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`; no second runtime resolver/download/PATH fallback for CX audio.
-- Recorder-side final-MP4 `ffprobe` remains optional PATH-based as today.
-- Keep successful-run disposable app-data behavior unchanged.
+- Project mode only: Windows project on Windows, Mac project on macOS.
+- Keep one `RecordWorkflow` and one `ObsWebSocketRecorder`.
+- Mac certification is macOS 13+ and native arm64 only.
+- The recorder must launch the exact prebuilt Debug artifact that preflight checked.
+- Do not silently build inside the recorder launch path.
+- Run failed-preflight rejection before sandbox creation or OBS client construction.
 - Keep `DTXMANIA_APPDATA_ROOT` as the explicit source-app-data override.
-- Do not add strict media/remux/transcoding policy; HPA-506 owns that.
-- Do not add automated Mac OBS source/audio/privacy diagnostics; HPA-505 owns that.
-- Do not edit CI unless the existing Windows/macOS recorder jobs prove they do not execute the new tests.
+- Mirror the authoritative `AppPaths.GetAppDataRoot()` default behavior without adding a production `DTXMania.Game -> DTXMania.Automation` dependency.
+- Require HPA-512 `osx-arm64` bundled `ffmpeg` + `ffprobe` for recorder certification even though CX itself can fall back to other RIDs/PATH.
+- Keep recorder-side final-MP4 PATH `ffprobe` optional as today.
+- Keep ScreenCaptureKit source/audio/privacy configuration manual; HPA-505 owns automatic diagnostics.
+- Keep strict codec/remux policy deferred to HPA-506.
+- Do not edit CI unless existing jobs prove they skip the new tests.
 
-## File Structure
+## Planned files
 
 ```text
 Modify:
+  DTXMania.Automation/Process/GameProcessStartOptions.cs
+  DTXMania.Automation/Process/GameProcessDriver.cs
+  DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs
+
   DTXMania.VideoRecorder/RecorderCommandLine.cs
   DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
   DTXMania.VideoRecorder/Program.cs
@@ -41,6 +42,8 @@ Create:
   DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
   DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
   DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+  DTXMania.VideoRecorder.Tests/ProgramTests.cs
+
   docs/video-recorder/macos-obs-setup.md
   docs/verification/hpa-515-apple-silicon-live-recording.md
 
@@ -49,33 +52,75 @@ Normally unchanged:
   DTXMania.VideoRecorder/Obs/**
   DTXMania.VideoRecorder/Media/**
   DTXMania.VideoRecorder/Sandbox/**
-  DTXMania.Automation/Process/GameProcessDriver.cs
   DTXMania.Game/Lib/Resources/FfmpegRuntime.cs
+  DTXMania.Game/Lib/Utilities/AppPaths.cs
   DTXMania.Game/DTXMania.Game.Mac.csproj
   .github/workflows/**
 ```
 
-## Risks to keep visible during execution
+## Risks to keep visible
 
-- A native proof failure may be manual OBS source/audio/privacy setup, not a code defect. Do not change recorder code without evidence.
-- The runtime preflight intentionally targets `bin/Debug/net8.0` because `GameProcessDriver` launches `dotnet run --project` without `--configuration`. If that launch contract changes, update launch and preflight together.
-- Missing bundled FFmpeg can look like a capture/audio failure after Song Select. The pre-record gate must fail before OBS to remove that ambiguity.
-- Source-isolation evidence is invalid if the recorder hashes a different app-data root from CX. The explicit Mac default path is part of this task.
+- Preflight and launch are one contract: Debug + no-build. Do not change one without the other.
+- `--no-build` pins checked output to launched output, but does not prove source did not change after the manual build. The acceptance procedure builds immediately before evidence capture and records the commit SHA; do not invent a build-manifest system.
+- Mac OBS/source/privacy failures may be operator setup rather than recorder defects.
+- The recorder app-data default mirrors `AppPaths`; keep the link explicit and tests host-independent. Do not solve one small rule by making the game depend on Automation.
+- macOS 13 is intentional: the accepted OBS application-audio path requires macOS 13+.
 
 ---
 
-### Task 1: Share project-target resolution and align the Mac app-data default
+## Task 1: Launch the exact prebuilt Debug artifact
+
+**Scope:** small additive Automation seam + recorder launch policy. No workflow changes.
 
 **Files:**
+- Modify: `DTXMania.Automation/Process/GameProcessStartOptions.cs`
+- Modify: `DTXMania.Automation/Process/GameProcessDriver.cs`
+- Modify: `DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs`
 - Modify: `DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs`
-- Modify: `DTXMania.VideoRecorder/RecorderCommandLine.cs`
-- Modify: `DTXMania.VideoRecorder/Program.cs`
 - Create: `DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs`
-- Create: `DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs`
 
-**Interfaces:**
+### 1.1 Add failing Automation coverage for project-run arguments
 
-`RecorderGameLaunchPolicy` should own one resolved target shape, kept internal to VideoRecorder:
+Extend `GameProcessStartOptions` conceptually with one optional project-only list:
+
+```csharp
+IReadOnlyList<string>? ProjectRunArguments = null
+```
+
+Add a test that:
+
+1. creates the existing child fixture;
+2. builds it in Debug;
+3. changes the source so a rebuild would fail;
+4. launches it through `GameProcessDriver` with:
+
+```text
+--no-build
+--configuration
+Debug
+```
+
+5. asserts the previously built child still runs and returns the existing expected output/exit code.
+
+This is the key proof that `GameProcessDriver` actually honors no-build instead of silently rebuilding.
+
+Also add a small validation test that project-run arguments supplied to an executable target are rejected rather than ignored.
+
+Keep the existing default project-launch test unchanged; omission of the new field must preserve current build-on-run behavior for E2E/other callers.
+
+### 1.2 Implement the additive Automation seam
+
+For project targets only, append `ProjectRunArguments` to the existing command after:
+
+```text
+dotnet run --project <path>
+```
+
+Do not change process ownership, environment, readiness, cancellation, stdout/stderr, or executable-target behavior.
+
+### 1.3 Add shared recorder target resolution
+
+`RecorderGameLaunchPolicy` owns:
 
 ```csharp
 internal sealed record ResolvedRecorderTarget(
@@ -90,63 +135,137 @@ internal static GameProcessStartOptions CreateOptions(
     ResolvedRecorderTarget target);
 ```
 
-`ResolveTarget` uses `GameProjectPaths.Current`, resolves the absolute project path under the repository root, and uses the repository root as working directory. `CreateOptions` only adds sandbox app-data plus a fresh launch token.
+`ResolveTarget`:
 
-- [ ] **Step 1: Add failing launch-policy tests.**
+- reuses the existing repository-root walk;
+- selects `GameProjectPaths.Current`;
+- resolves the absolute project path;
+- uses repository root as working directory.
+
+`CreateOptions` adds only:
+
+- sandbox app-data root;
+- fresh launch token;
+- recorder-owned project args:
+
+```text
+--no-build --configuration Debug
+```
+
+Do not add executable/app-bundle launch support.
+
+### 1.4 Recorder launch-policy tests
 
 Cover:
 
 ```text
 ResolveTarget_FromRepositoryRoot
-  -> RepositoryRoot == repo root
-  -> WorkingDirectory == repo root
-  -> Target.Kind == Project
-  -> Target.Path == <repo>/<GameProjectPaths.Current>
-
 ResolveTarget_FromNestedDirectory
-  -> same target/root as repository root
-
-CreateOptions
-  -> preserves resolved working directory/target
-  -> AppDataRoot == sandbox.AppDataRoot
-  -> LaunchToken is non-empty and fresh across calls
+CreateOptions_PreservesResolvedTarget
+CreateOptions_AddsFreshLaunchToken
+CreateOptions_UsesNoBuildDebugArguments
 ```
 
-Use a temporary fake repo containing `DTXMania.sln` plus the current-platform project path. Do not test executable launch behavior.
+Use a temporary fake repo containing the solution marker and `GameProjectPaths.Current` project file.
 
-- [ ] **Step 2: Run the launch-policy tests and verify they fail before implementation.**
+### 1.5 Run focused tests
 
 ```bash
+dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~GameProcessDriverTests"
+
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --configuration Debug \
   --filter "FullyQualifiedName~RecorderGameLaunchPolicyTests"
 ```
 
-Expected: FAIL because `ResolvedRecorderTarget` / `ResolveTarget` do not exist.
+### 1.6 Commit checkpoint
 
-- [ ] **Step 3: Implement the minimal shared target resolver.**
+```bash
+git add \
+  DTXMania.Automation/Process/GameProcessStartOptions.cs \
+  DTXMania.Automation/Process/GameProcessDriver.cs \
+  DTXMania.Automation.Tests/Process/GameProcessDriverTests.cs \
+  DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs \
+  DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
 
-Replace the Windows-project constant inside `CreateOptions` with `ResolveTarget` + `GameProjectPaths.Current`.
-
-Keep the repository walk already owned by `RecorderGameLaunchPolicy`. Do not move it to Automation and do not add a platform abstraction.
-
-- [ ] **Step 4: Update record wiring to resolve the target before sandbox creation.**
-
-In the record path, resolve the project target once and pass it forward. `RunRecordAsync` should no longer discover a project independently after creating the sandbox.
-
-The next task inserts preflight between target resolution and `RunRecordAsync`.
-
-- [ ] **Step 5: Add failing Mac default-app-data coverage.**
-
-Use the existing injectable environment-variable reader. On the macOS test job, with `DTXMANIA_APPDATA_ROOT` unset, assert the resolved source root equals:
-
-```text
-$HOME/Library/Application Support/DTXManiaCX
+git commit -m "feat: pin recorder project launch to prebuilt output"
 ```
 
-Also retain coverage that an explicit `DTXMANIA_APPDATA_ROOT` wins on every platform.
+---
 
-- [ ] **Step 6: Run the focused command-line tests and verify the new Mac case fails before implementation.**
+## Task 2: Make command/platform/app-data inputs testable
+
+**Scope:** widen recorder host support and pin the mirrored app-data contract. No OBS work.
+
+**Files:**
+- Modify: `DTXMania.VideoRecorder/RecorderCommandLine.cs`
+- Create: `DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs`
+
+### 2.1 Add command-line coverage before changing behavior
+
+Cover existing behavior first:
+
+- required record arguments;
+- absolute/existing chart;
+- writable publish/OBS directories;
+- loopback OBS URL;
+- `DTXMANIA_APPDATA_ROOT` override.
+
+Then add platform/default-root cases.
+
+### 2.2 Widen only the basic record OS gate
+
+`ValidateRecord` should allow Windows or macOS and continue rejecting unsupported OSes.
+
+Do not put version, architecture, project-output, FFmpeg, or OBS source checks into command parsing.
+
+### 2.3 Make default app-data resolution injectable
+
+Keep the production wrapper simple, but expose an internal pure/testable resolver that accepts enough facts to avoid ambient-host tests, for example:
+
+```text
+isWindows
+isMacOS
+folder-path lookup
+HOME environment lookup
+```
+
+Mirror `AppPaths.GetAppDataRoot()` default behavior:
+
+```text
+Windows:
+  LocalApplicationData/DTXManiaCX
+
+macOS:
+  UserProfile
+  -> Personal fallback
+  -> $HOME fallback
+  -> Library/Application Support/DTXManiaCX
+
+Other:
+  ApplicationData/DTXManiaCX
+  -> existing home fallback when unusable
+```
+
+Keep a code comment naming `DTXMania.Game/Lib/Utilities/AppPaths.cs` as the authoritative contract being mirrored.
+
+Do **not** add a `DTXMania.Game -> DTXMania.Automation` project reference and do not create a shared assembly for this one helper.
+
+### 2.4 Host-independent default-root tests
+
+Run both Windows and Mac cases on every host by injecting facts/folder values. Include the Mac fallback chain:
+
+```text
+UserProfile available
+UserProfile empty -> Personal
+UserProfile + Personal empty -> HOME
+```
+
+Do not rely on “macOS CI will cover this branch” as the only test.
+
+### 2.5 Run focused tests
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
@@ -154,66 +273,31 @@ dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --filter "FullyQualifiedName~RecorderCommandLineTests"
 ```
 
-The Mac-specific assertion is expected to be exercised by existing macOS CI.
-
-- [ ] **Step 7: Make the Mac default explicit.**
-
-`GetDefaultSourceAppDataRoot()` should use this branch before `SpecialFolder.LocalApplicationData`:
-
-```csharp
-if (OperatingSystem.IsMacOS())
-{
-    var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    if (string.IsNullOrWhiteSpace(home))
-        throw new InvalidOperationException("Unable to determine the CX app-data root.");
-
-    return Path.Combine(home, "Library", "Application Support", "DTXManiaCX");
-}
-```
-
-Keep the Windows/default branch behavior unchanged.
-
-- [ ] **Step 8: Widen only the basic record host gate.**
-
-`RecorderCommandLine.ValidateRecord` should stop rejecting macOS solely because it is not Windows. It should allow Windows or macOS and continue rejecting unsupported OSes.
-
-Do not put macOS version, process architecture, or Debug-runtime layout checks in the command parser; Task 2 validates the resolved launch target before recorder startup.
-
-- [ ] **Step 9: Run the focused tests.**
-
-```bash
-dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
-  --configuration Debug \
-  --filter "FullyQualifiedName~RecorderCommandLineTests|FullyQualifiedName~RecorderGameLaunchPolicyTests"
-```
-
-Require all focused tests to pass on the current host. macOS CI remains the authoritative Mac-default-path execution.
-
-- [ ] **Step 10: Commit Task 1.**
+### 2.6 Commit checkpoint
 
 ```bash
 git add \
   DTXMania.VideoRecorder/RecorderCommandLine.cs \
-  DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs \
-  DTXMania.VideoRecorder/Program.cs \
-  DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs \
-  DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
+  DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs
 
-git commit -m "feat: resolve recorder project target by platform"
+git commit -m "feat: allow recorder commands on macOS"
 ```
 
 ---
 
-### Task 2: Add one shared Mac preflight used by record and doctor
+## Task 3: Add the shared preflight and enforce pre-OBS ordering
+
+**Scope:** one preflight result used by record and doctor; one real ordering test.
 
 **Files:**
 - Create: `DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs`
 - Modify: `DTXMania.VideoRecorder/Program.cs`
 - Create: `DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs`
+- Create: `DTXMania.VideoRecorder.Tests/ProgramTests.cs`
 
-**Interfaces:**
+### 3.1 Define a small testable preflight
 
-Keep the preflight internal and small. A practical shape is:
+Keep the helper internal. A practical shape is:
 
 ```csharp
 internal sealed record RecorderPlatformFacts(
@@ -233,109 +317,123 @@ internal sealed record RecorderPlatformPreflightResult(
 {
     public bool Passed => Gates.All(gate => gate.Passed);
 }
-
-internal static RecorderPlatformPreflightResult Evaluate(
-    ResolvedRecorderTarget target,
-    RecorderPlatformFacts facts);
-
-internal static RecorderPlatformFacts CaptureCurrentFacts();
 ```
 
-Exact names may be adjusted to repository style, but retain one result consumed by both doctor and record. The helper owns target-relative Debug-runtime resolution so `Program` never rebuilds the path itself.
+Exact names may follow repository style.
 
-- [ ] **Step 1: Add failing pure/temp-filesystem preflight tests.**
+### 3.2 Preflight behavior
 
-Cover:
+Windows:
+
+- no new native-runtime/version/architecture rejection.
+
+macOS hard gates:
 
 ```text
-Windows
-  -> no new runtime/architecture/version rejection
-
-macOS 12 arm64
-  -> fail supported-version gate
-
-macOS 13 x64
-  -> fail native-arm64 gate
-
-macOS 13 arm64 + Mac project + missing ffmpeg
-  -> fail with ffmpeg path/detail
-
-macOS 13 arm64 + Mac project + missing ffprobe
-  -> fail with ffprobe path/detail
-
-macOS 13 arm64 + both files not executable
-  -> fail executable gate
-
-macOS 13 arm64 + both executable
-  -> pass
-  -> NativeRuntimeDirectory == <Mac-project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools
+macOS >= 13
+ProcessArchitecture == Arm64
+resolved target is DTXMania.Game.Mac.csproj
+project exists
+<project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg exists + executable
+<project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe exists + executable
 ```
 
-Use a temporary fake repo/project. On Unix, set execute bits with `File.SetUnixFileMode`. Keep path-resolution assertions runnable on all hosts even if executable-bit assertions are Mac/Unix-specific.
-
-- [ ] **Step 2: Run the preflight tests and verify they fail before implementation.**
+The failure for missing/unusable Debug runtime must name the recovery command:
 
 ```bash
-dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
-  --configuration Debug \
-  --filter "FullyQualifiedName~RecorderPlatformPreflightTests"
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
 ```
 
-- [ ] **Step 3: Implement the preflight with no Game-project dependency.**
+The bundled-runtime hard failure is intentional recorder certification policy: a working PATH FFmpeg is not accepted as HPA-515 evidence.
 
-For macOS, resolve runtime from `target.Target.Path`:
+Do not call `FfmpegRuntime`, search PATH for CX audio runtime, probe codecs, download binaries, inspect OBS sources, or inspect macOS privacy state.
+
+### 3.3 Preflight unit tests
+
+Using synthetic facts/temp files, cover on every host:
 
 ```text
-<project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools
+Windows -> no new platform/runtime failure
+macOS 12 arm64 -> version failure
+macOS 13 x64 -> arm64 failure
+macOS 13 arm64 + wrong project -> target failure
+macOS 13 arm64 + missing ffmpeg -> runtime failure + build command
+macOS 13 arm64 + missing ffprobe -> runtime failure + build command
+macOS 13 arm64 + non-executable pair -> runtime failure
+macOS 13 arm64 + executable pair -> pass
 ```
 
-Validate host version, arm64 process, Mac project target, and executable `ffmpeg`/`ffprobe`.
+Use `File.SetUnixFileMode` where available for executable-bit cases.
 
-Do not reference `FfmpegRuntime`, search PATH, probe codecs, download binaries, or inspect OBS/privacy state.
+### 3.4 Enforce the record ordering in the method signature
 
-- [ ] **Step 4: Gate record before sandbox/OBS startup.**
-
-After `RecorderCommandLine.Validate(...)` and `RecorderGameLaunchPolicy.ResolveTarget(...)`, evaluate current preflight.
-
-If it fails, throw one actionable error containing the failed gate details **before** calling `RunRecordAsync`.
-
-Required ordering:
+Make `Program.RunRecordAsync` internal and pass:
 
 ```text
-parse/read environment
--> command/path validation
--> ResolveTarget
--> RecorderPlatformPreflight
--> create sandbox
--> create OBS client
--> existing RecordWorkflow
+command
+environment
+ResolvedRecorderTarget
+RecorderPlatformPreflightResult
 ```
 
-Do not put this check inside `RecordWorkflow`; it is launch readiness, not gameplay workflow state.
+At the very top of the side-effecting path, reject a failed preflight before:
 
-- [ ] **Step 5: Rework doctor to consume the same target and preflight.**
+- `RecordingSandbox.Create`;
+- diagnostics run-root creation;
+- game control construction;
+- OBS client construction;
+- `RecordWorkflow` creation.
 
-Delete doctor's duplicate repository-root walk and hard-coded Windows project string.
-
-Doctor should print the resolved project target and each preflight gate. On macOS it must make the required native runtime path visible.
-
-If target resolution fails, report a failed repository/target gate without creating a sandbox.
-
-- [ ] **Step 6: Keep doctor OBS behavior read-only.**
-
-Preserve exactly:
+`Main` ordering becomes:
 
 ```text
-Hello
-Identify
-GetRecordStatus
+Parse
+ReadEnvironment
+Validate
+ResolveTarget
+Evaluate preflight
+RunRecordAsync(...target, preflight...)
 ```
 
-No StartRecord/StopRecord or source APIs.
+Do not hide this check inside `RecordWorkflow`.
 
-- [ ] **Step 7: Make doctor manual guidance platform-specific.**
+### 3.5 Add the ordering regression test
 
-Windows retains existing Game Capture/application-audio guidance.
+Add one `ProgramTests` case that calls internal `RunRecordAsync` with a failing preflight and a temporary source-app-data root.
+
+Assert:
+
+- actionable preflight exception is returned;
+- no recorder sandbox/run directory is created under the temp root;
+- the method returns before any OBS connection can be attempted.
+
+The test should not require an OBS server. Its ability to complete without OBS is part of the invariant.
+
+### 3.6 Rework doctor to use the same target/result
+
+Delete doctor's duplicate repository-root/project reconstruction and the hard-coded Windows gate.
+
+Doctor should:
+
+1. resolve `ResolvedRecorderTarget` without a sandbox;
+2. evaluate the same `RecorderPlatformPreflight`;
+3. report each gate through the existing `Program.ReportGate` helper;
+4. continue the existing source config/raw-output/OBS auth-status checks;
+5. remain read-only: Hello + Identify + GetRecordStatus only.
+
+Do not add a second gate-printer abstraction.
+
+### 3.7 Pin doctor Mac parity
+
+Factor only the platform/preflight reporting portion enough to test it without a live OBS server.
+
+Add one test with a synthetic passing Mac preflight asserting that platform reporting succeeds and no separate Windows-only gate remains.
+
+This is not a full doctor integration harness; keep it small.
+
+### 3.8 Platform-specific doctor guidance
+
+Windows retains existing Game Capture/application-audio wording.
 
 macOS prints only:
 
@@ -353,69 +451,59 @@ Raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR
 
 Do not claim source/privacy state was programmatically verified.
 
-- [ ] **Step 8: Run focused preflight/OBS tests.**
+### 3.9 Run focused + full tests
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --configuration Debug \
-  --filter "FullyQualifiedName~RecorderPlatformPreflightTests|FullyQualifiedName~RecorderGameLaunchPolicyTests|FullyQualifiedName~Obs"
-```
+  --filter "FullyQualifiedName~RecorderPlatformPreflightTests|FullyQualifiedName~ProgramTests|FullyQualifiedName~RecorderGameLaunchPolicyTests|FullyQualifiedName~RecorderCommandLineTests"
 
-- [ ] **Step 9: Run the whole recorder and Automation test projects.**
-
-```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
 ```
 
-Do not edit CI unless the PR run demonstrates the macOS job skipped the new tests.
+Do not edit CI unless the PR run shows the existing OS matrix skipped the new tests.
 
-- [ ] **Step 10: Commit Task 2.**
+### 3.10 Commit checkpoint
 
 ```bash
 git add \
   DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs \
   DTXMania.VideoRecorder/Program.cs \
-  DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
+  DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs \
+  DTXMania.VideoRecorder.Tests/ProgramTests.cs
 
-git commit -m "feat: preflight native Mac recorder runtime"
+git commit -m "feat: preflight native Mac recorder before OBS"
 ```
 
 ---
 
-### Task 3: Prove the native Mac target/runtime before involving OBS
+## Task 4: Prove the native Debug target before OBS
 
-**Files:** normally no new files.
+**Scope:** real Apple Silicon validation of the exact no-build artifact. No product changes unless a directly related defect is proven.
 
-**Produces:** a green native Mac baseline proving the project target and HPA-512 audio runtime before manual capture is introduced.
-
-- [ ] **Step 1: Confirm the proof host.**
-
-Run on the Apple Silicon workstation:
+### 4.1 Record proof host facts
 
 ```bash
 uname -m
 sw_vers -productVersion
 dotnet --info
+git rev-parse HEAD
 ```
 
-Require:
+Require native `arm64` and macOS 13+.
 
-```text
-uname -m == arm64
-macOS major version >= 13
-.NET SDK 8.x available
-```
+### 4.2 Build the exact configuration the recorder will launch
 
-- [ ] **Step 2: Build the exact Debug project target the recorder will launch.**
+Immediately before architecture/doctor/record evidence:
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
 ```
 
-Do not publish an app/DMG for HPA-515 acceptance.
+Do not use publish/DMG/app-bundle mode for HPA-515.
 
-- [ ] **Step 3: Verify architecture of the actual Debug artifacts.**
+### 4.3 Inspect the exact Debug artifacts
 
 ```bash
 file DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac
@@ -423,88 +511,72 @@ file DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
 file DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
 ```
 
-Require `arm64` for the game apphost and both bundled tools.
+Retain sanitized output in `architecture.txt`.
 
-- [ ] **Step 4: Run HPA-512 focused audio coverage.**
+The subsequent recorder launch uses `--no-build`, so these are the artifacts it will run.
 
-```bash
-ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
-  --configuration Debug \
-  --no-build \
-  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegBundledRuntimeTests|FullyQualifiedName~ManagedSoundTests"
-```
+### 4.4 Reuse the existing HPA-512 audio proof
 
-Require the bundled-runtime/audio tests to pass before moving to OBS.
+Run the same focused native audio tests already used by macOS CI. Do not invent a new recorder-only FFmpeg test.
 
-- [ ] **Step 5: Run recorder + Automation suites on the same host.**
+### 4.5 Run recorder/Automation suites on the Mac
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
 ```
 
-- [ ] **Step 6: Run `doctor` once with OBS unavailable or unconfigured only to confirm the local project/runtime gates are independently visible.**
+### 4.6 Run doctor before configuring a record
 
-It is acceptable for OBS auth/status to fail at this checkpoint. Require the platform, project target, and bundled-runtime gates to report correctly first.
+Run `dtx-video doctor` and retain `doctor.txt`.
 
-If they do not, fix only HPA-515 launch/preflight defects before proceeding.
+Require automated gates for:
+
+- Mac host/version;
+- arm64 process;
+- Mac project;
+- Debug native runtime pair;
+- source config/output path;
+- OBS auth/status.
+
+Manual OBS source/privacy statements remain guidance, not automated proof.
 
 ---
 
-### Task 4: Produce and accept one real Apple Silicon ScreenCaptureKit recording
+## Task 5: Perform one real recording and retain acceptance evidence
 
-**Files:** local evidence only until Task 5.
+**Scope:** one successful ScreenCaptureKit journey, one cancellation check, and two docs.
 
-**Produces:** one accepted Hybrid MP4 plus architecture, isolation, telemetry, cleanup, and manual media evidence.
+**Files:**
+- Create: `docs/video-recorder/macos-obs-setup.md`
+- Create: `docs/verification/hpa-515-apple-silicon-live-recording.md`
 
-- [ ] **Step 1: Create a proof directory outside the checkout and choose one indexed encoded-audio chart.**
+### 5.1 Configure OBS manually
 
-Prefer MP3 preview/BGM or another encoded input that exercises the HPA-512 runtime.
+Use:
 
-Example local structure:
+- OBS Studio 30.2+;
+- dedicated DTXManiaCX profile/collection/scene;
+- ScreenCaptureKit application/window capture scoped to CX;
+- CX application audio through the source or one dedicated macOS Audio Capture source;
+- Desktop Audio disabled for the recorded track;
+- microphone disabled for the recorded track;
+- Hybrid MP4;
+- authenticated obs-websocket 5.x;
+- Screen Recording permission granted manually;
+- OBS idle before recorder start.
 
-```text
-<proof-root>/
-  raw/
-  published/
-```
+Do not add source discovery/auto-repair code if setup is wrong.
 
-Do not add a recorder-only fixture/chart for this native proof.
+### 5.2 Select one acceptance chart
 
-- [ ] **Step 2: Configure OBS manually.**
+Use a short chart already indexed by normal Song Select with preview audio. Prefer MP3/another encoded source that exercises HPA-512.
 
-Required:
+Do not create a recorder-only chart.
 
-```text
-OBS Studio 30.2+
-Dedicated DTXManiaCX profile + collection + scene
-ScreenCaptureKit application/window capture scoped to CX
-CX application audio through the source or one dedicated macOS Audio Capture source
-Desktop Audio disabled for recorded track
-Microphone disabled for recorded track
-Hybrid MP4
-obs-websocket 5.x authenticated
-Screen Recording permission granted manually
-OBS idle before recorder starts
-```
+### 5.3 Capture source app-data state before record
 
-Do not add source discovery or privacy automation if setup is wrong.
-
-- [ ] **Step 3: Export the existing recorder environment.**
-
-```bash
-export DTXMANIA_VIDEO_OBS_URL='ws://127.0.0.1:4455'
-export DTXMANIA_VIDEO_OBS_PASSWORD='<local-secret>'
-export DTXMANIA_VIDEO_OBS_OUTPUT_DIR='<absolute-proof-root>/raw'
-```
-
-Leave `DTXMANIA_APPDATA_ROOT` unset for the primary proof so the newly explicit normal Mac path is exercised.
-
-Do not write the secret into retained transcripts.
-
-- [ ] **Step 4: Capture source app-data before-state.**
-
-Against `~/Library/Application Support/DTXManiaCX`, record presence, size, and SHA-256 for:
+Against the resolved normal Mac root, capture presence, size, and SHA-256 for:
 
 ```text
 Config.ini
@@ -513,155 +585,124 @@ songs.db-wal
 songs.db-shm
 ```
 
-Record missing WAL/SHM as absent; do not create them.
+Store sanitized evidence outside Git.
 
-- [ ] **Step 5: Run live doctor with OBS idle.**
-
-```bash
-dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj \
-  --configuration Debug --no-build -- doctor
-```
-
-Require all recorder/platform/runtime/OBS gates to pass. Recorder-side PATH `ffprobe` may remain a warning-only final-media check.
-
-- [ ] **Step 6: Run the accepted recording.**
-
-```bash
-dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj \
-  --configuration Debug --no-build -- \
-  record --chart '<absolute-chart-path>' --output '<proof-root>/published'
-```
-
-Require exit code 0 and retain raw MP4, published MP4, `run.json`, CX stdout, and CX stderr outside Git.
-
-- [ ] **Step 7: Inspect the shared `run.json` contract.**
-
-Require:
+### 5.4 Run the successful acceptance journey
 
 ```text
-status == Completed
-SongSelectReady -> selected song present
-PreviewReady -> Playing and elapsed >= 10000 ms
-PerformanceReady -> ready + AutoPlay + totalNotes > 0
-ResultCompleted -> cleared by SongComplete + totalJudgements == totalNotes
-OBS -> Connect/Status/Start/Stop succeeded
-raw + published paths recorded
-no failure fields / retained successful sandbox
+Song Select populated
+-> preview stopped/prepared
+-> OBS recorder-owned start
+-> >= 10 seconds preview audio
+-> Song Transition
+-> full AutoPlay Performance
+-> completed Result
+-> >= 5 seconds Result hold
+-> recorder-owned OBS stop
+-> verify/publish
 ```
 
-Do not add Mac-only diagnostic fields unless a concrete evidence gap is discovered.
+Because Task 4 built immediately beforehand and launch uses `--no-build`, do not run another implicit build between architecture evidence and record.
 
-- [ ] **Step 8: Run one Ctrl+C ownership proof.**
+### 5.5 Validate `run.json`
 
-Start a second valid recording. After recorder-owned OBS recording has started, press Ctrl+C once.
+Require at least:
 
-Require:
+- `status == Completed`;
+- selected song present at `SongSelectReady`;
+- preview Playing and elapsed >= 10,000 ms;
+- Performance ready, AutoPlay enabled, total notes > 0;
+- Result completed/cleared;
+- `totalJudgements == totalNotes`;
+- OBS Connect/Status/Start/Stop succeeded;
+- raw/published paths present;
+- no failure fields/retained successful sandbox;
+- verifier warning absent or only the existing optional PATH-`ffprobe` warning.
 
-```text
-command exits through cancellation
-OBS is no longer recording
-partial raw artifact remains when OBS produced one
-diagnostics are retained when possible
-failed-run sandbox is retained/referenced for inspection
-```
+### 5.6 Capture source app-data state after record
 
-Delete the failed-run sandbox manually after evidence is captured.
+Repeat the same hashes. Acceptance requires no content change and no new WAL/SHM caused by the recorder.
 
-- [ ] **Step 9: Capture source app-data after-state and compare.**
+### 5.7 Run one Ctrl+C cleanup case
 
-Repeat the exact presence/size/SHA-256 capture from Step 4.
+Cancel only after recorder-owned OBS recording has started.
 
-Require no content change and no newly created source WAL/SHM file caused by the recorder.
+Confirm:
 
-- [ ] **Step 10: Watch the complete published MP4.**
+- recorder-owned OBS work stops;
+- diagnostics/raw evidence remain;
+- sandbox remains for failure diagnosis;
+- unrelated/pre-existing OBS ownership is not stopped.
 
-Require:
+Do not manufacture privacy failures or revoke permissions.
 
-```text
-[ ] intended populated Song Select is first
-[ ] preview audio starts after visible Song Select
-[ ] preview lasts >= 10 seconds
-[ ] complete Song Transition
-[ ] full AutoPlay gameplay
-[ ] BGM/chip audio audible
-[ ] fully rendered Result held >= 5 seconds
-[ ] recording ends after Result hold
-[ ] no OBS UI / desktop / unrelated window / cursor / notification
-[ ] no microphone or unrelated application audio
-[ ] no duplicated/echoed CX audio
-[ ] no severe stutter, aspect squeeze, or missing viewport region
-[ ] no Rosetta or user-installed FFmpeg required for CX audio
-```
+### 5.8 Watch the complete published MP4
 
-If capture/audio/privacy setup fails while recorder telemetry/runtime checks are healthy, fix OBS/privacy configuration rather than expanding recorder code.
+Confirm:
 
----
+- populated Song Select is first;
+- preview audio >= 10 seconds;
+- complete transition;
+- full AutoPlay gameplay;
+- BGM/chip audio audible;
+- Result fully rendered >= 5 seconds;
+- recording ends after Result hold;
+- no OBS UI/desktop/unrelated windows/cursor/notification/mic/unrelated audio;
+- no duplicated/echoed CX audio;
+- no unusable aspect squeeze/stutter/missing viewport;
+- no Rosetta or user-installed FFmpeg needed for CX audio.
 
-### Task 5: Commit the Mac operator runbook and sanitized proof record
+Strict codec/frame-rate/duration enforcement remains HPA-506.
 
-**Files:**
-- Create: `docs/video-recorder/macos-obs-setup.md`
-- Create: `docs/verification/hpa-515-apple-silicon-live-recording.md`
+### 5.9 Write the Mac setup runbook
 
-- [ ] **Step 1: Write the operator runbook.**
+`docs/video-recorder/macos-obs-setup.md` should cover only:
 
-Keep it concise and project-mode-only:
+- Apple Silicon + macOS 13+ prerequisite;
+- required Debug build command;
+- why recorder uses no-build after doctor/preflight;
+- ScreenCaptureKit/application-audio setup;
+- Screen Recording permission;
+- disabled Desktop Audio/microphone;
+- WebSocket environment variables;
+- doctor/record commands;
+- missing-runtime error and exact rebuild command;
+- artifact locations;
+- concise troubleshooting.
 
-```text
-Apple Silicon + macOS 13+ prerequisites
-Debug Mac project build
-ScreenCaptureKit source setup
-CX application-audio setup
-Screen Recording permission
-Desktop/microphone disabled
-WebSocket environment variables
-doctor command
-record command
-bundled FFmpeg preflight meaning
-raw/published/diagnostics locations
-troubleshooting: host/arm64/runtime/OBS auth/already-recording/source/privacy/audio
-```
+Do not document packaged-app mode or PATH FFmpeg as accepted certification.
 
-Do not document executable/app-bundle recording, HPA-505 diagnostics, or HPA-506 media hardening.
+### 5.10 Write sanitized verification record
 
-- [ ] **Step 2: Write the sanitized verification record.**
+`docs/verification/hpa-515-apple-silicon-live-recording.md` should include:
 
-Record:
+- accepted commit SHA;
+- Mac model/macOS/architecture;
+- .NET + OBS versions;
+- chart identity without private local path;
+- Debug build command/result;
+- apphost/ffmpeg/ffprobe arm64 evidence;
+- doctor result;
+- sanitized record command;
+- raw/published MP4 name, size, SHA-256;
+- key `run.json` values;
+- source before/after comparison;
+- Ctrl+C result;
+- manual media checklist;
+- focused/full automated test results;
+- warnings/deviations.
 
-```text
-accepted commit SHA
-macOS version + arm64 host
-.NET + OBS versions
-non-sensitive chart identity
-project target
-arm64 apphost/ffmpeg/ffprobe evidence
-doctor result summary
-successful command with private paths redacted
-raw/published MP4 filenames + sizes + SHA-256
-key run.json acceptance values
-source before/after hash result
-Ctrl+C ownership result
-manual media checklist result
-focused automated-test commands + pass counts
-warnings/deviations
-```
-
-Do not commit videos, raw logs, secrets, or private absolute paths.
-
-- [ ] **Step 3: Run final automated verification on Apple Silicon.**
+### 5.11 Final verification
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
-ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
-  --configuration Debug --no-build \
-  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegBundledRuntimeTests|FullyQualifiedName~ManagedSoundTests"
 git diff --check
 ```
 
-Also require the normal Windows CI recorder/Automation jobs to remain green before merge.
+Review the diff and confirm there is no scope creep into HPA-505/HPA-506, packaged launch, workflow subclasses, or CI unless evidence required it.
 
-- [ ] **Step 4: Commit the acceptance documentation.**
+### 5.12 Commit checkpoint
 
 ```bash
 git add \
@@ -673,20 +714,22 @@ git commit -m "docs: verify Apple Silicon recorder parity"
 
 ---
 
-## Completion Checklist
+## Completion criteria
 
-Before marking HPA-515 complete, verify all of these are true:
+HPA-515 is complete when all are true:
 
-```text
-[ ] unchanged doctor / record CLI works on native Apple Silicon macOS 13+
-[ ] record and doctor use one ResolvedRecorderTarget
-[ ] Mac preflight runs before sandbox/OBS creation
-[ ] missing/unusable bundled runtime fails before OBS
-[ ] default Mac source root is ~/Library/Application Support/DTXManiaCX
-[ ] one encoded-audio project-mode recording passes the HPA-513 journey contract
-[ ] source Config.ini/database/WAL/SHM are unchanged
-[ ] Ctrl+C stops only recorder-owned OBS work
-[ ] manual ScreenCaptureKit/audio acceptance passes
-[ ] Windows recorder behavior/tests remain green
-[ ] no packaged executable mode/platform adapter/HPA-505/HPA-506 scope was introduced
-```
+- unchanged recorder CLI works on native Apple Silicon macOS 13+;
+- record/doctor resolve the same Mac project;
+- Automation supports optional project-run arguments without changing default callers;
+- recorder launch is `--no-build --configuration Debug`;
+- preflight checks that exact Debug runtime and names the exact build recovery command;
+- failed preflight is automatically proven to create no sandbox and require no OBS server;
+- doctor has no Windows-only hard gate and a synthetic Mac pass case is tested;
+- recorder default app-data resolution matches the `AppPaths` contract and both OS branches are host-independently tested;
+- one native encoded-audio acceptance recording succeeds;
+- source app data is unchanged;
+- Ctrl+C ownership/retention behavior is proven;
+- complete MP4 is manually accepted;
+- Mac runbook + sanitized verification record are committed;
+- Windows/default Automation behavior remains unchanged;
+- no platform adapter, packaged-app mode, HPA-505, or HPA-506 scope is introduced.

--- a/docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md
+++ b/docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md
@@ -1,35 +1,37 @@
 # HPA-515 Apple Silicon Recorder Parity Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to execute this plan task-by-task. Keep the implementation minimal; HPA-515 is Mac parity for the existing recorder, not a recorder/platform redesign.
+> **For agentic workers:** REQUIRED SUB-SKILL: use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to execute this plan task-by-task. HPA-515 is Mac parity for the existing recorder. Keep one project-mode launch path and do not expand into packaged-app support.
 
-**Goal:** Make the existing `dtx-video` workflow run natively on Apple Silicon macOS, prove one real ScreenCaptureKit/OBS recording with bundled arm64 FFmpeg audio, and retain a concise Mac setup guide plus sanitized verification record.
+**Goal:** Make the existing `dtx-video` project-mode workflow run natively on Apple Silicon macOS, fail unsupported/missing-runtime Mac runs before OBS starts, prove one real ScreenCaptureKit recording with bundled arm64 FFmpeg audio, and retain a concise Mac setup guide plus sanitized verification record.
 
-**Architecture:** Preserve the existing `RecordWorkflow`, OBS client, sandbox, diagnostics, and finalization. Remove only the recorder's three Windows assumptions by making command validation and launch selection platform-aware and adding one focused Mac preflight helper for `doctor`. Use the existing `GameProjectPaths` / `GameLaunchTarget.Project` / `GameLaunchTarget.Executable` primitives from `DTXMania.Automation`; do not add platform adapters.
+**Architecture:** Preserve `RecordWorkflow`, OBS ownership, sandboxing, diagnostics, finalization, and `GameProcessDriver`. Extract one sandbox-free project-target resolver from `RecorderGameLaunchPolicy`, add one focused `RecorderPlatformPreflight` consumed by both record and doctor, and make the default Mac app-data path explicitly match CX. No platform adapter and no second launch mode.
 
-**Tech stack:** .NET 8, MonoGame CX Mac project, `DTXMania.Automation`, obs-websocket 5.x, OBS Studio 30.2+, ScreenCaptureKit, existing HPA-512 native FFmpeg runtime.
+**Tech Stack:** .NET 8, MonoGame Mac project, `DTXMania.Automation`, obs-websocket 5.x, OBS Studio 30.2+, ScreenCaptureKit, existing HPA-512 `osx-arm64` FFmpeg runtime.
 
 **Expected effort:** 2–3 engineer days including one real Apple Silicon/OBS acceptance run.
 
-## Global constraints
+## Global Constraints
 
 - Keep `dtx-video doctor` and `dtx-video record --chart ... --output ...` unchanged.
-- Windows behavior must remain unchanged.
-- Mac support is macOS 13+ on native arm64 only; no Intel Mac or Rosetta fallback.
+- HPA-515 supports project mode only: Windows project on Windows, Mac project on macOS.
+- Keep existing Windows behavior unchanged.
+- Mac support is macOS 13+ on native arm64 only; no Intel/Rosetta fallback.
+- Run the Mac host/runtime preflight before creating the recorder sandbox or touching OBS.
 - Reuse the same `RecordWorkflow`; no Mac workflow/session subclass.
-- Reuse `GameProcessDriver`; do not change process ownership/readiness semantics unless a proven blocker requires it.
-- Reuse `ObsWebSocketRecorder`; no ScreenCaptureKit source discovery or permission diagnosis.
-- Reuse HPA-512's bundled `osx-arm64` FFmpeg; do not add another resolver/download/dependency.
-- Recorder-side MP4 `ffprobe` stays optional PATH-based as today.
-- Keep the successful-run disposable app-data behavior unchanged.
-- Do not add strict media policy, remux, or transcoding; HPA-506 owns that.
-- Do not add automated Mac OBS diagnostics; HPA-505 owns that.
-- If the native proof exposes an unrelated recorder/game defect, stop and file a focused blocker instead of expanding HPA-515.
+- Reuse `GameProcessDriver`; do not change its process ownership/readiness behavior.
+- Reuse `ObsWebSocketRecorder`; do not add ScreenCaptureKit source discovery or privacy diagnosis.
+- Reuse HPA-512's bundled `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}`; no second runtime resolver/download/PATH fallback for CX audio.
+- Recorder-side final-MP4 `ffprobe` remains optional PATH-based as today.
+- Keep successful-run disposable app-data behavior unchanged.
+- Keep `DTXMANIA_APPDATA_ROOT` as the explicit source-app-data override.
+- Do not add strict media/remux/transcoding policy; HPA-506 owns that.
+- Do not add automated Mac OBS source/audio/privacy diagnostics; HPA-505 owns that.
+- Do not edit CI unless the existing Windows/macOS recorder jobs prove they do not execute the new tests.
 
-## Intended implementation PR file surface
+## File Structure
 
 ```text
 Modify:
-  DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs
   DTXMania.VideoRecorder/RecorderCommandLine.cs
   DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
   DTXMania.VideoRecorder/Program.cs
@@ -53,110 +55,66 @@ Normally unchanged:
   .github/workflows/**
 ```
 
+## Risks to keep visible during execution
+
+- A native proof failure may be manual OBS source/audio/privacy setup, not a code defect. Do not change recorder code without evidence.
+- The runtime preflight intentionally targets `bin/Debug/net8.0` because `GameProcessDriver` launches `dotnet run --project` without `--configuration`. If that launch contract changes, update launch and preflight together.
+- Missing bundled FFmpeg can look like a capture/audio failure after Song Select. The pre-record gate must fail before OBS to remove that ambiguity.
+- Source-isolation evidence is invalid if the recorder hashes a different app-data root from CX. The explicit Mac default path is part of this task.
+
 ---
 
-## Task 1: Make recorder validation and game launch target platform-aware
+### Task 1: Share project-target resolution and align the Mac app-data default
 
 **Files:**
-
-- Modify: `DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs`
-- Modify: `DTXMania.VideoRecorder/RecorderCommandLine.cs`
 - Modify: `DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs`
-- Create: `DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs`
+- Modify: `DTXMania.VideoRecorder/RecorderCommandLine.cs`
+- Modify: `DTXMania.VideoRecorder/Program.cs`
 - Create: `DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs`
+- Create: `DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs`
 
 **Interfaces:**
 
-- Add optional environment setting `DTXMANIA_VIDEO_GAME_EXECUTABLE` to `RecorderEnvironment`.
-- Keep the public CLI verbs/options unchanged.
-- Keep returning the existing `GameProcessStartOptions`; no new public Automation types.
-- Default launch target is the current platform project from `GameProjectPaths.Current`.
-- Explicit executable mode uses `GameLaunchTarget.Executable` and executable-parent working directory.
+`RecorderGameLaunchPolicy` should own one resolved target shape, kept internal to VideoRecorder:
 
-- [ ] **Step 1: Add failing command-line environment tests.**
+```csharp
+internal sealed record ResolvedRecorderTarget(
+    string RepositoryRoot,
+    string WorkingDirectory,
+    GameLaunchTarget Target);
 
-Cover these behaviors:
+internal static ResolvedRecorderTarget ResolveTarget(string startDirectory);
+
+internal static GameProcessStartOptions CreateOptions(
+    RecordingSandbox sandbox,
+    ResolvedRecorderTarget target);
+```
+
+`ResolveTarget` uses `GameProjectPaths.Current`, resolves the absolute project path under the repository root, and uses the repository root as working directory. `CreateOptions` only adds sandbox app-data plus a fresh launch token.
+
+- [ ] **Step 1: Add failing launch-policy tests.**
+
+Cover:
 
 ```text
-unset DTXMANIA_VIDEO_GAME_EXECUTABLE
-  -> RecorderEnvironment.GameExecutablePath == null
+ResolveTarget_FromRepositoryRoot
+  -> RepositoryRoot == repo root
+  -> WorkingDirectory == repo root
+  -> Target.Kind == Project
+  -> Target.Path == <repo>/<GameProjectPaths.Current>
 
-absolute existing executable path
-  -> value is normalized to a full path
+ResolveTarget_FromNestedDirectory
+  -> same target/root as repository root
 
-relative executable path
-  -> rejected with an actionable validation error
-
-missing executable path
-  -> rejected before record starts
+CreateOptions
+  -> preserves resolved working directory/target
+  -> AppDataRoot == sandbox.AppDataRoot
+  -> LaunchToken is non-empty and fresh across calls
 ```
 
-Do not add a new CLI option for the game target.
+Use a temporary fake repo containing `DTXMania.sln` plus the current-platform project path. Do not test executable launch behavior.
 
-- [ ] **Step 2: Run the focused command-line tests and confirm the new cases fail.**
-
-```bash
-dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
-  --configuration Debug \
-  --filter "FullyQualifiedName~RecorderCommandLineTests"
-```
-
-Expected before implementation: the new `GameExecutablePath`/environment behavior does not exist.
-
-- [ ] **Step 3: Extend `RecorderEnvironment` and environment parsing minimally.**
-
-Add one nullable field for the optional executable target and one environment-variable constant:
-
-```text
-DTXMANIA_VIDEO_GAME_EXECUTABLE
-```
-
-Normalize it only when non-empty. Preserve all existing OBS/app-data environment behavior.
-
-Validation rule:
-
-```text
-unset -> default project mode
-set   -> absolute existing file required
-```
-
-Do not inspect `.app` metadata or search for executables.
-
-- [ ] **Step 4: Replace the Windows-only record gate with the intended support contract.**
-
-`ValidateRecord` should allow:
-
-```text
-Windows -> existing behavior
-macOS   -> only macOS 13+ and native arm64
-other   -> PlatformNotSupportedException
-```
-
-Do not tighten existing Windows architecture/version behavior in this ticket.
-
-Keep chart/output/OBS/source validation ordering deterministic and actionable.
-
-- [ ] **Step 5: Add failing launch-policy tests.**
-
-Required cases:
-
-```text
-default target
-  -> resolves repository root
-  -> uses GameProjectPaths.Current
-  -> creates GameLaunchTarget.Project(absolute current-platform project)
-  -> working directory is repository root
-
-explicit executable
-  -> exact executable is selected through GameLaunchTarget.Executable
-  -> working directory is executable parent
-  -> sandbox AppDataRoot is preserved
-  -> launch token remains fresh/non-empty
-```
-
-Tests may branch on `OperatingSystem.IsWindows()` / `OperatingSystem.IsMacOS()`; the repository already runs VideoRecorder tests on both CI platforms.
-
-- [ ] **Step 6: Run the launch-policy tests and confirm the new cases fail.**
+- [ ] **Step 2: Run the launch-policy tests and verify they fail before implementation.**
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
@@ -164,28 +122,64 @@ dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --filter "FullyQualifiedName~RecorderGameLaunchPolicyTests"
 ```
 
-- [ ] **Step 7: Generalize `RecorderGameLaunchPolicy.CreateOptions`.**
+Expected: FAIL because `ResolvedRecorderTarget` / `ResolveTarget` do not exist.
 
-Keep repository-root resolution in this class.
+- [ ] **Step 3: Implement the minimal shared target resolver.**
 
-Implementation rules:
+Replace the Windows-project constant inside `CreateOptions` with `ResolveTarget` + `GameProjectPaths.Current`.
+
+Keep the repository walk already owned by `RecorderGameLaunchPolicy`. Do not move it to Automation and do not add a platform abstraction.
+
+- [ ] **Step 4: Update record wiring to resolve the target before sandbox creation.**
+
+In the record path, resolve the project target once and pass it forward. `RunRecordAsync` should no longer discover a project independently after creating the sandbox.
+
+The next task inserts preflight between target resolution and `RunRecordAsync`.
+
+- [ ] **Step 5: Add failing Mac default-app-data coverage.**
+
+Use the existing injectable environment-variable reader. On the macOS test job, with `DTXMANIA_APPDATA_ROOT` unset, assert the resolved source root equals:
 
 ```text
-if GameExecutablePath is null:
-  target = Project(repoRoot + GameProjectPaths.Current)
-  workingDirectory = repoRoot
-else:
-  target = Executable(GameExecutablePath)
-  workingDirectory = parent(GameExecutablePath)
+$HOME/Library/Application Support/DTXManiaCX
 ```
 
-Do not modify `GameProcessDriver`.
+Also retain coverage that an explicit `DTXMANIA_APPDATA_ROOT` wins on every platform.
 
-- [ ] **Step 8: Wire `RunRecordAsync` to pass the selected executable override into the launch policy.**
+- [ ] **Step 6: Run the focused command-line tests and verify the new Mac case fails before implementation.**
 
-No other workflow construction changes are expected.
+```bash
+dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
+  --configuration Debug \
+  --filter "FullyQualifiedName~RecorderCommandLineTests"
+```
 
-- [ ] **Step 9: Run the focused tests until green.**
+The Mac-specific assertion is expected to be exercised by existing macOS CI.
+
+- [ ] **Step 7: Make the Mac default explicit.**
+
+`GetDefaultSourceAppDataRoot()` should use this branch before `SpecialFolder.LocalApplicationData`:
+
+```csharp
+if (OperatingSystem.IsMacOS())
+{
+    var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    if (string.IsNullOrWhiteSpace(home))
+        throw new InvalidOperationException("Unable to determine the CX app-data root.");
+
+    return Path.Combine(home, "Library", "Application Support", "DTXManiaCX");
+}
+```
+
+Keep the Windows/default branch behavior unchanged.
+
+- [ ] **Step 8: Widen only the basic record host gate.**
+
+`RecorderCommandLine.ValidateRecord` should stop rejecting macOS solely because it is not Windows. It should allow Windows or macOS and continue rejecting unsupported OSes.
+
+Do not put macOS version, process architecture, or Debug-runtime layout checks in the command parser; Task 2 validates the resolved launch target before recorder startup.
+
+- [ ] **Step 9: Run the focused tests.**
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
@@ -193,71 +187,93 @@ dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --filter "FullyQualifiedName~RecorderCommandLineTests|FullyQualifiedName~RecorderGameLaunchPolicyTests"
 ```
 
+Require all focused tests to pass on the current host. macOS CI remains the authoritative Mac-default-path execution.
+
 - [ ] **Step 10: Commit Task 1.**
 
 ```bash
 git add \
-  DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs \
   DTXMania.VideoRecorder/RecorderCommandLine.cs \
   DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs \
   DTXMania.VideoRecorder/Program.cs \
   DTXMania.VideoRecorder.Tests/RecorderCommandLineTests.cs \
   DTXMania.VideoRecorder.Tests/Workflow/RecorderGameLaunchPolicyTests.cs
 
-git commit -m "feat: support Mac recorder launch targets"
+git commit -m "feat: resolve recorder project target by platform"
 ```
 
 ---
 
-## Task 2: Add a focused Mac `doctor` preflight without changing the recorder workflow
+### Task 2: Add one shared Mac preflight used by record and doctor
 
 **Files:**
-
 - Create: `DTXMania.VideoRecorder/Diagnostics/RecorderPlatformPreflight.cs`
 - Modify: `DTXMania.VideoRecorder/Program.cs`
 - Create: `DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs`
 
 **Interfaces:**
 
-Keep this helper internal to VideoRecorder. It owns only platform/target/native-runtime preflight needed by `doctor`; it does not launch CX or talk to OBS.
+Keep the preflight internal and small. A practical shape is:
 
-The helper must support these inputs already available to `Program`:
+```csharp
+internal sealed record RecorderPlatformFacts(
+    bool IsWindows,
+    bool IsMacOS,
+    Version OsVersion,
+    Architecture ProcessArchitecture);
 
-```text
-repository root
-GameProcessStartOptions / selected GameLaunchTarget
-current OS/version/process architecture
+internal sealed record RecorderPreflightGate(
+    string Name,
+    bool Passed,
+    string Detail);
+
+internal sealed record RecorderPlatformPreflightResult(
+    IReadOnlyList<RecorderPreflightGate> Gates,
+    string? NativeRuntimeDirectory)
+{
+    public bool Passed => Gates.All(gate => gate.Passed);
+}
+
+internal static RecorderPlatformPreflightResult Evaluate(
+    ResolvedRecorderTarget target,
+    RecorderPlatformFacts facts);
+
+internal static RecorderPlatformFacts CaptureCurrentFacts();
 ```
 
-It must expose enough result detail for `Program` to print individual pass/fail gates and the resolved Mac runtime directory. Do not create a generic plug-in interface.
+Exact names may be adjusted to repository style, but retain one result consumed by both doctor and record. The helper owns target-relative Debug-runtime resolution so `Program` never rebuilds the path itself.
 
-- [ ] **Step 1: Add failing preflight tests for project and executable runtime layout.**
+- [ ] **Step 1: Add failing pure/temp-filesystem preflight tests.**
 
-Use temporary directories/files rather than the real build output.
-
-Required path rules:
+Cover:
 
 ```text
-Mac project mode:
-  <repo>/DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}
+Windows
+  -> no new runtime/architecture/version rejection
 
-Mac explicit executable mode:
-  <executable-dir>/runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}
+macOS 12 arm64
+  -> fail supported-version gate
+
+macOS 13 x64
+  -> fail native-arm64 gate
+
+macOS 13 arm64 + Mac project + missing ffmpeg
+  -> fail with ffmpeg path/detail
+
+macOS 13 arm64 + Mac project + missing ffprobe
+  -> fail with ffprobe path/detail
+
+macOS 13 arm64 + both files not executable
+  -> fail executable gate
+
+macOS 13 arm64 + both executable
+  -> pass
+  -> NativeRuntimeDirectory == <Mac-project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools
 ```
 
-Required failure cases:
+Use a temporary fake repo/project. On Unix, set execute bits with `File.SetUnixFileMode`. Keep path-resolution assertions runnable on all hosts even if executable-bit assertions are Mac/Unix-specific.
 
-```text
-missing ffmpeg
-missing ffprobe
-non-executable runtime file on macOS
-unsupported macOS version
-non-arm64 Mac process
-```
-
-The path-resolution tests should remain runnable on either OS. Unix execute-bit assertions may be guarded to macOS.
-
-- [ ] **Step 2: Run the focused preflight tests and confirm they fail.**
+- [ ] **Step 2: Run the preflight tests and verify they fail before implementation.**
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
@@ -265,63 +281,63 @@ dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --filter "FullyQualifiedName~RecorderPlatformPreflightTests"
 ```
 
-- [ ] **Step 3: Implement the smallest internal preflight helper.**
+- [ ] **Step 3: Implement the preflight with no Game-project dependency.**
 
-Responsibilities only:
-
-```text
-validate supported host for record/doctor reporting
-resolve selected target description
-resolve expected Mac native runtime directory
-verify ffmpeg + ffprobe exist
-verify executable permission on macOS
-return actionable gate detail
-```
-
-Do not:
+For macOS, resolve runtime from `target.Target.Path`:
 
 ```text
-reference DTXMania.Game
-configure FFMpegCore
-probe codecs
-search PATH for CX audio runtime
-download FFmpeg
-inspect OBS sources
-modify privacy permissions
+<project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools
 ```
 
-- [ ] **Step 4: Rework `RunDoctorAsync` to use the same launch target selection as `record`.**
+Validate host version, arm64 process, Mac project target, and executable `ffmpeg`/`ffprobe`.
 
-Remove the hard-coded Windows project path and duplicate repository-root policy.
+Do not reference `FfmpegRuntime`, search PATH, probe codecs, download binaries, or inspect OBS/privacy state.
 
-`doctor` should report:
+- [ ] **Step 4: Gate record before sandbox/OBS startup.**
+
+After `RecorderCommandLine.Validate(...)` and `RecorderGameLaunchPolicy.ResolveTarget(...)`, evaluate current preflight.
+
+If it fails, throw one actionable error containing the failed gate details **before** calling `RunRecordAsync`.
+
+Required ordering:
 
 ```text
-Recorder platform
-Repository
-Selected game target
-Source config
-Raw output directory
-OBS URL/auth/status
+parse/read environment
+-> command/path validation
+-> ResolveTarget
+-> RecorderPlatformPreflight
+-> create sandbox
+-> create OBS client
+-> existing RecordWorkflow
 ```
 
-On macOS additionally report:
+Do not put this check inside `RecordWorkflow`; it is launch readiness, not gameplay workflow state.
+
+- [ ] **Step 5: Rework doctor to consume the same target and preflight.**
+
+Delete doctor's duplicate repository-root walk and hard-coded Windows project string.
+
+Doctor should print the resolved project target and each preflight gate. On macOS it must make the required native runtime path visible.
+
+If target resolution fails, report a failed repository/target gate without creating a sandbox.
+
+- [ ] **Step 6: Keep doctor OBS behavior read-only.**
+
+Preserve exactly:
 
 ```text
-macOS >= 13
-process architecture == arm64
-native CX FFmpeg runtime directory
-ffmpeg executable
-ffprobe executable
+Hello
+Identify
+GetRecordStatus
 ```
 
-The existing recorder-side PATH `ffprobe` message remains optional and must be clearly distinguished from the bundled CX FFmpeg gate.
+No StartRecord/StopRecord or source APIs.
 
-- [ ] **Step 5: Make manual OBS prerequisite text platform-specific.**
+- [ ] **Step 7: Make doctor manual guidance platform-specific.**
 
-Windows keeps existing Game Capture/application-audio text.
+Windows retains existing Game Capture/application-audio guidance.
 
-macOS prints only the minimal operator checklist:
+macOS prints only:
 
 ```text
 Dedicated profile/collection/scene selected
@@ -335,38 +351,26 @@ WebSocket enabled/authenticated
 Raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR
 ```
 
-Never print a claim that source selection or privacy permission was programmatically verified.
+Do not claim source/privacy state was programmatically verified.
 
-- [ ] **Step 6: Keep OBS mutation behavior unchanged.**
-
-`doctor` must still perform only:
-
-```text
-Hello
-Identify
-GetRecordStatus
-```
-
-No StartRecord/StopRecord and no source APIs.
-
-- [ ] **Step 7: Run focused preflight + existing OBS tests.**
+- [ ] **Step 8: Run focused preflight/OBS tests.**
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj \
   --configuration Debug \
-  --filter "FullyQualifiedName~RecorderPlatformPreflightTests|FullyQualifiedName~Obs"
+  --filter "FullyQualifiedName~RecorderPlatformPreflightTests|FullyQualifiedName~RecorderGameLaunchPolicyTests|FullyQualifiedName~Obs"
 ```
 
-- [ ] **Step 8: Run the whole VideoRecorder and Automation test projects.**
+- [ ] **Step 9: Run the whole recorder and Automation test projects.**
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
 ```
 
-Do not edit CI merely to create a new job; these suites already run on Windows and macOS CI.
+Do not edit CI unless the PR run demonstrates the macOS job skipped the new tests.
 
-- [ ] **Step 9: Commit Task 2.**
+- [ ] **Step 10: Commit Task 2.**
 
 ```bash
 git add \
@@ -374,20 +378,20 @@ git add \
   DTXMania.VideoRecorder/Program.cs \
   DTXMania.VideoRecorder.Tests/Diagnostics/RecorderPlatformPreflightTests.cs
 
-git commit -m "feat: add Mac recorder doctor preflight"
+git commit -m "feat: preflight native Mac recorder runtime"
 ```
 
 ---
 
-## Task 3: Validate the implementation on Apple Silicon before involving OBS
+### Task 3: Prove the native Mac target/runtime before involving OBS
 
 **Files:** normally no new files.
 
-**Produces:** a green native Mac build/test baseline and proof that the default CX target carries the HPA-512 runtime.
+**Produces:** a green native Mac baseline proving the project target and HPA-512 audio runtime before manual capture is introduced.
 
-- [ ] **Step 1: Confirm the host is native Apple Silicon.**
+- [ ] **Step 1: Confirm the proof host.**
 
-Run on the proof workstation:
+Run on the Apple Silicon workstation:
 
 ```bash
 uname -m
@@ -398,20 +402,20 @@ dotnet --info
 Require:
 
 ```text
-uname -m -> arm64
-macOS major version -> 13 or later
-.NET -> SDK 8.x available
+uname -m == arm64
+macOS major version >= 13
+.NET SDK 8.x available
 ```
 
-- [ ] **Step 2: Build the Mac game before `doctor`.**
+- [ ] **Step 2: Build the exact Debug project target the recorder will launch.**
 
 ```bash
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
 ```
 
-This materializes the HPA-512 runtime in the same Debug output used by default `dotnet run` project mode.
+Do not publish an app/DMG for HPA-515 acceptance.
 
-- [ ] **Step 3: Verify native runtime architecture directly.**
+- [ ] **Step 3: Verify architecture of the actual Debug artifacts.**
 
 ```bash
 file DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac
@@ -419,9 +423,9 @@ file DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
 file DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
 ```
 
-Require each relevant executable description to include `arm64`.
+Require `arm64` for the game apphost and both bundled tools.
 
-- [ ] **Step 4: Run Mac game/audio tests that prove bundled runtime use.**
+- [ ] **Step 4: Run HPA-512 focused audio coverage.**
 
 ```bash
 ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
@@ -430,6 +434,8 @@ ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
   --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegBundledRuntimeTests|FullyQualifiedName~ManagedSoundTests"
 ```
 
+Require the bundled-runtime/audio tests to pass before moving to OBS.
+
 - [ ] **Step 5: Run recorder + Automation suites on the same host.**
 
 ```bash
@@ -437,79 +443,68 @@ dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --c
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
 ```
 
-- [ ] **Step 6: Exercise both launch-selection modes without broadening the task.**
+- [ ] **Step 6: Run `doctor` once with OBS unavailable or unconfigured only to confirm the local project/runtime gates are independently visible.**
 
-Default project mode is required for the live proof.
+It is acceptable for OBS auth/status to fail at this checkpoint. Require the platform, project target, and bundled-runtime gates to report correctly first.
 
-For explicit executable mode, use an existing published/app-bundle executable if already available on the workstation. It is sufficient to verify `doctor` resolves the target/runtime correctly; HPA-515 does not require two full videos.
-
-Do not build a new DMG workflow just for this test.
-
-- [ ] **Step 7: Do not commit acceptance evidence yet.**
-
-If any Mac-only code defect is found, fix it inside HPA-515 only when it is directly caused by launch/preflight parity. Otherwise open a focused blocker.
+If they do not, fix only HPA-515 launch/preflight defects before proceeding.
 
 ---
 
-## Task 4: Produce and accept one native Apple Silicon recording
+### Task 4: Produce and accept one real Apple Silicon ScreenCaptureKit recording
 
-**Files:** local evidence only during this task.
+**Files:** local evidence only until Task 5.
 
-**Produces:** one accepted MP4, recorder diagnostics, source-isolation proof, and one cancellation/ownership proof.
+**Produces:** one accepted Hybrid MP4 plus architecture, isolation, telemetry, cleanup, and manual media evidence.
 
-- [ ] **Step 1: Prepare one proof directory outside the Git checkout.**
+- [ ] **Step 1: Create a proof directory outside the checkout and choose one indexed encoded-audio chart.**
 
-Create local variables pointing at actual workstation paths:
+Prefer MP3 preview/BGM or another encoded input that exercises the HPA-512 runtime.
 
-```bash
-export HPA515_PROOF_ROOT="$HOME/DTXManiaCX-HPA-515-proof"
-export HPA515_RAW="$HPA515_PROOF_ROOT/raw"
-export HPA515_PUBLISHED="$HPA515_PROOF_ROOT/published"
-mkdir -p "$HPA515_RAW" "$HPA515_PUBLISHED"
+Example local structure:
+
+```text
+<proof-root>/
+  raw/
+  published/
 ```
 
-Choose one existing indexed chart with MP3 or another encoded preview/BGM that exercises bundled FFmpeg and export its absolute path:
-
-```bash
-export HPA515_CHART="$(python3 -c 'import os; print(os.path.abspath(os.environ["HPA515_CHART_INPUT"]))')"
-```
-
-Before running the command, set `HPA515_CHART_INPUT` to the actual selected chart path in the local shell. Do not commit it.
+Do not add a recorder-only fixture/chart for this native proof.
 
 - [ ] **Step 2: Configure OBS manually.**
 
-Required state:
+Required:
 
 ```text
-OBS 30.2+
-Dedicated DTXManiaCX profile/collection/scene
-ScreenCaptureKit app/window source -> CX
-CX application audio enabled through that source or one dedicated macOS Audio Capture source
-Desktop Audio disabled
-Microphone disabled
+OBS Studio 30.2+
+Dedicated DTXManiaCX profile + collection + scene
+ScreenCaptureKit application/window capture scoped to CX
+CX application audio through the source or one dedicated macOS Audio Capture source
+Desktop Audio disabled for recorded track
+Microphone disabled for recorded track
 Hybrid MP4
-Screen Recording permission granted
-obs-websocket 5.x enabled/authenticated
-Recording directory == HPA515_RAW
-OBS idle
+obs-websocket 5.x authenticated
+Screen Recording permission granted manually
+OBS idle before recorder starts
 ```
 
-Visually confirm the source shows CX before starting the recorder. This manual check is the source/permission gate for HPA-515.
+Do not add source discovery or privacy automation if setup is wrong.
 
-- [ ] **Step 3: Export recorder environment.**
+- [ ] **Step 3: Export the existing recorder environment.**
 
 ```bash
-export DTXMANIA_VIDEO_OBS_URL="ws://127.0.0.1:4455"
-export DTXMANIA_VIDEO_OBS_PASSWORD="$HPA515_LOCAL_OBS_PASSWORD"
-export DTXMANIA_VIDEO_OBS_OUTPUT_DIR="$HPA515_RAW"
-unset DTXMANIA_VIDEO_GAME_EXECUTABLE
+export DTXMANIA_VIDEO_OBS_URL='ws://127.0.0.1:4455'
+export DTXMANIA_VIDEO_OBS_PASSWORD='<local-secret>'
+export DTXMANIA_VIDEO_OBS_OUTPUT_DIR='<absolute-proof-root>/raw'
 ```
 
-`HPA515_LOCAL_OBS_PASSWORD` is a local secret and must never be written to committed evidence.
+Leave `DTXMANIA_APPDATA_ROOT` unset for the primary proof so the newly explicit normal Mac path is exercised.
+
+Do not write the secret into retained transcripts.
 
 - [ ] **Step 4: Capture source app-data before-state.**
 
-For the actual source CX app-data root, record presence, byte size, and SHA-256 for:
+Against `~/Library/Application Support/DTXManiaCX`, record presence, size, and SHA-256 for:
 
 ```text
 Config.ini
@@ -518,67 +513,28 @@ songs.db-wal
 songs.db-shm
 ```
 
-Save the sanitized local output to:
+Record missing WAL/SHM as absent; do not create them.
 
-```text
-$HPA515_PROOF_ROOT/source-state-before.txt
-```
-
-Absent WAL/SHM files remain absent; do not create them for the proof.
-
-- [ ] **Step 5: Run `doctor` and retain output.**
+- [ ] **Step 5: Run live doctor with OBS idle.**
 
 ```bash
 dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj \
-  --configuration Debug -- doctor \
-  2>&1 | tee "$HPA515_PROOF_ROOT/doctor.txt"
+  --configuration Debug --no-build -- doctor
 ```
 
-Require exit code `0` and these Mac gates:
+Require all recorder/platform/runtime/OBS gates to pass. Recorder-side PATH `ffprobe` may remain a warning-only final-media check.
 
-```text
-supported macOS
-arm64 recorder process
-repository found
-Mac game target found
-native CX ffmpeg found/executable
-native CX ffprobe found/executable
-source config valid
-raw output directory valid
-OBS auth/status succeeded
-OBS recording inactive
-OBS state mutation none
-```
-
-- [ ] **Step 6: Retain architecture evidence.**
-
-Write sanitized `file` output for the game apphost and bundled FFmpeg pair to:
-
-```text
-$HPA515_PROOF_ROOT/architecture.txt
-```
-
-Require `arm64` for all three.
-
-- [ ] **Step 7: Run the accepted recording.**
+- [ ] **Step 6: Run the accepted recording.**
 
 ```bash
 dotnet run --project DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj \
   --configuration Debug --no-build -- \
-  record --chart "$HPA515_CHART" --output "$HPA515_PUBLISHED"
+  record --chart '<absolute-chart-path>' --output '<proof-root>/published'
 ```
 
-Require exit code `0` and retain:
+Require exit code 0 and retain raw MP4, published MP4, `run.json`, CX stdout, and CX stderr outside Git.
 
-```text
-raw OBS MP4
-published MP4
-published/diagnostics/<run-id>/run.json
-published/diagnostics/<run-id>/cx-stdout.log
-published/diagnostics/<run-id>/cx-stderr.log
-```
-
-- [ ] **Step 8: Validate `run.json` using the shared Windows contract.**
+- [ ] **Step 7: Inspect the shared `run.json` contract.**
 
 Require:
 
@@ -586,196 +542,151 @@ Require:
 status == Completed
 SongSelectReady -> selected song present
 PreviewReady -> Playing and elapsed >= 10000 ms
-PerformanceReady -> ready, AutoPlay enabled, totalNotes > 0
-ResultCompleted -> completed, clear, SongComplete, totalJudgements == totalNotes
-OBS Connect/Status/Start/Stop -> success
-raw/published paths -> present
-failure/failureType/retained successful sandbox -> absent
+PerformanceReady -> ready + AutoPlay + totalNotes > 0
+ResultCompleted -> cleared by SongComplete + totalJudgements == totalNotes
+OBS -> Connect/Status/Start/Stop succeeded
+raw + published paths recorded
+no failure fields / retained successful sandbox
 ```
 
-Do not add Mac-only telemetry just to make the proof easier.
+Do not add Mac-only diagnostic fields unless a concrete evidence gap is discovered.
 
-- [ ] **Step 9: Run one native Ctrl+C ownership check.**
+- [ ] **Step 8: Run one Ctrl+C ownership proof.**
 
-Start a second valid `record` run. After OBS is recorder-owned and preview/gameplay is active, press Ctrl+C once.
+Start a second valid recording. After recorder-owned OBS recording has started, press Ctrl+C once.
 
 Require:
 
 ```text
-command exits via cancellation
+command exits through cancellation
 OBS is no longer recording
-partial raw artifact retained when available
-failed-run diagnostics retained when available
-failed-run sandbox retained and referenced for debugging
-normal source app-data unchanged
+partial raw artifact remains when OBS produced one
+diagnostics are retained when possible
+failed-run sandbox is retained/referenced for inspection
 ```
 
-Delete the failed-run sandbox manually only after evidence is inspected.
+Delete the failed-run sandbox manually after evidence is captured.
 
-- [ ] **Step 10: Capture source app-data after-state.**
+- [ ] **Step 9: Capture source app-data after-state and compare.**
 
-Repeat the exact same presence/size/SHA-256 capture as Step 4.
+Repeat the exact presence/size/SHA-256 capture from Step 4.
 
-Require no source Config.ini/database/WAL/SHM content change and no new source WAL/SHM creation caused by the recorder.
+Require no content change and no newly created source WAL/SHM file caused by the recorder.
 
-- [ ] **Step 11: Watch the complete published MP4.**
+- [ ] **Step 10: Watch the complete published MP4.**
 
-Confirm:
+Require:
 
 ```text
-[ ] intended populated Song Select first
-[ ] preview begins after visible Song Select
-[ ] >= 10 seconds actual preview audio
+[ ] intended populated Song Select is first
+[ ] preview audio starts after visible Song Select
+[ ] preview lasts >= 10 seconds
 [ ] complete Song Transition
 [ ] full AutoPlay gameplay
 [ ] BGM/chip audio audible
-[ ] fully rendered Result
-[ ] Result held >= 5 seconds
+[ ] fully rendered Result held >= 5 seconds
 [ ] recording ends after Result hold
-[ ] no OBS UI / desktop / unrelated window
-[ ] no cursor / notifications
-[ ] no microphone / unrelated application audio
-[ ] no duplicated or echoed CX audio
-[ ] no aspect squeeze / severe stutter / missing viewport region
-[ ] encoded preview/gameplay audio works without user-installed FFmpeg or Rosetta
+[ ] no OBS UI / desktop / unrelated window / cursor / notification
+[ ] no microphone or unrelated application audio
+[ ] no duplicated/echoed CX audio
+[ ] no severe stutter, aspect squeeze, or missing viewport region
+[ ] no Rosetta or user-installed FFmpeg required for CX audio
 ```
 
-If capture selection/privacy is wrong, fix the manual OBS setup and rerun. Do not add automatic source diagnosis to HPA-515.
+If capture/audio/privacy setup fails while recorder telemetry/runtime checks are healthy, fix OBS/privacy configuration rather than expanding recorder code.
 
 ---
 
-## Task 5: Commit the Mac runbook and sanitized verification record
+### Task 5: Commit the Mac operator runbook and sanitized proof record
 
 **Files:**
-
 - Create: `docs/video-recorder/macos-obs-setup.md`
 - Create: `docs/verification/hpa-515-apple-silicon-live-recording.md`
 
-- [ ] **Step 1: Write `macos-obs-setup.md`.**
+- [ ] **Step 1: Write the operator runbook.**
 
-Keep it operator-focused and concise. Required sections:
+Keep it concise and project-mode-only:
 
 ```text
-Prerequisites: macOS 13+, Apple Silicon, OBS 30.2+
-Build the default Mac project target
-Optional DTXMANIA_VIDEO_GAME_EXECUTABLE usage
-ScreenCaptureKit app/window source
-CX application audio source
+Apple Silicon + macOS 13+ prerequisites
+Debug Mac project build
+ScreenCaptureKit source setup
+CX application-audio setup
 Screen Recording permission
-Disable Desktop Audio + microphone
-Hybrid MP4 + obs-websocket
-Required environment variables
+Desktop/microphone disabled
+WebSocket environment variables
 doctor command
 record command
-Native bundled FFmpeg gate
-Raw/published/diagnostics locations
-Troubleshooting:
-  unsupported/non-arm64 host
-  missing bundled runtime
-  OBS auth/already-recording
-  Screen Recording permission
-  stale/wrong ScreenCaptureKit target
-  duplicated/missing audio
-  invalid/unindexed chart
-  optional recorder-side ffprobe warning
+bundled FFmpeg preflight meaning
+raw/published/diagnostics locations
+troubleshooting: host/arm64/runtime/OBS auth/already-recording/source/privacy/audio
 ```
 
-Do not turn this into general OBS/macOS documentation.
+Do not document executable/app-bundle recording, HPA-505 diagnostics, or HPA-506 media hardening.
 
-- [ ] **Step 2: Write `hpa-515-apple-silicon-live-recording.md`.**
+- [ ] **Step 2: Write the sanitized verification record.**
 
-Record only sanitized evidence:
+Record:
 
 ```text
 accepted commit SHA
 macOS version + arm64 host
-.NET SDK/host version
-OBS version
-launch mode (project or explicit executable)
+.NET + OBS versions
 non-sensitive chart identity
-arm64 game/ffmpeg/ffprobe evidence summary
-doctor gate summary
-successful command summary with private paths redacted
-raw MP4 filename + size + SHA-256
-published MP4 filename + size + SHA-256
-key run.json values
-source before/after result
-Ctrl+C ownership/cleanup result
+project target
+arm64 apphost/ffmpeg/ffprobe evidence
+doctor result summary
+successful command with private paths redacted
+raw/published MP4 filenames + sizes + SHA-256
+key run.json acceptance values
+source before/after hash result
+Ctrl+C ownership result
 manual media checklist result
-focused test commands + pass counts
+focused automated-test commands + pass counts
 warnings/deviations
 ```
 
-Never embed passwords, API keys, private absolute chart paths, raw logs, or MP4 binaries.
+Do not commit videos, raw logs, secrets, or private absolute paths.
 
-- [ ] **Step 3: Run final cross-platform-safe validation on the implementation branch.**
-
-On Apple Silicon:
+- [ ] **Step 3: Run final automated verification on Apple Silicon.**
 
 ```bash
 dotnet test DTXMania.VideoRecorder.Tests/DTXMania.VideoRecorder.Tests.csproj --configuration Debug
 dotnet test DTXMania.Automation.Tests/DTXMania.Automation.Tests.csproj --configuration Debug
-ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj --configuration Debug --no-build
-```
-
-Then rely on the existing GitHub Windows/macOS CI jobs for the authoritative cross-platform gate.
-
-- [ ] **Step 4: Confirm scope before committing.**
-
-```bash
-git status --short
-git diff --stat main...HEAD
+ALSOFT_DRIVERS=null dotnet test DTXMania.Test/DTXMania.Test.Mac.csproj \
+  --configuration Debug --no-build \
+  --filter "FullyQualifiedName~FfmpegAudioVariantProcessorTests|FullyQualifiedName~FfmpegBundledRuntimeTests|FullyQualifiedName~ManagedSoundTests"
 git diff --check
 ```
 
-Reject unrelated changes and any unexpected edits under:
+Also require the normal Windows CI recorder/Automation jobs to remain green before merge.
 
-```text
-RecordWorkflow.cs
-Obs/
-Media/
-Sandbox/
-GameProcessDriver.cs
-FfmpegRuntime.cs
-.github/workflows/
-```
-
-unless a separately reviewed, directly necessary fix was explicitly added.
-
-- [ ] **Step 5: Commit the acceptance documents.**
+- [ ] **Step 4: Commit the acceptance documentation.**
 
 ```bash
 git add \
   docs/video-recorder/macos-obs-setup.md \
   docs/verification/hpa-515-apple-silicon-live-recording.md
 
-git commit -m "docs: record Apple Silicon recorder acceptance"
+git commit -m "docs: verify Apple Silicon recorder parity"
 ```
 
-- [ ] **Step 6: Final PR checklist.**
+---
 
-The implementation PR is ready for review only when all are true:
+## Completion Checklist
+
+Before marking HPA-515 complete, verify all of these are true:
 
 ```text
-[ ] same CLI contract on Windows + Mac
-[ ] Mac default project launch is DTXMania.Game.Mac.csproj
-[ ] optional explicit packaged executable works
-[ ] Mac doctor fails unsupported OS/arch and unusable bundled runtime
-[ ] existing Windows VideoRecorder/Automation tests green
-[ ] Mac VideoRecorder/Automation/audio tests green
-[ ] real Apple Silicon doctor green
-[ ] accepted MP4 manually inspected
-[ ] source app-data unchanged
-[ ] Ctrl+C stops only owned OBS recording
-[ ] no ScreenCaptureKit automation/platform framework/strict media scope added
+[ ] unchanged doctor / record CLI works on native Apple Silicon macOS 13+
+[ ] record and doctor use one ResolvedRecorderTarget
+[ ] Mac preflight runs before sandbox/OBS creation
+[ ] missing/unusable bundled runtime fails before OBS
+[ ] default Mac source root is ~/Library/Application Support/DTXManiaCX
+[ ] one encoded-audio project-mode recording passes the HPA-513 journey contract
+[ ] source Config.ini/database/WAL/SHM are unchanged
+[ ] Ctrl+C stops only recorder-owned OBS work
+[ ] manual ScreenCaptureKit/audio acceptance passes
+[ ] Windows recorder behavior/tests remain green
+[ ] no packaged executable mode/platform adapter/HPA-505/HPA-506 scope was introduced
 ```
-
-## Implementation-agent handoff
-
-Execute this as one HPA-515 implementation PR with three review checkpoints:
-
-1. **Launch parity:** command/environment validation and platform project/executable selection.
-2. **Doctor parity:** Mac host/native-runtime gates with focused tests; shared workflow remains untouched.
-3. **Native acceptance:** real Apple Silicon OBS proof plus the two committed docs.
-
-Do not parallelize Tasks 1 and 2 against different assumptions: Task 2 consumes the exact launch target selected by Task 1. Task 4 cannot be accepted until Tasks 1–3 are green.

--- a/docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md
@@ -6,9 +6,9 @@
 
 ## Goal
 
-Port the accepted HPA-503/HPA-513 recording workflow to native Apple Silicon macOS with the smallest possible platform-specific change, then retain one inspected Mac recording and a concise operator runbook.
+Port the accepted HPA-503/HPA-513 recorder workflow to native Apple Silicon macOS with the smallest possible platform-specific change, then retain one inspected Mac recording and a concise operator runbook.
 
-The successful journey and CLI stay unchanged:
+The public command and captured journey stay unchanged:
 
 ```text
 dtx-video record --chart <absolute-chart-path> --output <directory>
@@ -20,230 +20,269 @@ Song Select
 -> completed Result held for at least 5 seconds
 ```
 
-HPA-515 is parity work, not a second recorder architecture.
+HPA-515 is parity work. It is not a second recorder architecture and it does not add a second launch mode.
 
 ## Why this is the next actionable task
 
 - HPA-513 is Done and accepted the shared recorder workflow on Windows.
 - HPA-512 is Done and provides native `osx-arm64` FFmpeg/ffprobe for CX preview and gameplay audio.
 - HPA-515 is the remaining high-priority unblocked leaf under HPA-500.
-- HPA-505 and HPA-506 are explicitly optional hardening and should not precede parity.
+- HPA-505 and HPA-506 are optional hardening and should not precede parity.
 
 ## Current-state findings
 
 The existing recorder is already mostly platform-neutral:
 
-- `RecordWorkflow` drives the normal CX journey and contains no Windows-specific stage logic.
-- `ObsWebSocketRecorder` only uses obs-websocket 5.x and does not care whether OBS captures through Game Capture or ScreenCaptureKit.
-- `GameProcessDriver` already supports both `GameLaunchTarget.Project(...)` and `GameLaunchTarget.Executable(...)`.
-- `GameProjectPaths` already exposes both Windows and Mac CX project paths.
+- `RecordWorkflow` contains no Windows-specific stage flow.
+- `ObsWebSocketRecorder` speaks obs-websocket 5.x and does not care whether OBS captures with Game Capture or ScreenCaptureKit.
+- `GameProcessDriver` already launches a project through `dotnet run --project`.
+- `GameProjectPaths.Current` already selects the Windows or Mac CX project.
 - macOS CI already runs `DTXMania.VideoRecorder.Tests` and `DTXMania.Automation.Tests`.
-- HPA-512 already packages `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}` into Mac build/publish output and verifies the binaries are executable arm64 files.
+- HPA-512 already places executable arm64 `ffmpeg` and `ffprobe` under `runtimes/osx-arm64/MMTools` in Mac build/publish output.
 
-The actual Windows assumptions are narrow:
+The relevant Windows assumptions are narrow:
 
 1. `RecorderCommandLine.ValidateRecord` rejects every non-Windows host.
-2. `RecorderGameLaunchPolicy` hard-codes `DTXMania.Game.Windows.csproj`.
-3. `Program.RunDoctorAsync` hard-codes the Windows gate/project and Windows OBS guidance.
+2. `RecorderGameLaunchPolicy.CreateOptions` hard-codes `DTXMania.Game.Windows.csproj` and requires a `RecordingSandbox` even though target resolution itself does not.
+3. `Program.RunDoctorAsync` duplicates repository-root discovery and hard-codes the Windows project/guidance.
+4. the recorder's default app-data lookup does not explicitly encode CX's macOS `~/Library/Application Support/DTXManiaCX` contract.
 
-That is the intended implementation surface.
+Those are the intended implementation seams.
 
 ## Approaches considered
 
-### A. Extend the existing recorder with a small platform-aware launch/preflight seam — recommended
+### A. Extend the existing recorder with one project-target resolver and one focused preflight — recommended
 
-Keep one `RecordWorkflow`, one OBS client, and one CLI. Reuse `GameProjectPaths.Current` and the existing Automation launch target types. Add only the Mac platform checks, optional packaged-executable selection, and Mac-specific `doctor`/documentation behavior.
+Keep one `RecordWorkflow`, one OBS client, one CLI, and one project launch path. Reuse `GameProjectPaths.Current` and `GameLaunchTarget.Project(...)`. Resolve the launch target once, run a small platform/runtime preflight before recording, and reuse both in `doctor`.
 
 **Pros**
 
-- smallest change;
-- preserves the proven Windows workflow;
-- no duplicated workflow state;
-- easy to test on the existing Windows + macOS CI matrix;
-- leaves HPA-505/HPA-506 cleanly deferred.
+- smallest production change;
+- preserves the proven Windows journey;
+- prevents doctor and record from drifting onto different game targets;
+- fails missing Mac runtime before OBS starts;
+- naturally uses the existing Windows/macOS test matrix.
 
 **Cons**
 
-- a few conditional Mac branches remain in recorder launch/preflight code.
+- a few Mac-specific checks remain in recorder preflight code.
 
-### B. Move recorder platform selection into `DTXMania.Automation`
+### B. Move recorder platform policy into `DTXMania.Automation`
 
-Teach Automation about recorder-specific Mac/Windows defaults and native FFmpeg preflight.
-
-**Rejected:** Automation already has the generic primitives the recorder needs. Moving OBS/recorder policy into it would couple a reusable automation library to one consumer and expand the public API without a second use case.
+Rejected. Automation already exposes the generic project-path and launch primitives. Moving recorder-specific runtime/OBS policy there would broaden a reusable library for one consumer.
 
 ### C. Add `IRecorderPlatform` with Windows/Mac implementations
 
-Create platform adapters owning launch, doctor, capture guidance, and media/runtime checks.
+Rejected. Two platform branches do not justify an adapter framework. It adds indirection without a second workflow or launch model.
 
-**Rejected:** this is configuration-by-abstraction for two small branches. It adds more files and indirection than HPA-515 needs and conflicts with the ticket's explicit “no platform-adapter framework” constraint.
+### D. Add packaged-executable recording now
+
+Rejected for HPA-515. The accepted Windows proof uses project mode and the Mac parity proof should exercise the same contract. A packaged executable adds a second working-directory/runtime-layout path that the acceptance run would not prove.
+
+If packaged-app recording becomes useful later, it can be added behind the single launch-policy seam created here.
 
 ## Design decision
 
-Use approach A.
+Use approach A and keep HPA-515 project-mode-only.
 
-The implementation should remain one recorder with three targeted extensions:
+The recorder gains three focused changes:
 
 ```text
-RecorderCommandLine
-  -> support Windows OR native Apple Silicon macOS
-
 RecorderGameLaunchPolicy
-  -> select current platform project by default
-  -> optionally select an explicit packaged executable
+  -> ResolveTarget(...) without a sandbox
+  -> current platform project + repository-root working directory
+  -> CreateOptions(...) only adds sandbox app-data + launch token
 
-Program doctor
-  -> report shared gates
-  -> add small platform-specific diagnostics/guidance
+RecorderPlatformPreflight
+  -> validate native Mac host and bundled Debug runtime
+  -> consume the already-resolved project target
+
+Program / RecorderCommandLine
+  -> permit macOS as a recorder host
+  -> run preflight before record creates sandbox or talks to OBS
+  -> doctor prints the same resolved target/preflight gates
 ```
 
-`RecordWorkflow`, `IGameRecordingControl`, `ObsWebSocketRecorder`, sandboxing, diagnostics, and artifact finalization remain unchanged unless the native proof exposes a real defect.
+`RecordWorkflow`, `IGameRecordingControl`, `ObsWebSocketRecorder`, sandbox semantics, diagnostics schema, finalization, and `GameProcessDriver` remain unchanged unless the native proof exposes a directly related defect.
 
-## Supported platform contract
+## Project target resolution
 
-### Windows
+Add one sandbox-free resolved-target result owned by `RecorderGameLaunchPolicy`, for example:
 
-Keep current behavior unchanged. Do not tighten existing Windows validation as part of Mac parity.
+```csharp
+internal sealed record ResolvedRecorderTarget(
+    string RepositoryRoot,
+    string WorkingDirectory,
+    GameLaunchTarget Target);
+```
 
-### macOS
+`ResolveTarget(startDirectory)` must:
 
-`record` is supported only when all of the following are true:
+1. reuse the existing repository-root walk;
+2. read `GameProjectPaths.Current`;
+3. combine it with the repository root to produce an absolute project path;
+4. create `GameLaunchTarget.Project(projectPath)`;
+5. use the repository root as the working directory.
 
-- macOS 13 or later;
-- the recorder process is native `arm64`;
-- the selected CX target is the Mac project or an explicit Mac executable;
-- the expected native CX FFmpeg runtime is present and executable before the acceptance run.
-
-Intel macOS and Rosetta are out of scope. There is no fallback to the Windows project, x64 Mac runtime, or a generic PATH-only CX audio configuration.
-
-## Game launch selection
-
-### Default project mode
-
-When no override is provided:
-
-1. resolve the repository root exactly as today;
-2. use `GameProjectPaths.Current` to choose the platform project;
-3. resolve that path under the repository root;
-4. preserve repository root as the process working directory;
-5. let `GameProcessDriver` continue launching it through `dotnet run --project ...`.
-
-On Apple Silicon this resolves to:
+On Apple Silicon the target is:
 
 ```text
 DTXMania.Game/DTXMania.Game.Mac.csproj
 ```
 
-Do not add a `--platform` command option. The host platform already determines the supported project unambiguously.
-
-### Optional packaged executable mode
-
-Add one optional environment override:
+On Windows it remains:
 
 ```text
-DTXMANIA_VIDEO_GAME_EXECUTABLE=<absolute executable path>
+DTXMania.Game/DTXMania.Game.Windows.csproj
 ```
 
-When set:
+`CreateOptions` then combines the resolved target with:
 
-- require an absolute existing file;
-- create `GameLaunchTarget.Executable(...)` through the existing Automation API;
-- use the executable's parent directory as the game process working directory;
-- preserve the disposable app-data root and launch-token behavior exactly as in project mode.
+- `RecordingSandbox.AppDataRoot`;
+- a fresh launch token.
 
-For the current Mac app bundle, the expected executable is:
+This separation lets `doctor` inspect exactly what `record` would launch without creating a disposable sandbox just to discover a path.
+
+Do not add platform arguments, executable overrides, app-bundle discovery, DMG mounting, or `open`-based launch behavior.
+
+## Supported platform contract
+
+### Windows
+
+Keep current behavior unchanged. Do not add new Windows version, architecture, or runtime requirements as part of Mac parity.
+
+### macOS
+
+Recording is supported only when all of the following are true:
+
+- macOS 13 or later;
+- the recorder process is native `arm64`;
+- `GameProjectPaths.Current` resolves to the Mac project;
+- the project exists;
+- the expected HPA-512 Debug runtime contains executable `ffmpeg` and `ffprobe`.
+
+Intel macOS and Rosetta are out of scope. There is no PATH fallback for the supported CX audio runtime.
+
+`RecorderCommandLine` should continue owning syntax/path/environment validation and may widen the existing OS gate from Windows-only to Windows-or-macOS. Native host/build-layout validation belongs to the focused preflight below rather than command parsing.
+
+## Native platform/runtime preflight
+
+Add one internal pure-ish helper, `RecorderPlatformPreflight`, that consumes the already-resolved project target plus testable host/file facts.
+
+For Windows, it preserves today's supported behavior and adds no new gate.
+
+For macOS, it validates:
 
 ```text
-DTXMania.app/Contents/MacOS/DTXMania.Game.Mac
+macOS major version >= 13
+process architecture == Arm64
+resolved project == DTXMania.Game.Mac.csproj
+project file exists
+<project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg exists + executable
+<project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe exists + executable
 ```
 
-This is deliberately an executable override, not an app-bundle discovery feature. The recorder should not mount DMGs, search `/Applications`, parse `Info.plist`, or launch through `open`.
-
-The override may work on Windows as well because the underlying Automation target is generic, but HPA-515 only needs it for explicit Mac packaged-layout validation.
-
-## Native FFmpeg preflight
-
-The recorder must not take a dependency on `DTXMania.Game` or duplicate `FfmpegRuntime`.
-
-`doctor` should perform a small filesystem preflight against the target that will actually be launched:
-
-### Default Mac project target
-
-Require the normal Debug build output to contain:
+The Debug layout is intentional. `GameProcessDriver` currently invokes:
 
 ```text
-DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
-DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
+dotnet run --project <project>
 ```
 
-The runbook should build `DTXMania.Game.Mac.csproj` before `doctor`. HPA-512 already owns generation/copy correctness and CI verification; HPA-515 only checks that the local proof target contains the runtime it is about to exercise.
+without `--configuration`, so the recorder's supported project-mode launch is Debug. HPA-515 should state and test that contract instead of adding configuration/RID search logic.
 
-### Explicit executable target
+The helper must not:
 
-Resolve the runtime relative to the executable directory:
+- reference `DTXMania.Game`;
+- call or duplicate `FfmpegRuntime`;
+- configure FFMpegCore;
+- search PATH for the CX runtime;
+- probe codecs;
+- download FFmpeg;
+- inspect OBS sources or privacy permissions.
+
+The recorder-side `RecordingArtifactVerifier` may continue its existing optional PATH `ffprobe` lookup for final MP4 inspection. That is separate from the required bundled CX runtime.
+
+### Record call site
+
+A Mac `record` command must execute the same preflight **before** `RunRecordAsync` creates the disposable sandbox, initializes OBS, or starts the workflow.
+
+This is intentionally a program/orchestration gate rather than a `RecorderCommandLine` build-layout check: command parsing validates the command; launch/preflight code validates the target that will actually run.
+
+Missing/unusable bundled FFmpeg therefore fails loudly before any OBS recording can begin.
+
+### Doctor call site
+
+`doctor` resolves the same target and consumes the same preflight result to print individual pass/fail gates. It must not independently reconstruct the Mac project or runtime path.
+
+## Default source app-data contract
+
+Keep `DTXMANIA_APPDATA_ROOT` as the explicit override.
+
+When no override is supplied, encode the CX macOS contract directly:
 
 ```text
-<executable-dir>/runtimes/osx-arm64/MMTools/ffmpeg
-<executable-dir>/runtimes/osx-arm64/MMTools/ffprobe
+~/Library/Application Support/DTXManiaCX
 ```
 
-For both modes:
+Do not depend on `SpecialFolder.LocalApplicationData` happening to map to the same location on current .NET/macOS. The source path used for sandbox creation and before/after isolation hashes must be the same path CX considers its normal data root.
 
-- both files must exist;
-- both files must have executable permission on macOS;
-- `doctor` reports the resolved runtime directory;
-- missing/unusable files fail the Mac doctor gate with an actionable message.
-
-Do not add a second FFmpeg resolver, codec probe, download path, or PATH fallback to the recorder. HPA-512's existing game/runtime tests plus the real MP3 acceptance chart provide the deeper proof.
-
-The native acceptance record should additionally retain `file` output showing the selected game executable and bundled `ffmpeg`/`ffprobe` are arm64. That verification belongs to the proof, not a new runtime abstraction.
+Windows default behavior stays unchanged.
 
 ## `doctor` behavior
 
-Keep `doctor` read-only with respect to OBS. It still performs only Hello/Identify/GetRecordStatus.
+Keep `doctor` read-only with respect to OBS. It still performs only:
 
-Shared gates remain:
+```text
+Hello
+Identify
+GetRecordStatus
+```
+
+Shared output should include:
 
 - recorder configuration;
 - repository root;
-- selected CX target;
+- selected project target;
 - source Config.ini validation;
 - raw OBS output directory;
 - OBS auth/status;
-- optional recorder-side PATH `ffprobe` warning for final MP4 inspection.
+- optional recorder-side PATH `ffprobe` warning.
 
-Mac-specific gates add:
+Mac-specific gates should include:
 
 - macOS 13+;
-- recorder process architecture is arm64;
-- selected target is usable;
-- native CX FFmpeg runtime pair is present/executable.
+- recorder process `arm64`;
+- Mac project target;
+- native CX runtime directory;
+- bundled `ffmpeg` executable;
+- bundled `ffprobe` executable.
 
-Mac guidance printed by `doctor` should say only:
+Mac manual guidance should state only:
 
 ```text
-Dedicated DTXManiaCX OBS profile/collection/scene selected
+Dedicated DTXManiaCX profile/collection/scene selected
 ScreenCaptureKit application/window capture scoped to CX
 CX application audio enabled through that source or one dedicated macOS Audio Capture source
-Desktop Audio and microphone disabled for the recorded track
+Desktop Audio disabled for the recorded track
+Microphone disabled for the recorded track
 Hybrid MP4 configured
-OBS Screen Recording permission granted manually
+Screen Recording permission granted manually
 WebSocket enabled/authenticated
 raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR
 ```
 
-The tool must not claim it can inspect ScreenCaptureKit selection, distinguish stale source selection from privacy denial, inspect audio meters, or grant macOS privacy permission.
+The tool must not claim to inspect ScreenCaptureKit selection, audio meters, stale selectors, or macOS privacy state.
 
-Windows doctor output should retain the existing Game Capture/application-audio guidance.
+Windows doctor guidance remains the existing Game Capture/application-audio guidance.
 
 ## Recording workflow
 
 No workflow fork is introduced.
 
-On macOS the existing sequence stays:
+After preflight succeeds, macOS follows the existing workflow unchanged:
 
 1. create disposable recorder app-data sandbox;
-2. launch CX through `DTXMania.Automation`;
+2. launch the resolved Mac project through `DTXMania.Automation`;
 3. wait for populated Song Select;
 4. prepare the exact chart with preview stopped;
 5. start owned OBS recording;
@@ -256,36 +295,28 @@ On macOS the existing sequence stays:
 12. verify/publish the raw artifact;
 13. write diagnostics and delete only the successful sandbox.
 
-No Mac-specific stage timing or retry policy is added.
+No Mac-specific stage timing, retry policy, or diagnostics schema is added.
 
 ## OBS / ScreenCaptureKit contract
 
-Keep the OBS scene fully manual.
-
-Required proof configuration:
+Keep OBS setup manual and minimal:
 
 - OBS Studio 30.2+;
-- dedicated DTXManiaCX profile, scene collection, and scene;
+- dedicated DTXManiaCX profile, collection, and scene;
 - ScreenCaptureKit application/window capture scoped to CX;
 - CX application audio enabled through that source or one dedicated macOS Audio Capture source;
 - global Desktop Audio disabled for the recorded track;
-- microphone inputs disabled for the recorded track;
+- microphone disabled for the recorded track;
 - Hybrid MP4;
 - authenticated obs-websocket 5.x;
-- Screen Recording privacy permission granted manually;
+- Screen Recording permission granted manually;
 - OBS idle before `record` starts.
 
-No scene/source enumeration or auto-repair is added. HPA-505 remains the optional follow-up if manual setup proves too fragile.
+HPA-505 remains the optional source/audio/privacy diagnostic follow-up. HPA-506 remains the optional strict media/remux follow-up.
 
-## Acceptance chart
+## Acceptance chart and native evidence
 
-Use one short chart that is already indexed by normal CX Song Select and has preview audio.
-
-The accepted Mac proof must exercise the HPA-512 runtime. Prefer an MP3 preview/BGM input; otherwise use another encoded input that demonstrably invokes the bundled native FFmpeg path.
-
-Do not create a special recorder-only chart.
-
-## Native acceptance evidence
+Use one short chart already indexed by normal CX Song Select with valid preview audio. Prefer MP3 preview/BGM or another encoded input that demonstrably exercises the HPA-512 runtime.
 
 Retain outside Git:
 
@@ -295,33 +326,27 @@ Retain outside Git:
   architecture.txt
   source-state-before.txt
   source-state-after.txt
-  raw/
-    <obs-produced-file>.mp4
-  published/
-    <published-file>.mp4
-    diagnostics/<run-id>/
-      run.json
-      cx-stdout.log
-      cx-stderr.log
+  raw/<obs-produced-file>.mp4
+  published/<published-file>.mp4
+  published/diagnostics/<run-id>/run.json
+  published/diagnostics/<run-id>/cx-stdout.log
+  published/diagnostics/<run-id>/cx-stderr.log
 ```
 
-The exact local path is not a product contract.
-
-`architecture.txt` should record enough sanitized evidence to show:
+`architecture.txt` should show, without private paths or secrets:
 
 - host is Apple Silicon;
-- `dtx-video` process is arm64;
-- selected CX executable/apphost is arm64;
+- selected CX apphost is arm64;
 - bundled `ffmpeg` is arm64;
 - bundled `ffprobe` is arm64.
 
-Do not commit binaries or private local paths.
+The preflight proves executable presence before OBS. The HPA-512 focused audio tests plus encoded acceptance chart prove the runtime is actually useful for CX audio.
 
 ## Source app-data isolation
 
-Reuse the HPA-513 proof technique.
+Reuse the HPA-513 before/after hash proof against the resolved normal Mac app-data root.
 
-Immediately before and after the accepted Mac run, capture presence, size, and SHA-256 for source files when present:
+Capture presence, byte size, and SHA-256 for:
 
 ```text
 Config.ini
@@ -330,214 +355,139 @@ songs.db-wal
 songs.db-shm
 ```
 
-Acceptance requires no content change and no new source WAL/SHM creation caused by the recorder.
+Acceptance requires no content change and no new source WAL/SHM file caused by the recorder.
 
-Do not add recorder instrumentation for this; filesystem hashes are sufficient.
+Do not add recorder instrumentation for this proof.
 
 ## Automated telemetry acceptance
 
-Reuse the same `run.json` contract accepted by HPA-513. Require at least:
+Reuse the HPA-513 `run.json` contract. Require at least:
 
 - `status == Completed`;
-- selected song is present at `SongSelectReady`;
-- preview state is Playing and elapsed preview >= 10,000 ms;
-- Performance is ready, AutoPlay is enabled, and total notes > 0;
-- Result is completed/cleared by song completion;
+- selected song present at `SongSelectReady`;
+- preview state Playing and elapsed preview >= 10,000 ms;
+- Performance ready, AutoPlay enabled, total notes > 0;
+- Result completed/cleared by song completion;
 - `totalJudgements == totalNotes`;
 - OBS Connect/Status/Start/Stop succeeded;
-- raw/published paths are recorded;
+- raw/published paths recorded;
 - no failure fields or retained successful sandbox;
-- verifier warning is absent or only the existing optional recorder-side PATH `ffprobe` warning.
-
-Do not create a Mac-only diagnostics schema.
+- verifier warning absent or only the existing optional PATH-`ffprobe` warning.
 
 ## Manual media acceptance
 
 Watch the complete published MP4 and confirm:
 
 - intended populated Song Select is first;
-- preview begins after Song Select is visibly captured;
-- preview audio lasts at least 10 seconds;
+- preview begins after Song Select is visibly captured and lasts at least 10 seconds;
 - Song Transition is complete;
-- full AutoPlay gameplay is visible;
-- BGM/chip audio is audible;
+- full AutoPlay gameplay is visible and BGM/chip audio is audible;
 - Result is fully rendered and held at least 5 seconds;
 - recording ends after the Result hold;
 - no OBS UI, desktop, unrelated window, cursor, notification, microphone, or unrelated application audio is captured;
 - CX audio is not duplicated or echoed;
 - no aspect squeeze, severe stutter, or missing viewport region makes the recording unusable;
-- no user-installed FFmpeg or Rosetta is required for CX preview/gameplay audio.
-
-Strict codec/frame-rate/duration enforcement remains HPA-506.
+- CX preview/gameplay audio does not require Rosetta or user-installed FFmpeg.
 
 ## Failure and cleanup strategy
 
-Do not duplicate all HPA-503/HPA-513 platform-neutral cleanup checks manually.
+Keep existing automated tests as the primary proof for platform-neutral ownership and cleanup.
 
-Automated tests remain the primary proof for:
+The native Mac proof adds only high-value evidence:
 
-- pre-existing OBS ownership;
-- Start failure ownership;
-- cancellation after owned OBS start;
-- unexpected stage/performance/result failure;
-- artifact-finalization failure;
-- sandbox retention/deletion ordering.
+1. real Apple Silicon `doctor`;
+2. one successful encoded-audio recording;
+3. one Ctrl+C after recorder-owned OBS start, confirming OBS stops and partial evidence is retained;
+4. manual confirmation that ScreenCaptureKit/privacy setup failures remain operator-visible and are not falsely classified by `doctor`.
 
-Mac-native proof should add only high-value platform evidence:
-
-1. `doctor` on the real Apple Silicon workstation;
-2. one successful recording using the native bundled FFmpeg path;
-3. one Ctrl+C cancellation after recorder-owned OBS start, confirming OBS stops and diagnostics/raw evidence are retained;
-4. manual confirmation that an invalid ScreenCaptureKit selection or missing Screen Recording permission is an operator-visible setup problem, not something `doctor` falsely claims to classify.
-
-Do not revoke privacy permissions or invent source-diagnostic APIs merely to create a synthetic failure test.
-
-## Documentation outputs
-
-The HPA-515 implementation/acceptance PR should add:
-
-```text
-docs/video-recorder/macos-obs-setup.md
-docs/verification/hpa-515-apple-silicon-live-recording.md
-```
-
-`macos-obs-setup.md` should cover only:
-
-- Apple Silicon/macOS prerequisites;
-- default project-mode build;
-- optional `DTXMANIA_VIDEO_GAME_EXECUTABLE` packaged-target usage;
-- ScreenCaptureKit source and application-audio setup;
-- Screen Recording permission;
-- disabled desktop/microphone audio;
-- WebSocket environment variables;
-- `doctor` and `record` commands;
-- native FFmpeg gate;
-- artifact locations;
-- concise troubleshooting.
-
-`hpa-515-apple-silicon-live-recording.md` should record sanitized proof:
-
-- accepted commit SHA;
-- macOS version and Apple Silicon model/architecture;
-- .NET and OBS versions;
-- project or packaged-executable launch mode;
-- non-sensitive chart identity;
-- arm64 evidence summary;
-- doctor result;
-- successful command summary with private paths redacted;
-- raw/published MP4 name, size, and SHA-256;
-- key `run.json` acceptance values;
-- source before/after comparison;
-- Ctrl+C cleanup result;
-- manual media checklist result;
-- focused automated test command/results;
-- warnings/deviations.
+Do not revoke permissions or add source-diagnostic APIs merely to manufacture a failure case.
 
 ## Testing strategy
 
-### Portable unit tests
-
 Extend `DTXMania.VideoRecorder.Tests` for:
 
-- environment parsing/validation of the optional game executable;
-- default launch target resolves the current platform project;
-- explicit executable launch target uses the exact executable and its parent working directory;
-- existing Windows behavior remains unchanged;
-- Mac native-runtime path resolution for project and executable launch modes;
-- missing/unexecutable Mac runtime files produce actionable preflight failure.
+- `ResolveTarget` choosing the current platform project and repository-root working directory;
+- `CreateOptions` adding only sandbox app-data and a fresh launch token;
+- Mac default app-data resolving explicitly to `~/Library/Application Support/DTXManiaCX` when no override is set;
+- Windows record behavior remaining accepted;
+- Mac host version/architecture gates;
+- Mac Debug runtime path resolution from the already-resolved project target;
+- missing or non-executable bundled runtime files producing actionable preflight failure;
+- record preflight occurring before recorder/OBS workflow startup through a focused orchestration seam if needed.
 
-Do not mock `RecordWorkflow` into a second Mac workflow test matrix; its existing tests remain shared.
+Do not create a second Mac `RecordWorkflow` test matrix. Its existing tests remain shared.
 
-### Existing CI
+No CI edit is planned initially. Existing Windows/macOS VideoRecorder and Automation jobs should execute the new tests; change CI only if implementation proves otherwise.
 
-No workflow edit should be required initially:
+## Documentation outputs
 
-- Windows already runs VideoRecorder/Automation tests;
-- macOS already runs VideoRecorder/Automation tests;
-- macOS already verifies bundled arm64 FFmpeg and executes focused audio tests.
-
-Only touch CI if implementation proves an existing job does not execute the new tests. Do not add a dedicated recorder platform job pre-emptively.
-
-### Native proof
-
-Hosted CI does not replace real OBS + ScreenCaptureKit + privacy-permission acceptance. One local or self-hosted Apple Silicon proof remains required.
-
-## Expected production/test file surface
-
-Expected modifications:
-
-```text
-DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs
-DTXMania.VideoRecorder/RecorderCommandLine.cs
-DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
-DTXMania.VideoRecorder/Program.cs
-```
-
-Expected small additions only if they keep doctor/preflight testable:
-
-```text
-DTXMania.VideoRecorder/Diagnostics/<one focused platform-preflight helper>.cs
-DTXMania.VideoRecorder.Tests/<focused command-line/launch tests>.cs
-DTXMania.VideoRecorder.Tests/Diagnostics/<focused platform-preflight tests>.cs
-```
-
-Expected documentation additions:
+The implementation/acceptance PR should add:
 
 ```text
 docs/video-recorder/macos-obs-setup.md
 docs/verification/hpa-515-apple-silicon-live-recording.md
 ```
 
-Normally unchanged:
+The runbook should cover only native Apple Silicon prerequisites, Debug project build, ScreenCaptureKit/application-audio setup, Screen Recording permission, OBS/WebSocket environment, `doctor`, `record`, bundled-runtime diagnostics, artifacts, and troubleshooting.
 
-```text
-DTXMania.VideoRecorder/Workflow/RecordWorkflow.cs
-DTXMania.VideoRecorder/Obs/**
-DTXMania.VideoRecorder/Media/**
-DTXMania.VideoRecorder/Sandbox/**
-DTXMania.Automation/Process/GameProcessDriver.cs
-DTXMania.Game/Lib/Resources/FfmpegRuntime.cs
-DTXMania.Game/DTXMania.Game.Mac.csproj
-.github/workflows/**
-```
+The verification record should contain the accepted commit SHA, macOS/architecture/.NET/OBS versions, chart identity, arm64 evidence, doctor result, sanitized command, MP4 file metadata/hashes, key `run.json` values, source before/after comparison, Ctrl+C result, manual media checklist, focused automated-test results, and warnings/deviations.
 
-If implementation requires broad changes in the “normally unchanged” set, stop and re-evaluate scope before proceeding.
+Do not document a packaged executable mode in HPA-515.
 
-## Estimated implementation shape
+## Risks
 
-One 2–3 engineer-day implementation/acceptance task, split into reviewer-friendly checkpoints:
+### Manual OBS/privacy setup may fail before code does
 
-1. cross-platform command validation + project/executable launch selection;
-2. Mac `doctor` platform/native-runtime preflight + focused tests;
-3. native Apple Silicon OBS proof and sanitized runbook/verification documents.
+Hosted CI cannot prove ScreenCaptureKit selection, application-audio routing, or Screen Recording permission. The first native proof may require only an OBS/privacy correction, not a recorder change. Keep these as operator acceptance failures unless code evidence proves otherwise.
 
-This is small enough to stay one HPA-515 implementation PR. If the native proof exposes an unrelated recorder or game defect, split that defect into a blocker instead of expanding HPA-515.
+### Debug runtime layout is coupled to the current project launch contract
+
+`GameProcessDriver` uses `dotnet run --project` without `--configuration`, which means Debug output. The preflight therefore deliberately checks `bin/Debug/net8.0`. If recorder launch configuration changes later, launch policy and preflight must change together.
+
+### Missing bundled FFmpeg can look like a capture/audio problem
+
+A missing native runtime could otherwise surface after Song Select/OBS start as bad preview/gameplay audio. Running preflight before sandbox/OBS creation makes this a deterministic recorder error instead.
+
+### Wrong default app-data path invalidates the isolation proof
+
+HPA-515's source hashes are meaningful only if the recorder reads the same normal data root as CX. The explicit Mac default-path rule is therefore part of parity, not incidental cleanup.
+
+## Out of scope
+
+- packaged executable/app-bundle recording;
+- app-bundle discovery or DMG mounting;
+- Intel Mac or Rosetta support;
+- PATH fallback for the supported CX audio runtime;
+- automated ScreenCaptureKit source/audio/privacy diagnosis;
+- strict codec/frame-rate/duration enforcement;
+- MKV fallback/remux/transcoding;
+- YouTube upload/editing;
+- new platform abstraction/framework;
+- unrelated `GameProcessDriver` refactoring.
+
+## Implementation slice
+
+One 2–3 engineer-day implementation/acceptance PR is sufficient:
+
+1. shared project target resolution + explicit Mac app-data default;
+2. shared Mac host/runtime preflight used by both record and doctor;
+3. native Apple Silicon build/audio proof before OBS;
+4. one real ScreenCaptureKit recording + cleanup/isolation/media acceptance;
+5. Mac operator runbook + sanitized verification record.
+
+Each checkpoint is independently reviewable. If the native proof exposes an unrelated defect, file a focused blocker rather than expanding HPA-515.
 
 ## Acceptance criteria
 
 HPA-515 is complete when:
 
-- the same `doctor`/`record` CLI contract works on Windows and native Apple Silicon macOS;
-- default Mac project launch uses `DTXMania.Game.Mac.csproj` through Automation;
-- optional explicit packaged Mac executable launch is supported without a new platform framework;
-- Mac `doctor` rejects unsupported OS/architecture and missing/unusable native CX FFmpeg runtime;
-- one inspected Apple Silicon MP4 covers Song Select -> >=10s preview -> transition -> full AutoPlay gameplay -> >=5s Result;
-- MP3/encoded preview/gameplay audio works from bundled native FFmpeg without user-installed FFmpeg or Rosetta;
+- the unchanged recorder CLI works on native Apple Silicon macOS 13+;
+- record and doctor resolve the same Mac project target;
+- record rejects an unsupported Mac host or missing/unusable bundled runtime before starting OBS;
+- the default Mac source app-data root matches CX's `~/Library/Application Support/DTXManiaCX` contract;
+- one encoded-audio chart completes the accepted Song Select -> preview -> transition -> AutoPlay -> Result journey;
+- one inspected Hybrid MP4 and sanitized evidence bundle are retained;
 - normal CX app data remains unchanged;
-- cancellation stops only recorder-owned OBS work and retains useful failed-run evidence;
-- Windows behavior and shared recorder tests remain green;
-- no ScreenCaptureKit diagnostic automation, strict media hardening, or adapter framework is introduced.
-
-## Non-goals
-
-- Intel Mac or Rosetta support;
-- changing the shared recording journey;
-- app/DMG discovery, mounting, or installation;
-- automatic OBS scene/source selection;
-- ScreenCaptureKit screenshot/source/meter diagnosis;
-- macOS privacy-permission classification or mutation;
-- bundled FFmpeg upgrades or a second FFmpeg resolver;
-- recorder-side bundled `ffprobe` for final MP4 verification;
-- MKV remux, transcoding, strict codec/frame-rate/duration policy;
-- YouTube upload/editing/batch recording;
-- general platform abstraction for hypothetical future operating systems.
+- Ctrl+C stops only recorder-owned OBS work and retains useful failure evidence;
+- Windows behavior remains unchanged;
+- no platform adapter, packaged-executable mode, HPA-505, or HPA-506 scope is introduced.

--- a/docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md
@@ -6,7 +6,7 @@
 
 ## Goal
 
-Port the accepted HPA-503/HPA-513 recorder workflow to native Apple Silicon macOS with the smallest possible platform-specific change, then retain one inspected Mac recording and a concise operator runbook.
+Port the accepted HPA-503/HPA-513 recorder workflow to native Apple Silicon macOS with the smallest platform-specific change, then retain one inspected Mac recording and a concise operator runbook.
 
 The public command and captured journey stay unchanged:
 
@@ -20,94 +20,92 @@ Song Select
 -> completed Result held for at least 5 seconds
 ```
 
-HPA-515 is parity work. It is not a second recorder architecture and it does not add a second launch mode.
-
-## Why this is the next actionable task
-
-- HPA-513 is Done and accepted the shared recorder workflow on Windows.
-- HPA-512 is Done and provides native `osx-arm64` FFmpeg/ffprobe for CX preview and gameplay audio.
-- HPA-515 is the remaining high-priority unblocked leaf under HPA-500.
-- HPA-505 and HPA-506 are optional hardening and should not precede parity.
+HPA-515 is parity work. It keeps one workflow and one project-mode launch path.
 
 ## Current-state findings
 
-The existing recorder is already mostly platform-neutral:
+The recorder is already mostly platform-neutral:
 
 - `RecordWorkflow` contains no Windows-specific stage flow.
-- `ObsWebSocketRecorder` speaks obs-websocket 5.x and does not care whether OBS captures with Game Capture or ScreenCaptureKit.
-- `GameProcessDriver` already launches a project through `dotnet run --project`.
+- `ObsWebSocketRecorder` only speaks obs-websocket 5.x.
 - `GameProjectPaths.Current` already selects the Windows or Mac CX project.
-- macOS CI already runs `DTXMania.VideoRecorder.Tests` and `DTXMania.Automation.Tests`.
-- HPA-512 already places executable arm64 `ffmpeg` and `ffprobe` under `runtimes/osx-arm64/MMTools` in Mac build/publish output.
+- `GameProcessDriver` already owns project launch through `dotnet run --project`.
+- macOS CI already runs the VideoRecorder and Automation test projects.
+- HPA-512 already builds/copies native arm64 `ffmpeg` and `ffprobe` into the Mac build output.
 
-The relevant Windows assumptions are narrow:
+The remaining Windows assumptions are narrow:
 
-1. `RecorderCommandLine.ValidateRecord` rejects every non-Windows host.
-2. `RecorderGameLaunchPolicy.CreateOptions` hard-codes `DTXMania.Game.Windows.csproj` and requires a `RecordingSandbox` even though target resolution itself does not.
-3. `Program.RunDoctorAsync` duplicates repository-root discovery and hard-codes the Windows project/guidance.
-4. the recorder's default app-data lookup does not explicitly encode CX's macOS `~/Library/Application Support/DTXManiaCX` contract.
+1. `RecorderCommandLine.ValidateRecord` rejects non-Windows hosts.
+2. `RecorderGameLaunchPolicy.CreateOptions` hard-codes the Windows project and couples target discovery to sandbox creation.
+3. `Program.RunDoctorAsync` duplicates repository/project discovery and prints a Windows-only gate.
+4. recorder default app-data resolution is not explicitly pinned to the same macOS contract as `AppPaths.GetAppDataRoot()`.
 
-Those are the intended implementation seams.
+There is one additional launch correctness issue that HPA-515 must address: a preflight cannot certify `bin/Debug` while `GameProcessDriver` immediately runs a build that may replace that output.
 
 ## Approaches considered
 
-### A. Extend the existing recorder with one project-target resolver and one focused preflight — recommended
+### A. One project target + prebuilt/no-build launch + one focused preflight — recommended
 
-Keep one `RecordWorkflow`, one OBS client, one CLI, and one project launch path. Reuse `GameProjectPaths.Current` and `GameLaunchTarget.Project(...)`. Resolve the launch target once, run a small platform/runtime preflight before recording, and reuse both in `doctor`.
+Keep the existing recorder architecture. Resolve the current-platform project once, require the Debug output before recording, launch that exact output via `dotnet run --no-build --configuration Debug`, and use one preflight result in both record and doctor.
 
 **Pros**
 
-- smallest production change;
-- preserves the proven Windows journey;
-- prevents doctor and record from drifting onto different game targets;
-- fails missing Mac runtime before OBS starts;
-- naturally uses the existing Windows/macOS test matrix.
+- the runtime inspected before OBS is the runtime actually launched;
+- clean-checkout failure is actionable rather than ambiguous;
+- no stale-output check followed by an implicit rebuild;
+- no workflow fork or platform adapter;
+- existing Automation callers keep today's build-on-run behavior unless they opt into project arguments.
 
 **Cons**
 
-- a few Mac-specific checks remain in recorder preflight code.
+- `GameProcessStartOptions` / `GameProcessDriver` need one small additive extension for project-run arguments.
 
 ### B. Move recorder platform policy into `DTXMania.Automation`
 
-Rejected. Automation already exposes the generic project-path and launch primitives. Moving recorder-specific runtime/OBS policy there would broaden a reusable library for one consumer.
+Rejected. Automation should expose generic launch primitives, not OBS/recorder policy.
 
-### C. Add `IRecorderPlatform` with Windows/Mac implementations
+### C. Add `IRecorderPlatform`
 
-Rejected. Two platform branches do not justify an adapter framework. It adds indirection without a second workflow or launch model.
+Rejected. Two small platform branches do not justify a platform framework.
 
-### D. Add packaged-executable recording now
+### D. Add packaged executable recording
 
-Rejected for HPA-515. The accepted Windows proof uses project mode and the Mac parity proof should exercise the same contract. A packaged executable adds a second working-directory/runtime-layout path that the acceptance run would not prove.
-
-If packaged-app recording becomes useful later, it can be added behind the single launch-policy seam created here.
+Rejected for HPA-515. The accepted Windows proof is project mode and the Mac parity proof should exercise the same contract.
 
 ## Design decision
 
-Use approach A and keep HPA-515 project-mode-only.
-
-The recorder gains three focused changes:
+Use approach A.
 
 ```text
 RecorderGameLaunchPolicy
   -> ResolveTarget(...) without a sandbox
-  -> current platform project + repository-root working directory
-  -> CreateOptions(...) only adds sandbox app-data + launch token
+  -> current-platform project + repository-root working directory
+  -> CreateOptions(...) adds sandbox app-data, launch token,
+     and recorder-owned project run arguments
+
+GameProcessStartOptions / GameProcessDriver
+  -> optional project run arguments
+  -> recorder supplies: --no-build --configuration Debug
+  -> all existing callers may omit them and retain current behavior
 
 RecorderPlatformPreflight
-  -> validate native Mac host and bundled Debug runtime
-  -> consume the already-resolved project target
+  -> consumes the already-resolved project target
+  -> validates Mac host + the exact Debug runtime that no-build will launch
 
-Program / RecorderCommandLine
-  -> permit macOS as a recorder host
-  -> run preflight before record creates sandbox or talks to OBS
-  -> doctor prints the same resolved target/preflight gates
+Program
+  -> record resolves target and evaluates preflight
+  -> RunRecordAsync receives that target/result and rejects failure at its top
+  -> only then create sandbox / OBS / workflow
+  -> doctor consumes the same target/result
 ```
 
-`RecordWorkflow`, `IGameRecordingControl`, `ObsWebSocketRecorder`, sandbox semantics, diagnostics schema, finalization, and `GameProcessDriver` remain unchanged unless the native proof exposes a directly related defect.
+`RecordWorkflow`, OBS ownership, diagnostics schema, finalization, and sandbox semantics remain unchanged.
 
-## Project target resolution
+## Launch the artifact that was checked
 
-Add one sandbox-free resolved-target result owned by `RecorderGameLaunchPolicy`, for example:
+### Shared target resolution
+
+Add one sandbox-free recorder-local result:
 
 ```csharp
 internal sealed record ResolvedRecorderTarget(
@@ -116,15 +114,15 @@ internal sealed record ResolvedRecorderTarget(
     GameLaunchTarget Target);
 ```
 
-`ResolveTarget(startDirectory)` must:
+`RecorderGameLaunchPolicy.ResolveTarget(startDirectory)` must:
 
 1. reuse the existing repository-root walk;
-2. read `GameProjectPaths.Current`;
-3. combine it with the repository root to produce an absolute project path;
+2. use `GameProjectPaths.Current`;
+3. resolve an absolute project path under the repository root;
 4. create `GameLaunchTarget.Project(projectPath)`;
 5. use the repository root as the working directory.
 
-On Apple Silicon the target is:
+On macOS this resolves to:
 
 ```text
 DTXMania.Game/DTXMania.Game.Mac.csproj
@@ -136,42 +134,95 @@ On Windows it remains:
 DTXMania.Game/DTXMania.Game.Windows.csproj
 ```
 
-`CreateOptions` then combines the resolved target with:
+### Additive Automation launch option
 
-- `RecordingSandbox.AppDataRoot`;
-- a fresh launch token.
+Extend `GameProcessStartOptions` with one optional project-only argument list, for example:
 
-This separation lets `doctor` inspect exactly what `record` would launch without creating a disposable sandbox just to discover a path.
+```csharp
+IReadOnlyList<string>? ProjectRunArguments = null
+```
 
-Do not add platform arguments, executable overrides, app-bundle discovery, DMG mounting, or `open`-based launch behavior.
+For `GameLaunchKind.Project`, `GameProcessDriver.Start` appends those arguments to the `dotnet run` command after the project path. Existing callers that omit the field retain today's behavior.
+
+The recorder's `CreateOptions(...)` supplies:
+
+```text
+--no-build
+--configuration
+Debug
+```
+
+The recorder therefore launches:
+
+```text
+dotnet run --project <resolved-project> --no-build --configuration Debug
+```
+
+Do not change E2E/default Automation callers to no-build as part of HPA-515.
+
+If project-run arguments are supplied for an executable target, reject them rather than silently ignoring them.
+
+### Prebuild contract
+
+The recorder does not compile the game itself. Before `doctor` or `record`, the Mac runbook requires:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+```
+
+If the required Debug output is missing, preflight fails before sandbox/OBS with an actionable message naming that exact command.
+
+This intentionally changes HPA-515 from “build during launch” to “build, certify, then no-build launch”. It removes the clean-tree false failure/stale-output replacement race from the previous design.
 
 ## Supported platform contract
 
 ### Windows
 
-Keep current behavior unchanged. Do not add new Windows version, architecture, or runtime requirements as part of Mac parity.
+Keep accepted Windows recorder behavior. HPA-515 does not add Windows version, architecture, or bundled-runtime requirements.
 
 ### macOS
 
-Recording is supported only when all of the following are true:
+Recording is supported when:
 
 - macOS 13 or later;
 - the recorder process is native `arm64`;
 - `GameProjectPaths.Current` resolves to the Mac project;
 - the project exists;
-- the expected HPA-512 Debug runtime contains executable `ffmpeg` and `ffprobe`.
+- the expected Debug output contains executable HPA-512 `ffmpeg` and `ffprobe` under `runtimes/osx-arm64/MMTools`.
 
-Intel macOS and Rosetta are out of scope. There is no PATH fallback for the supported CX audio runtime.
+macOS 13 remains a hard requirement, not a warning. The HPA-515 capture contract requires CX application audio through OBS ScreenCaptureKit/macOS Audio Capture; OBS documents audio capture for this source path on macOS 13+ while macOS 12.3-12.6 is video-only.
 
-`RecorderCommandLine` should continue owning syntax/path/environment validation and may widen the existing OS gate from Windows-only to Windows-or-macOS. Native host/build-layout validation belongs to the focused preflight below rather than command parsing.
+Intel macOS and Rosetta are out of scope.
 
 ## Native platform/runtime preflight
 
-Add one internal pure-ish helper, `RecorderPlatformPreflight`, that consumes the already-resolved project target plus testable host/file facts.
+Add one internal testable helper, `RecorderPlatformPreflight`, that consumes the resolved target plus injectable host/file facts.
 
-For Windows, it preserves today's supported behavior and adds no new gate.
+A practical shape is:
 
-For macOS, it validates:
+```csharp
+internal sealed record RecorderPlatformFacts(
+    bool IsWindows,
+    bool IsMacOS,
+    Version OsVersion,
+    Architecture ProcessArchitecture);
+
+internal sealed record RecorderPreflightGate(
+    string Name,
+    bool Passed,
+    string Detail);
+
+internal sealed record RecorderPlatformPreflightResult(
+    IReadOnlyList<RecorderPreflightGate> Gates,
+    string? NativeRuntimeDirectory)
+{
+    public bool Passed => Gates.All(gate => gate.Passed);
+}
+```
+
+For Windows, preserve today's supported behavior without a new native-runtime gate.
+
+For macOS, validate:
 
 ```text
 macOS major version >= 13
@@ -182,55 +233,57 @@ project file exists
 <project-dir>/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe exists + executable
 ```
 
-The Debug layout is intentional. `GameProcessDriver` currently invokes:
+The helper must not reference `DTXMania.Game`, call `FfmpegRuntime`, configure FFMpegCore, probe codecs, download binaries, inspect OBS sources, or inspect privacy permissions.
+
+### Bundled-runtime certification policy
+
+`FfmpegRuntime` can fall back to other bundled RIDs or PATH. HPA-515 intentionally applies a stricter recorder certification rule:
+
+> `dtx-video` refuses to certify a native Apple Silicon acceptance run unless the managed HPA-512 `osx-arm64` FFmpeg pair is present and executable.
+
+This is not a claim that CX itself cannot run with PATH FFmpeg. It is a recorder proof requirement so the accepted Mac artifact demonstrates the runtime delivered by HPA-512 rather than an unmanaged local installation.
+
+The recorder-side final-MP4 verifier may continue its existing optional PATH `ffprobe` lookup; that is a separate post-record inspection aid.
+
+## Record ordering is an enforced invariant
+
+Make `Program.RunRecordAsync` internal and pass the already-resolved target plus already-evaluated preflight result into it:
 
 ```text
-dotnet run --project <project>
+parse/read environment
+-> command/path validation
+-> ResolveTarget
+-> RecorderPlatformPreflight.Evaluate
+-> RunRecordAsync(command, environment, target, preflight)
+     -> fail immediately if preflight failed
+     -> create sandbox
+     -> create diagnostics/game/OBS
+     -> existing RecordWorkflow
 ```
 
-without `--configuration`, so the recorder's supported project-mode launch is Debug. HPA-515 should state and test that contract instead of adding configuration/RID search logic.
+`RunRecordAsync` must reject a failed preflight at its first side-effect boundary, before creating the sandbox or OBS client.
 
-The helper must not:
-
-- reference `DTXMania.Game`;
-- call or duplicate `FfmpegRuntime`;
-- configure FFMpegCore;
-- search PATH for the CX runtime;
-- probe codecs;
-- download FFmpeg;
-- inspect OBS sources or privacy permissions.
-
-The recorder-side `RecordingArtifactVerifier` may continue its existing optional PATH `ffprobe` lookup for final MP4 inspection. That is separate from the required bundled CX runtime.
-
-### Record call site
-
-A Mac `record` command must execute the same preflight **before** `RunRecordAsync` creates the disposable sandbox, initializes OBS, or starts the workflow.
-
-This is intentionally a program/orchestration gate rather than a `RecorderCommandLine` build-layout check: command parsing validates the command; launch/preflight code validates the target that will actually run.
-
-Missing/unusable bundled FFmpeg therefore fails loudly before any OBS recording can begin.
-
-### Doctor call site
-
-`doctor` resolves the same target and consumes the same preflight result to print individual pass/fail gates. It must not independently reconstruct the Mac project or runtime path.
+This is more robust than relying only on statement order in `Main`: the method signature carries the launch-readiness decision into the side-effecting path, and a unit test can pin the invariant.
 
 ## Default source app-data contract
 
-Keep `DTXMANIA_APPDATA_ROOT` as the explicit override.
+`AppPaths.GetAppDataRoot()` remains the authoritative game behavior. Do **not** make `DTXMania.Game` reference `DTXMania.Automation` solely to share one path helper; that would invert the intended dependency direction for production code.
 
-When no override is supplied, encode the CX macOS contract directly:
+Keep `DTXMANIA_APPDATA_ROOT` as the explicit override. For the default resolver, mirror the existing `AppPaths` behavior, including its home fallback order:
 
 ```text
-~/Library/Application Support/DTXManiaCX
+Windows -> LocalApplicationData/DTXManiaCX
+macOS   -> (UserProfile -> Personal -> $HOME)/Library/Application Support/DTXManiaCX
+other   -> ApplicationData/DTXManiaCX with the existing home fallback
 ```
 
-Do not depend on `SpecialFolder.LocalApplicationData` happening to map to the same location on current .NET/macOS. The source path used for sandbox creation and before/after isolation hashes must be the same path CX considers its normal data root.
+Make the recorder default-root resolver injectable/pure enough that Windows and macOS cases run on every test host. Do not leave the Mac branch dependent on ambient `OperatingSystem.IsMacOS()` or `Environment.GetFolderPath()` in unit tests.
 
-Windows default behavior stays unchanged.
+Add comments/tests on the recorder side naming `AppPaths.GetAppDataRoot()` as the contract it mirrors. If a neutral shared runtime project is introduced for other reasons later, this small rule can move there; HPA-515 does not create one.
 
 ## `doctor` behavior
 
-Keep `doctor` read-only with respect to OBS. It still performs only:
+Keep doctor read-only with respect to OBS:
 
 ```text
 Hello
@@ -238,7 +291,9 @@ Identify
 GetRecordStatus
 ```
 
-Shared output should include:
+Delete the current hard-coded `Windows` gate. Doctor resolves the shared target and reports the same `RecorderPlatformPreflightResult` through the existing `Program.ReportGate` helper; do not add a second gate printer.
+
+Shared output includes:
 
 - recorder configuration;
 - repository root;
@@ -248,16 +303,16 @@ Shared output should include:
 - OBS auth/status;
 - optional recorder-side PATH `ffprobe` warning.
 
-Mac-specific gates should include:
+Mac gates include:
 
 - macOS 13+;
-- recorder process `arm64`;
+- recorder process arm64;
 - Mac project target;
-- native CX runtime directory;
+- native runtime directory;
 - bundled `ffmpeg` executable;
 - bundled `ffprobe` executable.
 
-Mac manual guidance should state only:
+Mac manual guidance remains intentionally non-diagnostic:
 
 ```text
 Dedicated DTXManiaCX profile/collection/scene selected
@@ -271,18 +326,14 @@ WebSocket enabled/authenticated
 raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR
 ```
 
-The tool must not claim to inspect ScreenCaptureKit selection, audio meters, stale selectors, or macOS privacy state.
-
-Windows doctor guidance remains the existing Game Capture/application-audio guidance.
+Add a focused test for doctor platform reporting so a synthetic passing Mac preflight is not rejected merely because the test host is not Windows.
 
 ## Recording workflow
 
-No workflow fork is introduced.
-
-After preflight succeeds, macOS follows the existing workflow unchanged:
+After preflight succeeds, the existing sequence stays unchanged:
 
 1. create disposable recorder app-data sandbox;
-2. launch the resolved Mac project through `DTXMania.Automation`;
+2. launch the resolved project with recorder-owned `--no-build --configuration Debug`;
 3. wait for populated Song Select;
 4. prepare the exact chart with preview stopped;
 5. start owned OBS recording;
@@ -290,21 +341,22 @@ After preflight succeeds, macOS follows the existing workflow unchanged:
 7. activate the chart;
 8. observe Song Transition;
 9. complete full AutoPlay Performance;
-10. observe completed Result and hold it for at least 5 seconds;
-11. stop only the owned OBS recording;
+10. observe completed Result and hold at least 5 seconds;
+11. stop only recorder-owned OBS recording;
 12. verify/publish the raw artifact;
 13. write diagnostics and delete only the successful sandbox.
 
-No Mac-specific stage timing, retry policy, or diagnostics schema is added.
+No Mac-specific stage timing, retry policy, workflow subclass, or diagnostics schema is added.
 
 ## OBS / ScreenCaptureKit contract
 
-Keep OBS setup manual and minimal:
+Keep OBS setup manual:
 
 - OBS Studio 30.2+;
+- macOS 13+;
 - dedicated DTXManiaCX profile, collection, and scene;
 - ScreenCaptureKit application/window capture scoped to CX;
-- CX application audio enabled through that source or one dedicated macOS Audio Capture source;
+- CX application audio through that source or one dedicated macOS Audio Capture source;
 - global Desktop Audio disabled for the recorded track;
 - microphone disabled for the recorded track;
 - Hybrid MP4;
@@ -312,11 +364,11 @@ Keep OBS setup manual and minimal:
 - Screen Recording permission granted manually;
 - OBS idle before `record` starts.
 
-HPA-505 remains the optional source/audio/privacy diagnostic follow-up. HPA-506 remains the optional strict media/remux follow-up.
+HPA-505 remains optional source/audio/privacy diagnostics. HPA-506 remains optional strict media/remux handling.
 
-## Acceptance chart and native evidence
+## Acceptance chart and evidence
 
-Use one short chart already indexed by normal CX Song Select with valid preview audio. Prefer MP3 preview/BGM or another encoded input that demonstrably exercises the HPA-512 runtime.
+Use one short chart already indexed by normal CX Song Select with valid preview audio. Prefer MP3 preview/BGM or another encoded input that exercises HPA-512.
 
 Retain outside Git:
 
@@ -333,20 +385,18 @@ Retain outside Git:
   published/diagnostics/<run-id>/cx-stderr.log
 ```
 
-`architecture.txt` should show, without private paths or secrets:
+`architecture.txt` should show:
 
 - host is Apple Silicon;
-- selected CX apphost is arm64;
+- the Debug CX apphost inspected before `record` is arm64;
 - bundled `ffmpeg` is arm64;
 - bundled `ffprobe` is arm64.
 
-The preflight proves executable presence before OBS. The HPA-512 focused audio tests plus encoded acceptance chart prove the runtime is actually useful for CX audio.
+Because record launches with `--no-build`, those inspected Debug artifacts are the artifacts used by the acceptance run.
 
 ## Source app-data isolation
 
-Reuse the HPA-513 before/after hash proof against the resolved normal Mac app-data root.
-
-Capture presence, byte size, and SHA-256 for:
+Reuse HPA-513 before/after hashes against the resolved normal Mac app-data root:
 
 ```text
 Config.ini
@@ -355,17 +405,15 @@ songs.db-wal
 songs.db-shm
 ```
 
-Acceptance requires no content change and no new source WAL/SHM file caused by the recorder.
-
-Do not add recorder instrumentation for this proof.
+Capture presence, size, and SHA-256. Acceptance requires no content change and no new source WAL/SHM file caused by the recorder.
 
 ## Automated telemetry acceptance
 
-Reuse the HPA-513 `run.json` contract. Require at least:
+Reuse HPA-513 `run.json`. Require at least:
 
 - `status == Completed`;
 - selected song present at `SongSelectReady`;
-- preview state Playing and elapsed preview >= 10,000 ms;
+- preview Playing and elapsed >= 10,000 ms;
 - Performance ready, AutoPlay enabled, total notes > 0;
 - Result completed/cleared by song completion;
 - `totalJudgements == totalNotes`;
@@ -376,118 +424,138 @@ Reuse the HPA-513 `run.json` contract. Require at least:
 
 ## Manual media acceptance
 
-Watch the complete published MP4 and confirm:
+Watch the complete MP4 and confirm:
 
-- intended populated Song Select is first;
-- preview begins after Song Select is visibly captured and lasts at least 10 seconds;
+- populated Song Select is first;
+- preview is visibly captured and lasts at least 10 seconds;
 - Song Transition is complete;
-- full AutoPlay gameplay is visible and BGM/chip audio is audible;
+- full AutoPlay gameplay and BGM/chip audio are present;
 - Result is fully rendered and held at least 5 seconds;
-- recording ends after the Result hold;
+- recording ends after Result hold;
 - no OBS UI, desktop, unrelated window, cursor, notification, microphone, or unrelated application audio is captured;
-- CX audio is not duplicated or echoed;
+- CX audio is not duplicated/echoed;
 - no aspect squeeze, severe stutter, or missing viewport region makes the recording unusable;
-- CX preview/gameplay audio does not require Rosetta or user-installed FFmpeg.
-
-## Failure and cleanup strategy
-
-Keep existing automated tests as the primary proof for platform-neutral ownership and cleanup.
-
-The native Mac proof adds only high-value evidence:
-
-1. real Apple Silicon `doctor`;
-2. one successful encoded-audio recording;
-3. one Ctrl+C after recorder-owned OBS start, confirming OBS stops and partial evidence is retained;
-4. manual confirmation that ScreenCaptureKit/privacy setup failures remain operator-visible and are not falsely classified by `doctor`.
-
-Do not revoke permissions or add source-diagnostic APIs merely to manufacture a failure case.
+- CX audio does not require Rosetta or user-installed FFmpeg.
 
 ## Testing strategy
 
-Extend `DTXMania.VideoRecorder.Tests` for:
+### Automation tests
 
-- `ResolveTarget` choosing the current platform project and repository-root working directory;
-- `CreateOptions` adding only sandbox app-data and a fresh launch token;
-- Mac default app-data resolving explicitly to `~/Library/Application Support/DTXManiaCX` when no override is set;
-- Windows record behavior remaining accepted;
-- Mac host version/architecture gates;
-- Mac Debug runtime path resolution from the already-resolved project target;
-- missing or non-executable bundled runtime files producing actionable preflight failure;
-- record preflight occurring before recorder/OBS workflow startup through a focused orchestration seam if needed.
+Extend `GameProcessDriverTests` for the additive project-run-argument behavior:
 
-Do not create a second Mac `RecordWorkflow` test matrix. Its existing tests remain shared.
+- existing project launch with no extra arguments still builds/runs as today;
+- build a child Debug project, then make its source uncompilable; launching with `--no-build --configuration Debug` still runs the already-built child, proving the driver honored no-build;
+- project-run arguments on an executable target are rejected.
 
-No CI edit is planned initially. Existing Windows/macOS VideoRecorder and Automation jobs should execute the new tests; change CI only if implementation proves otherwise.
+### VideoRecorder tests
+
+Cover:
+
+- shared target resolution from repository root and nested directories;
+- recorder `CreateOptions` preserves the target/working directory and adds `--no-build --configuration Debug`, sandbox app-data, and a fresh launch token;
+- both Windows and Mac default app-data resolution through injected platform/folder facts, including the `UserProfile -> Personal -> $HOME` Mac fallback;
+- Windows record behavior remains accepted;
+- Mac host version/architecture gates from synthetic facts;
+- exact Debug runtime path resolution;
+- missing/non-executable native runtime fails with the exact build command in the message;
+- `RunRecordAsync` with a failed preflight creates no sandbox and cannot initialize OBS;
+- doctor platform reporting accepts a passing synthetic Mac result and has no separate Windows-only gate.
+
+Do not create a second Mac `RecordWorkflow` matrix.
+
+No CI edit is planned initially; existing Windows/macOS jobs already run Automation and VideoRecorder tests.
+
+## Native proof
+
+On the Apple Silicon workstation:
+
+1. capture host/.NET versions;
+2. run `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug`;
+3. use `file` on the Debug apphost and bundled `ffmpeg`/`ffprobe`;
+4. run the existing focused HPA-512 audio tests;
+5. run `dtx-video doctor` and confirm all automated gates;
+6. configure OBS manually;
+7. capture source app-data hashes;
+8. run one successful `record` acceptance journey;
+9. repeat source hashes;
+10. run one Ctrl+C case after recorder-owned OBS start;
+11. inspect the complete published MP4.
 
 ## Documentation outputs
 
-The implementation/acceptance PR should add:
+The implementation/acceptance PR adds:
 
 ```text
 docs/video-recorder/macos-obs-setup.md
 docs/verification/hpa-515-apple-silicon-live-recording.md
 ```
 
-The runbook should cover only native Apple Silicon prerequisites, Debug project build, ScreenCaptureKit/application-audio setup, Screen Recording permission, OBS/WebSocket environment, `doctor`, `record`, bundled-runtime diagnostics, artifacts, and troubleshooting.
+The runbook covers Apple Silicon/macOS prerequisites, the required Debug build, ScreenCaptureKit/application-audio setup, Screen Recording permission, OBS/WebSocket environment, doctor/record commands, runtime-gate failure recovery, artifacts, and concise troubleshooting.
 
-The verification record should contain the accepted commit SHA, macOS/architecture/.NET/OBS versions, chart identity, arm64 evidence, doctor result, sanitized command, MP4 file metadata/hashes, key `run.json` values, source before/after comparison, Ctrl+C result, manual media checklist, focused automated-test results, and warnings/deviations.
-
-Do not document a packaged executable mode in HPA-515.
+The verification record captures the accepted commit SHA, host/.NET/OBS versions, chart identity, Debug apphost/runtime architecture evidence, doctor result, sanitized record command, MP4 metadata/hash, key `run.json` values, source before/after comparison, Ctrl+C result, manual media checklist, focused automated tests, and deviations.
 
 ## Risks
 
+### Build and launch must stay pinned
+
+The recorder now intentionally checks Debug output and launches it with `--no-build --configuration Debug`. If launch configuration changes, preflight and recorder launch policy must change in the same patch.
+
+### A stale prebuild is possible by operator choice
+
+`--no-build` guarantees the checked output is the launched output, but it does not prove source files have not changed since the operator ran `dotnet build`. The native acceptance procedure therefore records the commit SHA and performs the build immediately before architecture/doctor/record evidence.
+
+Do not add source-hash/build-manifest machinery for HPA-515.
+
 ### Manual OBS/privacy setup may fail before code does
 
-Hosted CI cannot prove ScreenCaptureKit selection, application-audio routing, or Screen Recording permission. The first native proof may require only an OBS/privacy correction, not a recorder change. Keep these as operator acceptance failures unless code evidence proves otherwise.
+Hosted CI cannot prove ScreenCaptureKit selection, application-audio routing, or Screen Recording permission. Treat these as operator setup failures unless code evidence proves otherwise.
 
-### Debug runtime layout is coupled to the current project launch contract
+### Bundled runtime certification is intentionally stricter than CX runtime fallback
 
-`GameProcessDriver` uses `dotnet run --project` without `--configuration`, which means Debug output. The preflight therefore deliberately checks `bin/Debug/net8.0`. If recorder launch configuration changes later, launch policy and preflight must change together.
+The game may fall back to another bundled RID or PATH. The recorder intentionally refuses to certify that as HPA-515 native Apple Silicon evidence.
 
-### Missing bundled FFmpeg can look like a capture/audio problem
+### App-data rule is mirrored, not shared
 
-A missing native runtime could otherwise surface after Song Select/OBS start as bad preview/gameplay audio. Running preflight before sandbox/OBS creation makes this a deterministic recorder error instead.
-
-### Wrong default app-data path invalidates the isolation proof
-
-HPA-515's source hashes are meaningful only if the recorder reads the same normal data root as CX. The explicit Mac default-path rule is therefore part of parity, not incidental cleanup.
+`AppPaths` remains authoritative and the recorder mirrors its small default-root rule to avoid a Game -> Automation production dependency. Keep the mirrored code/test comment explicit; if this rule grows, move it to a neutral shared runtime component rather than Automation.
 
 ## Out of scope
 
 - packaged executable/app-bundle recording;
 - app-bundle discovery or DMG mounting;
 - Intel Mac or Rosetta support;
-- PATH fallback for the supported CX audio runtime;
+- accepting unmanaged PATH FFmpeg as HPA-515 certification;
 - automated ScreenCaptureKit source/audio/privacy diagnosis;
 - strict codec/frame-rate/duration enforcement;
 - MKV fallback/remux/transcoding;
 - YouTube upload/editing;
-- new platform abstraction/framework;
-- unrelated `GameProcessDriver` refactoring.
+- platform adapter framework;
+- changing default Automation/E2E build-on-run behavior;
+- a new shared runtime project solely for app-data path resolution.
 
 ## Implementation slice
 
-One 2–3 engineer-day implementation/acceptance PR is sufficient:
+One 2–3 engineer-day implementation/acceptance PR remains sufficient:
 
-1. shared project target resolution + explicit Mac app-data default;
-2. shared Mac host/runtime preflight used by both record and doctor;
+1. pin recorder launch to a prebuilt Debug project and share target resolution;
+2. add Mac preflight, testable app-data resolution, enforced preflight ordering, and doctor parity;
 3. native Apple Silicon build/audio proof before OBS;
 4. one real ScreenCaptureKit recording + cleanup/isolation/media acceptance;
-5. Mac operator runbook + sanitized verification record.
-
-Each checkpoint is independently reviewable. If the native proof exposes an unrelated defect, file a focused blocker rather than expanding HPA-515.
+5. Mac runbook + sanitized verification record.
 
 ## Acceptance criteria
 
 HPA-515 is complete when:
 
-- the unchanged recorder CLI works on native Apple Silicon macOS 13+;
+- unchanged recorder CLI works on native Apple Silicon macOS 13+;
 - record and doctor resolve the same Mac project target;
-- record rejects an unsupported Mac host or missing/unusable bundled runtime before starting OBS;
-- the default Mac source app-data root matches CX's `~/Library/Application Support/DTXManiaCX` contract;
-- one encoded-audio chart completes the accepted Song Select -> preview -> transition -> AutoPlay -> Result journey;
+- recorder launches the same prebuilt Debug artifact that preflight certified;
+- missing/unusable native runtime fails before sandbox/OBS with the exact build recovery command;
+- failed preflight ordering is covered by an automated no-sandbox test;
+- doctor no longer fails merely because the host is macOS;
+- default Mac source app-data resolution matches the `AppPaths` contract and is host-independently unit tested;
+- one encoded-audio chart completes Song Select -> preview -> transition -> AutoPlay -> Result;
 - one inspected Hybrid MP4 and sanitized evidence bundle are retained;
 - normal CX app data remains unchanged;
-- Ctrl+C stops only recorder-owned OBS work and retains useful failure evidence;
-- Windows behavior remains unchanged;
+- Ctrl+C stops only recorder-owned OBS work and retains useful evidence;
+- Windows/default Automation behavior remains unchanged;
 - no platform adapter, packaged-executable mode, HPA-505, or HPA-506 scope is introduced.

--- a/docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md
+++ b/docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md
@@ -1,0 +1,543 @@
+# HPA-515 Apple Silicon Recorder Parity Design
+
+**Issue:** [HPA-515](https://linear.app/cwchanap/issue/HPA-515/port-the-proven-recorder-workflow-to-apple-silicon-macos-and-validate)  
+**Date:** 2026-08-16  
+**Status:** Proposed
+
+## Goal
+
+Port the accepted HPA-503/HPA-513 recording workflow to native Apple Silicon macOS with the smallest possible platform-specific change, then retain one inspected Mac recording and a concise operator runbook.
+
+The successful journey and CLI stay unchanged:
+
+```text
+dtx-video record --chart <absolute-chart-path> --output <directory>
+
+Song Select
+-> at least 10 seconds of prepared preview audio
+-> complete Song Transition
+-> full AutoPlay Performance
+-> completed Result held for at least 5 seconds
+```
+
+HPA-515 is parity work, not a second recorder architecture.
+
+## Why this is the next actionable task
+
+- HPA-513 is Done and accepted the shared recorder workflow on Windows.
+- HPA-512 is Done and provides native `osx-arm64` FFmpeg/ffprobe for CX preview and gameplay audio.
+- HPA-515 is the remaining high-priority unblocked leaf under HPA-500.
+- HPA-505 and HPA-506 are explicitly optional hardening and should not precede parity.
+
+## Current-state findings
+
+The existing recorder is already mostly platform-neutral:
+
+- `RecordWorkflow` drives the normal CX journey and contains no Windows-specific stage logic.
+- `ObsWebSocketRecorder` only uses obs-websocket 5.x and does not care whether OBS captures through Game Capture or ScreenCaptureKit.
+- `GameProcessDriver` already supports both `GameLaunchTarget.Project(...)` and `GameLaunchTarget.Executable(...)`.
+- `GameProjectPaths` already exposes both Windows and Mac CX project paths.
+- macOS CI already runs `DTXMania.VideoRecorder.Tests` and `DTXMania.Automation.Tests`.
+- HPA-512 already packages `runtimes/osx-arm64/MMTools/{ffmpeg,ffprobe}` into Mac build/publish output and verifies the binaries are executable arm64 files.
+
+The actual Windows assumptions are narrow:
+
+1. `RecorderCommandLine.ValidateRecord` rejects every non-Windows host.
+2. `RecorderGameLaunchPolicy` hard-codes `DTXMania.Game.Windows.csproj`.
+3. `Program.RunDoctorAsync` hard-codes the Windows gate/project and Windows OBS guidance.
+
+That is the intended implementation surface.
+
+## Approaches considered
+
+### A. Extend the existing recorder with a small platform-aware launch/preflight seam — recommended
+
+Keep one `RecordWorkflow`, one OBS client, and one CLI. Reuse `GameProjectPaths.Current` and the existing Automation launch target types. Add only the Mac platform checks, optional packaged-executable selection, and Mac-specific `doctor`/documentation behavior.
+
+**Pros**
+
+- smallest change;
+- preserves the proven Windows workflow;
+- no duplicated workflow state;
+- easy to test on the existing Windows + macOS CI matrix;
+- leaves HPA-505/HPA-506 cleanly deferred.
+
+**Cons**
+
+- a few conditional Mac branches remain in recorder launch/preflight code.
+
+### B. Move recorder platform selection into `DTXMania.Automation`
+
+Teach Automation about recorder-specific Mac/Windows defaults and native FFmpeg preflight.
+
+**Rejected:** Automation already has the generic primitives the recorder needs. Moving OBS/recorder policy into it would couple a reusable automation library to one consumer and expand the public API without a second use case.
+
+### C. Add `IRecorderPlatform` with Windows/Mac implementations
+
+Create platform adapters owning launch, doctor, capture guidance, and media/runtime checks.
+
+**Rejected:** this is configuration-by-abstraction for two small branches. It adds more files and indirection than HPA-515 needs and conflicts with the ticket's explicit “no platform-adapter framework” constraint.
+
+## Design decision
+
+Use approach A.
+
+The implementation should remain one recorder with three targeted extensions:
+
+```text
+RecorderCommandLine
+  -> support Windows OR native Apple Silicon macOS
+
+RecorderGameLaunchPolicy
+  -> select current platform project by default
+  -> optionally select an explicit packaged executable
+
+Program doctor
+  -> report shared gates
+  -> add small platform-specific diagnostics/guidance
+```
+
+`RecordWorkflow`, `IGameRecordingControl`, `ObsWebSocketRecorder`, sandboxing, diagnostics, and artifact finalization remain unchanged unless the native proof exposes a real defect.
+
+## Supported platform contract
+
+### Windows
+
+Keep current behavior unchanged. Do not tighten existing Windows validation as part of Mac parity.
+
+### macOS
+
+`record` is supported only when all of the following are true:
+
+- macOS 13 or later;
+- the recorder process is native `arm64`;
+- the selected CX target is the Mac project or an explicit Mac executable;
+- the expected native CX FFmpeg runtime is present and executable before the acceptance run.
+
+Intel macOS and Rosetta are out of scope. There is no fallback to the Windows project, x64 Mac runtime, or a generic PATH-only CX audio configuration.
+
+## Game launch selection
+
+### Default project mode
+
+When no override is provided:
+
+1. resolve the repository root exactly as today;
+2. use `GameProjectPaths.Current` to choose the platform project;
+3. resolve that path under the repository root;
+4. preserve repository root as the process working directory;
+5. let `GameProcessDriver` continue launching it through `dotnet run --project ...`.
+
+On Apple Silicon this resolves to:
+
+```text
+DTXMania.Game/DTXMania.Game.Mac.csproj
+```
+
+Do not add a `--platform` command option. The host platform already determines the supported project unambiguously.
+
+### Optional packaged executable mode
+
+Add one optional environment override:
+
+```text
+DTXMANIA_VIDEO_GAME_EXECUTABLE=<absolute executable path>
+```
+
+When set:
+
+- require an absolute existing file;
+- create `GameLaunchTarget.Executable(...)` through the existing Automation API;
+- use the executable's parent directory as the game process working directory;
+- preserve the disposable app-data root and launch-token behavior exactly as in project mode.
+
+For the current Mac app bundle, the expected executable is:
+
+```text
+DTXMania.app/Contents/MacOS/DTXMania.Game.Mac
+```
+
+This is deliberately an executable override, not an app-bundle discovery feature. The recorder should not mount DMGs, search `/Applications`, parse `Info.plist`, or launch through `open`.
+
+The override may work on Windows as well because the underlying Automation target is generic, but HPA-515 only needs it for explicit Mac packaged-layout validation.
+
+## Native FFmpeg preflight
+
+The recorder must not take a dependency on `DTXMania.Game` or duplicate `FfmpegRuntime`.
+
+`doctor` should perform a small filesystem preflight against the target that will actually be launched:
+
+### Default Mac project target
+
+Require the normal Debug build output to contain:
+
+```text
+DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg
+DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe
+```
+
+The runbook should build `DTXMania.Game.Mac.csproj` before `doctor`. HPA-512 already owns generation/copy correctness and CI verification; HPA-515 only checks that the local proof target contains the runtime it is about to exercise.
+
+### Explicit executable target
+
+Resolve the runtime relative to the executable directory:
+
+```text
+<executable-dir>/runtimes/osx-arm64/MMTools/ffmpeg
+<executable-dir>/runtimes/osx-arm64/MMTools/ffprobe
+```
+
+For both modes:
+
+- both files must exist;
+- both files must have executable permission on macOS;
+- `doctor` reports the resolved runtime directory;
+- missing/unusable files fail the Mac doctor gate with an actionable message.
+
+Do not add a second FFmpeg resolver, codec probe, download path, or PATH fallback to the recorder. HPA-512's existing game/runtime tests plus the real MP3 acceptance chart provide the deeper proof.
+
+The native acceptance record should additionally retain `file` output showing the selected game executable and bundled `ffmpeg`/`ffprobe` are arm64. That verification belongs to the proof, not a new runtime abstraction.
+
+## `doctor` behavior
+
+Keep `doctor` read-only with respect to OBS. It still performs only Hello/Identify/GetRecordStatus.
+
+Shared gates remain:
+
+- recorder configuration;
+- repository root;
+- selected CX target;
+- source Config.ini validation;
+- raw OBS output directory;
+- OBS auth/status;
+- optional recorder-side PATH `ffprobe` warning for final MP4 inspection.
+
+Mac-specific gates add:
+
+- macOS 13+;
+- recorder process architecture is arm64;
+- selected target is usable;
+- native CX FFmpeg runtime pair is present/executable.
+
+Mac guidance printed by `doctor` should say only:
+
+```text
+Dedicated DTXManiaCX OBS profile/collection/scene selected
+ScreenCaptureKit application/window capture scoped to CX
+CX application audio enabled through that source or one dedicated macOS Audio Capture source
+Desktop Audio and microphone disabled for the recorded track
+Hybrid MP4 configured
+OBS Screen Recording permission granted manually
+WebSocket enabled/authenticated
+raw output directory matches DTXMANIA_VIDEO_OBS_OUTPUT_DIR
+```
+
+The tool must not claim it can inspect ScreenCaptureKit selection, distinguish stale source selection from privacy denial, inspect audio meters, or grant macOS privacy permission.
+
+Windows doctor output should retain the existing Game Capture/application-audio guidance.
+
+## Recording workflow
+
+No workflow fork is introduced.
+
+On macOS the existing sequence stays:
+
+1. create disposable recorder app-data sandbox;
+2. launch CX through `DTXMania.Automation`;
+3. wait for populated Song Select;
+4. prepare the exact chart with preview stopped;
+5. start owned OBS recording;
+6. play at least 10 seconds of preview;
+7. activate the chart;
+8. observe Song Transition;
+9. complete full AutoPlay Performance;
+10. observe completed Result and hold it for at least 5 seconds;
+11. stop only the owned OBS recording;
+12. verify/publish the raw artifact;
+13. write diagnostics and delete only the successful sandbox.
+
+No Mac-specific stage timing or retry policy is added.
+
+## OBS / ScreenCaptureKit contract
+
+Keep the OBS scene fully manual.
+
+Required proof configuration:
+
+- OBS Studio 30.2+;
+- dedicated DTXManiaCX profile, scene collection, and scene;
+- ScreenCaptureKit application/window capture scoped to CX;
+- CX application audio enabled through that source or one dedicated macOS Audio Capture source;
+- global Desktop Audio disabled for the recorded track;
+- microphone inputs disabled for the recorded track;
+- Hybrid MP4;
+- authenticated obs-websocket 5.x;
+- Screen Recording privacy permission granted manually;
+- OBS idle before `record` starts.
+
+No scene/source enumeration or auto-repair is added. HPA-505 remains the optional follow-up if manual setup proves too fragile.
+
+## Acceptance chart
+
+Use one short chart that is already indexed by normal CX Song Select and has preview audio.
+
+The accepted Mac proof must exercise the HPA-512 runtime. Prefer an MP3 preview/BGM input; otherwise use another encoded input that demonstrably invokes the bundled native FFmpeg path.
+
+Do not create a special recorder-only chart.
+
+## Native acceptance evidence
+
+Retain outside Git:
+
+```text
+<proof-root>/
+  doctor.txt
+  architecture.txt
+  source-state-before.txt
+  source-state-after.txt
+  raw/
+    <obs-produced-file>.mp4
+  published/
+    <published-file>.mp4
+    diagnostics/<run-id>/
+      run.json
+      cx-stdout.log
+      cx-stderr.log
+```
+
+The exact local path is not a product contract.
+
+`architecture.txt` should record enough sanitized evidence to show:
+
+- host is Apple Silicon;
+- `dtx-video` process is arm64;
+- selected CX executable/apphost is arm64;
+- bundled `ffmpeg` is arm64;
+- bundled `ffprobe` is arm64.
+
+Do not commit binaries or private local paths.
+
+## Source app-data isolation
+
+Reuse the HPA-513 proof technique.
+
+Immediately before and after the accepted Mac run, capture presence, size, and SHA-256 for source files when present:
+
+```text
+Config.ini
+songs.db
+songs.db-wal
+songs.db-shm
+```
+
+Acceptance requires no content change and no new source WAL/SHM creation caused by the recorder.
+
+Do not add recorder instrumentation for this; filesystem hashes are sufficient.
+
+## Automated telemetry acceptance
+
+Reuse the same `run.json` contract accepted by HPA-513. Require at least:
+
+- `status == Completed`;
+- selected song is present at `SongSelectReady`;
+- preview state is Playing and elapsed preview >= 10,000 ms;
+- Performance is ready, AutoPlay is enabled, and total notes > 0;
+- Result is completed/cleared by song completion;
+- `totalJudgements == totalNotes`;
+- OBS Connect/Status/Start/Stop succeeded;
+- raw/published paths are recorded;
+- no failure fields or retained successful sandbox;
+- verifier warning is absent or only the existing optional recorder-side PATH `ffprobe` warning.
+
+Do not create a Mac-only diagnostics schema.
+
+## Manual media acceptance
+
+Watch the complete published MP4 and confirm:
+
+- intended populated Song Select is first;
+- preview begins after Song Select is visibly captured;
+- preview audio lasts at least 10 seconds;
+- Song Transition is complete;
+- full AutoPlay gameplay is visible;
+- BGM/chip audio is audible;
+- Result is fully rendered and held at least 5 seconds;
+- recording ends after the Result hold;
+- no OBS UI, desktop, unrelated window, cursor, notification, microphone, or unrelated application audio is captured;
+- CX audio is not duplicated or echoed;
+- no aspect squeeze, severe stutter, or missing viewport region makes the recording unusable;
+- no user-installed FFmpeg or Rosetta is required for CX preview/gameplay audio.
+
+Strict codec/frame-rate/duration enforcement remains HPA-506.
+
+## Failure and cleanup strategy
+
+Do not duplicate all HPA-503/HPA-513 platform-neutral cleanup checks manually.
+
+Automated tests remain the primary proof for:
+
+- pre-existing OBS ownership;
+- Start failure ownership;
+- cancellation after owned OBS start;
+- unexpected stage/performance/result failure;
+- artifact-finalization failure;
+- sandbox retention/deletion ordering.
+
+Mac-native proof should add only high-value platform evidence:
+
+1. `doctor` on the real Apple Silicon workstation;
+2. one successful recording using the native bundled FFmpeg path;
+3. one Ctrl+C cancellation after recorder-owned OBS start, confirming OBS stops and diagnostics/raw evidence are retained;
+4. manual confirmation that an invalid ScreenCaptureKit selection or missing Screen Recording permission is an operator-visible setup problem, not something `doctor` falsely claims to classify.
+
+Do not revoke privacy permissions or invent source-diagnostic APIs merely to create a synthetic failure test.
+
+## Documentation outputs
+
+The HPA-515 implementation/acceptance PR should add:
+
+```text
+docs/video-recorder/macos-obs-setup.md
+docs/verification/hpa-515-apple-silicon-live-recording.md
+```
+
+`macos-obs-setup.md` should cover only:
+
+- Apple Silicon/macOS prerequisites;
+- default project-mode build;
+- optional `DTXMANIA_VIDEO_GAME_EXECUTABLE` packaged-target usage;
+- ScreenCaptureKit source and application-audio setup;
+- Screen Recording permission;
+- disabled desktop/microphone audio;
+- WebSocket environment variables;
+- `doctor` and `record` commands;
+- native FFmpeg gate;
+- artifact locations;
+- concise troubleshooting.
+
+`hpa-515-apple-silicon-live-recording.md` should record sanitized proof:
+
+- accepted commit SHA;
+- macOS version and Apple Silicon model/architecture;
+- .NET and OBS versions;
+- project or packaged-executable launch mode;
+- non-sensitive chart identity;
+- arm64 evidence summary;
+- doctor result;
+- successful command summary with private paths redacted;
+- raw/published MP4 name, size, and SHA-256;
+- key `run.json` acceptance values;
+- source before/after comparison;
+- Ctrl+C cleanup result;
+- manual media checklist result;
+- focused automated test command/results;
+- warnings/deviations.
+
+## Testing strategy
+
+### Portable unit tests
+
+Extend `DTXMania.VideoRecorder.Tests` for:
+
+- environment parsing/validation of the optional game executable;
+- default launch target resolves the current platform project;
+- explicit executable launch target uses the exact executable and its parent working directory;
+- existing Windows behavior remains unchanged;
+- Mac native-runtime path resolution for project and executable launch modes;
+- missing/unexecutable Mac runtime files produce actionable preflight failure.
+
+Do not mock `RecordWorkflow` into a second Mac workflow test matrix; its existing tests remain shared.
+
+### Existing CI
+
+No workflow edit should be required initially:
+
+- Windows already runs VideoRecorder/Automation tests;
+- macOS already runs VideoRecorder/Automation tests;
+- macOS already verifies bundled arm64 FFmpeg and executes focused audio tests.
+
+Only touch CI if implementation proves an existing job does not execute the new tests. Do not add a dedicated recorder platform job pre-emptively.
+
+### Native proof
+
+Hosted CI does not replace real OBS + ScreenCaptureKit + privacy-permission acceptance. One local or self-hosted Apple Silicon proof remains required.
+
+## Expected production/test file surface
+
+Expected modifications:
+
+```text
+DTXMania.VideoRecorder/Configuration/RecorderEnvironment.cs
+DTXMania.VideoRecorder/RecorderCommandLine.cs
+DTXMania.VideoRecorder/Workflow/RecorderGameLaunchPolicy.cs
+DTXMania.VideoRecorder/Program.cs
+```
+
+Expected small additions only if they keep doctor/preflight testable:
+
+```text
+DTXMania.VideoRecorder/Diagnostics/<one focused platform-preflight helper>.cs
+DTXMania.VideoRecorder.Tests/<focused command-line/launch tests>.cs
+DTXMania.VideoRecorder.Tests/Diagnostics/<focused platform-preflight tests>.cs
+```
+
+Expected documentation additions:
+
+```text
+docs/video-recorder/macos-obs-setup.md
+docs/verification/hpa-515-apple-silicon-live-recording.md
+```
+
+Normally unchanged:
+
+```text
+DTXMania.VideoRecorder/Workflow/RecordWorkflow.cs
+DTXMania.VideoRecorder/Obs/**
+DTXMania.VideoRecorder/Media/**
+DTXMania.VideoRecorder/Sandbox/**
+DTXMania.Automation/Process/GameProcessDriver.cs
+DTXMania.Game/Lib/Resources/FfmpegRuntime.cs
+DTXMania.Game/DTXMania.Game.Mac.csproj
+.github/workflows/**
+```
+
+If implementation requires broad changes in the “normally unchanged” set, stop and re-evaluate scope before proceeding.
+
+## Estimated implementation shape
+
+One 2–3 engineer-day implementation/acceptance task, split into reviewer-friendly checkpoints:
+
+1. cross-platform command validation + project/executable launch selection;
+2. Mac `doctor` platform/native-runtime preflight + focused tests;
+3. native Apple Silicon OBS proof and sanitized runbook/verification documents.
+
+This is small enough to stay one HPA-515 implementation PR. If the native proof exposes an unrelated recorder or game defect, split that defect into a blocker instead of expanding HPA-515.
+
+## Acceptance criteria
+
+HPA-515 is complete when:
+
+- the same `doctor`/`record` CLI contract works on Windows and native Apple Silicon macOS;
+- default Mac project launch uses `DTXMania.Game.Mac.csproj` through Automation;
+- optional explicit packaged Mac executable launch is supported without a new platform framework;
+- Mac `doctor` rejects unsupported OS/architecture and missing/unusable native CX FFmpeg runtime;
+- one inspected Apple Silicon MP4 covers Song Select -> >=10s preview -> transition -> full AutoPlay gameplay -> >=5s Result;
+- MP3/encoded preview/gameplay audio works from bundled native FFmpeg without user-installed FFmpeg or Rosetta;
+- normal CX app data remains unchanged;
+- cancellation stops only recorder-owned OBS work and retains useful failed-run evidence;
+- Windows behavior and shared recorder tests remain green;
+- no ScreenCaptureKit diagnostic automation, strict media hardening, or adapter framework is introduced.
+
+## Non-goals
+
+- Intel Mac or Rosetta support;
+- changing the shared recording journey;
+- app/DMG discovery, mounting, or installation;
+- automatic OBS scene/source selection;
+- ScreenCaptureKit screenshot/source/meter diagnosis;
+- macOS privacy-permission classification or mutation;
+- bundled FFmpeg upgrades or a second FFmpeg resolver;
+- recorder-side bundled `ffprobe` for final MP4 verification;
+- MKV remux, transcoding, strict codec/frame-rate/duration policy;
+- YouTube upload/editing/batch recording;
+- general platform abstraction for hypothetical future operating systems.

--- a/docs/verification/hpa-515-apple-silicon-live-recording.md
+++ b/docs/verification/hpa-515-apple-silicon-live-recording.md
@@ -1,0 +1,117 @@
+# HPA-515 Apple Silicon recorder parity — verification record
+
+> **Status: PARTIAL — code complete and host-validated; live OBS acceptance
+> pending.** All automated sections below were captured on the recorded
+> host/commit. Sections marked **PENDING** require OBS Studio to be
+> installed and manually configured (see
+> `docs/video-recorder/macos-obs-setup.md`); they must be completed before
+> HPA-515 is accepted.
+
+## Recorded environment
+
+- Implementation commit: `900b1940` (`feat: preflight native Mac recorder
+  before OBS`); docs commit adds this record.
+- Host: MacBookPro18,3 (Apple M1 Pro), native `arm64`
+- macOS: 26.5.2
+- .NET SDK: 10.0.100
+
+## Debug build (the exact artifact the recorder launches)
+
+Command (run immediately before evidence capture):
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+```
+
+Result: 0 errors (140 pre-existing nullable warnings).
+
+## Architecture evidence (`file` on the launched output)
+
+```text
+DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac:
+    Mach-O 64-bit executable arm64
+DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg:
+    Mach-O 64-bit executable arm64
+DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe:
+    Mach-O 64-bit executable arm64
+```
+
+## Doctor result (pre-OBS gates)
+
+`dtx-video doctor` on this host reported:
+
+- Recorder configuration validation: passed
+- macOS >= 13: passed
+- Apple Silicon (arm64): passed
+- Mac game project + project exists: passed (`DTXMania.Game/DTXMania.Game.Mac.csproj`)
+- Bundled ffmpeg + ffprobe: passed (both under
+  `bin/Debug/net8.0/runtimes/osx-arm64/MMTools/`)
+- Source config + validation: passed
+  (`~/Library/Application Support/DTXManiaCX/Config.ini`)
+- Raw output directory: passed
+- ffprobe on PATH: available (optional, final MP4 verification only)
+- **OBS auth/status: FAILED — OBS Studio is not installed on this host.**
+  This is operator setup, not a recorder defect; the gate failure is the
+  expected behavior.
+- OBS state mutation: none (doctor is read-only)
+
+Doctor also printed the macOS manual OBS prerequisites (ScreenCaptureKit
+source scoping, application audio, disabled Desktop Audio/microphone,
+Hybrid MP4, Screen Recording permission, authenticated WebSocket) as
+guidance only.
+
+## Automated tests (all on this Mac)
+
+- HPA-512 focused native audio (same filter as macOS CI):
+  `FfmpegAudioVariantProcessorTests | FfmpegBundledRuntimeTests |
+  ManagedSoundTests` — 86/86 passed
+- `DTXMania.VideoRecorder.Tests` — 104/104 passed
+- `DTXMania.Automation.Tests` — 66/66 passed
+
+Key regression proofs included in those suites:
+
+- `--no-build` launch honored by `GameProcessDriver` (prebuilt child runs
+  after source is corrupted; a silent rebuild would fail the test)
+- Failed preflight rejects before sandbox/OBS construction and needs no OBS
+  server (mutation-tested: moving the rejection after sandbox creation
+  fails the test)
+- Both Windows and Mac app-data branches run on every host via injected
+  facts (full `UserProfile -> Personal -> $HOME` Mac fallback chain)
+- Doctor reports a synthetic passing Mac preflight with no Windows-only
+  gate remaining
+
+## PENDING — live OBS acceptance
+
+The following require OBS Studio 30.2+ installed and manually configured
+(dedicated profile/collection/scene, ScreenCaptureKit application capture
+scoped to CX, CX application audio, Desktop Audio/microphone disabled,
+Hybrid MP4, authenticated obs-websocket, Screen Recording permission
+granted):
+
+- OBS version recorded; doctor OBS auth/status gate passing
+- One acceptance chart (short, Song Select-indexed, encoded preview audio)
+  recorded via the full journey (Song Select → preview ≥ 10 s → transition
+  → full AutoPlay performance → Result ≥ 5 s hold → recorder-owned stop)
+- `run.json` acceptance values (status/song/preview/performance/result/
+  judgements/OBS events/raw+published paths)
+- Source app-data `Config.ini` / `songs.db` / WAL / SHM SHA-256 comparison
+  before vs. after (must be unchanged)
+- One Ctrl+C cancellation case after recorder-owned OBS start (recorder
+  work stops, diagnostics retained, sandbox retained, unrelated OBS
+  ownership untouched)
+- Manual viewing of the complete published MP4 against the media checklist
+  (Song Select first, audible preview/gameplay audio, full Result hold, no
+  desktop/mic/cursor/unrelated audio, no duplicated audio, no aspect
+  squeeze; ScreenCaptureKit content only)
+- Published MP4 name, size, SHA-256
+
+Strict codec/frame-rate/duration enforcement remains deferred to HPA-506.
+
+## Warnings / deviations
+
+- Doctor's macOS version gate detail renders a converted version label on
+  Darwin 25+ hosts (display-only; gate outcome uses the correct comparison).
+- Windows doctor output no longer prints repository/game-project gates:
+  Windows preflight intentionally has no native gates.
+- The chmod-based "non-executable runtime" preflight test is a no-op on
+  Windows hosts (executable bit is Unix-only); macOS CI covers it.

--- a/docs/video-recorder/macos-obs-setup.md
+++ b/docs/video-recorder/macos-obs-setup.md
@@ -103,7 +103,7 @@ Set `DTXMANIA_VIDEO_OBS_PASSWORD` without echoing it into shell history. Either
 prompt for it silently in the same shell that will run the recorder:
 
 ```bash
-read -rs DTXMANIA_VIDEO_OBS_PASSWORD
+read -rs -p "OBS WebSocket password: " DTXMANIA_VIDEO_OBS_PASSWORD
 export DTXMANIA_VIDEO_OBS_PASSWORD
 printf '\n'
 ```

--- a/docs/video-recorder/macos-obs-setup.md
+++ b/docs/video-recorder/macos-obs-setup.md
@@ -14,7 +14,7 @@ Windows.
 - .NET SDK 8+ (`dotnet --info`).
 - OBS Studio 30.2 or newer with obs-websocket 5.x.
 
-## Build the exact artifact the recorder launches
+## Build the exact artifacts the recorder uses
 
 The recorder launches the game project in-place with
 `--no-build --configuration Debug`. Build the current source first:
@@ -23,11 +23,24 @@ The recorder launches the game project in-place with
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
 ```
 
-Preflight (`doctor` and `record` both run it) verifies exactly this output:
+The `dtx-video` recorder is a separate project; building the game alone
+does not produce it. Build it too:
 
-- `DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac` (native arm64 apphost)
+```bash
+dotnet build DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug
+```
+
+Preflight (`doctor` and `record` both run it) checks that the recorder
+process runs arm64, that the game project is the Mac project, and that the
+bundled FFmpeg pair exists and is executable:
+
 - `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg`
 - `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe`
+
+Preflight does not gate the apphost binary itself. That
+`DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac` is a native arm64
+apphost is manually inspected acceptance evidence (the `file` check in the
+verification record), not a preflight check.
 
 The HPA-512 `osx-arm64` FFmpeg pair is required for recorder certification:
 a working FFmpeg on `PATH` is not accepted as native evidence, even though
@@ -35,8 +48,9 @@ the game itself may fall back to other runtimes.
 
 ## Why the recorder uses `--no-build`
 
-Preflight certifies the Debug output above, and the recorder then launches
-that same output with `dotnet run --project ... --no-build --configuration
+Preflight checks the Debug output above (runtime pair and project
+identity), and the recorder then launches that same output with
+`dotnet run --project ... --no-build --configuration
 Debug`. This pins the checked artifact to the launched artifact: the
 recorder never silently rebuilds between certification and recording. Build
 immediately before capturing evidence so source cannot drift after the
@@ -89,6 +103,9 @@ The default source app-data root mirrors the game's own resolution:
 ```bash
 # build once, immediately before recording
 dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+
+# build the dtx-video recorder itself
+dotnet build DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug
 
 # check host, project, runtime pair, config, and OBS connectivity
 DTXMania.VideoRecorder/bin/Debug/net8.0/dtx-video doctor

--- a/docs/video-recorder/macos-obs-setup.md
+++ b/docs/video-recorder/macos-obs-setup.md
@@ -94,12 +94,34 @@ prints these as manual prerequisites only.
 
 ```bash
 export DTXMANIA_VIDEO_OBS_URL=ws://127.0.0.1:4455      # loopback only
-# Replace the quoted values below before running.
-export DTXMANIA_VIDEO_OBS_PASSWORD="your-obs-websocket-password"
 export DTXMANIA_VIDEO_OBS_OUTPUT_DIR="/path/to/obs-raw-mp4-output"
 # optional: record against an app-data copy other than the default root
 export DTXMANIA_APPDATA_ROOT="/path/to/app-data-root"
 ```
+
+Set `DTXMANIA_VIDEO_OBS_PASSWORD` without echoing it into shell history. Either
+prompt for it silently in the same shell that will run the recorder:
+
+```bash
+read -rs DTXMANIA_VIDEO_OBS_PASSWORD
+export DTXMANIA_VIDEO_OBS_PASSWORD
+printf '\n'
+```
+
+…or load it from a protected environment file whose permissions are restricted
+to your user (e.g. `chmod 600 ~/.config/dtx-video/obs.env`):
+
+```bash
+# ~/.config/dtx-video/obs.env  (chmod 600, never committed)
+# DTXMANIA_VIDEO_OBS_PASSWORD=your-obs-websocket-password
+set -a
+. ~/.config/dtx-video/obs.env
+set +a
+```
+
+Do not type the real password directly into a `export
+DTXMANIA_VIDEO_OBS_PASSWORD="..."` command line: that value is recorded in
+shell history and process listings.
 
 The default source app-data root mirrors the game's own resolution:
 `~/Library/Application Support/DTXManiaCX` on macOS.

--- a/docs/video-recorder/macos-obs-setup.md
+++ b/docs/video-recorder/macos-obs-setup.md
@@ -1,0 +1,123 @@
+# macOS OBS setup for the DTXManiaCX video recorder
+
+This runbook covers manual, one-time operator setup for running the
+`dtx-video` recorder on Apple Silicon macOS. The recorder itself is
+unchanged: `dtx-video doctor` and
+`dtx-video record --chart <chart.dtx> --output <dir>` work the same as on
+Windows.
+
+## Prerequisites
+
+- Apple Silicon Mac (`arm64`) running macOS 13 or newer. The bundled
+  application-audio path (ScreenCaptureKit / macOS Audio Capture) requires
+  macOS 13+, so older systems are rejected before any recording starts.
+- .NET SDK 8+ (`dotnet --info`).
+- OBS Studio 30.2 or newer with obs-websocket 5.x.
+
+## Build the exact artifact the recorder launches
+
+The recorder launches the game project in-place with
+`--no-build --configuration Debug`. Build the current source first:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+```
+
+Preflight (`doctor` and `record` both run it) verifies exactly this output:
+
+- `DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac` (native arm64 apphost)
+- `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg`
+- `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe`
+
+The HPA-512 `osx-arm64` FFmpeg pair is required for recorder certification:
+a working FFmpeg on `PATH` is not accepted as native evidence, even though
+the game itself may fall back to other runtimes.
+
+## Why the recorder uses `--no-build`
+
+Preflight certifies the Debug output above, and the recorder then launches
+that same output with `dotnet run --project ... --no-build --configuration
+Debug`. This pins the checked artifact to the launched artifact: the
+recorder never silently rebuilds between certification and recording. Build
+immediately before capturing evidence so source cannot drift after the
+check.
+
+If the runtime pair is missing or not executable, preflight fails before
+creating any sandbox or contacting OBS, naming the recovery command:
+
+```bash
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+```
+
+## OBS manual setup
+
+Configure once in OBS Studio 30.2+:
+
+1. Create a dedicated DTXManiaCX profile, scene collection, and scene.
+2. Add a ScreenCaptureKit application/window capture source scoped to the
+   DTXManiaCX window. Do not use full-display capture.
+3. Configure DTXManiaCX application audio via the capture source or one
+   dedicated macOS Audio Capture source (macOS 13+).
+4. Disable Desktop Audio on the recorded track.
+5. Disable the microphone on the recorded track.
+6. Set output to Hybrid MP4.
+7. Enable the obs-websocket 5.x server with a password
+   (Tools → WebSocket Server Settings).
+8. Grant OBS Screen Recording permission in System Settings → Privacy &
+   Security when prompted, then restart OBS.
+9. Leave OBS idle (not recording) before the recorder starts; the recorder
+   owns start/stop via WebSocket.
+
+The recorder does not verify source selection or privacy state; `doctor`
+prints these as manual prerequisites only.
+
+## Environment variables
+
+```bash
+export DTXMANIA_VIDEO_OBS_URL=ws://127.0.0.1:4455      # loopback only
+export DTXMANIA_VIDEO_OBS_PASSWORD=<obs-websocket password>
+export DTXMANIA_VIDEO_OBS_OUTPUT_DIR=<OBS raw MP4 output directory>
+# optional: record against an app-data copy other than the default root
+export DTXMANIA_APPDATA_ROOT=<path>
+```
+
+The default source app-data root mirrors the game's own resolution:
+`~/Library/Application Support/DTXManiaCX` on macOS.
+
+## Commands
+
+```bash
+# build once, immediately before recording
+dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
+
+# check host, project, runtime pair, config, and OBS connectivity
+DTXMania.VideoRecorder/bin/Debug/net8.0/dtx-video doctor
+
+# record one chart
+DTXMania.VideoRecorder/bin/Debug/net8.0/dtx-video record \
+  --chart <chart.dtx> --output <publish directory>
+```
+
+## Artifacts
+
+- Diagnostics (`run.json`, game logs) land under the `--output` directory in
+  a per-run subdirectory.
+- The raw OBS MP4 lands in `DTXMANIA_VIDEO_OBS_OUTPUT_DIR`.
+- The published MP4 lands in the `--output` directory.
+- On failure the sandbox (copied app data) is retained for diagnosis; on
+  success it is deleted.
+
+## Troubleshooting
+
+- `Recorder platform preflight failed ... Bundled ffmpeg/ffprobe` — run the
+  Debug build command above; a PATH FFmpeg does not satisfy certification.
+- `OBS auth/status: FAILED` — OBS not running, websocket disabled, or wrong
+  password. Check the URL is loopback and matches the websocket server
+  settings.
+- Black or silent capture — re-check the ScreenCaptureKit source is scoped
+  to the DTXManiaCX window and Screen Recording permission is granted.
+- No application audio — confirm macOS 13+, the macOS Audio Capture source
+  exists, and Desktop Audio/microphone tracks are disabled.
+- Recorder launches but no video appears — confirm OBS is idle before the
+  recorder starts and the raw output directory matches
+  `DTXMANIA_VIDEO_OBS_OUTPUT_DIR`.

--- a/docs/video-recorder/macos-obs-setup.md
+++ b/docs/video-recorder/macos-obs-setup.md
@@ -36,16 +36,22 @@ dotnet build DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuratio
 ```
 
 Preflight (`doctor` and `record` both run it) checks that the recorder
-process runs arm64, that the game project is the Mac project, and that the
-bundled FFmpeg pair exists and is executable:
+process runs arm64, that the game project is the Mac project, that the
+native apphost exists and is executable, and that the bundled FFmpeg pair
+exists and is executable:
 
+- `DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac` (native arm64 apphost;
+  `dotnet run --no-build` on a net8.0 `WinExe` with `UseAppHost=true`
+  executes this binary, not the managed DLL, so preflight gates its
+  existence and executable bit)
 - `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg`
 - `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe`
 
-Preflight does not gate the apphost binary itself.
-`DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac` is a native arm64
-apphost; manually inspecting it (including the `file` check recorded in the
-verification record) is acceptance evidence, not a preflight gate.
+The apphost gate is named "Debug output" in `doctor` output. Manually
+inspecting the apphost with `file` and confirming it is `arm64` (the `file`
+check recorded in the verification record) is separate acceptance evidence
+that the gated binary is the expected native architecture — it is not
+itself a preflight gate.
 
 The HPA-512 `osx-arm64` FFmpeg pair is required for recorder certification:
 a working FFmpeg on `PATH` is not accepted as native evidence, even though
@@ -53,8 +59,8 @@ the game itself may fall back to other runtimes.
 
 ## Why the recorder uses `--no-build`
 
-Preflight checks the Debug output above (runtime pair and project
-identity), and the recorder then launches that same output with
+Preflight checks the Debug output above (apphost, runtime pair, and
+project identity), and the recorder then launches that same output with
 `dotnet run --project ... --no-build --configuration
 Debug`. This pins the checked artifact to the launched artifact: the
 recorder never silently rebuilds between certification and recording. Build
@@ -135,7 +141,7 @@ dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug
 # build the dtx-video recorder itself
 dotnet build DTXMania.VideoRecorder/DTXMania.VideoRecorder.csproj --configuration Debug
 
-# check host, project, runtime pair, config, and OBS connectivity
+# check host, project, apphost, runtime pair, config, and OBS connectivity
 DTXMania.VideoRecorder/bin/Debug/net8.0/dtx-video doctor
 
 # record one chart

--- a/docs/video-recorder/macos-obs-setup.md
+++ b/docs/video-recorder/macos-obs-setup.md
@@ -1,10 +1,11 @@
 # macOS OBS setup for the DTXManiaCX video recorder
 
 This runbook covers manual, one-time operator setup for running the
-`dtx-video` recorder on Apple Silicon macOS. The recorder itself is
-unchanged: `dtx-video doctor` and
-`dtx-video record --chart <chart.dtx> --output <dir>` work the same as on
-Windows.
+`dtx-video` recorder on Apple Silicon macOS. The `dtx-video` CLI commands
+(`dtx-video doctor`, `dtx-video record --chart <chart.dtx> --output <dir>`)
+are unchanged from Windows, but the recorder now performs environment
+reading, target resolution, and platform preflight (arm64, macOS 13+,
+bundled FFmpeg pair) before recording.
 
 ## Prerequisites
 
@@ -15,6 +16,10 @@ Windows.
 - OBS Studio 30.2 or newer with obs-websocket 5.x.
 
 ## Build the exact artifacts the recorder uses
+
+Run all build commands from the repository root. The commands below use
+relative paths (`DTXMania.Game/DTXMania.Game.Mac.csproj`) that only resolve
+from that location.
 
 The recorder launches the game project in-place with
 `--no-build --configuration Debug`. Build the current source first:
@@ -37,10 +42,10 @@ bundled FFmpeg pair exists and is executable:
 - `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffmpeg`
 - `DTXMania.Game/bin/Debug/net8.0/runtimes/osx-arm64/MMTools/ffprobe`
 
-Preflight does not gate the apphost binary itself. That
+Preflight does not gate the apphost binary itself.
 `DTXMania.Game/bin/Debug/net8.0/DTXMania.Game.Mac` is a native arm64
-apphost is manually inspected acceptance evidence (the `file` check in the
-verification record), not a preflight check.
+apphost; manually inspecting it (including the `file` check recorded in the
+verification record) is acceptance evidence, not a preflight gate.
 
 The HPA-512 `osx-arm64` FFmpeg pair is required for recorder certification:
 a working FFmpeg on `PATH` is not accepted as native evidence, even though
@@ -89,10 +94,11 @@ prints these as manual prerequisites only.
 
 ```bash
 export DTXMANIA_VIDEO_OBS_URL=ws://127.0.0.1:4455      # loopback only
-export DTXMANIA_VIDEO_OBS_PASSWORD=<obs-websocket password>
-export DTXMANIA_VIDEO_OBS_OUTPUT_DIR=<OBS raw MP4 output directory>
+# Replace the quoted values below before running.
+export DTXMANIA_VIDEO_OBS_PASSWORD="your-obs-websocket-password"
+export DTXMANIA_VIDEO_OBS_OUTPUT_DIR="/path/to/obs-raw-mp4-output"
 # optional: record against an app-data copy other than the default root
-export DTXMANIA_APPDATA_ROOT=<path>
+export DTXMANIA_APPDATA_ROOT="/path/to/app-data-root"
 ```
 
 The default source app-data root mirrors the game's own resolution:


### PR DESCRIPTION
## Summary

Planning-only PR for [HPA-515](https://linear.app/cwchanap/issue/HPA-515/port-the-proven-recorder-workflow-to-apple-silicon-macos-and-validate): port the proven recorder workflow to native Apple Silicon macOS and retain one accepted recording.

This PR changes only the HPA-515 design and implementation-plan documents.

## Final design direction

- Keep one `RecordWorkflow`, one OBS client, one sandbox/finalization path, and the unchanged `doctor` / `record --chart --output` CLI.
- Keep HPA-515 project-mode-only; packaged executable/app-bundle recording stays deferred.
- Resolve the current-platform project once through `GameProjectPaths.Current` and share that target between record and doctor.
- Add one small additive Automation seam: optional project-run arguments on `GameProcessStartOptions` / `GameProcessDriver`.
- Recorder project launch is explicitly `dotnet run --project <project> --no-build --configuration Debug`.
- The operator builds Debug first; preflight certifies that exact output before sandbox/OBS. Missing output fails with the exact `dotnet build DTXMania.Game/DTXMania.Game.Mac.csproj --configuration Debug` recovery command.
- `RunRecordAsync` receives the resolved target + preflight result and rejects a failed result at its first side-effect boundary, with an automated no-sandbox/no-OBS regression test.
- `doctor` consumes the same preflight gates through the existing `ReportGate` path and removes the current Windows-only gate.
- Keep macOS 13+ as a hard requirement because the accepted OBS application-audio path requires macOS 13+.
- Require the managed HPA-512 `osx-arm64` FFmpeg pair for recorder certification. CX may have broader runtime fallback, but unmanaged PATH FFmpeg does not count as HPA-515 native evidence.
- Mirror `AppPaths.GetAppDataRoot()` exactly in the recorder with injected folder/platform facts so Windows and Mac branches run on every test host. Do not introduce a production `DTXMania.Game -> DTXMania.Automation` dependency for one path helper.
- Keep ScreenCaptureKit source/audio/privacy setup manual; HPA-505/HPA-506 remain deferred.

## Latest review decisions

1. **F1 launch/preflight mismatch — accepted.** The previous plan checked `bin/Debug` and then let `dotnet run` rebuild it. The revised design prebuilds, checks, and then launches the same Debug artifact with `--no-build`.
2. **F2 pre-OBS ordering coverage — accepted.** The invariant is now carried into internal `RunRecordAsync(..., preflight)` and pinned by a test proving failed preflight creates no sandbox and needs no OBS server.
3. **F3 app-data drift — concern accepted, suggested dependency rejected.** `AppPaths` stays authoritative, but the recorder mirrors its complete `UserProfile -> Personal -> $HOME` fallback with host-independent tests. Making the production game depend on Automation solely for this helper would be the wrong dependency direction.
4. **F4 runtime/OS gates — partially accepted.** The bundled-runtime hard failure is now documented as deliberate recorder certification policy. The proposed macOS-13 downgrade was rejected because the accepted ScreenCaptureKit/macOS Audio Capture path requires macOS 13+.
5. **F5 ambient Mac-path test — accepted.** Default-root resolution is explicitly injectable so both platform branches run on every host.
6. **F6 doctor Mac regression — accepted.** Add a focused synthetic-Mac platform-reporting test and remove the separate Windows-only gate.

## Implementation shape

One 2–3 engineer-day implementation/acceptance PR with five checkpoints:

1. additive Automation project arguments + shared recorder target resolution;
2. testable command/platform/app-data inputs;
3. shared native preflight + enforced pre-OBS ordering + doctor parity;
4. native Debug build/architecture/audio proof before OBS;
5. one ScreenCaptureKit recording, Ctrl+C/source-isolation/manual-media acceptance, runbook, and sanitized verification record.

## Validation

Planning branch still changes only:

- `docs/superpowers/specs/2026-08-16-hpa-515-apple-silicon-recorder-parity-design.md`
- `docs/superpowers/plans/2026-08-16-hpa-515-apple-silicon-recorder-parity.md`

No production/test/CI changes are part of this planning PR. No build/tests were run because this PR remains planning-only.

This PR does not close HPA-515; the follow-up implementation/acceptance PR executes the plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added macOS and Apple Silicon support for video recording.
  - Added platform preflight checks for compatibility, project setup, runtimes, tools, and executable permissions.
  - Recording now launches resolved Debug targets without rebuilding and supports project run arguments.
  - Improved platform-aware application-data paths and Doctor prerequisite reporting.

- **Documentation**
  - Added Apple Silicon OBS setup, troubleshooting guidance, and verification records.

- **Tests**
  - Expanded coverage for command-line validation, launch behavior, platform checks, and recording workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->